### PR TITLE
Agentic email security platform (edge pipeline + MISP-compatible hub)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ opencode.jsonc
 skills-lock.json
 .DS_Store
 worker-configuration.d.ts
+.claude/

--- a/app/components/ReportPhishButton.tsx
+++ b/app/components/ReportPhishButton.tsx
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { Button, Tooltip, useKumoToastManager } from "@cloudflare/kumo";
+import { ShieldWarningIcon } from "@phosphor-icons/react";
+import { useNavigate } from "react-router";
+import { useState } from "react";
+
+/**
+ * Convert an email into a local case and (future milestones) push anonymized
+ * observables to the configured community hub. Safe to click multiple times —
+ * the server creates one case per click, so the user can manage duplicates.
+ */
+export default function ReportPhishButton({
+	mailboxId,
+	emailId,
+}: {
+	mailboxId?: string;
+	emailId: string;
+}) {
+	const navigate = useNavigate();
+	const toast = useKumoToastManager();
+	const [pending, setPending] = useState(false);
+
+	const handle = async () => {
+		if (!mailboxId) return;
+		setPending(true);
+		try {
+			const res = await fetch(
+				`/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/cases/report-phish`,
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ emailId }),
+				},
+			);
+			if (!res.ok) throw new Error(await res.text());
+			const data = (await res.json()) as { caseId?: string };
+			toast.add({ title: "Phish reported", description: "A case was opened." });
+			if (data.caseId) navigate(`/mailbox/${encodeURIComponent(mailboxId)}/cases/${data.caseId}`);
+		} catch (e) {
+			toast.add({ title: "Report failed", description: (e as Error).message, variant: "error" });
+		} finally {
+			setPending(false);
+		}
+	};
+
+	return (
+		<Tooltip content="Report as phish" side="bottom" asChild>
+			<Button
+				variant="ghost"
+				shape="square"
+				size="sm"
+				icon={<ShieldWarningIcon size={18} />}
+				onClick={handle}
+				loading={pending}
+				aria-label="Report as phish"
+			/>
+		</Tooltip>
+	);
+}

--- a/app/components/VerdictBadge.tsx
+++ b/app/components/VerdictBadge.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { ShieldCheckIcon, ShieldWarningIcon, ShieldIcon } from "@phosphor-icons/react";
+import { parseVerdict, type Email } from "~/types";
+
+/**
+ * Compact verdict pill for the email list row. Renders nothing when the
+ * security pipeline didn't run for this email.
+ */
+export default function VerdictBadge({ email }: { email: Pick<Email, "security_verdict" | "security_score"> }) {
+	const verdict = parseVerdict(email.security_verdict);
+	if (!verdict) return null;
+	if (verdict.action === "allow") return null;
+
+	const { icon, label, className } = presentation(verdict.action);
+	return (
+		<span
+			title={verdict.explanation}
+			className={`shrink-0 inline-flex items-center gap-1 text-xs font-medium rounded-full px-1.5 py-0.5 ${className}`}
+		>
+			{icon}
+			{label}
+		</span>
+	);
+}
+
+function presentation(action: string) {
+	switch (action) {
+		case "quarantine":
+		case "block":
+			return {
+				icon: <ShieldWarningIcon size={12} weight="fill" />,
+				label: action === "block" ? "Blocked" : "Quarantined",
+				className: "text-kumo-destructive bg-kumo-fill",
+			};
+		case "tag":
+			return {
+				icon: <ShieldIcon size={12} weight="bold" />,
+				label: "Suspicious",
+				className: "text-kumo-warning bg-kumo-fill",
+			};
+		default:
+			return {
+				icon: <ShieldCheckIcon size={12} />,
+				label: "Safe",
+				className: "text-kumo-subtle",
+			};
+	}
+}

--- a/app/components/email-panel/EmailPanelToolbar.tsx
+++ b/app/components/email-panel/EmailPanelToolbar.tsx
@@ -15,10 +15,13 @@ import {
 	FolderSimpleIcon,
 	PaperPlaneTiltIcon,
 	PencilSimpleIcon,
+	ShieldCheckIcon,
 	StarIcon,
 	TrashIcon,
 	XIcon,
 } from "@phosphor-icons/react";
+import { Folders } from "shared/folders";
+import ReportPhishButton from "~/components/ReportPhishButton";
 import type { Folder, Email } from "~/types";
 
 interface EmailPanelToolbarProps {
@@ -70,6 +73,19 @@ export default function EmailPanelToolbar({
 				aria-label="Back to list"
 				className="md:hidden shrink-0"
 			/>
+
+			{email.folder_id === Folders.QUARANTINE ? (
+				<Tooltip content="Release to Inbox" side="bottom" asChild>
+					<Button
+						variant="secondary"
+						size="sm"
+						icon={<ShieldCheckIcon size={16} />}
+						onClick={() => onMove(Folders.INBOX)}
+					>
+						Release
+					</Button>
+				</Tooltip>
+			) : null}
 
 			{isDraftFolder ? (
 				<>
@@ -157,6 +173,8 @@ export default function EmailPanelToolbar({
 			</Tooltip>
 
 			<MoveToFolderMenu folders={moveToFolders} onMove={onMove} />
+
+			<ReportPhishButton mailboxId={mailboxId} emailId={email.id} />
 
 			<div className="ml-auto flex items-center gap-0.5">
 				<Tooltip content="View source" side="bottom" asChild>

--- a/app/components/email-panel/SecurityVerdictPanel.tsx
+++ b/app/components/email-panel/SecurityVerdictPanel.tsx
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { useState } from "react";
+import {
+	CaretDownIcon,
+	CaretUpIcon,
+	ShieldCheckIcon,
+	ShieldWarningIcon,
+	ShieldIcon,
+} from "@phosphor-icons/react";
+import { parseVerdict, type Email } from "~/types";
+
+/**
+ * Renders the security pipeline's verdict for an email: action, score, auth
+ * chips (SPF/DKIM/DMARC), classifier label, and a collapsible signals list.
+ */
+export default function SecurityVerdictPanel({ email }: { email: Email }) {
+	const verdict = parseVerdict(email.security_verdict);
+	const [expanded, setExpanded] = useState(false);
+
+	if (!verdict) return null;
+	// Quiet path for the normal allow case, but surface hard-block explicitly
+	// even when the user is reading the quarantined message.
+	if (verdict.action === "allow" && verdict.triage !== "hard_block") return null;
+
+	const { borderClass, bgClass, iconColorClass, icon, headline } = ui(verdict.action);
+	const triageTag = verdict.triage === "hard_allow"
+		? "allowlist fast-path"
+		: verdict.triage === "hard_block"
+			? "triage hard-block"
+			: null;
+
+	return (
+		<div className={`px-4 md:px-6 pt-3`}>
+			<div className={`rounded-lg border ${borderClass} ${bgClass} text-sm`}>
+				<button
+					type="button"
+					className="w-full flex items-center gap-2 px-3 py-2 text-left"
+					onClick={() => setExpanded((e) => !e)}
+				>
+					<span className={iconColorClass}>{icon}</span>
+					<span className="font-medium text-kumo-default">{headline}</span>
+					{triageTag && (
+						<span className="text-xs rounded-full bg-kumo-fill px-1.5 py-0.5 text-kumo-subtle">
+							{triageTag}
+						</span>
+					)}
+					<span className="text-xs text-kumo-subtle ml-1">score {verdict.score}/100</span>
+					<span className="ml-auto text-kumo-subtle">
+						{expanded ? <CaretUpIcon size={16} /> : <CaretDownIcon size={16} />}
+					</span>
+				</button>
+				{expanded && (
+					<div className="px-3 pb-3 pt-0 space-y-2">
+						<div className="text-kumo-default">{verdict.explanation}</div>
+
+						<div className="flex flex-wrap gap-1.5">
+							<AuthChip label="SPF" value={verdict.auth.spf} />
+							<AuthChip label="DKIM" value={verdict.auth.dkim} />
+							<AuthChip label="DMARC" value={verdict.auth.dmarc} />
+							<ClassifierChip label={verdict.classification.label} confidence={verdict.classification.confidence} />
+						</div>
+
+						{verdict.classification.reasoning && (
+							<div className="text-xs text-kumo-subtle italic">
+								Classifier: "{verdict.classification.reasoning}"
+							</div>
+						)}
+
+						{verdict.signals.length > 0 && (
+							<div>
+								<div className="text-xs font-medium text-kumo-subtle mb-1">Contributing signals</div>
+								<ul className="text-xs text-kumo-default list-disc ml-4 space-y-0.5">
+									{verdict.signals.map((s, i) => <li key={i}>{s}</li>)}
+								</ul>
+							</div>
+						)}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function ui(action: string) {
+	switch (action) {
+		case "quarantine":
+		case "block":
+			return {
+				borderClass: "border-kumo-destructive/40",
+				bgClass: "bg-kumo-fill",
+				iconColorClass: "text-kumo-destructive",
+				icon: <ShieldWarningIcon size={16} weight="fill" />,
+				headline: action === "block" ? "Blocked by security pipeline" : "Quarantined by security pipeline",
+			};
+		case "tag":
+			return {
+				borderClass: "border-kumo-warning/40",
+				bgClass: "bg-kumo-fill",
+				iconColorClass: "text-kumo-warning",
+				icon: <ShieldIcon size={16} weight="bold" />,
+				headline: "Flagged as suspicious",
+			};
+		default:
+			return {
+				borderClass: "border-kumo-line",
+				bgClass: "bg-kumo-elevated",
+				iconColorClass: "text-kumo-subtle",
+				icon: <ShieldCheckIcon size={16} />,
+				headline: "Security verdict",
+			};
+	}
+}
+
+function AuthChip({ label, value }: { label: string; value: string }) {
+	const color =
+		value === "pass" ? "text-kumo-success" :
+		value === "fail" || value === "softfail" ? "text-kumo-destructive" :
+		"text-kumo-subtle";
+	return (
+		<span className="text-xs rounded border border-kumo-line px-1.5 py-0.5 bg-kumo-elevated">
+			<span className="text-kumo-subtle">{label} </span>
+			<span className={`font-medium ${color}`}>{value}</span>
+		</span>
+	);
+}
+
+function ClassifierChip({ label, confidence }: { label: string; confidence: number }) {
+	const color =
+		label === "phishing" || label === "bec" ? "text-kumo-destructive" :
+		label === "suspicious" ? "text-kumo-warning" :
+		label === "spam" ? "text-kumo-subtle" :
+		"text-kumo-success";
+	return (
+		<span className="text-xs rounded border border-kumo-line px-1.5 py-0.5 bg-kumo-elevated">
+			<span className="text-kumo-subtle">LLM </span>
+			<span className={`font-medium ${color}`}>{label}</span>
+			<span className="text-kumo-subtle"> ({Math.round(confidence * 100)}%)</span>
+		</span>
+	);
+}

--- a/app/components/email-panel/SingleMessageView.tsx
+++ b/app/components/email-panel/SingleMessageView.tsx
@@ -4,6 +4,7 @@
 
 import EmailAttachmentList from "~/components/EmailAttachmentList";
 import EmailIframe from "~/components/EmailIframe";
+import SecurityVerdictPanel from "~/components/email-panel/SecurityVerdictPanel";
 import { formatDetailDate, rewriteInlineImages } from "~/lib/utils";
 import type { Email } from "~/types";
 
@@ -38,6 +39,8 @@ export default function SingleMessageView({
 					</span>
 				</div>
 			</div>
+
+			<SecurityVerdictPanel email={email} />
 
 			<div className="flex-1 min-h-0">
 				<EmailIframe

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -15,6 +15,9 @@ export default [
 		route("emails/:folder", "routes/email-list.tsx"),
 		route("settings", "routes/settings.tsx"),
 		route("search", "routes/search-results.tsx"),
+		route("dmarc", "routes/dmarc.tsx"),
+		route("cases", "routes/cases.tsx"),
+		route("cases/:caseId", "routes/case-detail.tsx"),
 	]),
 	route("*", "routes/not-found.tsx"),
 ] satisfies RouteConfig;

--- a/app/routes/case-detail.tsx
+++ b/app/routes/case-detail.tsx
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { Button, Loader, useKumoToastManager } from "@cloudflare/kumo";
+import { useCallback, useEffect, useState } from "react";
+import { Link, useParams } from "react-router";
+
+interface CaseEmail { case_id: string; email_id: string; }
+interface CaseObservable { id: string; kind: string; value: string; }
+interface CaseRecord {
+	id: string;
+	created_at: string;
+	updated_at: string;
+	status: string;
+	title: string;
+	notes: string | null;
+	shared_to_hub: number;
+	hub_event_uuid: string | null;
+	emails: CaseEmail[];
+	observables: CaseObservable[];
+}
+
+export default function CaseDetailRoute() {
+	const { mailboxId, caseId } = useParams<{ mailboxId: string; caseId: string }>();
+	const toast = useKumoToastManager();
+	const [data, setData] = useState<CaseRecord | null>(null);
+
+	const load = useCallback(async () => {
+		if (!mailboxId || !caseId) return;
+		const res = await fetch(`/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/cases/${encodeURIComponent(caseId)}`);
+		if (!res.ok) return setData(null);
+		const body = (await res.json()) as { case: CaseRecord };
+		setData(body.case);
+	}, [mailboxId, caseId]);
+
+	useEffect(() => { load(); }, [load]);
+
+	const updateStatus = async (status: string) => {
+		if (!mailboxId || !caseId) return;
+		await fetch(`/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/cases/${encodeURIComponent(caseId)}`, {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ status }),
+		});
+		toast.add({ title: "Case updated" });
+		await load();
+	};
+
+	if (!data) return <div className="flex justify-center py-20"><Loader size="lg" /></div>;
+
+	return (
+		<div className="max-w-3xl px-4 py-6 md:px-8 h-full overflow-y-auto">
+			<Link
+				to={`/mailbox/${encodeURIComponent(mailboxId ?? "")}/cases`}
+				className="text-sm text-kumo-subtle hover:underline"
+			>
+				← All cases
+			</Link>
+
+			<h1 className="text-lg font-semibold text-kumo-default mt-2 mb-1">{data.title}</h1>
+			<div className="text-xs text-kumo-subtle mb-6">
+				Opened {new Date(data.created_at).toLocaleString()} · Status {data.status}
+				{data.shared_to_hub ? ` · Shared (${data.hub_event_uuid ?? "pending"})` : " · Not shared"}
+			</div>
+
+			<div className="flex gap-2 mb-6">
+				{data.status === "open" && (
+					<>
+						<Button size="sm" variant="secondary" onClick={() => updateStatus("closed-tp")}>
+							Close as true positive
+						</Button>
+						<Button size="sm" variant="secondary" onClick={() => updateStatus("closed-fp")}>
+							Close as false positive
+						</Button>
+						<Button size="sm" variant="ghost" onClick={() => updateStatus("closed-dup")}>
+							Close as duplicate
+						</Button>
+					</>
+				)}
+				{data.status !== "open" && (
+					<Button size="sm" variant="secondary" onClick={() => updateStatus("open")}>
+						Reopen
+					</Button>
+				)}
+			</div>
+
+			<section className="mb-6">
+				<h2 className="text-sm font-semibold text-kumo-default mb-2">Observables ({data.observables.length})</h2>
+				{data.observables.length === 0 ? (
+					<div className="text-kumo-subtle text-sm">None extracted.</div>
+				) : (
+					<div className="overflow-x-auto rounded-lg border border-kumo-line">
+						<table className="w-full text-sm">
+							<thead className="bg-kumo-fill text-kumo-subtle text-xs uppercase">
+								<tr>
+									<th className="text-left px-3 py-2">Kind</th>
+									<th className="text-left px-3 py-2">Value</th>
+								</tr>
+							</thead>
+							<tbody>
+								{data.observables.map((o) => (
+									<tr key={o.id} className="border-t border-kumo-line">
+										<td className="px-3 py-2 text-kumo-subtle">{o.kind}</td>
+										<td className="px-3 py-2 font-mono break-all">{o.value}</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				)}
+			</section>
+
+			{data.emails.length > 0 && (
+				<section>
+					<h2 className="text-sm font-semibold text-kumo-default mb-2">Linked emails ({data.emails.length})</h2>
+					<ul className="text-sm text-kumo-default space-y-1">
+						{data.emails.map((e) => (
+							<li key={e.email_id} className="font-mono text-xs text-kumo-subtle">{e.email_id}</li>
+						))}
+					</ul>
+				</section>
+			)}
+
+			{data.notes && (
+				<section className="mt-6">
+					<h2 className="text-sm font-semibold text-kumo-default mb-2">Notes</h2>
+					<div className="text-sm text-kumo-default whitespace-pre-wrap">{data.notes}</div>
+				</section>
+			)}
+		</div>
+	);
+}

--- a/app/routes/cases.tsx
+++ b/app/routes/cases.tsx
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { Loader } from "@cloudflare/kumo";
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router";
+
+interface CaseRow {
+	id: string;
+	created_at: string;
+	updated_at: string;
+	status: string;
+	title: string;
+	shared_to_hub: number;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+	open: "Open",
+	"closed-tp": "Closed — true positive",
+	"closed-fp": "Closed — false positive",
+	"closed-dup": "Closed — duplicate",
+};
+
+export default function CasesRoute() {
+	const { mailboxId } = useParams<{ mailboxId: string }>();
+	const [cases, setCases] = useState<CaseRow[] | null>(null);
+	const [filter, setFilter] = useState<string>("all");
+
+	useEffect(() => {
+		if (!mailboxId) return;
+		const q = filter === "all" ? "" : `?status=${filter}`;
+		fetch(`/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/cases${q}`)
+			.then((r) => r.json() as Promise<{ cases: CaseRow[] }>)
+			.then((r) => setCases(r.cases))
+			.catch((e) => console.error("cases fetch failed", e));
+	}, [mailboxId, filter]);
+
+	if (!cases) return <div className="flex justify-center py-20"><Loader size="lg" /></div>;
+
+	return (
+		<div className="max-w-4xl px-4 py-6 md:px-8 h-full overflow-y-auto">
+			<h1 className="text-lg font-semibold text-kumo-default mb-4">Cases</h1>
+			<div className="mb-4 flex items-center gap-2 text-sm">
+				{["all", "open", "closed-tp", "closed-fp", "closed-dup"].map((s) => (
+					<button
+						key={s}
+						type="button"
+						onClick={() => setFilter(s)}
+						className={`px-2 py-1 rounded ${filter === s ? "bg-kumo-fill text-kumo-default" : "text-kumo-subtle hover:bg-kumo-tint"}`}
+					>
+						{s === "all" ? "All" : STATUS_LABEL[s] ?? s}
+					</button>
+				))}
+			</div>
+
+			{cases.length === 0 ? (
+				<div className="rounded-lg border border-kumo-line p-6 text-kumo-subtle">
+					No cases yet. Report a phish from any email in your inbox to open one.
+				</div>
+			) : (
+				<div className="overflow-x-auto rounded-lg border border-kumo-line">
+					<table className="w-full text-sm">
+						<thead className="bg-kumo-fill text-kumo-subtle text-xs uppercase">
+							<tr>
+								<th className="text-left px-3 py-2">Title</th>
+								<th className="text-left px-3 py-2">Status</th>
+								<th className="text-left px-3 py-2">Shared</th>
+								<th className="text-left px-3 py-2">Updated</th>
+							</tr>
+						</thead>
+						<tbody>
+							{cases.map((c) => (
+								<tr key={c.id} className="border-t border-kumo-line hover:bg-kumo-tint cursor-pointer">
+									<td className="px-3 py-2">
+										<Link
+											to={`/mailbox/${encodeURIComponent(mailboxId ?? "")}/cases/${c.id}`}
+											className="text-kumo-default hover:underline"
+										>
+											{c.title}
+										</Link>
+									</td>
+									<td className="px-3 py-2 text-kumo-subtle">{STATUS_LABEL[c.status] ?? c.status}</td>
+									<td className="px-3 py-2">{c.shared_to_hub ? "Yes" : "No"}</td>
+									<td className="px-3 py-2 text-kumo-subtle">{new Date(c.updated_at).toLocaleString()}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/app/routes/dmarc.tsx
+++ b/app/routes/dmarc.tsx
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { Loader } from "@cloudflare/kumo";
+import { useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router";
+
+interface DmarcReport {
+	id: string;
+	received_at: string;
+	org_name: string | null;
+	domain: string;
+	date_range_begin: string | null;
+	date_range_end: string | null;
+	policy_p: string | null;
+}
+
+interface DmarcSource {
+	source_ip: string;
+	total_count: number;
+	pass_count: number;
+	quarantine_count: number;
+	reject_count: number;
+	first_seen: string;
+	last_seen: string;
+}
+
+/**
+ * DMARC aggregate-report dashboard. Shows legitimate vs forged sending
+ * sources for a domain over the last 90 days of ingested reports.
+ */
+export default function DmarcRoute() {
+	const { mailboxId } = useParams<{ mailboxId: string }>();
+	const [reports, setReports] = useState<DmarcReport[] | null>(null);
+	const [domain, setDomain] = useState<string | null>(null);
+	const [sources, setSources] = useState<DmarcSource[] | null>(null);
+
+	useEffect(() => {
+		if (!mailboxId) return;
+		fetch(`/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/dmarc/reports?limit=100`)
+			.then((r) => r.json() as Promise<{ reports: DmarcReport[] }>)
+			.then((r) => {
+				setReports(r.reports);
+				if (r.reports.length > 0 && !domain) setDomain(r.reports[0].domain);
+			})
+			.catch((e) => console.error("dmarc reports fetch failed", e));
+	}, [mailboxId, domain]);
+
+	useEffect(() => {
+		if (!mailboxId || !domain) return;
+		fetch(`/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/dmarc/summary?domain=${encodeURIComponent(domain)}`)
+			.then((r) => r.json() as Promise<{ sources: DmarcSource[] }>)
+			.then((r) => setSources(r.sources))
+			.catch((e) => console.error("dmarc summary fetch failed", e));
+	}, [mailboxId, domain]);
+
+	const domains = useMemo(() => {
+		if (!reports) return [];
+		const set = new Set(reports.map((r) => r.domain));
+		return Array.from(set).sort();
+	}, [reports]);
+
+	if (!reports) {
+		return <div className="flex justify-center py-20"><Loader size="lg" /></div>;
+	}
+
+	if (reports.length === 0) {
+		return (
+			<div className="max-w-3xl px-4 py-6 md:px-8">
+				<h1 className="text-lg font-semibold text-kumo-default mb-4">DMARC Reports</h1>
+				<div className="rounded-lg border border-kumo-line p-6 text-kumo-subtle">
+					No DMARC reports received yet. Publish <code>rua=mailto:dmarc-reports@your-domain</code>
+					in your domain's DMARC record to start receiving them.
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="max-w-5xl px-4 py-6 md:px-8 h-full overflow-y-auto">
+			<h1 className="text-lg font-semibold text-kumo-default mb-4">DMARC Reports</h1>
+
+			<div className="mb-6 flex items-center gap-3">
+				<label className="text-sm text-kumo-subtle">Domain:</label>
+				<select
+					value={domain ?? ""}
+					onChange={(e) => setDomain(e.target.value)}
+					className="rounded border border-kumo-line bg-kumo-elevated px-2 py-1 text-sm"
+				>
+					{domains.map((d) => <option key={d} value={d}>{d}</option>)}
+				</select>
+			</div>
+
+			<section className="mb-8">
+				<h2 className="text-sm font-semibold text-kumo-default mb-3">Sending sources</h2>
+				{!sources ? (
+					<div className="text-kumo-subtle text-sm">Loading…</div>
+				) : sources.length === 0 ? (
+					<div className="text-kumo-subtle text-sm">No records for this domain.</div>
+				) : (
+					<div className="overflow-x-auto rounded-lg border border-kumo-line">
+						<table className="w-full text-sm">
+							<thead className="bg-kumo-fill text-kumo-subtle text-xs uppercase">
+								<tr>
+									<th className="text-left px-3 py-2">Source IP</th>
+									<th className="text-right px-3 py-2">Messages</th>
+									<th className="text-right px-3 py-2">Pass</th>
+									<th className="text-right px-3 py-2">Quarantine</th>
+									<th className="text-right px-3 py-2">Reject</th>
+									<th className="text-left px-3 py-2">Pass rate</th>
+								</tr>
+							</thead>
+							<tbody>
+								{sources.map((s) => {
+									const rate = s.total_count > 0 ? s.pass_count / s.total_count : 0;
+									const suspect = rate < 0.5 && s.total_count >= 5;
+									return (
+										<tr key={s.source_ip} className={`border-t border-kumo-line ${suspect ? "bg-kumo-fill" : ""}`}>
+											<td className="px-3 py-2 font-mono text-kumo-default">{s.source_ip}</td>
+											<td className="px-3 py-2 text-right">{s.total_count}</td>
+											<td className="px-3 py-2 text-right text-kumo-success">{s.pass_count}</td>
+											<td className="px-3 py-2 text-right text-kumo-warning">{s.quarantine_count}</td>
+											<td className="px-3 py-2 text-right text-kumo-destructive">{s.reject_count}</td>
+											<td className="px-3 py-2">
+												<span className={suspect ? "text-kumo-destructive" : "text-kumo-default"}>
+													{Math.round(rate * 100)}%
+												</span>
+											</td>
+										</tr>
+									);
+								})}
+							</tbody>
+						</table>
+					</div>
+				)}
+			</section>
+
+			<section>
+				<h2 className="text-sm font-semibold text-kumo-default mb-3">Recent reports</h2>
+				<div className="overflow-x-auto rounded-lg border border-kumo-line">
+					<table className="w-full text-sm">
+						<thead className="bg-kumo-fill text-kumo-subtle text-xs uppercase">
+							<tr>
+								<th className="text-left px-3 py-2">Received</th>
+								<th className="text-left px-3 py-2">Reporter</th>
+								<th className="text-left px-3 py-2">Domain</th>
+								<th className="text-left px-3 py-2">Policy</th>
+							</tr>
+						</thead>
+						<tbody>
+							{reports.filter((r) => !domain || r.domain === domain).map((r) => (
+								<tr key={r.id} className="border-t border-kumo-line">
+									<td className="px-3 py-2 text-kumo-subtle">{new Date(r.received_at).toLocaleString()}</td>
+									<td className="px-3 py-2">{r.org_name ?? "unknown"}</td>
+									<td className="px-3 py-2 font-mono">{r.domain}</td>
+									<td className="px-3 py-2">{r.policy_p ?? "none"}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			</section>
+		</div>
+	);
+}

--- a/app/routes/email-list.tsx
+++ b/app/routes/email-list.tsx
@@ -12,6 +12,7 @@ import {
 	FileIcon,
 	PaperPlaneTiltIcon,
 	PencilSimpleIcon,
+	ShieldWarningIcon,
 	StarIcon,
 	TrashIcon,
 	TrayIcon,
@@ -22,6 +23,7 @@ import { useParams } from "react-router";
 import { Folders } from "shared/folders";
 import { formatListDate } from "shared/dates";
 import MailboxSplitView from "~/components/MailboxSplitView";
+import VerdictBadge from "~/components/VerdictBadge";
 import { getSnippetText } from "~/lib/utils";
 import {
 	useDeleteEmail,
@@ -77,6 +79,12 @@ const FOLDER_EMPTY_STATES: Record<
 		title: "Trash is empty",
 		description:
 			"Deleted emails will appear here. You can restore them or permanently delete them.",
+	},
+	[Folders.QUARANTINE]: {
+		icon: <ShieldWarningIcon size={48} weight="thin" className="text-kumo-subtle" />,
+		title: "No quarantined emails",
+		description:
+			"Emails the security pipeline classifies as high-risk appear here. Review and release to inbox if safe.",
 	},
 };
 
@@ -384,6 +392,7 @@ export default function EmailListRoute() {
 														</span>
 													</Tooltip>
 												)}
+												<VerdictBadge email={email} />
 												<span className="text-sm text-kumo-subtle shrink-0 ml-auto">
 													{formatListDate(email.date)}
 												</span>

--- a/app/routes/search-results.tsx
+++ b/app/routes/search-results.tsx
@@ -65,7 +65,7 @@ export default function SearchResultsRoute() {
 	const isPanelOpen = selectedEmailId !== null || isComposing;
 
 	const handleRowClick = (email: Email) => { selectEmail(email.id); if (!email.read && mailboxId) updateEmail.mutate({ mailboxId, id: email.id, data: { read: true } }); };
-	const folderDisplayName = (name: string | null | undefined): string => { if (!name) return ""; const map: Record<string, string> = { inbox: "Inbox", sent: "Sent", draft: "Drafts", archive: "Archive", trash: "Trash" }; return map[name.toLowerCase()] || name; };
+	const folderDisplayName = (name: string | null | undefined): string => { if (!name) return ""; const map: Record<string, string> = { inbox: "Inbox", sent: "Sent", draft: "Drafts", archive: "Archive", trash: "Trash", quarantine: "Quarantine" }; return map[name.toLowerCase()] || name; };
 
 	return (
 		<MailboxSplitView

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -48,6 +48,40 @@ export interface Email {
 	participants?: string;
 	needs_reply?: boolean;
 	has_draft?: boolean;
+	// Security pipeline verdict (null when the pipeline didn't run)
+	security_verdict?: string | null;
+	security_score?: number | null;
+	security_explanation?: string | null;
+}
+
+/** Shape of the JSON stored in Email.security_verdict. */
+export interface SecurityVerdict {
+	action: "allow" | "tag" | "quarantine" | "block";
+	score: number;
+	explanation: string;
+	auth: {
+		spf: string;
+		dkim: string;
+		dmarc: string;
+		authservId?: string;
+	};
+	classification: {
+		label: "safe" | "spam" | "phishing" | "bec" | "suspicious";
+		confidence: number;
+		reasoning: string;
+	};
+	signals: string[];
+	/** Present when a triage tier short-circuited the pipeline. */
+	triage?: "hard_allow" | "hard_block";
+}
+
+export function parseVerdict(raw: string | null | undefined): SecurityVerdict | null {
+	if (!raw) return null;
+	try {
+		return JSON.parse(raw) as SecurityVerdict;
+	} catch {
+		return null;
+	}
 }
 
 export interface Attachment {

--- a/hub/README.md
+++ b/hub/README.md
@@ -1,0 +1,72 @@
+# AIS Hub
+
+A community threat-intel hub for the Agentic Inbox Security project. MISP-compatible (subset). Runs on Cloudflare Workers + D1 + Queues.
+
+## Supported API surface
+
+This is not a full MISP implementation. Adopters needing complete MISP functionality should run a real MISP instance; this is a minimal reference aimed at the phishing-report-and-feed-pull loop.
+
+| Method | Path | Auth | Notes |
+| --- | --- | --- | --- |
+| `POST` | `/events` | API key | MISP event schema; upserts attributes, runs corroboration. |
+| `GET` | `/events/{uuid}` | API key | Visibility scoped to own org + sharing-group membership. |
+| `POST` | `/events/restSearch` | API key | Filters: `type`, `value`, `limit`, `page`. |
+| `GET` | `/feeds/destroylist.txt` | API key | Plain-text list of promoted attributes. |
+| `GET` | `/sharing_groups` | API key | Own groups only. |
+| `POST` | `/sharing_groups` | API key | Caller becomes owner. |
+| `POST` | `/orgs/invite` | API key | Issues one-time token, optionally binds to a sharing group. |
+| `POST` | `/orgs/accept` | (public) | Redeems token; returns new `api_key` (shown once). |
+| `GET` | `/orgs/me` | API key | Authenticated org. |
+
+## Auth
+
+Header is either `Authorization: <key>` (MISP convention) or `Authorization: Bearer <key>`.
+
+## Trust-weighted aggregation
+
+`hub/src/lib/aggregate.ts` implements a simple score model:
+
+- On each `POST /events`, each attribute value gets a per-(type, value, sharing_group) row in `corroboration`.
+- A distinct contributor org adds `org.trust` points (default 1.0). Repeat contributions from the same org don't re-add trust.
+- An attribute promotes to the sharing group's `destroylist.txt` when `score ≥ 2.0` and `contributor_count ≥ 2`.
+
+Tune the thresholds in `aggregate.ts`. Manual trust adjustments on `orgs.trust` let you amplify or dampen specific contributors.
+
+## Agent triage
+
+`hub/src/agent/triage.ts` is a Queue consumer that runs Workers AI against each new event to propose MISP taxonomy tags. **LLM output never affects scoring** — tags are the only mutation the triage agent makes. This is a deliberate invariant: attacker-crafted content is in its input, so anything it returns has to be non-load-bearing.
+
+## Bootstrap
+
+```bash
+# 1. create D1 database, note the id, paste into wrangler.jsonc
+npx wrangler d1 create ais-hub
+
+# 2. apply schema
+npm run db:migrate:remote
+
+# 3. create queue
+npx wrangler queues create ais-hub-triage
+
+# 4. deploy
+npm run deploy
+
+# 5. seed a bootstrap org + key (via SQL — no self-serve signup in MVP)
+npx wrangler d1 execute ais-hub --remote --command "
+  INSERT INTO orgs (uuid, name) VALUES ('<ORG_UUID>', 'bootstrap');
+  INSERT INTO api_keys (key_hash, org_uuid, label) VALUES ('<sha256_of_key>', '<ORG_UUID>', 'bootstrap');
+"
+```
+
+## Security notes
+
+- API keys are stored as SHA-256 hashes — D1 leaks don't permit impersonation.
+- Invite tokens are hashed identically.
+- Event visibility is enforced on read via `orgc_uuid` + `sharing_group_uuid` checks — no tenant can read another tenant's non-shared events.
+- Prompt-injection defense for the triage agent: the LLM only controls tags, not scores or promotions.
+
+## Future work
+
+- STIX 2.1 export on `/events/{uuid}` (content negotiation).
+- Server-to-server sync with real MISP instances (`/events/index`, `/servers/pull`).
+- Per-attribute confidence decay over time (cron already wired; logic TBD).

--- a/hub/migrations/0001_schema.sql
+++ b/hub/migrations/0001_schema.sql
@@ -1,0 +1,123 @@
+-- Copyright (c) 2026 Cloudflare, Inc.
+-- Licensed under the Apache 2.0 license found in the LICENSE file or at:
+--     https://opensource.org/licenses/Apache-2.0
+
+-- Orgs contribute intel. Each contributor has a trust multiplier that ramps
+-- up with confirmed true-positives and decays with confirmed false-positives.
+CREATE TABLE orgs (
+    uuid TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    contact TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    trust REAL NOT NULL DEFAULT 1.0
+);
+
+-- Invite-based trust circles — MISP "sharing groups".
+CREATE TABLE sharing_groups (
+    uuid TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE sharing_group_orgs (
+    sharing_group_uuid TEXT NOT NULL,
+    org_uuid TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'member', -- owner | member
+    PRIMARY KEY (sharing_group_uuid, org_uuid),
+    FOREIGN KEY (sharing_group_uuid) REFERENCES sharing_groups(uuid) ON DELETE CASCADE,
+    FOREIGN KEY (org_uuid) REFERENCES orgs(uuid) ON DELETE CASCADE
+);
+
+-- API keys. Stored as sha256(key) so leaked DB can't impersonate. Each key
+-- belongs to exactly one org; org permissions flow from sharing_group_orgs.
+CREATE TABLE api_keys (
+    key_hash TEXT PRIMARY KEY,
+    org_uuid TEXT NOT NULL,
+    label TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    last_used_at TEXT,
+    revoked INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (org_uuid) REFERENCES orgs(uuid) ON DELETE CASCADE
+);
+CREATE INDEX idx_api_keys_org ON api_keys(org_uuid);
+
+-- Single-use invite tokens. Accepting an invite creates an org + api_key.
+CREATE TABLE invites (
+    token_hash TEXT PRIMARY KEY,
+    sharing_group_uuid TEXT,
+    note TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    expires_at TEXT NOT NULL,
+    consumed_at TEXT
+);
+
+-- MISP-compatible events + attributes. `event_json` stores the full payload
+-- for opaque passthrough; normalized fields are extracted for querying.
+CREATE TABLE events (
+    uuid TEXT PRIMARY KEY,
+    orgc_uuid TEXT NOT NULL,
+    sharing_group_uuid TEXT,
+    info TEXT NOT NULL,
+    date TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    distribution TEXT NOT NULL DEFAULT '1',
+    analysis TEXT NOT NULL DEFAULT '0',
+    threat_level_id TEXT NOT NULL DEFAULT '2',
+    event_json TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (orgc_uuid) REFERENCES orgs(uuid) ON DELETE CASCADE
+);
+CREATE INDEX idx_events_orgc ON events(orgc_uuid);
+CREATE INDEX idx_events_sharing_group ON events(sharing_group_uuid);
+CREATE INDEX idx_events_date ON events(date);
+
+CREATE TABLE attributes (
+    uuid TEXT PRIMARY KEY,
+    event_uuid TEXT NOT NULL,
+    type TEXT NOT NULL,
+    category TEXT NOT NULL,
+    value TEXT NOT NULL,
+    to_ids INTEGER NOT NULL DEFAULT 0,
+    comment TEXT,
+    FOREIGN KEY (event_uuid) REFERENCES events(uuid) ON DELETE CASCADE
+);
+CREATE INDEX idx_attributes_type_value ON attributes(type, value);
+CREATE INDEX idx_attributes_event ON attributes(event_uuid);
+
+-- Per-(type,value,sharing_group) corroboration record. Updated by the
+-- aggregate step: each attribute contribution adds orgc.trust to the score;
+-- contributors[] dedups on orgc_uuid.
+CREATE TABLE corroboration (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sharing_group_uuid TEXT,
+    attribute_type TEXT NOT NULL,
+    value TEXT NOT NULL,
+    first_seen TEXT NOT NULL DEFAULT (datetime('now')),
+    last_seen TEXT NOT NULL DEFAULT (datetime('now')),
+    contributor_count INTEGER NOT NULL DEFAULT 0,
+    score REAL NOT NULL DEFAULT 0.0,
+    UNIQUE (sharing_group_uuid, attribute_type, value)
+);
+CREATE INDEX idx_corroboration_type_value ON corroboration(attribute_type, value);
+CREATE INDEX idx_corroboration_sharing_group ON corroboration(sharing_group_uuid);
+
+CREATE TABLE corroboration_contributors (
+    corroboration_id INTEGER NOT NULL,
+    orgc_uuid TEXT NOT NULL,
+    PRIMARY KEY (corroboration_id, orgc_uuid),
+    FOREIGN KEY (corroboration_id) REFERENCES corroboration(id) ON DELETE CASCADE,
+    FOREIGN KEY (orgc_uuid) REFERENCES orgs(uuid) ON DELETE CASCADE
+);
+
+CREATE TABLE tags (
+    name TEXT PRIMARY KEY
+);
+
+CREATE TABLE event_tags (
+    event_uuid TEXT NOT NULL,
+    tag_name TEXT NOT NULL,
+    PRIMARY KEY (event_uuid, tag_name),
+    FOREIGN KEY (event_uuid) REFERENCES events(uuid) ON DELETE CASCADE,
+    FOREIGN KEY (tag_name) REFERENCES tags(name) ON DELETE CASCADE
+);

--- a/hub/package-lock.json
+++ b/hub/package-lock.json
@@ -1,0 +1,1631 @@
+{
+	"name": "ais-hub",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "ais-hub",
+			"version": "0.1.0",
+			"dependencies": {
+				"hono": "^4.6.0",
+				"zod": "^3.23.0"
+			},
+			"devDependencies": {
+				"@cloudflare/workers-types": "^4.20250101.0",
+				"typescript": "^5.5.0",
+				"wrangler": "^3.80.0"
+			}
+		},
+		"node_modules/@cloudflare/kv-asset-handler": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+			"integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"dependencies": {
+				"mime": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/@cloudflare/unenv-preset": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
+			"integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"peerDependencies": {
+				"unenv": "2.0.0-rc.14",
+				"workerd": "^1.20250124.0"
+			},
+			"peerDependenciesMeta": {
+				"workerd": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@cloudflare/workerd-darwin-64": {
+			"version": "1.20250718.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
+			"integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/workerd-darwin-arm64": {
+			"version": "1.20250718.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
+			"integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/workerd-linux-64": {
+			"version": "1.20250718.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
+			"integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/workerd-linux-arm64": {
+			"version": "1.20250718.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
+			"integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/workerd-windows-64": {
+			"version": "1.20250718.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
+			"integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/workers-types": {
+			"version": "4.20260417.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260417.1.tgz",
+			"integrity": "sha512-ke3GkFfFyfSxdLRR6LPbnfYAu3RNKqX0eYfu/FNnluBN9rLgYVqT+QEPgSEx1yq7XTOok+Bub1td9xvknaOz4A==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"peer": true
+		},
+		"node_modules/@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@esbuild-plugins/node-globals-polyfill": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+			"integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+			"dev": true,
+			"license": "ISC",
+			"peerDependencies": {
+				"esbuild": "*"
+			}
+		},
+		"node_modules/@esbuild-plugins/node-modules-polyfill": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+			"integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"escape-string-regexp": "^4.0.0",
+				"rollup-plugin-node-polyfills": "^0.2.1"
+			},
+			"peerDependencies": {
+				"esbuild": "*"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+			"integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+			"integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+			"integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+			"integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+			"integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+			"integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+			"integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+			"integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+			"integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+			"integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+			"integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+			"integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+			"integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+			"integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+			"integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+			"integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+			"integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+			"integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+			"integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+			"integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+			"integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+			"integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@fastify/busboy": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@img/sharp-darwin-arm64": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+			"integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-arm64": "1.0.4"
+			}
+		},
+		"node_modules/@img/sharp-darwin-x64": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+			"integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-x64": "1.0.4"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-arm64": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+			"integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-x64": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+			"integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+			"integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm64": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+			"integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-s390x": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+			"integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-x64": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+			"integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+			"integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+			"integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+			"integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm": "1.0.5"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm64": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+			"integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm64": "1.0.4"
+			}
+		},
+		"node_modules/@img/sharp-linux-s390x": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+			"integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-s390x": "1.0.4"
+			}
+		},
+		"node_modules/@img/sharp-linux-x64": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+			"integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-x64": "1.0.4"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-arm64": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+			"integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-x64": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+			"integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+			}
+		},
+		"node_modules/@img/sharp-wasm32": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+			"integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/runtime": "^1.2.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-ia32": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+			"integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-x64": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+			"integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "8.14.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+			"integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/as-table": {
+			"version": "1.0.55",
+			"resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+			"integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"printable-characters": "^1.0.42"
+			}
+		},
+		"node_modules/blake3-wasm": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+			"integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/color": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+			"integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"color-convert": "^2.0.1",
+				"color-string": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=12.5.0"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/color-string": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"color-name": "^1.0.0",
+				"simple-swizzle": "^0.2.2"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+			"integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/defu": {
+			"version": "6.1.7",
+			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+			"integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.17.19",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+			"integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"@esbuild/android-arm": "0.17.19",
+				"@esbuild/android-arm64": "0.17.19",
+				"@esbuild/android-x64": "0.17.19",
+				"@esbuild/darwin-arm64": "0.17.19",
+				"@esbuild/darwin-x64": "0.17.19",
+				"@esbuild/freebsd-arm64": "0.17.19",
+				"@esbuild/freebsd-x64": "0.17.19",
+				"@esbuild/linux-arm": "0.17.19",
+				"@esbuild/linux-arm64": "0.17.19",
+				"@esbuild/linux-ia32": "0.17.19",
+				"@esbuild/linux-loong64": "0.17.19",
+				"@esbuild/linux-mips64el": "0.17.19",
+				"@esbuild/linux-ppc64": "0.17.19",
+				"@esbuild/linux-riscv64": "0.17.19",
+				"@esbuild/linux-s390x": "0.17.19",
+				"@esbuild/linux-x64": "0.17.19",
+				"@esbuild/netbsd-x64": "0.17.19",
+				"@esbuild/openbsd-x64": "0.17.19",
+				"@esbuild/sunos-x64": "0.17.19",
+				"@esbuild/win32-arm64": "0.17.19",
+				"@esbuild/win32-ia32": "0.17.19",
+				"@esbuild/win32-x64": "0.17.19"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/estree-walker": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+			"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/exit-hook": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+			"integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/exsolve": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+			"integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/get-source": {
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+			"integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+			"dev": true,
+			"license": "Unlicense",
+			"dependencies": {
+				"data-uri-to-buffer": "^2.0.0",
+				"source-map": "^0.6.1"
+			}
+		},
+		"node_modules/glob-to-regexp": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/hono": {
+			"version": "4.12.14",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+			"integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/is-arrayish": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+			"integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/magic-string": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"sourcemap-codec": "^1.4.8"
+			}
+		},
+		"node_modules/mime": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/miniflare": {
+			"version": "3.20250718.3",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
+			"integrity": "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspotcode/source-map-support": "0.8.1",
+				"acorn": "8.14.0",
+				"acorn-walk": "8.3.2",
+				"exit-hook": "2.2.1",
+				"glob-to-regexp": "0.4.1",
+				"stoppable": "1.1.0",
+				"undici": "^5.28.5",
+				"workerd": "1.20250718.0",
+				"ws": "8.18.0",
+				"youch": "3.3.4",
+				"zod": "3.22.3"
+			},
+			"bin": {
+				"miniflare": "bootstrap.js"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/miniflare/node_modules/zod": {
+			"version": "3.22.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+			"integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/mustache": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+			"integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mustache": "bin/mustache"
+			}
+		},
+		"node_modules/ohash": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/printable-characters": {
+			"version": "1.0.42",
+			"resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+			"integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+			"dev": true,
+			"license": "Unlicense"
+		},
+		"node_modules/rollup-plugin-inject": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+			"integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+			"deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"estree-walker": "^0.6.1",
+				"magic-string": "^0.25.3",
+				"rollup-pluginutils": "^2.8.1"
+			}
+		},
+		"node_modules/rollup-plugin-node-polyfills": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+			"integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"rollup-plugin-inject": "^3.0.0"
+			}
+		},
+		"node_modules/rollup-pluginutils": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"estree-walker": "^0.6.1"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/sharp": {
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+			"integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"color": "^4.2.3",
+				"detect-libc": "^2.0.3",
+				"semver": "^7.6.3"
+			},
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-darwin-arm64": "0.33.5",
+				"@img/sharp-darwin-x64": "0.33.5",
+				"@img/sharp-libvips-darwin-arm64": "1.0.4",
+				"@img/sharp-libvips-darwin-x64": "1.0.4",
+				"@img/sharp-libvips-linux-arm": "1.0.5",
+				"@img/sharp-libvips-linux-arm64": "1.0.4",
+				"@img/sharp-libvips-linux-s390x": "1.0.4",
+				"@img/sharp-libvips-linux-x64": "1.0.4",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+				"@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+				"@img/sharp-linux-arm": "0.33.5",
+				"@img/sharp-linux-arm64": "0.33.5",
+				"@img/sharp-linux-s390x": "0.33.5",
+				"@img/sharp-linux-x64": "0.33.5",
+				"@img/sharp-linuxmusl-arm64": "0.33.5",
+				"@img/sharp-linuxmusl-x64": "0.33.5",
+				"@img/sharp-wasm32": "0.33.5",
+				"@img/sharp-win32-ia32": "0.33.5",
+				"@img/sharp-win32-x64": "0.33.5"
+			}
+		},
+		"node_modules/simple-swizzle": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+			"integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"is-arrayish": "^0.3.1"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"deprecated": "Please use @jridgewell/sourcemap-codec instead",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/stacktracey": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+			"integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+			"dev": true,
+			"license": "Unlicense",
+			"dependencies": {
+				"as-table": "^1.0.36",
+				"get-source": "^2.0.12"
+			}
+		},
+		"node_modules/stoppable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD",
+			"optional": true
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/ufo": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+			"integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/undici": {
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@fastify/busboy": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.0"
+			}
+		},
+		"node_modules/unenv": {
+			"version": "2.0.0-rc.14",
+			"resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
+			"integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"defu": "^6.1.4",
+				"exsolve": "^1.0.1",
+				"ohash": "^2.0.10",
+				"pathe": "^2.0.3",
+				"ufo": "^1.5.4"
+			}
+		},
+		"node_modules/workerd": {
+			"version": "1.20250718.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
+			"integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"workerd": "bin/workerd"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@cloudflare/workerd-darwin-64": "1.20250718.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20250718.0",
+				"@cloudflare/workerd-linux-64": "1.20250718.0",
+				"@cloudflare/workerd-linux-arm64": "1.20250718.0",
+				"@cloudflare/workerd-windows-64": "1.20250718.0"
+			}
+		},
+		"node_modules/wrangler": {
+			"version": "3.114.17",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
+			"integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"dependencies": {
+				"@cloudflare/kv-asset-handler": "0.3.4",
+				"@cloudflare/unenv-preset": "2.0.2",
+				"@esbuild-plugins/node-globals-polyfill": "0.2.3",
+				"@esbuild-plugins/node-modules-polyfill": "0.2.2",
+				"blake3-wasm": "2.1.5",
+				"esbuild": "0.17.19",
+				"miniflare": "3.20250718.3",
+				"path-to-regexp": "6.3.0",
+				"unenv": "2.0.0-rc.14",
+				"workerd": "1.20250718.0"
+			},
+			"bin": {
+				"wrangler": "bin/wrangler.js",
+				"wrangler2": "bin/wrangler.js"
+			},
+			"engines": {
+				"node": ">=16.17.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2",
+				"sharp": "^0.33.5"
+			},
+			"peerDependencies": {
+				"@cloudflare/workers-types": "^4.20250408.0"
+			},
+			"peerDependenciesMeta": {
+				"@cloudflare/workers-types": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/youch": {
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+			"integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cookie": "^0.7.1",
+				"mustache": "^4.2.0",
+				"stacktracey": "^2.1.8"
+			}
+		},
+		"node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		}
+	}
+}

--- a/hub/package.json
+++ b/hub/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "ais-hub",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "wrangler dev",
+		"deploy": "wrangler deploy",
+		"typecheck": "wrangler types && tsc --noEmit",
+		"db:migrate:local": "wrangler d1 migrations apply ais-hub --local",
+		"db:migrate:remote": "wrangler d1 migrations apply ais-hub --remote"
+	},
+	"dependencies": {
+		"hono": "^4.6.0",
+		"zod": "^3.23.0"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20250101.0",
+		"typescript": "^5.5.0",
+		"wrangler": "^3.80.0"
+	}
+}

--- a/hub/src/agent/triage.ts
+++ b/hub/src/agent/triage.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Queue consumer. For each new event, run the LLM to:
+ *   - suggest MISP taxonomy tags
+ *   - write a one-line summary stored as an event comment
+ *
+ * Dedup decisions and trust-weighting are handled by the aggregation step at
+ * write time — the LLM is intentionally not allowed to change scores. Its
+ * outputs are tags and human-readable text, nothing that affects promotion.
+ */
+
+import type { Env, TriageMessage } from "../types";
+
+const TAG_PROMPT = `You are assigning MISP taxonomy tags to a threat intel event. Return a JSON array of up to 5 lowercase tag strings drawn from this allowlist:
+["phishing", "bec", "malware-delivery", "credential-theft", "impersonation", "tlp:green", "tlp:amber", "type:osint", "campaign-unknown"]
+No explanation, no other text — just the JSON array.`;
+
+export async function consumeTriageBatch(
+	batch: MessageBatch<TriageMessage>,
+	env: Env,
+): Promise<void> {
+	for (const msg of batch.messages) {
+		try {
+			await triageEvent(env, msg.body.event_uuid);
+			msg.ack();
+		} catch (e) {
+			console.error("triage failed:", (e as Error).message);
+			msg.retry();
+		}
+	}
+}
+
+async function triageEvent(env: Env, uuid: string) {
+	const event = await env.DB
+		.prepare(`SELECT event_json FROM events WHERE uuid = ?1`)
+		.bind(uuid)
+		.first<{ event_json: string }>();
+	if (!event) return;
+	const parsed = JSON.parse(event.event_json) as { Event: { info?: string; Attribute?: Array<{ type: string; value: string }> } };
+	const info = parsed.Event?.info ?? "";
+	const attrs = parsed.Event?.Attribute ?? [];
+	const summary = `info="${info}" attrs=${attrs.slice(0, 10).map((a) => `${a.type}:${a.value}`).join(",")}`;
+
+	let tags: string[] = [];
+	try {
+		const response = (await env.AI.run(
+			"@cf/meta/llama-3.1-8b-instruct-fast" as Parameters<Ai["run"]>[0],
+			{
+				messages: [
+					{ role: "system", content: TAG_PROMPT },
+					{ role: "user", content: summary.slice(0, 2000) },
+				],
+				max_tokens: 120,
+				temperature: 0,
+			},
+		)) as { response?: string };
+		const match = response?.response?.match(/\[[\s\S]*\]/);
+		if (match) {
+			const arr = JSON.parse(match[0]);
+			if (Array.isArray(arr)) tags = arr.filter((t) => typeof t === "string").slice(0, 5);
+		}
+	} catch (e) {
+		console.error("tag generation failed:", (e as Error).message);
+	}
+
+	for (const t of tags) {
+		await env.DB.prepare(`INSERT OR IGNORE INTO tags (name) VALUES (?1)`).bind(t).run();
+		await env.DB
+			.prepare(`INSERT OR IGNORE INTO event_tags (event_uuid, tag_name) VALUES (?1, ?2)`)
+			.bind(uuid, t)
+			.run();
+	}
+}

--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * AIS community hub — MISP-compatible reporting & feed distribution.
+ *
+ * This is an open-source reference implementation, not a full MISP server.
+ * Supported surface:
+ *   POST   /events
+ *   GET    /events/{uuid}
+ *   POST   /events/restSearch
+ *   GET    /feeds/destroylist.txt
+ *   GET    /sharing_groups
+ *   POST   /sharing_groups
+ *   POST   /orgs/invite    (authenticated — existing org invites another)
+ *   POST   /orgs/accept    (public — consumes an invite token, creates org + key)
+ *   GET    /orgs/me
+ */
+
+import { Hono } from "hono";
+import { eventRoutes } from "./routes/events";
+import { feedRoutes } from "./routes/feeds";
+import { orgRoutes, orgAcceptApp } from "./routes/orgs";
+import { sharingGroupRoutes } from "./routes/sharing-groups";
+import { consumeTriageBatch } from "./agent/triage";
+import type { Env, TriageMessage } from "./types";
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.get("/", (c) => c.text("AIS Hub — MISP-compatible threat-intel sharing. See /events, /feeds/destroylist.txt, /orgs."));
+
+app.route("/events", eventRoutes);
+app.route("/feeds", feedRoutes);
+app.route("/orgs", orgAcceptApp); // public /orgs/accept
+app.route("/orgs", orgRoutes);    // authed /orgs/me, /orgs/invite
+app.route("/sharing_groups", sharingGroupRoutes);
+
+export default {
+	fetch: app.fetch,
+	async queue(batch: MessageBatch<TriageMessage>, env: Env) {
+		await consumeTriageBatch(batch, env);
+	},
+	async scheduled(_event: ScheduledController, env: Env, ctx: ExecutionContext) {
+		// Placeholder for periodic re-scoring/cleanup work. Aggregation is
+		// fully event-driven right now; leave a hook for decay/retention later.
+		ctx.waitUntil(Promise.resolve());
+	},
+};

--- a/hub/src/lib/aggregate.ts
+++ b/hub/src/lib/aggregate.ts
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Trust-weighted aggregation.
+ *
+ * When a new event lands, we update a per-(type, value, sharing_group) row in
+ * `corroboration`. Each distinct contributor org contributes `org.trust`
+ * points (first-time contribution only — de-duped via corroboration_contributors).
+ *
+ * An attribute promotes to a sharing group's public feed when BOTH:
+ *   - score ≥ PROMOTION_SCORE
+ *   - contributor_count ≥ PROMOTION_CONTRIBUTORS
+ */
+
+import type { D1Database } from "@cloudflare/workers-types";
+
+export const PROMOTION_SCORE = 2.0;
+export const PROMOTION_CONTRIBUTORS = 2;
+
+/** Attribute types that belong on the published destroylist feed. */
+const PROMOTABLE_TYPES = new Set(["url", "domain", "hostname", "ip-src", "ip-dst", "sha256"]);
+
+interface AggregateInput {
+	event_uuid: string;
+	orgc_uuid: string;
+	sharing_group_uuid: string | null;
+	attributes: Array<{ type: string; value: string }>;
+}
+
+export async function applyCorroboration(db: D1Database, input: AggregateInput) {
+	const orgRow = await db
+		.prepare(`SELECT trust FROM orgs WHERE uuid = ?1`)
+		.bind(input.orgc_uuid)
+		.first<{ trust: number }>();
+	const trust = orgRow?.trust ?? 1.0;
+	const now = new Date().toISOString();
+
+	for (const attr of input.attributes) {
+		if (!PROMOTABLE_TYPES.has(attr.type)) continue;
+
+		// Upsert corroboration row
+		await db
+			.prepare(
+				`INSERT INTO corroboration
+				   (sharing_group_uuid, attribute_type, value, first_seen, last_seen, contributor_count, score)
+				 VALUES (?1, ?2, ?3, ?4, ?4, 0, 0.0)
+				 ON CONFLICT (sharing_group_uuid, attribute_type, value)
+				 DO UPDATE SET last_seen = ?4`,
+			)
+			.bind(input.sharing_group_uuid, attr.type, attr.value, now)
+			.run();
+
+		const row = await db
+			.prepare(
+				`SELECT id FROM corroboration
+				 WHERE (sharing_group_uuid IS ?1 OR (sharing_group_uuid IS NULL AND ?1 IS NULL))
+				   AND attribute_type = ?2 AND value = ?3`,
+			)
+			.bind(input.sharing_group_uuid, attr.type, attr.value)
+			.first<{ id: number }>();
+		if (!row) continue;
+
+		// Attempt contributor insert; if it's already there, INSERT OR IGNORE
+		// is a no-op and we do not re-add their trust.
+		const res = await db
+			.prepare(
+				`INSERT OR IGNORE INTO corroboration_contributors (corroboration_id, orgc_uuid)
+				 VALUES (?1, ?2)`,
+			)
+			.bind(row.id, input.orgc_uuid)
+			.run();
+
+		const newlyAdded = (res.meta.changes ?? 0) > 0;
+		if (newlyAdded) {
+			await db
+				.prepare(
+					`UPDATE corroboration
+					 SET contributor_count = contributor_count + 1,
+					     score = score + ?1
+					 WHERE id = ?2`,
+				)
+				.bind(trust, row.id)
+				.run();
+		}
+	}
+}
+
+export interface PromotedEntry {
+	attribute_type: string;
+	value: string;
+	score: number;
+	contributor_count: number;
+}
+
+export async function getPromotedForSharingGroup(
+	db: D1Database,
+	sharingGroupUuid: string | null,
+): Promise<PromotedEntry[]> {
+	const res = await db
+		.prepare(
+			`SELECT attribute_type, value, score, contributor_count
+			 FROM corroboration
+			 WHERE (sharing_group_uuid IS ?1 OR (sharing_group_uuid IS NULL AND ?1 IS NULL))
+			   AND score >= ?2
+			   AND contributor_count >= ?3
+			 ORDER BY score DESC
+			 LIMIT 50000`,
+		)
+		.bind(sharingGroupUuid, PROMOTION_SCORE, PROMOTION_CONTRIBUTORS)
+		.all<PromotedEntry>();
+	return res.results ?? [];
+}

--- a/hub/src/lib/auth.ts
+++ b/hub/src/lib/auth.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { createMiddleware } from "hono/factory";
+import type { Env, AuthedOrg } from "../types";
+import { sha256 } from "./hash";
+
+export type HubContext = {
+	Bindings: Env;
+	Variables: {
+		org: AuthedOrg;
+		apiKeyHash: string;
+	};
+};
+
+/**
+ * Auth middleware. Accepts either the MISP-native form
+ * (`Authorization: <key>`) or standard `Authorization: Bearer <key>` — both
+ * are common in the wild.
+ */
+export const requireOrg = createMiddleware<HubContext>(async (c, next) => {
+	const header = c.req.header("authorization") ?? c.req.header("Authorization");
+	if (!header) return c.json({ error: "missing authorization" }, 401);
+	const token = header.startsWith("Bearer ") ? header.slice(7).trim() : header.trim();
+	if (!token) return c.json({ error: "missing token" }, 401);
+
+	const keyHash = await sha256(token);
+	const row = await c.env.DB.prepare(
+		`SELECT k.key_hash, k.org_uuid, k.revoked, o.name, o.trust
+		 FROM api_keys k JOIN orgs o ON o.uuid = k.org_uuid
+		 WHERE k.key_hash = ?1`,
+	).bind(keyHash).first<{
+		key_hash: string;
+		org_uuid: string;
+		revoked: number;
+		name: string;
+		trust: number;
+	}>();
+
+	if (!row || row.revoked) return c.json({ error: "invalid or revoked token" }, 401);
+
+	c.set("org", { uuid: row.org_uuid, name: row.name, trust: row.trust });
+	c.set("apiKeyHash", row.key_hash);
+
+	// Best-effort last_used_at. Intentionally fire-and-forget — failures
+	// here shouldn't break the request.
+	c.env.DB
+		.prepare(`UPDATE api_keys SET last_used_at = ?1 WHERE key_hash = ?2`)
+		.bind(new Date().toISOString(), row.key_hash)
+		.run()
+		.catch(() => {});
+
+	await next();
+});

--- a/hub/src/lib/hash.ts
+++ b/hub/src/lib/hash.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * SHA-256 hex digest. Used for API-key storage and invite-token hashing so
+ * a leaked D1 snapshot doesn't allow impersonation of contributors.
+ */
+export async function sha256(input: string): Promise<string> {
+	const data = new TextEncoder().encode(input);
+	const hash = await crypto.subtle.digest("SHA-256", data);
+	return Array.from(new Uint8Array(hash))
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+/** 43 random base64url chars (≈256 bits of entropy). */
+export function generateSecret(): string {
+	const buf = new Uint8Array(32);
+	crypto.getRandomValues(buf);
+	return btoa(String.fromCharCode(...buf))
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/, "");
+}

--- a/hub/src/routes/events.ts
+++ b/hub/src/routes/events.ts
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * MISP-compatible event endpoints.
+ *
+ * Supports the subset needed for the report/pull loop: POST /events,
+ * GET /events/{uuid}, POST /events/restSearch. Full MISP has dozens more
+ * endpoints; consumers needing those can run a real MISP instance.
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { requireOrg, type HubContext } from "../lib/auth";
+import { applyCorroboration } from "../lib/aggregate";
+
+export const eventRoutes = new Hono<HubContext>();
+
+eventRoutes.use("*", requireOrg);
+
+const AttributeSchema = z.object({
+	uuid: z.string().uuid().optional(),
+	type: z.string().min(1).max(64),
+	category: z.string().min(1).max(64),
+	value: z.string().min(1).max(2000),
+	to_ids: z.union([z.boolean(), z.literal(0), z.literal(1)]).optional(),
+	comment: z.string().max(500).optional(),
+});
+
+const EventSchema = z.object({
+	Event: z.object({
+		uuid: z.string().uuid().optional(),
+		info: z.string().min(1).max(500),
+		date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+		timestamp: z.string(),
+		analysis: z.string().optional(),
+		threat_level_id: z.string().optional(),
+		distribution: z.string().optional(),
+		orgc_uuid: z.string().uuid().optional(),
+		sharing_group_uuid: z.string().uuid().optional(),
+		Tag: z.array(z.object({ name: z.string().min(1).max(128) })).optional(),
+		Attribute: z.array(AttributeSchema).default([]),
+	}),
+});
+
+eventRoutes.post("/", async (c) => {
+	const body = await c.req.json().catch(() => null);
+	const parsed = EventSchema.safeParse(body);
+	if (!parsed.success) return c.json({ error: parsed.error.flatten() }, 400);
+	const incoming = parsed.data.Event;
+
+	const org = c.var.org;
+	// Orgc_uuid must match the authenticated org — prevents impersonation.
+	if (incoming.orgc_uuid && incoming.orgc_uuid !== org.uuid) {
+		return c.json({ error: "orgc_uuid does not match authenticated org" }, 403);
+	}
+	// If a sharing group is specified, the org must belong to it.
+	if (incoming.sharing_group_uuid) {
+		const mem = await c.env.DB
+			.prepare(`SELECT 1 FROM sharing_group_orgs WHERE sharing_group_uuid = ?1 AND org_uuid = ?2`)
+			.bind(incoming.sharing_group_uuid, org.uuid)
+			.first();
+		if (!mem) return c.json({ error: "org not in sharing_group" }, 403);
+	}
+
+	const eventUuid = incoming.uuid ?? crypto.randomUUID();
+	await c.env.DB
+		.prepare(
+			`INSERT INTO events
+			 (uuid, orgc_uuid, sharing_group_uuid, info, date, timestamp,
+			  distribution, analysis, threat_level_id, event_json)
+			 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)`,
+		)
+		.bind(
+			eventUuid,
+			org.uuid,
+			incoming.sharing_group_uuid ?? null,
+			incoming.info,
+			incoming.date,
+			incoming.timestamp,
+			incoming.distribution ?? "1",
+			incoming.analysis ?? "0",
+			incoming.threat_level_id ?? "2",
+			JSON.stringify(parsed.data),
+		)
+		.run();
+
+	// Insert attributes and tags in batches where possible.
+	const attrStatements = incoming.Attribute.map((a) =>
+		c.env.DB
+			.prepare(
+				`INSERT INTO attributes (uuid, event_uuid, type, category, value, to_ids, comment)
+				 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)`,
+			)
+			.bind(
+				a.uuid ?? crypto.randomUUID(),
+				eventUuid,
+				a.type,
+				a.category,
+				a.value,
+				a.to_ids === true || a.to_ids === 1 ? 1 : 0,
+				a.comment ?? null,
+			),
+	);
+	if (attrStatements.length > 0) await c.env.DB.batch(attrStatements);
+
+	for (const t of incoming.Tag ?? []) {
+		await c.env.DB.prepare(`INSERT OR IGNORE INTO tags (name) VALUES (?1)`).bind(t.name).run();
+		await c.env.DB
+			.prepare(`INSERT OR IGNORE INTO event_tags (event_uuid, tag_name) VALUES (?1, ?2)`)
+			.bind(eventUuid, t.name)
+			.run();
+	}
+
+	// Corroboration update (sync — keeps feed generation consistent; a Queue
+	// push is also sent so the triage agent can dedupe/tag asynchronously).
+	await applyCorroboration(c.env.DB, {
+		event_uuid: eventUuid,
+		orgc_uuid: org.uuid,
+		sharing_group_uuid: incoming.sharing_group_uuid ?? null,
+		attributes: incoming.Attribute.map((a) => ({ type: a.type, value: a.value })),
+	});
+
+	await c.env.TRIAGE_QUEUE.send({ kind: "event", event_uuid: eventUuid }).catch((e) =>
+		console.error("triage enqueue failed:", (e as Error).message),
+	);
+
+	return c.json({ Event: { uuid: eventUuid } }, 201);
+});
+
+eventRoutes.get("/:uuid", async (c) => {
+	const uuid = c.req.param("uuid");
+	const event = await c.env.DB
+		.prepare(`SELECT event_json, orgc_uuid, sharing_group_uuid FROM events WHERE uuid = ?1`)
+		.bind(uuid)
+		.first<{ event_json: string; orgc_uuid: string; sharing_group_uuid: string | null }>();
+	if (!event) return c.json({ error: "not found" }, 404);
+	// Visibility: own org, or member of the event's sharing group.
+	if (event.orgc_uuid !== c.var.org.uuid) {
+		if (!event.sharing_group_uuid) return c.json({ error: "forbidden" }, 403);
+		const mem = await c.env.DB
+			.prepare(`SELECT 1 FROM sharing_group_orgs WHERE sharing_group_uuid = ?1 AND org_uuid = ?2`)
+			.bind(event.sharing_group_uuid, c.var.org.uuid)
+			.first();
+		if (!mem) return c.json({ error: "forbidden" }, 403);
+	}
+	return c.json(JSON.parse(event.event_json));
+});
+
+/** MISP `/events/restSearch`. Minimal filter set. */
+const RestSearchSchema = z.object({
+	returnFormat: z.literal("json").optional(),
+	type: z.string().optional(),
+	value: z.string().optional(),
+	limit: z.number().int().min(1).max(1000).optional(),
+	page: z.number().int().min(1).optional(),
+});
+
+eventRoutes.post("/restSearch", async (c) => {
+	const parsed = RestSearchSchema.safeParse(await c.req.json().catch(() => ({})));
+	if (!parsed.success) return c.json({ error: parsed.error.flatten() }, 400);
+	const { type, value, limit = 100, page = 1 } = parsed.data;
+	const offset = (page - 1) * limit;
+
+	// Visibility-aware — include own events plus events in any sharing group
+	// the org belongs to.
+	const membershipRows = await c.env.DB
+		.prepare(`SELECT sharing_group_uuid FROM sharing_group_orgs WHERE org_uuid = ?1`)
+		.bind(c.var.org.uuid)
+		.all<{ sharing_group_uuid: string }>();
+	const visibleGroups = (membershipRows.results ?? []).map((r) => r.sharing_group_uuid);
+
+	// Build WHERE via parameters.
+	const whereParts: string[] = [
+		`(e.orgc_uuid = ?1${visibleGroups.length > 0 ? ` OR e.sharing_group_uuid IN (${visibleGroups.map((_, i) => `?${i + 2}`).join(",")})` : ""})`,
+	];
+	const params: (string | number)[] = [c.var.org.uuid, ...visibleGroups];
+
+	if (type) { whereParts.push(`a.type = ?${params.length + 1}`); params.push(type); }
+	if (value) { whereParts.push(`a.value = ?${params.length + 1}`); params.push(value); }
+
+	const join = (type || value) ? `JOIN attributes a ON a.event_uuid = e.uuid` : ``;
+	params.push(limit, offset);
+
+	const sql = `SELECT DISTINCT e.event_json FROM events e ${join}
+		WHERE ${whereParts.join(" AND ")}
+		ORDER BY e.timestamp DESC
+		LIMIT ?${params.length - 1} OFFSET ?${params.length}`;
+
+	const rows = await c.env.DB.prepare(sql).bind(...params).all<{ event_json: string }>();
+	const events = (rows.results ?? []).map((r) => JSON.parse(r.event_json));
+	return c.json({ response: events });
+});

--- a/hub/src/routes/feeds.ts
+++ b/hub/src/routes/feeds.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Published feeds: the community's distilled intel. PhishDestroy/URLhaus
+ * consumers can pull a plain newline-delimited file here; MISP-aware tools
+ * can pull structured events via /events/restSearch.
+ */
+
+import { Hono } from "hono";
+import { requireOrg, type HubContext } from "../lib/auth";
+import { getPromotedForSharingGroup } from "../lib/aggregate";
+
+export const feedRoutes = new Hono<HubContext>();
+
+feedRoutes.use("*", requireOrg);
+
+/**
+ * Plain destroylist of promoted URLs/domains visible to the caller.
+ * Returns one value per line; `# ` lines are metadata comments.
+ *
+ * Query params:
+ *   sharing_group — restrict to one group (must be a member)
+ *   kinds — comma-separated attribute types to include (default url,domain)
+ */
+feedRoutes.get("/destroylist.txt", async (c) => {
+	const sharingGroup = c.req.query("sharing_group") ?? null;
+	const kinds = (c.req.query("kinds") ?? "url,domain").split(",").map((s) => s.trim());
+
+	if (sharingGroup) {
+		const mem = await c.env.DB
+			.prepare(`SELECT 1 FROM sharing_group_orgs WHERE sharing_group_uuid = ?1 AND org_uuid = ?2`)
+			.bind(sharingGroup, c.var.org.uuid)
+			.first();
+		if (!mem) return c.text("not a member of that sharing group", 403);
+	}
+
+	// Collect promoted entries from the requested group plus all groups this
+	// org belongs to (if no specific group requested).
+	const groups: (string | null)[] = [];
+	if (sharingGroup) {
+		groups.push(sharingGroup);
+	} else {
+		groups.push(null);
+		const memberships = await c.env.DB
+			.prepare(`SELECT sharing_group_uuid FROM sharing_group_orgs WHERE org_uuid = ?1`)
+			.bind(c.var.org.uuid)
+			.all<{ sharing_group_uuid: string }>();
+		for (const m of memberships.results ?? []) groups.push(m.sharing_group_uuid);
+	}
+
+	const seen = new Set<string>();
+	const lines: string[] = [
+		`# destroylist published ${new Date().toISOString()}`,
+		`# caller org ${c.var.org.uuid}`,
+		`# kinds ${kinds.join(",")}`,
+		"",
+	];
+	for (const g of groups) {
+		const promoted = await getPromotedForSharingGroup(c.env.DB, g);
+		for (const p of promoted) {
+			if (!kinds.includes(p.attribute_type)) continue;
+			if (seen.has(p.value)) continue;
+			seen.add(p.value);
+			lines.push(p.value);
+		}
+	}
+
+	return c.text(lines.join("\n"), 200, { "Content-Type": "text/plain; charset=utf-8" });
+});

--- a/hub/src/routes/orgs.ts
+++ b/hub/src/routes/orgs.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Org + invite endpoints. MVP shape:
+ *   POST /orgs/invite — create a one-time invite token (requires an existing
+ *     authenticated org; the invite can optionally bind to a sharing group).
+ *   POST /orgs/accept — redeem an invite token to create a new org + API key.
+ *   GET  /orgs/me    — return the authenticated org.
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { requireOrg, type HubContext } from "../lib/auth";
+import { generateSecret, sha256 } from "../lib/hash";
+import type { Env } from "../types";
+
+// --- Open endpoint (accept): separate app, not auth-gated ---
+
+export const orgAcceptApp = new Hono<{ Bindings: Env }>();
+
+const AcceptSchema = z.object({
+	token: z.string().min(16).max(256),
+	name: z.string().min(1).max(200),
+	contact: z.string().max(500).optional(),
+});
+
+orgAcceptApp.post("/accept", async (c) => {
+	const parsed = AcceptSchema.safeParse(await c.req.json().catch(() => null));
+	if (!parsed.success) return c.json({ error: parsed.error.flatten() }, 400);
+	const { token, name, contact } = parsed.data;
+
+	const tokenHash = await sha256(token);
+	const invite = await c.env.DB
+		.prepare(
+			`SELECT token_hash, sharing_group_uuid, expires_at, consumed_at
+			 FROM invites WHERE token_hash = ?1`,
+		)
+		.bind(tokenHash)
+		.first<{ token_hash: string; sharing_group_uuid: string | null; expires_at: string; consumed_at: string | null }>();
+
+	if (!invite) return c.json({ error: "invalid token" }, 404);
+	if (invite.consumed_at) return c.json({ error: "token already used" }, 410);
+	if (new Date(invite.expires_at).getTime() < Date.now()) return c.json({ error: "token expired" }, 410);
+
+	const orgUuid = crypto.randomUUID();
+	const apiKey = generateSecret();
+	const keyHash = await sha256(apiKey);
+	const now = new Date().toISOString();
+
+	await c.env.DB.batch([
+		c.env.DB
+			.prepare(`INSERT INTO orgs (uuid, name, contact, created_at, trust) VALUES (?1, ?2, ?3, ?4, 1.0)`)
+			.bind(orgUuid, name, contact ?? null, now),
+		c.env.DB
+			.prepare(`INSERT INTO api_keys (key_hash, org_uuid, label, created_at) VALUES (?1, ?2, 'initial', ?3)`)
+			.bind(keyHash, orgUuid, now),
+		c.env.DB
+			.prepare(`UPDATE invites SET consumed_at = ?1 WHERE token_hash = ?2`)
+			.bind(now, tokenHash),
+		...(invite.sharing_group_uuid
+			? [
+				c.env.DB
+					.prepare(
+						`INSERT INTO sharing_group_orgs (sharing_group_uuid, org_uuid, role) VALUES (?1, ?2, 'member')`,
+					)
+					.bind(invite.sharing_group_uuid, orgUuid),
+			]
+			: []),
+	]);
+
+	return c.json({
+		org: { uuid: orgUuid, name },
+		api_key: apiKey, // returned ONCE — the caller must store it
+		sharing_group_uuid: invite.sharing_group_uuid,
+	}, 201);
+});
+
+// --- Authenticated endpoints ---
+
+export const orgRoutes = new Hono<HubContext>();
+
+orgRoutes.use("*", requireOrg);
+
+orgRoutes.get("/me", async (c) => {
+	return c.json({ org: c.var.org });
+});
+
+const InviteSchema = z.object({
+	sharing_group_uuid: z.string().uuid().optional(),
+	note: z.string().max(500).optional(),
+	ttl_hours: z.number().int().min(1).max(24 * 30).optional(),
+});
+
+orgRoutes.post("/invite", async (c) => {
+	const parsed = InviteSchema.safeParse(await c.req.json().catch(() => ({})));
+	if (!parsed.success) return c.json({ error: parsed.error.flatten() }, 400);
+	const { sharing_group_uuid, note, ttl_hours = 72 } = parsed.data;
+
+	// Inviting into a sharing group requires the inviter is a member.
+	if (sharing_group_uuid) {
+		const mem = await c.env.DB
+			.prepare(`SELECT 1 FROM sharing_group_orgs WHERE sharing_group_uuid = ?1 AND org_uuid = ?2`)
+			.bind(sharing_group_uuid, c.var.org.uuid)
+			.first();
+		if (!mem) return c.json({ error: "not a member of that sharing group" }, 403);
+	}
+
+	const token = generateSecret();
+	const tokenHash = await sha256(token);
+	const expiresAt = new Date(Date.now() + ttl_hours * 3600 * 1000).toISOString();
+
+	await c.env.DB
+		.prepare(
+			`INSERT INTO invites (token_hash, sharing_group_uuid, note, expires_at)
+			 VALUES (?1, ?2, ?3, ?4)`,
+		)
+		.bind(tokenHash, sharing_group_uuid ?? null, note ?? null, expiresAt)
+		.run();
+
+	return c.json({ token, expires_at: expiresAt }, 201);
+});

--- a/hub/src/routes/sharing-groups.ts
+++ b/hub/src/routes/sharing-groups.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { requireOrg, type HubContext } from "../lib/auth";
+
+export const sharingGroupRoutes = new Hono<HubContext>();
+
+sharingGroupRoutes.use("*", requireOrg);
+
+sharingGroupRoutes.get("/", async (c) => {
+	const rows = await c.env.DB
+		.prepare(
+			`SELECT sg.uuid, sg.name, sg.description, sgo.role
+			 FROM sharing_groups sg
+			 JOIN sharing_group_orgs sgo ON sgo.sharing_group_uuid = sg.uuid
+			 WHERE sgo.org_uuid = ?1
+			 ORDER BY sg.name ASC`,
+		)
+		.bind(c.var.org.uuid)
+		.all();
+	return c.json({ sharing_groups: rows.results ?? [] });
+});
+
+const CreateSchema = z.object({
+	name: z.string().min(1).max(200),
+	description: z.string().max(1000).optional(),
+});
+
+sharingGroupRoutes.post("/", async (c) => {
+	const parsed = CreateSchema.safeParse(await c.req.json().catch(() => null));
+	if (!parsed.success) return c.json({ error: parsed.error.flatten() }, 400);
+
+	const uuid = crypto.randomUUID();
+	await c.env.DB.batch([
+		c.env.DB
+			.prepare(`INSERT INTO sharing_groups (uuid, name, description) VALUES (?1, ?2, ?3)`)
+			.bind(uuid, parsed.data.name, parsed.data.description ?? null),
+		c.env.DB
+			.prepare(
+				`INSERT INTO sharing_group_orgs (sharing_group_uuid, org_uuid, role) VALUES (?1, ?2, 'owner')`,
+			)
+			.bind(uuid, c.var.org.uuid),
+	]);
+	return c.json({ sharing_group: { uuid, ...parsed.data } }, 201);
+});

--- a/hub/src/types.ts
+++ b/hub/src/types.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+export interface Env {
+	DB: D1Database;
+	AI: Ai;
+	TRIAGE_QUEUE: Queue<TriageMessage>;
+}
+
+export interface TriageMessage {
+	kind: "event";
+	event_uuid: string;
+}
+
+export interface AuthedOrg {
+	uuid: string;
+	name: string;
+	trust: number;
+}

--- a/hub/tsconfig.json
+++ b/hub/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "es2022",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"lib": ["es2022"],
+		"types": ["@cloudflare/workers-types"],
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true,
+		"esModuleInterop": true,
+		"isolatedModules": true,
+		"resolveJsonModule": true,
+		"jsx": "react-jsx"
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/hub/wrangler.jsonc
+++ b/hub/wrangler.jsonc
@@ -1,0 +1,41 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "ais-hub",
+	"compatibility_date": "2025-11-28",
+	"main": "./src/index.ts",
+	"observability": {
+		"enabled": true
+	},
+	"compatibility_flags": ["nodejs_compat"],
+	"ai": {
+		"binding": "AI"
+	},
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "ais-hub",
+			"database_id": "REPLACE_WITH_D1_DATABASE_ID",
+			"migrations_dir": "./migrations"
+		}
+	],
+	"queues": {
+		"producers": [
+			{
+				"binding": "TRIAGE_QUEUE",
+				"queue": "ais-hub-triage"
+			}
+		],
+		"consumers": [
+			{
+				"queue": "ais-hub-triage",
+				"max_batch_size": 10,
+				"max_batch_timeout": 5
+			}
+		]
+	},
+	"triggers": {
+		"crons": [
+			"*/5 * * * *"
+		]
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,29 +70,12 @@
 				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
-		"node_modules/@ai-sdk/openai": {
-			"version": "3.0.41",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.41.tgz",
-			"integrity": "sha512-IZ42A+FO+vuEQCVNqlnAPYQnnUpUfdJIwn1BEDOBywiEHa23fw7PahxVtlX9zm3/zMvTW4JKPzWyvAgDu+SQ2A==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@ai-sdk/provider": "3.0.8",
-				"@ai-sdk/provider-utils": "4.0.19"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.76 || ^4.1.8"
-			}
-		},
 		"node_modules/@ai-sdk/provider": {
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
 			"integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"json-schema": "^0.4.0"
 			},
@@ -184,6 +167,7 @@
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -694,13 +678,15 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
 			"integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@cloudflare/ai-chat": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/@cloudflare/ai-chat/-/ai-chat-0.1.8.tgz",
 			"integrity": "sha512-ukEKQGCnoqhE9OYiOW1MCWhYxomPQG6BCdFJ/JusyvbNZP4cYDNgfpo4vXd0dXtTnp24E1thDuCGaaWhRFM4xg==",
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@ai-sdk/react": "^3.0.0",
 				"agents": "^0.7.3",
@@ -873,7 +859,8 @@
 			"version": "4.20260316.1",
 			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260316.1.tgz",
 			"integrity": "sha512-HUZ+vQD8/1A4Fz/8WAlzYWcS5W5u3Nu7Dv9adkIkmLfeKqMIRn01vc4nSUBar60KkmohyQHkPi8jtWV/zazvAg==",
-			"license": "MIT OR Apache-2.0"
+			"license": "MIT OR Apache-2.0",
+			"peer": true
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -1380,6 +1367,7 @@
 			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
 			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@floating-ui/core": "^1.7.5",
 				"@floating-ui/utils": "^0.2.11"
@@ -2014,6 +2002,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -2023,6 +2012,7 @@
 			"resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
 			"integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -3016,6 +3006,7 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.2.tgz",
 			"integrity": "sha512-zKW4LqZt+aNdvz9o4R0/j+D+gfhwzuFItwh7wbqz8g8bWi0jaV95VybeVFVKeg/KGTc3sAa4mm+hGgvgrY+Gvg==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -3277,6 +3268,7 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.20.2.tgz",
 			"integrity": "sha512-x9h1fDeaLah60WJTb6517nRbAKcbdBsTpmglqxQ9c827PUOUyiVEAu2o2cFEuOMw6Htvty4obOKBUgYi8EAgDA==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -3382,6 +3374,7 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.20.2.tgz",
 			"integrity": "sha512-jvVRtFdEJNjKgIL8wtMg3W4BJMlKyH9aF2jYNU2rf3jA9GJM0rtqtth3jjFnApZoyINtx6jr4o4Ot6+/5d0XYA==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -3408,6 +3401,7 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.20.2.tgz",
 			"integrity": "sha512-gzntns6z/kTgwrX89ydc3rNqDsv8D8sAkyl8HE9X+2D9wtdCgNljevIR6MBNcxG7bVm2+XnId1P9YciCZLuefg==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -3422,6 +3416,7 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.2.tgz",
 			"integrity": "sha512-tEMZlLy/6ms41PQtyjmniZ3tTd8elavd8htjYzHLPSHtz11zaYV9YjnmnwHK8gynhcSES1orO9z1U4nT4ZLpqg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"prosemirror-changeset": "^2.3.0",
 				"prosemirror-collab": "^1.3.1",
@@ -3608,6 +3603,7 @@
 			"integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -3617,6 +3613,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
 			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -3626,6 +3623,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
@@ -3707,6 +3705,7 @@
 			"resolved": "https://registry.npmjs.org/agents/-/agents-0.7.6.tgz",
 			"integrity": "sha512-wR5L+3t+kIN1aog7AqAs5RBKfW4GhYtdSEE2thNvWefaZXrEZXDzN8NVaO2CMVEwNWAG+edqEfxzMOViMOlUJQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@cfworker/json-schema": "^4.1.1",
 				"@modelcontextprotocol/sdk": "1.26.0",
@@ -3786,6 +3785,7 @@
 			"resolved": "https://registry.npmjs.org/ai/-/ai-6.0.116.tgz",
 			"integrity": "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@ai-sdk/gateway": "3.0.66",
 				"@ai-sdk/provider": "3.0.8",
@@ -3956,6 +3956,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -5076,7 +5077,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"resolve-pkg-maps": "^1.0.0"
 			},
@@ -5202,6 +5202,7 @@
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
 			"integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -7287,6 +7288,7 @@
 			"resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
 			"integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"orderedmap": "^2.0.0"
 			}
@@ -7316,6 +7318,7 @@
 			"resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
 			"integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"prosemirror-model": "^1.0.0",
 				"prosemirror-transform": "^1.0.0",
@@ -7364,6 +7367,7 @@
 			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.6.tgz",
 			"integrity": "sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"prosemirror-model": "^1.20.0",
 				"prosemirror-state": "^1.0.0",
@@ -7436,6 +7440,7 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
 			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -7467,6 +7472,7 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
 			"integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -7516,6 +7522,7 @@
 			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
 			"integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cookie": "^1.0.1",
 				"set-cookie-parser": "^2.6.0"
@@ -7659,7 +7666,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
 			}
@@ -8116,7 +8122,6 @@
 			"resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
 			"integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"dequal": "^2.0.3",
 				"use-sync-external-store": "^1.6.0"
@@ -8167,7 +8172,6 @@
 			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
 			"integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -8245,8 +8249,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
 			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-			"license": "0BSD",
-			"peer": true
+			"license": "0BSD"
 		},
 		"node_modules/tsx": {
 			"version": "4.21.0",
@@ -8255,7 +8258,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.27.0",
 				"get-tsconfig": "^4.7.5"
@@ -8283,7 +8285,6 @@
 			"os": [
 				"aix"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8301,7 +8302,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8319,7 +8319,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8337,7 +8336,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8355,7 +8353,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8373,7 +8370,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8391,7 +8387,6 @@
 			"os": [
 				"freebsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8409,7 +8404,6 @@
 			"os": [
 				"freebsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8427,7 +8421,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8445,7 +8438,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8463,7 +8455,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8481,7 +8472,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8499,7 +8489,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8517,7 +8506,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8535,7 +8523,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8553,7 +8540,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8571,7 +8557,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8589,7 +8574,6 @@
 			"os": [
 				"netbsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8607,7 +8591,6 @@
 			"os": [
 				"netbsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8625,7 +8608,6 @@
 			"os": [
 				"openbsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8643,7 +8625,6 @@
 			"os": [
 				"openbsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8661,7 +8642,6 @@
 			"os": [
 				"openharmony"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8679,7 +8659,6 @@
 			"os": [
 				"sunos"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8697,7 +8676,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8715,7 +8693,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8733,7 +8710,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8746,7 +8722,6 @@
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -8827,6 +8802,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -8864,6 +8840,7 @@
 			"integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"pathe": "^2.0.3"
 			}
@@ -9069,6 +9046,7 @@
 			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",
@@ -9216,6 +9194,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"workerd": "bin/workerd"
 			},
@@ -9820,24 +9799,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/yaml": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
-			}
-		},
 		"node_modules/yargs": {
 			"version": "18.0.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
@@ -9894,6 +9855,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
 			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -9912,7 +9874,6 @@
 			"resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
 			"integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"tslib": "2.3.0"
 			}

--- a/shared/folders.ts
+++ b/shared/folders.ts
@@ -17,6 +17,7 @@ export const Folders = {
 	ARCHIVE: "archive",
 	TRASH: "trash",
 	SPAM: "spam",
+	QUARANTINE: "quarantine",
 } as const;
 
 export type FolderId = (typeof Folders)[keyof typeof Folders];
@@ -30,6 +31,7 @@ export const SYSTEM_FOLDER_IDS: readonly FolderId[] = [
 	Folders.SENT,
 	Folders.DRAFT,
 	Folders.ARCHIVE,
+	Folders.QUARANTINE,
 	Folders.TRASH,
 ];
 
@@ -44,15 +46,16 @@ export const FOLDER_DISPLAY_NAMES: Record<string, string> = {
 	[Folders.ARCHIVE]: "Archive",
 	[Folders.TRASH]: "Trash",
 	[Folders.SPAM]: "Spam",
+	[Folders.QUARANTINE]: "Quarantine",
 };
 
 /** Formatted string for tool parameter descriptions (agent + MCP). */
 export const FOLDER_TOOL_DESCRIPTION =
-	"Folder to list: inbox, sent, draft, archive, trash";
+	"Folder to list: inbox, sent, draft, archive, trash, quarantine";
 
 /** Formatted string for move-email tool descriptions. */
 export const MOVE_FOLDER_TOOL_DESCRIPTION =
-	"Target folder: inbox, sent, draft, archive, trash";
+	"Target folder: inbox, sent, draft, archive, trash, quarantine";
 
 /**
  * Look up a display name for a folder ID, falling back to the raw ID

--- a/workers/agent/index.ts
+++ b/workers/agent/index.ts
@@ -244,7 +244,7 @@ function createEmailTools(env: Env, mailboxId: string) {
 
 		move_email: defineTool({
 			description:
-				"Move an email to a different folder (inbox, sent, draft, archive, trash).",
+				"Move an email to a different folder (inbox, sent, draft, archive, trash, quarantine).",
 			parameters: z.object({
 				emailId: z.string().describe("The email ID"),
 				folderId: z
@@ -332,7 +332,32 @@ export class EmailAgent extends AIChatAgent<any> {
 		sender: string;
 		subject: string;
 		threadId: string;
+		securityVerdict?: { action: string; score: number; explanation: string } | null;
 	}) {
+		// Respect the security pipeline: if the email was quarantined/blocked,
+		// skip the auto-draft and log why. See workers/security/index.ts.
+		if (emailData.securityVerdict && (emailData.securityVerdict.action === "quarantine" || emailData.securityVerdict.action === "block")) {
+			const v = emailData.securityVerdict;
+			const note = `🛡️ Security pipeline ${v.action === "block" ? "blocked" : "quarantined"} this email (score ${v.score}). ${v.explanation}`;
+			const newMessages = [
+				{
+					id: crypto.randomUUID(),
+					role: "user" as const,
+					content: `[Auto-triggered] New email from ${emailData.sender}: "${emailData.subject}"`,
+					createdAt: new Date(),
+					parts: [{ type: "text" as const, text: `[Auto-triggered] New email from ${emailData.sender}: "${emailData.subject}"` }],
+				},
+				{
+					id: crypto.randomUUID(),
+					role: "assistant" as const,
+					content: note,
+					createdAt: new Date(),
+					parts: [{ type: "text" as const, text: note }],
+				},
+			];
+			await this.persistMessages([...this.messages, ...newMessages]);
+			return;
+		}
 		const env = this.env as Env;
 		const workersai = createWorkersAI({ binding: env.AI });
 		const tools = createEmailTools(env, emailData.mailboxId);

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -8,6 +8,7 @@ import { jwtVerify, createRemoteJWKSet } from "jose";
 import { createRequestHandler } from "react-router";
 import { app as apiApp, receiveEmail } from "./index";
 import { EmailMCP } from "./mcp";
+import { refreshAllFeeds } from "./intel/feeds";
 import type { Env } from "./types";
 
 export { MailboxDO } from "./durableObject";
@@ -113,5 +114,17 @@ export default {
 			// Swallowing the error would silently drop the email.
 			throw e;
 		}
+	},
+	async scheduled(
+		_event: ScheduledController,
+		env: Env,
+		ctx: ExecutionContext,
+	) {
+		ctx.waitUntil(
+			refreshAllFeeds(env).then(
+				(r) => console.log(`intel: refreshed ${r.feeds} feeds, ${r.entries} entries`),
+				(e) => console.error("intel feed refresh failed:", (e as Error).message),
+			),
+		);
 	},
 };

--- a/workers/db/schema.ts
+++ b/workers/db/schema.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real, primaryKey } from "drizzle-orm/sqlite-core";
 
 export const folders = sqliteTable("folders", {
 	id: text("id").primaryKey(),
@@ -29,6 +29,10 @@ export const emails = sqliteTable("emails", {
 	thread_id: text("thread_id"),
 	message_id: text("message_id"),
 	raw_headers: text("raw_headers"),
+	security_verdict: text("security_verdict"),
+	security_score: integer("security_score"),
+	security_explanation: text("security_explanation"),
+	deep_scan_status: text("deep_scan_status").default("pending"),
 });
 
 export const attachments = sqliteTable("attachments", {
@@ -41,4 +45,113 @@ export const attachments = sqliteTable("attachments", {
 	size: integer("size").notNull(),
 	content_id: text("content_id"),
 	disposition: text("disposition"),
+	scan_status: text("scan_status").default("pending"),
+	scan_verdict: text("scan_verdict"),
+});
+
+// ── Security ─────────────────────────────────────────────────────
+
+export const urls = sqliteTable("urls", {
+	id: text("id").primaryKey(),
+	email_id: text("email_id")
+		.notNull()
+		.references(() => emails.id, { onDelete: "cascade" }),
+	url: text("url").notNull(),
+	display_text: text("display_text"),
+	is_homograph: integer("is_homograph").notNull().default(0),
+	is_shortener: integer("is_shortener").notNull().default(0),
+	resolved_url: text("resolved_url"),
+	page_title: text("page_title"),
+	fetch_status: text("fetch_status").default("pending"),
+	verdict: text("verdict"),
+	created_at: text("created_at").notNull().default("CURRENT_TIMESTAMP"),
+});
+
+export const senderReputation = sqliteTable("sender_reputation", {
+	sender: text("sender").primaryKey(),
+	first_seen: text("first_seen").notNull(),
+	last_seen: text("last_seen").notNull(),
+	message_count: integer("message_count").notNull().default(1),
+	avg_score: real("avg_score").notNull().default(50.0),
+	flagged: integer("flagged").notNull().default(0),
+});
+
+// ── Threat intel ─────────────────────────────────────────────────
+
+export const intelFeedState = sqliteTable("intel_feed_state", {
+	feed_id: text("feed_id").primaryKey(),
+	url: text("url").notNull(),
+	last_fetched_at: text("last_fetched_at"),
+	etag: text("etag"),
+	entry_count: integer("entry_count"),
+	bloom_kv_key: text("bloom_kv_key"),
+});
+
+// ── DMARC ────────────────────────────────────────────────────────
+
+export const dmarcReports = sqliteTable("dmarc_reports", {
+	id: text("id").primaryKey(),
+	received_at: text("received_at").notNull(),
+	org_name: text("org_name"),
+	report_id: text("report_id"),
+	domain: text("domain").notNull(),
+	date_range_begin: text("date_range_begin"),
+	date_range_end: text("date_range_end"),
+	policy_p: text("policy_p"),
+	raw_r2_key: text("raw_r2_key"),
+});
+
+export const dmarcRecords = sqliteTable("dmarc_records", {
+	id: text("id").primaryKey(),
+	report_id: text("report_id")
+		.notNull()
+		.references(() => dmarcReports.id, { onDelete: "cascade" }),
+	source_ip: text("source_ip").notNull(),
+	count: integer("count").notNull(),
+	disposition: text("disposition"),
+	dkim_result: text("dkim_result"),
+	spf_result: text("spf_result"),
+	header_from: text("header_from"),
+});
+
+export const dmarcSources = sqliteTable("dmarc_sources", {
+	source_ip: text("source_ip").primaryKey(),
+	label: text("label"),
+	legitimate: integer("legitimate").notNull().default(0),
+	notes: text("notes"),
+});
+
+// ── Cases (TheHive-lite) ─────────────────────────────────────────
+
+export const cases = sqliteTable("cases", {
+	id: text("id").primaryKey(),
+	created_at: text("created_at").notNull().default("CURRENT_TIMESTAMP"),
+	updated_at: text("updated_at").notNull().default("CURRENT_TIMESTAMP"),
+	status: text("status").notNull().default("open"),
+	title: text("title").notNull(),
+	notes: text("notes"),
+	shared_to_hub: integer("shared_to_hub").notNull().default(0),
+	hub_event_uuid: text("hub_event_uuid"),
+});
+
+export const caseEmails = sqliteTable(
+	"case_emails",
+	{
+		case_id: text("case_id")
+			.notNull()
+			.references(() => cases.id, { onDelete: "cascade" }),
+		email_id: text("email_id").notNull(),
+	},
+	(t) => ({
+		pk: primaryKey({ columns: [t.case_id, t.email_id] }),
+	}),
+);
+
+export const caseObservables = sqliteTable("case_observables", {
+	id: text("id").primaryKey(),
+	case_id: text("case_id")
+		.notNull()
+		.references(() => cases.id, { onDelete: "cascade" }),
+	kind: text("kind").notNull(),
+	value: text("value").notNull(),
 });

--- a/workers/dmarc/ingest.ts
+++ b/workers/dmarc/ingest.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * DMARC aggregate-report ingestion.
+ *
+ * DMARC reports arrive as email with a gzipped XML attachment. We divert
+ * them out of the normal security pipeline (no sense classifying machine
+ * reports as phish) and feed them into the per-mailbox dashboard DB.
+ */
+
+import type { Email } from "postal-mime";
+import type { Env } from "../types";
+import { getMailboxStub } from "../lib/email-helpers";
+import { bufferToXmlText, gunzip, parseDmarcXml } from "./parser";
+
+/** Heuristic: does this parsed email look like a DMARC aggregate report? */
+export function isDmarcReport(parsed: Email): boolean {
+	const from = parsed.from?.address?.toLowerCase() ?? "";
+	const subject = (parsed.subject ?? "").toLowerCase();
+	if (from.includes("dmarc") || from.includes("noreply-dmarc")) return true;
+	if (subject.startsWith("report domain:") || subject.includes("dmarc aggregate report")) return true;
+	for (const a of parsed.attachments ?? []) {
+		const fn = (a.filename ?? "").toLowerCase();
+		if (fn.endsWith(".xml.gz") || fn.endsWith(".xml.zip")) return true;
+		const mt = (a.mimeType ?? "").toLowerCase();
+		if (mt === "application/gzip" || mt === "application/zip" || mt === "application/xml") {
+			if (fn.includes("!")) return true; // DMARC RUA conventionally names `example.com!google.com!start!end.xml.gz`
+		}
+	}
+	return false;
+}
+
+export async function ingestDmarcReport(
+	env: Env,
+	mailboxId: string,
+	messageId: string,
+	parsed: Email,
+): Promise<{ ingested: boolean; reason?: string }> {
+	const attachments = parsed.attachments ?? [];
+	let xmlText: string | null = null;
+
+	for (const att of attachments) {
+		const fn = (att.filename ?? "").toLowerCase();
+		const raw = normalizeContent(att.content);
+		if (!raw) continue;
+		if (fn.endsWith(".xml.gz") || (att.mimeType ?? "").toLowerCase() === "application/gzip") {
+			try {
+				const decompressed = await gunzip(raw);
+				xmlText = bufferToXmlText(decompressed);
+				break;
+			} catch (e) {
+				console.error("dmarc gunzip failed:", (e as Error).message);
+			}
+		} else if (fn.endsWith(".xml")) {
+			xmlText = bufferToXmlText(raw);
+			break;
+		}
+		// .xml.zip: deferred — zip needs a proper parser. See plan M4 notes.
+	}
+
+	if (!xmlText) return { ingested: false, reason: "no decodable XML attachment" };
+
+	const report = parseDmarcXml(xmlText);
+	if (!report.policy_domain) return { ingested: false, reason: "no policy_domain in XML" };
+
+	const stub = getMailboxStub(env, mailboxId);
+	await stub.insertDmarcReport({
+		id: messageId,
+		received_at: new Date().toISOString(),
+		org_name: report.org_name ?? null,
+		report_id: report.report_id ?? null,
+		domain: report.policy_domain,
+		date_range_begin: report.date_range_begin ?? null,
+		date_range_end: report.date_range_end ?? null,
+		policy_p: report.policy_p ?? null,
+		raw_r2_key: null,
+	}, report.records.map((r) => ({
+		id: crypto.randomUUID(),
+		source_ip: r.source_ip,
+		count: r.count,
+		disposition: r.disposition ?? null,
+		dkim_result: r.dkim_result ?? null,
+		spf_result: r.spf_result ?? null,
+		header_from: r.header_from ?? null,
+	})));
+
+	return { ingested: true };
+}
+
+function normalizeContent(content: unknown): ArrayBuffer | null {
+	if (!content) return null;
+	if (content instanceof ArrayBuffer) return content;
+	if (ArrayBuffer.isView(content)) {
+		return (content.buffer as ArrayBuffer).slice(content.byteOffset, content.byteOffset + content.byteLength);
+	}
+	if (typeof content === "string") {
+		return new TextEncoder().encode(content).buffer as ArrayBuffer;
+	}
+	return null;
+}

--- a/workers/dmarc/parser.ts
+++ b/workers/dmarc/parser.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Minimal DMARC RUA (aggregate report) XML parser.
+ *
+ * DMARC's aggregate-feedback schema is small and fixed — see RFC 7489 §7.2.
+ * A hand-written tag extractor is simpler than pulling in a full XML parser.
+ * We only capture the fields needed for the dashboard and forger intel.
+ */
+
+export interface DmarcReport {
+	org_name?: string;
+	report_id?: string;
+	date_range_begin?: string; // epoch seconds
+	date_range_end?: string;
+	policy_domain?: string;
+	policy_p?: string;
+	records: DmarcRecord[];
+}
+
+export interface DmarcRecord {
+	source_ip: string;
+	count: number;
+	disposition?: string;
+	dkim_result?: string;
+	spf_result?: string;
+	header_from?: string;
+}
+
+/** Gunzip an arraybuffer using the runtime's DecompressionStream. */
+export async function gunzip(buf: ArrayBuffer): Promise<ArrayBuffer> {
+	const stream = new Response(buf).body!.pipeThrough(new DecompressionStream("gzip"));
+	return new Response(stream).arrayBuffer();
+}
+
+/** Read the first XML-looking text out of a raw buffer. */
+export function bufferToXmlText(buf: ArrayBuffer): string {
+	return new TextDecoder("utf-8", { fatal: false }).decode(buf);
+}
+
+/**
+ * Extract the text content of the first tag matching `name` within `scope`.
+ * `name` is matched case-sensitively; DMARC XML uses lowercase throughout
+ * the standard schema.
+ */
+function tag(scope: string, name: string): string | undefined {
+	const re = new RegExp(`<${name}\\b[^>]*>([\\s\\S]*?)<\\/${name}>`, "i");
+	const match = scope.match(re);
+	return match?.[1]?.trim();
+}
+
+function allTags(scope: string, name: string): string[] {
+	const re = new RegExp(`<${name}\\b[^>]*>([\\s\\S]*?)<\\/${name}>`, "gi");
+	const out: string[] = [];
+	for (const match of scope.matchAll(re)) out.push(match[1]);
+	return out;
+}
+
+export function parseDmarcXml(xml: string): DmarcReport {
+	const metadata = tag(xml, "report_metadata") ?? "";
+	const policy = tag(xml, "policy_published") ?? "";
+
+	const records: DmarcRecord[] = [];
+	for (const rec of allTags(xml, "record")) {
+		const row = tag(rec, "row") ?? "";
+		const identifiers = tag(rec, "identifiers") ?? "";
+		const authResults = tag(rec, "auth_results") ?? "";
+		const policyEval = tag(row, "policy_evaluated") ?? "";
+		const source_ip = tag(row, "source_ip")?.trim();
+		if (!source_ip) continue;
+		const countStr = tag(row, "count") ?? "0";
+		records.push({
+			source_ip,
+			count: Math.max(0, Math.min(1000000, parseInt(countStr, 10) || 0)),
+			disposition: tag(policyEval, "disposition"),
+			dkim_result: tag(policyEval, "dkim"),
+			spf_result: tag(policyEval, "spf"),
+			header_from: tag(identifiers, "header_from"),
+		});
+	}
+
+	return {
+		org_name: tag(metadata, "org_name"),
+		report_id: tag(metadata, "report_id"),
+		date_range_begin: tag(tag(metadata, "date_range") ?? "", "begin"),
+		date_range_end: tag(tag(metadata, "date_range") ?? "", "end"),
+		policy_domain: tag(policy, "domain"),
+		policy_p: tag(policy, "p"),
+		records,
+	};
+}

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -160,6 +160,9 @@ export class MailboxDO extends DurableObject<Env> {
 				email_references: schema.emails.email_references,
 				thread_id: schema.emails.thread_id,
 				folder_id: schema.emails.folder_id,
+				security_verdict: schema.emails.security_verdict,
+				security_score: schema.emails.security_score,
+				security_explanation: schema.emails.security_explanation,
 				snippet: sql<string>`SUBSTR(${schema.emails.body}, 1, 300)`,
 			})
 			.from(schema.emails)
@@ -868,5 +871,344 @@ export class MailboxDO extends DurableObject<Env> {
 		if (attachments.length > 0) {
 			this.db.insert(schema.attachments).values(attachments).run();
 		}
+	}
+
+	// ── Security pipeline persistence ──────────────────────────────
+
+	async persistSecurityVerdict(
+		emailId: string,
+		data: { verdict_json: string; score: number; explanation: string },
+	) {
+		this.db
+			.update(schema.emails)
+			.set({
+				security_verdict: data.verdict_json,
+				security_score: data.score,
+				security_explanation: data.explanation,
+			})
+			.where(eq(schema.emails.id, emailId))
+			.run();
+	}
+
+	async insertUrls(
+		emailId: string,
+		urls: Array<{
+			url: string;
+			display_text: string | null;
+			is_homograph: number;
+			is_shortener: number;
+		}>,
+	) {
+		if (urls.length === 0) return;
+		this.db
+			.insert(schema.urls)
+			.values(
+				urls.map((u) => ({
+					id: crypto.randomUUID(),
+					email_id: emailId,
+					url: u.url,
+					display_text: u.display_text,
+					is_homograph: u.is_homograph,
+					is_shortener: u.is_shortener,
+				})),
+			)
+			.run();
+	}
+
+	async getSenderReputation(sender: string) {
+		const row = this.db
+			.select()
+			.from(schema.senderReputation)
+			.where(eq(schema.senderReputation.sender, sender))
+			.get();
+		if (!row) return null;
+		return {
+			sender: row.sender,
+			first_seen: row.first_seen,
+			last_seen: row.last_seen,
+			message_count: row.message_count,
+			avg_score: row.avg_score,
+			flagged: row.flagged === 1,
+		};
+	}
+
+	async upsertSenderReputation(sender: string, newScore: number) {
+		const now = new Date().toISOString();
+		// Rolling average, capped so an old sender can still be retrained.
+		const existing = this.db
+			.select()
+			.from(schema.senderReputation)
+			.where(eq(schema.senderReputation.sender, sender))
+			.get();
+		if (!existing) {
+			this.db
+				.insert(schema.senderReputation)
+				.values({
+					sender,
+					first_seen: now,
+					last_seen: now,
+					message_count: 1,
+					avg_score: newScore,
+					flagged: 0,
+				})
+				.run();
+			return;
+		}
+		const cappedCount = Math.min(existing.message_count, 1000);
+		const newAvg = (existing.avg_score * cappedCount + newScore) / (cappedCount + 1);
+		this.db
+			.update(schema.senderReputation)
+			.set({
+				last_seen: now,
+				message_count: cappedCount + 1,
+				avg_score: newAvg,
+			})
+			.where(eq(schema.senderReputation.sender, sender))
+			.run();
+	}
+
+	async flagSender(sender: string, flagged: boolean) {
+		this.db
+			.update(schema.senderReputation)
+			.set({ flagged: flagged ? 1 : 0 })
+			.where(eq(schema.senderReputation.sender, sender))
+			.run();
+	}
+
+	// ── Threat intel feed state ────────────────────────────────────
+
+	async getIntelFeedState(feedId: string) {
+		return this.db
+			.select()
+			.from(schema.intelFeedState)
+			.where(eq(schema.intelFeedState.feed_id, feedId))
+			.get() ?? null;
+	}
+
+	async upsertIntelFeedState(
+		feedId: string,
+		data: {
+			url: string;
+			last_fetched_at: string;
+			etag: string | null;
+			entry_count: number;
+			bloom_kv_key: string;
+		},
+	) {
+		const existing = this.db
+			.select()
+			.from(schema.intelFeedState)
+			.where(eq(schema.intelFeedState.feed_id, feedId))
+			.get();
+		if (!existing) {
+			this.db
+				.insert(schema.intelFeedState)
+				.values({ feed_id: feedId, ...data })
+				.run();
+		} else {
+			this.db
+				.update(schema.intelFeedState)
+				.set(data)
+				.where(eq(schema.intelFeedState.feed_id, feedId))
+				.run();
+		}
+	}
+
+	// ── DMARC ──────────────────────────────────────────────────────
+
+	async insertDmarcReport(
+		report: {
+			id: string;
+			received_at: string;
+			org_name: string | null;
+			report_id: string | null;
+			domain: string;
+			date_range_begin: string | null;
+			date_range_end: string | null;
+			policy_p: string | null;
+			raw_r2_key: string | null;
+		},
+		records: Array<{
+			id: string;
+			source_ip: string;
+			count: number;
+			disposition: string | null;
+			dkim_result: string | null;
+			spf_result: string | null;
+			header_from: string | null;
+		}>,
+	) {
+		this.db.insert(schema.dmarcReports).values(report).run();
+		if (records.length > 0) {
+			this.db
+				.insert(schema.dmarcRecords)
+				.values(records.map((r) => ({ ...r, report_id: report.id })))
+				.run();
+		}
+	}
+
+	async listDmarcReports(options: { domain?: string; limit?: number; offset?: number } = {}) {
+		const limit = Math.min(Math.max(options.limit ?? 50, 1), 200);
+		const offset = Math.max(options.offset ?? 0, 0);
+		const conditions: SQL[] = [];
+		if (options.domain) conditions.push(eq(schema.dmarcReports.domain, options.domain));
+		return this.db
+			.select()
+			.from(schema.dmarcReports)
+			.where(conditions.length > 0 ? and(...conditions) : undefined)
+			.orderBy(desc(schema.dmarcReports.received_at))
+			.limit(limit)
+			.offset(offset)
+			.all();
+	}
+
+	async getDmarcRecords(reportId: string) {
+		return this.db
+			.select()
+			.from(schema.dmarcRecords)
+			.where(eq(schema.dmarcRecords.report_id, reportId))
+			.all();
+	}
+
+	// ── Cases (TheHive-lite) ───────────────────────────────────────
+
+	async createCase(input: {
+		title: string;
+		notes?: string;
+		emailId?: string;
+		observables?: Array<{ kind: string; value: string }>;
+	}) {
+		const id = crypto.randomUUID();
+		const now = new Date().toISOString();
+		this.db
+			.insert(schema.cases)
+			.values({
+				id,
+				created_at: now,
+				updated_at: now,
+				status: "open",
+				title: input.title.slice(0, 500),
+				notes: input.notes ?? null,
+				shared_to_hub: 0,
+				hub_event_uuid: null,
+			})
+			.run();
+		if (input.emailId) {
+			this.db.insert(schema.caseEmails).values({ case_id: id, email_id: input.emailId }).run();
+		}
+		if (input.observables && input.observables.length > 0) {
+			this.db
+				.insert(schema.caseObservables)
+				.values(input.observables.map((o) => ({
+					id: crypto.randomUUID(),
+					case_id: id,
+					kind: o.kind,
+					value: o.value,
+				})))
+				.run();
+		}
+		return { id };
+	}
+
+	async listCases(options: { status?: string; limit?: number; offset?: number } = {}) {
+		const limit = Math.min(Math.max(options.limit ?? 50, 1), 200);
+		const offset = Math.max(options.offset ?? 0, 0);
+		const conditions: SQL[] = [];
+		if (options.status) conditions.push(eq(schema.cases.status, options.status));
+		return this.db
+			.select()
+			.from(schema.cases)
+			.where(conditions.length > 0 ? and(...conditions) : undefined)
+			.orderBy(desc(schema.cases.updated_at))
+			.limit(limit)
+			.offset(offset)
+			.all();
+	}
+
+	async getCase(id: string) {
+		const row = this.db
+			.select()
+			.from(schema.cases)
+			.where(eq(schema.cases.id, id))
+			.get();
+		if (!row) return null;
+		const emails = this.db
+			.select()
+			.from(schema.caseEmails)
+			.where(eq(schema.caseEmails.case_id, id))
+			.all();
+		const observables = this.db
+			.select()
+			.from(schema.caseObservables)
+			.where(eq(schema.caseObservables.case_id, id))
+			.all();
+		return { ...row, emails, observables };
+	}
+
+	async updateCase(
+		id: string,
+		changes: {
+			status?: string;
+			notes?: string;
+			shared_to_hub?: boolean;
+			hub_event_uuid?: string | null;
+		},
+	) {
+		const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+		if (changes.status !== undefined) patch.status = changes.status;
+		if (changes.notes !== undefined) patch.notes = changes.notes;
+		if (changes.shared_to_hub !== undefined) patch.shared_to_hub = changes.shared_to_hub ? 1 : 0;
+		if (changes.hub_event_uuid !== undefined) patch.hub_event_uuid = changes.hub_event_uuid;
+		this.db
+			.update(schema.cases)
+			.set(patch)
+			.where(eq(schema.cases.id, id))
+			.run();
+	}
+
+	async deleteCase(id: string) {
+		this.db.delete(schema.cases).where(eq(schema.cases.id, id)).run();
+	}
+
+	async addCaseObservable(caseId: string, kind: string, value: string) {
+		const id = crypto.randomUUID();
+		this.db
+			.insert(schema.caseObservables)
+			.values({ id, case_id: caseId, kind, value })
+			.run();
+		return { id };
+	}
+
+	async getDmarcSummary(domain: string) {
+		// Aggregate per-source-IP over the last 90 days. Raw SQL for the
+		// multi-column GROUP BY + derived rates.
+		const rows = [
+			...this.ctx.storage.sql.exec(
+				`SELECT
+				   r.source_ip as source_ip,
+				   SUM(r.count) as total_count,
+				   SUM(CASE WHEN r.dkim_result = 'pass' AND r.spf_result = 'pass' THEN r.count ELSE 0 END) as pass_count,
+				   SUM(CASE WHEN r.disposition = 'quarantine' THEN r.count ELSE 0 END) as quarantine_count,
+				   SUM(CASE WHEN r.disposition = 'reject' THEN r.count ELSE 0 END) as reject_count,
+				   MIN(rep.received_at) as first_seen,
+				   MAX(rep.received_at) as last_seen
+				 FROM dmarc_records r
+				 JOIN dmarc_reports rep ON rep.id = r.report_id
+				 WHERE rep.domain = ?1
+				 GROUP BY r.source_ip
+				 ORDER BY total_count DESC
+				 LIMIT 200`,
+				domain,
+			),
+		] as Array<{
+			source_ip: string;
+			total_count: number;
+			pass_count: number;
+			quarantine_count: number;
+			reject_count: number;
+			first_seen: string;
+			last_seen: string;
+		}>;
+		return rows;
 	}
 }

--- a/workers/durableObject/migrations.ts
+++ b/workers/durableObject/migrations.ts
@@ -168,4 +168,122 @@ export const mailboxMigrations: Migration[] = [
             CREATE INDEX IF NOT EXISTS idx_emails_folder_date ON emails(folder_id, date DESC);
         `,
 	},
+	{
+		name: "9_add_quarantine_folder",
+		sql: txn(`INSERT INTO folders (id, name, is_deletable) VALUES ('quarantine', 'Quarantine', 0);`),
+	},
+	{
+		// Security pipeline, threat intel, DMARC analytics, and case workflow
+		// all land together so a fresh deploy ends up with the full schema after
+		// one migration pass. Columns added via ALTER TABLE in this same
+		// migration — each statement is idempotent-safe because migrations only
+		// run once per name (see d1_migrations table).
+		name: "10_security_intel_dmarc_cases",
+		sql: `
+            ALTER TABLE emails ADD COLUMN security_verdict TEXT;
+            ALTER TABLE emails ADD COLUMN security_score INTEGER;
+            ALTER TABLE emails ADD COLUMN security_explanation TEXT;
+            ALTER TABLE emails ADD COLUMN deep_scan_status TEXT DEFAULT 'pending';
+
+            ALTER TABLE attachments ADD COLUMN scan_status TEXT DEFAULT 'pending';
+            ALTER TABLE attachments ADD COLUMN scan_verdict TEXT;
+
+            CREATE TABLE IF NOT EXISTS urls (
+                id TEXT PRIMARY KEY,
+                email_id TEXT NOT NULL,
+                url TEXT NOT NULL,
+                display_text TEXT,
+                is_homograph INTEGER NOT NULL DEFAULT 0,
+                is_shortener INTEGER NOT NULL DEFAULT 0,
+                resolved_url TEXT,
+                page_title TEXT,
+                fetch_status TEXT DEFAULT 'pending',
+                verdict TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                FOREIGN KEY(email_id) REFERENCES emails(id) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_urls_email_id ON urls(email_id);
+
+            CREATE TABLE IF NOT EXISTS sender_reputation (
+                sender TEXT PRIMARY KEY,
+                first_seen TEXT NOT NULL,
+                last_seen TEXT NOT NULL,
+                message_count INTEGER NOT NULL DEFAULT 1,
+                avg_score REAL NOT NULL DEFAULT 50.0,
+                flagged INTEGER NOT NULL DEFAULT 0
+            );
+
+            CREATE TABLE IF NOT EXISTS intel_feed_state (
+                feed_id TEXT PRIMARY KEY,
+                url TEXT NOT NULL,
+                last_fetched_at TEXT,
+                etag TEXT,
+                entry_count INTEGER,
+                bloom_kv_key TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS dmarc_reports (
+                id TEXT PRIMARY KEY,
+                received_at TEXT NOT NULL,
+                org_name TEXT,
+                report_id TEXT,
+                domain TEXT NOT NULL,
+                date_range_begin TEXT,
+                date_range_end TEXT,
+                policy_p TEXT,
+                raw_r2_key TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_dmarc_reports_domain ON dmarc_reports(domain);
+            CREATE INDEX IF NOT EXISTS idx_dmarc_reports_received_at ON dmarc_reports(received_at);
+
+            CREATE TABLE IF NOT EXISTS dmarc_records (
+                id TEXT PRIMARY KEY,
+                report_id TEXT NOT NULL,
+                source_ip TEXT NOT NULL,
+                count INTEGER NOT NULL,
+                disposition TEXT,
+                dkim_result TEXT,
+                spf_result TEXT,
+                header_from TEXT,
+                FOREIGN KEY(report_id) REFERENCES dmarc_reports(id) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_dmarc_records_source_ip ON dmarc_records(source_ip);
+            CREATE INDEX IF NOT EXISTS idx_dmarc_records_report_id ON dmarc_records(report_id);
+
+            CREATE TABLE IF NOT EXISTS dmarc_sources (
+                source_ip TEXT PRIMARY KEY,
+                label TEXT,
+                legitimate INTEGER NOT NULL DEFAULT 0,
+                notes TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS cases (
+                id TEXT PRIMARY KEY,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                status TEXT NOT NULL DEFAULT 'open',
+                title TEXT NOT NULL,
+                notes TEXT,
+                shared_to_hub INTEGER NOT NULL DEFAULT 0,
+                hub_event_uuid TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_cases_status ON cases(status);
+
+            CREATE TABLE IF NOT EXISTS case_emails (
+                case_id TEXT NOT NULL,
+                email_id TEXT NOT NULL,
+                PRIMARY KEY (case_id, email_id),
+                FOREIGN KEY(case_id) REFERENCES cases(id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS case_observables (
+                id TEXT PRIMARY KEY,
+                case_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                value TEXT NOT NULL,
+                FOREIGN KEY(case_id) REFERENCES cases(id) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_case_observables_case_id ON case_observables(case_id);
+        `,
+	},
 ];

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -20,6 +20,10 @@ import { handleReplyEmail, handleForwardEmail } from "./routes/reply-forward";
 import { Folders } from "../shared/folders";
 import type { Env } from "./types";
 import { requireMailbox, type MailboxContext } from "./lib/mailbox";
+import { runSecurityPipeline } from "./security";
+import { isDmarcReport, ingestDmarcReport } from "./dmarc/ingest";
+import { dmarcRoutes } from "./routes/dmarc";
+import { caseRoutes } from "./routes/cases";
 
 type AppContext = Context<MailboxContext>;
 
@@ -84,6 +88,9 @@ app.use("/api/*", cors({
 app.use("/api/v1/mailboxes/:mailboxId/*", requireMailbox);
 
 // -- Config ---------------------------------------------------------
+
+app.route("/api/v1/mailboxes/:mailboxId/dmarc", dmarcRoutes);
+app.route("/api/v1/mailboxes/:mailboxId/cases", caseRoutes);
 
 app.get("/api/v1/config", (c) => {
 	const domainsRaw = c.env.DOMAINS || "";
@@ -402,10 +409,59 @@ async function receiveEmail(event: { raw: ReadableStream; rawSize: number }, env
 		thread_id: threadId, message_id: originalMessageId, raw_headers: JSON.stringify(parsedEmail.headers),
 	}, attachmentData);
 
+	// DMARC aggregate reports arrive as email. Detect and divert to the
+	// dashboard rather than running the content classifier against what is
+	// obviously automated machine mail. See workers/dmarc/ingest.ts.
+	if (isDmarcReport(parsedEmail)) {
+		try {
+			const result = await ingestDmarcReport(env, mailboxId, messageId, parsedEmail);
+			if (result.ingested) {
+				await stub.moveEmail(messageId, Folders.ARCHIVE);
+				return;
+			}
+		} catch (e) {
+			console.error("dmarc ingest failed:", (e as Error).message);
+		}
+	}
+
+	// Security pipeline (opt-in per mailbox via settings.security.enabled).
+	// Runs synchronously so quarantine decisions are made before the agent
+	// auto-draft fires. See workers/security/index.ts.
+	let securityVerdict: Awaited<ReturnType<typeof runSecurityPipeline>>["verdict"] = null;
+	try {
+		const result = await runSecurityPipeline({
+			env,
+			mailboxId,
+			messageId,
+			parsedEmail: {
+				subject: parsedEmail.subject,
+				from: parsedEmail.from,
+				html: parsedEmail.html,
+				text: parsedEmail.text,
+				headers: parsedEmail.headers,
+			},
+		});
+		securityVerdict = result.verdict;
+		if (securityVerdict?.action === "quarantine" || securityVerdict?.action === "block") {
+			await stub.moveEmail(messageId, Folders.QUARANTINE);
+		}
+	} catch (e) {
+		console.error("Security pipeline failed:", (e as Error).message);
+	}
+
 	const agentStub = env.EMAIL_AGENT.get(env.EMAIL_AGENT.idFromName(mailboxId));
 	ctx.waitUntil(agentStub.fetch(new Request("https://agents/onNewEmail", {
 		method: "POST", headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ mailboxId, emailId: messageId, sender: (parsedEmail.from?.address || "").toLowerCase(), subject: parsedEmail.subject || "", threadId }),
+		body: JSON.stringify({
+			mailboxId,
+			emailId: messageId,
+			sender: (parsedEmail.from?.address || "").toLowerCase(),
+			subject: parsedEmail.subject || "",
+			threadId,
+			securityVerdict: securityVerdict
+				? { action: securityVerdict.action, score: securityVerdict.score, explanation: securityVerdict.explanation }
+				: null,
+		}),
 	})).catch((e) => console.error("Auto-draft trigger failed:", (e as Error).message)));
 }
 

--- a/workers/intel/bloom.ts
+++ b/workers/intel/bloom.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Tiny bloom filter for threat-intel membership checks.
+ *
+ * Purpose: cheap "is this URL/domain on a known-bad list" test without
+ * shipping a multi-MB list to every hot-path request. A positive match
+ * still triggers a secondary exact-match lookup (`BLOOM_KV.get(exact:<value>)`)
+ * before we act on it — bloom false-positives must not cause blocking.
+ *
+ * Sizing: m = ceil(-n * ln(p) / (ln(2))^2), k = ceil((m/n) * ln(2))
+ * For n = 100k entries, p = 0.01 → m ≈ 958k bits (≈120KB), k ≈ 7.
+ */
+
+const FNV_OFFSET_32 = 2166136261;
+const FNV_PRIME_32 = 16777619;
+
+/**
+ * FNV-1a 32-bit hash. Two independent hashes are derived by varying a seed;
+ * k hashes are built via the standard double-hashing construction
+ * h_i(x) = (h1(x) + i * h2(x)) mod m.
+ */
+function fnv1a(value: string, seed: number): number {
+	let hash = (FNV_OFFSET_32 ^ seed) >>> 0;
+	for (let i = 0; i < value.length; i++) {
+		hash ^= value.charCodeAt(i);
+		hash = Math.imul(hash, FNV_PRIME_32) >>> 0;
+	}
+	return hash >>> 0;
+}
+
+export interface BloomFilter {
+	bits: Uint8Array;
+	m: number;
+	k: number;
+}
+
+export function createBloom(n: number, p = 0.01): BloomFilter {
+	const m = Math.max(64, Math.ceil((-n * Math.log(p)) / Math.LN2 ** 2));
+	const mBytes = Math.ceil(m / 8);
+	const k = Math.max(1, Math.round((m / Math.max(n, 1)) * Math.LN2));
+	return { bits: new Uint8Array(mBytes), m, k };
+}
+
+function positions(value: string, m: number, k: number): number[] {
+	const h1 = fnv1a(value, 0x9e3779b9);
+	const h2 = fnv1a(value, 0x85ebca6b) || 1;
+	const out: number[] = new Array(k);
+	for (let i = 0; i < k; i++) {
+		out[i] = (h1 + i * h2) % m;
+	}
+	return out;
+}
+
+export function addToBloom(filter: BloomFilter, value: string) {
+	for (const pos of positions(value, filter.m, filter.k)) {
+		filter.bits[pos >>> 3] |= 1 << (pos & 7);
+	}
+}
+
+export function checkBloom(filter: BloomFilter, value: string): boolean {
+	for (const pos of positions(value, filter.m, filter.k)) {
+		if ((filter.bits[pos >>> 3] & (1 << (pos & 7))) === 0) return false;
+	}
+	return true;
+}
+
+/**
+ * Serialise to a compact binary with a 12-byte header:
+ *   bytes 0-3  "BLM1" magic
+ *   bytes 4-7  m (uint32 little-endian)
+ *   bytes 8-11 k (uint32 little-endian)
+ *   bytes 12+  bits
+ */
+export function serializeBloom(filter: BloomFilter): Uint8Array {
+	const out = new Uint8Array(12 + filter.bits.length);
+	out[0] = 0x42; out[1] = 0x4c; out[2] = 0x4d; out[3] = 0x31; // "BLM1"
+	const dv = new DataView(out.buffer);
+	dv.setUint32(4, filter.m, true);
+	dv.setUint32(8, filter.k, true);
+	out.set(filter.bits, 12);
+	return out;
+}
+
+export function deserializeBloom(buf: ArrayBuffer | Uint8Array): BloomFilter | null {
+	const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+	if (bytes.length < 12) return null;
+	if (bytes[0] !== 0x42 || bytes[1] !== 0x4c || bytes[2] !== 0x4d || bytes[3] !== 0x31) return null;
+	const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	const m = dv.getUint32(4, true);
+	const k = dv.getUint32(8, true);
+	const bits = bytes.slice(12);
+	return { bits, m, k };
+}

--- a/workers/intel/defaults.ts
+++ b/workers/intel/defaults.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Default threat-intel feeds shipped with the project.
+ *
+ * Each feed is a newline-delimited list of domains or URLs. The refresh
+ * worker tolerates comments (lines starting with `#`) and blank lines.
+ *
+ * Licensing notes for redistribution:
+ * - URLhaus is public-domain (CC0) — safe to mirror.
+ * - PhishTank requires an API key + attribution — ship as opt-in config only.
+ * - PhishDestroy / DestroyList publish plain text feeds; check their current
+ *   terms before redistributing aggregated copies from the hub.
+ * Consumers are free to add their own feeds via mailbox settings.
+ */
+
+export interface FeedDefinition {
+	id: string;
+	url: string;
+	/** `domain` feeds contain registrable hostnames; `url` feeds contain full URLs. */
+	kind: "domain" | "url";
+	refreshHours: number;
+	/** One-line human description. */
+	description: string;
+	/**
+	 * Optional per-feed extra request headers. Used for authenticated pulls
+	 * (e.g. hub destroylist with `Authorization: <api-key>`).
+	 */
+	headers?: Record<string, string>;
+}
+
+export const DEFAULT_FEEDS: FeedDefinition[] = [
+	{
+		id: "urlhaus",
+		url: "https://urlhaus.abuse.ch/downloads/text_online/",
+		kind: "url",
+		refreshHours: 1,
+		description: "abuse.ch URLhaus — active malicious URL feed (CC0).",
+	},
+	{
+		id: "openphish",
+		url: "https://openphish.com/feed.txt",
+		kind: "url",
+		refreshHours: 6,
+		description: "OpenPhish community phishing URL feed.",
+	},
+];

--- a/workers/intel/feeds.ts
+++ b/workers/intel/feeds.ts
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Threat-intel feed refresh and lookup.
+ *
+ * Refresh flow (runs on cron, see workers/app.ts scheduled handler):
+ *   1. Read mailbox list from R2.
+ *   2. For each mailbox with `intel.feeds`, fetch each feed (If-None-Match).
+ *   3. Parse entries (domain or URL, ignore `#` comments).
+ *   4. Build a bloom filter and store under KV key `intel:{feedId}:bloom`.
+ *   5. Also write an `intel:{feedId}:exact:<value>` marker for a subset of
+ *      high-confidence entries so we can confirm a bloom hit without false
+ *      positives. (Bounded to prevent runaway KV writes.)
+ *   6. Update `intel_feed_state` row on the mailbox DO.
+ *
+ * Lookup flow:
+ *   - `checkUrlAgainstFeeds(env, mailboxId, url)` — called by the security
+ *     pipeline. Returns `{ matched: true, feed: string }` on confirmed hit,
+ *     `null` otherwise.
+ */
+
+import type { Env } from "../types";
+import { DEFAULT_FEEDS, type FeedDefinition } from "./defaults";
+import {
+	addToBloom,
+	checkBloom,
+	createBloom,
+	deserializeBloom,
+	serializeBloom,
+} from "./bloom";
+import { getMailboxStub, listMailboxes } from "../lib/email-helpers";
+
+const EXACT_KEY_CAP = 2000; // per-feed cap — we only fast-path confirm up to this many
+
+function bloomKey(feedId: string) { return `intel:${feedId}:bloom`; }
+function exactKey(feedId: string, value: string) { return `intel:${feedId}:exact:${value}`; }
+
+export interface MailboxIntelSettings {
+	feeds?: Array<{
+		id: string;
+		url?: string;
+		kind?: "domain" | "url";
+		refresh_hours?: number;
+		headers?: Record<string, string>;
+		/** If set, reads header value from a Worker secret of this name at refresh time. */
+		auth_secret?: string;
+	}>;
+	hub?: {
+		url: string;
+		org_uuid: string;
+		api_key_secret_name: string;
+		auto_report: boolean;
+		default_sharing_group_uuid?: string;
+	};
+}
+
+async function loadMailboxIntelSettings(env: Env, mailboxId: string): Promise<MailboxIntelSettings> {
+	const obj = await env.BUCKET.get(`mailboxes/${mailboxId}.json`);
+	if (!obj) return {};
+	try {
+		const json = (await obj.json()) as { intel?: MailboxIntelSettings } | null;
+		return json?.intel ?? {};
+	} catch {
+		return {};
+	}
+}
+
+function resolveFeeds(env: Env, settings: MailboxIntelSettings): FeedDefinition[] {
+	const defaults = settings.feeds && settings.feeds.length > 0 ? [] : DEFAULT_FEEDS;
+	const byId = new Map<string, FeedDefinition>(DEFAULT_FEEDS.map((f) => [f.id, f]));
+	const user: FeedDefinition[] = [];
+	for (const f of settings.feeds ?? []) {
+		const base = byId.get(f.id);
+		const headers: Record<string, string> = { ...(f.headers ?? {}) };
+		if (f.auth_secret) {
+			const secretValue = (env as unknown as Record<string, string>)[f.auth_secret];
+			if (secretValue) headers["Authorization"] = secretValue;
+		}
+		user.push({
+			id: f.id,
+			url: f.url ?? base?.url ?? "",
+			kind: f.kind ?? base?.kind ?? "url",
+			refreshHours: f.refresh_hours ?? base?.refreshHours ?? 6,
+			description: base?.description ?? "User-configured feed",
+			headers: Object.keys(headers).length > 0 ? headers : undefined,
+		});
+	}
+	return [...defaults, ...user].filter((f) => f.url);
+}
+
+function parseFeedBody(body: string, kind: "domain" | "url"): string[] {
+	const lines = body.split(/\r?\n/);
+	const out: string[] = [];
+	for (const raw of lines) {
+		const line = raw.trim();
+		if (!line || line.startsWith("#")) continue;
+		if (kind === "domain") {
+			out.push(normalizeDomain(line));
+		} else {
+			out.push(line);
+			const host = safeHostname(line);
+			if (host) out.push(normalizeDomain(host));
+		}
+	}
+	return out;
+}
+
+function normalizeDomain(s: string): string {
+	return s.toLowerCase().replace(/^https?:\/\//, "").split(/[\/?#]/)[0];
+}
+
+function safeHostname(url: string): string | null {
+	try { return new URL(url).hostname.toLowerCase(); } catch { return null; }
+}
+
+/** Refresh all feeds across all mailboxes. Called from the cron handler. */
+export async function refreshAllFeeds(env: Env): Promise<{ feeds: number; entries: number }> {
+	if (!env.BLOOM_KV) {
+		console.warn("BLOOM_KV binding not configured — skipping intel feed refresh");
+		return { feeds: 0, entries: 0 };
+	}
+	const mailboxes = await listMailboxes(env.BUCKET);
+	const handled = new Set<string>();
+	let feeds = 0;
+	let entries = 0;
+	for (const { id: mailboxId } of mailboxes) {
+		const settings = await loadMailboxIntelSettings(env, mailboxId);
+		const resolved = resolveFeeds(env, settings);
+		for (const feed of resolved) {
+			if (handled.has(feed.id)) continue; // global, not per-mailbox, to avoid duplicate work
+			handled.add(feed.id);
+			try {
+				const refreshed = await refreshFeed(env, mailboxId, feed);
+				feeds++;
+				entries += refreshed.entries;
+			} catch (e) {
+				console.error(`feed refresh ${feed.id} failed:`, (e as Error).message);
+			}
+		}
+	}
+	return { feeds, entries };
+}
+
+async function refreshFeed(
+	env: Env,
+	mailboxId: string,
+	feed: FeedDefinition,
+): Promise<{ entries: number }> {
+	const stub = getMailboxStub(env, mailboxId);
+	const state = await stub.getIntelFeedState(feed.id);
+
+	const headers: Record<string, string> = { ...(feed.headers ?? {}) };
+	if (state?.etag) headers["If-None-Match"] = state.etag;
+
+	const res = await fetch(feed.url, { headers, signal: AbortSignal.timeout(15000) });
+	if (res.status === 304) return { entries: state?.entry_count ?? 0 };
+	if (!res.ok) throw new Error(`${feed.url} returned ${res.status}`);
+
+	const body = await res.text();
+	const values = parseFeedBody(body, feed.kind);
+	if (values.length === 0) return { entries: 0 };
+
+	const bloom = createBloom(values.length);
+	for (const v of values) addToBloom(bloom, v);
+	await env.BLOOM_KV.put(bloomKey(feed.id), serializeBloom(bloom), {
+		// Bounded TTL — a dead cron should eventually stop consulting stale data.
+		expirationTtl: Math.max(feed.refreshHours * 3600 * 4, 86400),
+	});
+
+	// Write a bounded subset of exact-match markers for secondary confirmation.
+	const exactSlice = values.slice(0, EXACT_KEY_CAP);
+	const writes: Promise<void>[] = [];
+	for (const v of exactSlice) {
+		writes.push(
+			env.BLOOM_KV
+				.put(exactKey(feed.id, v), "1", {
+					expirationTtl: feed.refreshHours * 3600 * 4,
+				})
+				.catch(() => {}), // isolated; individual failures shouldn't abort refresh
+		);
+	}
+	await Promise.all(writes);
+
+	await stub.upsertIntelFeedState(feed.id, {
+		url: feed.url,
+		last_fetched_at: new Date().toISOString(),
+		etag: res.headers.get("ETag") ?? null,
+		entry_count: values.length,
+		bloom_kv_key: bloomKey(feed.id),
+	});
+
+	return { entries: values.length };
+}
+
+export interface FeedMatch {
+	matched: true;
+	feedId: string;
+	value: string;
+	confirmed: boolean;
+}
+
+/**
+ * Check a URL's hostname and full URL against all configured feeds.
+ * Returns the first confirmed match, or the first bloom-only hit if no
+ * exact confirmations are available.
+ */
+export async function checkUrlAgainstFeeds(
+	env: Env,
+	mailboxId: string,
+	fullUrl: string,
+): Promise<FeedMatch | null> {
+	if (!env.BLOOM_KV) return null;
+	const host = safeHostname(fullUrl);
+	if (!host) return null;
+	const settings = await loadMailboxIntelSettings(env, mailboxId);
+	const feeds = resolveFeeds(env, settings);
+	let bloomOnly: FeedMatch | null = null;
+
+	for (const feed of feeds) {
+		const serialized = await env.BLOOM_KV.get(bloomKey(feed.id), "arrayBuffer");
+		if (!serialized) continue;
+		const filter = deserializeBloom(serialized);
+		if (!filter) continue;
+		const candidates = feed.kind === "domain" ? [host] : [fullUrl, host];
+		for (const v of candidates) {
+			if (!checkBloom(filter, v)) continue;
+			const exact = await env.BLOOM_KV.get(exactKey(feed.id, v), "text");
+			if (exact === "1") return { matched: true, feedId: feed.id, value: v, confirmed: true };
+			if (!bloomOnly) bloomOnly = { matched: true, feedId: feed.id, value: v, confirmed: false };
+		}
+	}
+	return bloomOnly;
+}

--- a/workers/intel/misp-client.ts
+++ b/workers/intel/misp-client.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * MISP-compatible client. Posts events to our hub (or any MISP instance that
+ * accepts the standard REST shape) and pulls the hub's published feeds.
+ *
+ * Auth matches MISP convention: `Authorization: <api-key>` (not Bearer).
+ */
+
+import type { MispEvent } from "./report";
+
+export interface MispClientConfig {
+	baseUrl: string;
+	apiKey: string;
+}
+
+export class MispClient {
+	constructor(private cfg: MispClientConfig) {}
+
+	async postEvent(event: MispEvent): Promise<{ uuid: string } | null> {
+		const res = await fetch(`${this.cfg.baseUrl.replace(/\/$/, "")}/events`, {
+			method: "POST",
+			headers: {
+				"Authorization": this.cfg.apiKey,
+				"Accept": "application/json",
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(event),
+			signal: AbortSignal.timeout(10000),
+		});
+		if (!res.ok) {
+			const body = await res.text().catch(() => "");
+			console.error(`hub POST /events ${res.status}: ${body.slice(0, 200)}`);
+			return null;
+		}
+		const json = (await res.json().catch(() => null)) as { Event?: { uuid?: string } } | null;
+		return json?.Event?.uuid ? { uuid: json.Event.uuid } : null;
+	}
+
+	async fetchDestroyList(): Promise<string[]> {
+		const res = await fetch(`${this.cfg.baseUrl.replace(/\/$/, "")}/feeds/destroylist.txt`, {
+			headers: { "Authorization": this.cfg.apiKey, "Accept": "text/plain" },
+			signal: AbortSignal.timeout(10000),
+		});
+		if (!res.ok) return [];
+		const body = await res.text();
+		return body.split(/\r?\n/).map((s) => s.trim()).filter((s) => s && !s.startsWith("#"));
+	}
+}

--- a/workers/intel/report.ts
+++ b/workers/intel/report.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Build a MISP-compatible event from a locally-classified phish.
+ *
+ * Anonymization policy (applied here, asserted by tests in `report.test.ts`
+ * once we add them): strip the `to`/`cc`/`bcc` recipients, keep the `from`
+ * address and domain, keep the subject, replace the body with a sha256 hash,
+ * keep all extracted URLs verbatim (those ARE the shareable intel).
+ *
+ * The client in `misp-client.ts` handles transport + auth.
+ */
+
+export interface LocalPhishReportInput {
+	/** Reporting org UUID assigned by the hub. */
+	orgUuid?: string;
+	/** Desired MISP sharing group for this event. */
+	sharingGroupUuid?: string;
+	/** Short human-readable title ("Invoice phish impersonating Acme"). */
+	info: string;
+	/** Reporter's observation time (ISO 8601). */
+	observedAt: string;
+	sender: string;
+	subject: string;
+	/** Parsed body as plain text. */
+	bodyText: string;
+	urls: Array<{ url: string; hostname: string }>;
+	/** Optional attachment SHA-256 hashes. */
+	attachmentSha256?: string[];
+}
+
+export interface MispEvent {
+	Event: {
+		uuid: string;
+		info: string;
+		date: string; // YYYY-MM-DD
+		timestamp: string; // unix seconds as string, per MISP convention
+		analysis: "0" | "1" | "2";
+		threat_level_id: "1" | "2" | "3" | "4";
+		distribution: "0" | "1" | "2" | "3" | "4";
+		orgc_uuid?: string;
+		sharing_group_uuid?: string;
+		Tag: Array<{ name: string }>;
+		Attribute: Array<{
+			uuid: string;
+			type: string;
+			category: string;
+			value: string;
+			to_ids: boolean;
+			comment?: string;
+		}>;
+	};
+}
+
+async function sha256(s: string): Promise<string> {
+	const data = new TextEncoder().encode(s);
+	const hash = await crypto.subtle.digest("SHA-256", data);
+	return Array.from(new Uint8Array(hash))
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+export async function buildMispEvent(input: LocalPhishReportInput): Promise<MispEvent> {
+	const now = new Date();
+	const date = now.toISOString().slice(0, 10);
+	const timestamp = Math.floor(now.getTime() / 1000).toString();
+
+	const bodyHash = await sha256(input.bodyText);
+	const senderDomain = input.sender.split("@")[1] ?? "";
+
+	const attrs: MispEvent["Event"]["Attribute"] = [];
+
+	attrs.push({
+		uuid: crypto.randomUUID(),
+		type: "email-src",
+		category: "Payload delivery",
+		value: input.sender,
+		to_ids: true,
+		comment: "Reported sender",
+	});
+	if (senderDomain) {
+		attrs.push({
+			uuid: crypto.randomUUID(),
+			type: "email-src-display-name",
+			category: "Payload delivery",
+			value: senderDomain,
+			to_ids: false,
+		});
+	}
+	attrs.push({
+		uuid: crypto.randomUUID(),
+		type: "email-subject",
+		category: "Payload delivery",
+		value: input.subject.slice(0, 500),
+		to_ids: false,
+	});
+	attrs.push({
+		uuid: crypto.randomUUID(),
+		type: "sha256",
+		category: "Payload delivery",
+		value: bodyHash,
+		to_ids: false,
+		comment: "sha256 of plain-text body",
+	});
+	for (const u of input.urls) {
+		attrs.push({
+			uuid: crypto.randomUUID(),
+			type: "url",
+			category: "Network activity",
+			value: u.url,
+			to_ids: true,
+		});
+		attrs.push({
+			uuid: crypto.randomUUID(),
+			type: "domain",
+			category: "Network activity",
+			value: u.hostname,
+			to_ids: true,
+		});
+	}
+	for (const h of input.attachmentSha256 ?? []) {
+		attrs.push({
+			uuid: crypto.randomUUID(),
+			type: "sha256",
+			category: "Payload delivery",
+			value: h,
+			to_ids: true,
+			comment: "Attachment SHA-256",
+		});
+	}
+
+	return {
+		Event: {
+			uuid: crypto.randomUUID(),
+			info: input.info.slice(0, 256),
+			date,
+			timestamp,
+			analysis: "1",
+			threat_level_id: "2",
+			// Distribution 4 = sharing group. `orgc_uuid` + `sharing_group_uuid`
+			// identify which org shared it and to whom. Hub validates the caller
+			// matches orgc_uuid via API key.
+			distribution: input.sharingGroupUuid ? "4" : "1",
+			orgc_uuid: input.orgUuid,
+			sharing_group_uuid: input.sharingGroupUuid,
+			Tag: [
+				{ name: 'type:"OSINT"' },
+				{ name: 'tlp:"amber"' },
+				{ name: 'misp-galaxy:mitre-attack-pattern="T1566"' },
+				{ name: "phishing" },
+			],
+			Attribute: attrs,
+		},
+	};
+}

--- a/workers/mcp/index.ts
+++ b/workers/mcp/index.ts
@@ -403,7 +403,7 @@ export class EmailMCP extends McpAgent<Env> {
 		// ── move_email ─────────────────────────────────────────────
 		this.server.tool(
 			"move_email",
-			"Move an email to a different folder (inbox, sent, draft, archive, trash).",
+			"Move an email to a different folder (inbox, sent, draft, archive, trash, quarantine).",
 			{
 				mailboxId: z.string().describe("The mailbox email address"),
 				emailId: z.string().describe("The email ID"),

--- a/workers/routes/cases.ts
+++ b/workers/routes/cases.ts
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Case REST endpoints. Mounted under
+ * `/api/v1/mailboxes/:mailboxId/cases`.
+ *
+ * The report-as-phish flow also triggers an optional hub push — see
+ * `workers/intel/report.ts` + `workers/intel/misp-client.ts`. That's wired up
+ * in M7 once the hub project exists; for now cases are local-only and
+ * `shared_to_hub = 0`.
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import type { EmailFull } from "../lib/schemas";
+import { requireMailbox, type MailboxContext } from "../lib/mailbox";
+import { extractUrls } from "../security/urls";
+import { stripHtmlToText } from "../lib/email-helpers";
+import { buildMispEvent } from "../intel/report";
+import { MispClient } from "../intel/misp-client";
+
+export const caseRoutes = new Hono<MailboxContext>();
+
+caseRoutes.use("*", requireMailbox);
+
+const CreateCaseBody = z.object({
+	title: z.string().min(1).max(500),
+	notes: z.string().optional(),
+	emailId: z.string().optional(),
+	observables: z.array(z.object({
+		kind: z.string().min(1).max(32),
+		value: z.string().min(1).max(500),
+	})).optional(),
+});
+
+const UpdateCaseBody = z.object({
+	status: z.enum(["open", "closed-tp", "closed-fp", "closed-dup"]).optional(),
+	notes: z.string().optional(),
+});
+
+const ReportPhishBody = z.object({ emailId: z.string().min(1) });
+
+caseRoutes.get("/", async (c) => {
+	const status = c.req.query("status") ?? undefined;
+	const limit = Number(c.req.query("limit") ?? 50);
+	const cases = await c.var.mailboxStub.listCases({ status, limit });
+	return c.json({ cases });
+});
+
+caseRoutes.post("/", async (c) => {
+	const parsed = CreateCaseBody.safeParse(await c.req.json().catch(() => null));
+	if (!parsed.success) return c.json({ error: parsed.error.flatten() }, 400);
+	const result = await c.var.mailboxStub.createCase(parsed.data);
+	return c.json(result, 201);
+});
+
+caseRoutes.get("/:caseId", async (c) => {
+	const caseData = await c.var.mailboxStub.getCase(c.req.param("caseId"));
+	if (!caseData) return c.json({ error: "Not found" }, 404);
+	return c.json({ case: caseData });
+});
+
+caseRoutes.patch("/:caseId", async (c) => {
+	const parsed = UpdateCaseBody.safeParse(await c.req.json().catch(() => null));
+	if (!parsed.success) return c.json({ error: parsed.error.flatten() }, 400);
+	await c.var.mailboxStub.updateCase(c.req.param("caseId"), parsed.data);
+	return c.json({ ok: true });
+});
+
+caseRoutes.delete("/:caseId", async (c) => {
+	await c.var.mailboxStub.deleteCase(c.req.param("caseId"));
+	return c.json({ ok: true });
+});
+
+/**
+ * Shortcut: take an email id, auto-extract observables, create a case.
+ * The UI's "Report phish" button hits this endpoint.
+ */
+caseRoutes.post("/report-phish", async (c) => {
+	const parsed = ReportPhishBody.safeParse(await c.req.json().catch(() => null));
+	if (!parsed.success) return c.json({ error: parsed.error.flatten() }, 400);
+	const { emailId } = parsed.data;
+
+	const email = (await c.var.mailboxStub.getEmail(emailId)) as EmailFull | null;
+	if (!email) return c.json({ error: "Email not found" }, 404);
+
+	const urls = extractUrls(email.body || "");
+	const observables: Array<{ kind: string; value: string }> = [];
+	if (email.sender) observables.push({ kind: "email", value: email.sender });
+	for (const u of urls) {
+		observables.push({ kind: "url", value: u.url });
+		observables.push({ kind: "domain", value: u.hostname });
+	}
+
+	const { id } = await c.var.mailboxStub.createCase({
+		title: `Reported phish: ${email.subject || "(no subject)"}`,
+		notes: `Reported from email ${emailId}. Sender: ${email.sender}.`,
+		emailId,
+		observables,
+	});
+
+	// Reputation penalty on the sender so the pipeline flags future mail.
+	if (email.sender) {
+		await c.var.mailboxStub.flagSender(email.sender, true).catch(() => {});
+	}
+
+	// Optional push to the community hub. Mailbox must opt in via
+	// `intel.hub.auto_report = true` and configure hub credentials.
+	let hubUuid: string | null = null;
+	try {
+		const mailboxId = c.req.param("mailboxId");
+		if (mailboxId) {
+			const hub = await loadHubSettings(c.env.BUCKET, mailboxId);
+			if (hub?.auto_report) {
+				const apiKey = (c.env as unknown as Record<string, string | undefined>)[hub.api_key_secret_name];
+				if (apiKey && hub.url && hub.org_uuid) {
+					const event = await buildMispEvent({
+						orgUuid: hub.org_uuid,
+						sharingGroupUuid: hub.default_sharing_group_uuid,
+						info: email.subject || "Reported phish",
+						observedAt: email.date,
+						sender: email.sender,
+						subject: email.subject || "",
+						bodyText: stripHtmlToText(email.body || "").slice(0, 10_000),
+						urls: urls.map((u) => ({ url: u.url, hostname: u.hostname })),
+					});
+					const client = new MispClient({ baseUrl: hub.url, apiKey });
+					const posted = await client.postEvent(event);
+					if (posted?.uuid) {
+						hubUuid = posted.uuid;
+						await c.var.mailboxStub.updateCase(id, {
+							shared_to_hub: true,
+							hub_event_uuid: posted.uuid,
+						});
+					}
+				}
+			}
+		}
+	} catch (e) {
+		console.error("hub report failed:", (e as Error).message);
+	}
+
+	return c.json({ caseId: id, hubEventUuid: hubUuid }, 201);
+});
+
+async function loadHubSettings(
+	bucket: R2Bucket,
+	mailboxId: string,
+): Promise<{
+	url: string;
+	org_uuid: string;
+	api_key_secret_name: string;
+	auto_report: boolean;
+	default_sharing_group_uuid?: string;
+} | null> {
+	const obj = await bucket.get(`mailboxes/${mailboxId}.json`);
+	if (!obj) return null;
+	try {
+		const json = (await obj.json()) as { intel?: { hub?: unknown } } | null;
+		return (json?.intel?.hub as ReturnType<typeof loadHubSettings> extends Promise<infer T> ? T : never) ?? null;
+	} catch {
+		return null;
+	}
+}

--- a/workers/routes/dmarc.ts
+++ b/workers/routes/dmarc.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * DMARC dashboard REST endpoints. Mounted under
+ * `/api/v1/mailboxes/:mailboxId/dmarc`.
+ */
+
+import { Hono } from "hono";
+import { requireMailbox, type MailboxContext } from "../lib/mailbox";
+
+export const dmarcRoutes = new Hono<MailboxContext>();
+
+dmarcRoutes.use("*", requireMailbox);
+
+dmarcRoutes.get("/reports", async (c) => {
+	const domain = c.req.query("domain") ?? undefined;
+	const limit = Number(c.req.query("limit") ?? 50);
+	const offset = Number(c.req.query("offset") ?? 0);
+	const reports = await c.var.mailboxStub.listDmarcReports({ domain, limit, offset });
+	return c.json({ reports });
+});
+
+dmarcRoutes.get("/reports/:reportId/records", async (c) => {
+	const reportId = c.req.param("reportId");
+	const records = await c.var.mailboxStub.getDmarcRecords(reportId);
+	return c.json({ records });
+});
+
+dmarcRoutes.get("/summary", async (c) => {
+	const domain = c.req.query("domain");
+	if (!domain) return c.json({ error: "domain query param required" }, 400);
+	const summary = await c.var.mailboxStub.getDmarcSummary(domain);
+	return c.json({ domain, sources: summary });
+});

--- a/workers/security/auth.ts
+++ b/workers/security/auth.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * SPF/DKIM/DMARC verdict extraction from `Authentication-Results` headers.
+ *
+ * Cloudflare Email Routing preserves upstream auth headers and adds its own.
+ * This parser handles the IANA-standard `Authentication-Results` format plus
+ * the common Gmail and Microsoft variants.
+ */
+
+export type AuthResult =
+	| "pass"
+	| "fail"
+	| "neutral"
+	| "none"
+	| "softfail"
+	| "temperror"
+	| "permerror";
+
+export interface AuthVerdict {
+	spf: AuthResult;
+	dkim: AuthResult;
+	dmarc: AuthResult;
+	/** The `authserv-id` that produced the verdict, if captured. */
+	authservId?: string;
+}
+
+export function emptyVerdict(): AuthVerdict {
+	return { spf: "none", dkim: "none", dmarc: "none" };
+}
+
+/**
+ * Extract `Authentication-Results` header value(s) from the raw-headers JSON
+ * that PostalMime produces. Each header entry is `{ key, value }`; the key
+ * casing varies across senders so we compare lowercased.
+ */
+function findAuthHeaders(rawHeaders: unknown): string[] {
+	if (!Array.isArray(rawHeaders)) return [];
+	const out: string[] = [];
+	for (const h of rawHeaders) {
+		if (!h || typeof h !== "object") continue;
+		const rec = h as { key?: unknown; name?: unknown; value?: unknown };
+		const key = rec.key ?? rec.name;
+		const value = rec.value;
+		if (typeof key !== "string" || typeof value !== "string") continue;
+		if (key.toLowerCase() === "authentication-results") out.push(value);
+	}
+	return out;
+}
+
+const RESULT_RE = /(spf|dkim|dmarc)\s*=\s*(pass|fail|neutral|none|softfail|temperror|permerror)/gi;
+
+export function parseAuthResults(rawHeaders: unknown): AuthVerdict {
+	const verdict = emptyVerdict();
+	const headerValues = findAuthHeaders(rawHeaders);
+	if (headerValues.length === 0) return verdict;
+
+	for (const raw of headerValues) {
+		if (!verdict.authservId) {
+			const firstToken = raw.split(";")[0]?.trim();
+			if (firstToken && !firstToken.includes("=")) verdict.authservId = firstToken;
+		}
+		for (const match of raw.matchAll(RESULT_RE)) {
+			const method = match[1].toLowerCase() as "spf" | "dkim" | "dmarc";
+			const result = match[2].toLowerCase() as AuthResult;
+			// First verdict wins if multiple Authentication-Results headers
+			// disagree — we trust the innermost (first-listed) authserv-id.
+			if (verdict[method] === "none") verdict[method] = result;
+		}
+	}
+	return verdict;
+}
+
+/** Auth-signal score contribution (positive = suspicious). */
+export function scoreAuth(verdict: AuthVerdict): { score: number; reasons: string[] } {
+	const reasons: string[] = [];
+	let score = 0;
+	if (verdict.dmarc === "fail") { score += 20; reasons.push("DMARC failed"); }
+	if (verdict.spf === "fail" || verdict.spf === "softfail") { score += 10; reasons.push("SPF failed"); }
+	if (verdict.dkim === "fail") { score += 10; reasons.push("DKIM failed"); }
+	if (score > 30) score = 30;
+	if (verdict.dmarc === "pass") score -= 10;
+	return { score, reasons };
+}

--- a/workers/security/classification.ts
+++ b/workers/security/classification.ts
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * LLM-based content classification. One structured-output call per email.
+ *
+ * Tool-using agent triage (fetchUrlPreview, getSenderHistory, etc.) is layered
+ * on later — see `workers/security/tools.ts` (added in a follow-up milestone).
+ * The synchronous pipeline keeps latency bounded by avoiding tool loops here.
+ */
+
+import { stripHtmlToText } from "../lib/email-helpers";
+import type { AuthVerdict } from "./auth";
+
+export type ClassificationLabel =
+	| "safe"
+	| "spam"
+	| "phishing"
+	| "bec"
+	| "suspicious";
+
+export interface ClassificationResult {
+	label: ClassificationLabel;
+	confidence: number;
+	reasoning: string;
+}
+
+const SYSTEM_PROMPT = `You are an email security classifier. Classify the email into exactly ONE label and return a confidence and short reasoning.
+
+Labels:
+- safe: a normal email (newsletter, personal, business correspondence, automated transactional)
+- spam: unsolicited bulk/marketing content with no malicious intent
+- phishing: credential theft, fake login, malicious link, impersonates a known brand or service
+- bec: business email compromise — impersonates an executive, vendor, colleague to request wire transfer / gift cards / changes to banking details
+- suspicious: worrying signals but not clearly malicious; err here instead of safe when in doubt
+
+Return STRICT JSON in this exact shape:
+{"label": "safe"|"spam"|"phishing"|"bec"|"suspicious", "confidence": 0.0-1.0, "reasoning": "one short sentence"}
+
+No prose, no code fences, no preamble — just the JSON object.`;
+
+export async function classifyEmail(
+	ai: Ai,
+	input: {
+		subject: string;
+		sender: string;
+		bodyHtml: string;
+		auth: AuthVerdict;
+	},
+): Promise<ClassificationResult> {
+	const plain = stripHtmlToText(input.bodyHtml || "").slice(0, 4000);
+	const userMessage = `SENDER: ${input.sender}
+AUTH: spf=${input.auth.spf} dkim=${input.auth.dkim} dmarc=${input.auth.dmarc}
+SUBJECT: ${input.subject || "(no subject)"}
+
+BODY:
+${plain}`;
+
+	try {
+		const response = (await Promise.race([
+			ai.run(
+				// @ts-expect-error — model string not in generated union
+				"@cf/meta/llama-3.1-8b-instruct-fast",
+				{
+					messages: [
+						{ role: "system", content: SYSTEM_PROMPT },
+						{ role: "user", content: userMessage },
+					],
+					max_tokens: 200,
+					temperature: 0,
+				},
+			),
+			new Promise((_, reject) =>
+				setTimeout(() => reject(new Error("classify-timeout")), 5000),
+			),
+		])) as { response?: string };
+
+		return parseClassifierOutput(response?.response ?? "");
+	} catch (e) {
+		// Fail closed: unparsable / unavailable classifier → suspicious.
+		// We do NOT quarantine solely on classifier failure; the verdict
+		// aggregator combines with auth / URL / reputation signals.
+		console.error("classifyEmail failed:", (e as Error).message);
+		return { label: "suspicious", confidence: 0.3, reasoning: "classifier unavailable" };
+	}
+}
+
+function parseClassifierOutput(raw: string): ClassificationResult {
+	const trimmed = raw.trim();
+	// Try to locate the first { ... } block if the model wrapped it.
+	const match = trimmed.match(/\{[\s\S]*\}/);
+	if (!match) {
+		return { label: "suspicious", confidence: 0.3, reasoning: "classifier output not JSON" };
+	}
+	try {
+		const obj = JSON.parse(match[0]);
+		const label = normalizeLabel(obj.label);
+		const confidence = typeof obj.confidence === "number"
+			? Math.max(0, Math.min(1, obj.confidence))
+			: 0.5;
+		const reasoning = typeof obj.reasoning === "string" ? obj.reasoning.slice(0, 500) : "";
+		return { label, confidence, reasoning };
+	} catch {
+		return { label: "suspicious", confidence: 0.3, reasoning: "classifier output malformed" };
+	}
+}
+
+function normalizeLabel(raw: unknown): ClassificationLabel {
+	if (typeof raw !== "string") return "suspicious";
+	const s = raw.toLowerCase().trim();
+	if (s === "safe" || s === "spam" || s === "phishing" || s === "bec" || s === "suspicious") {
+		return s;
+	}
+	return "suspicious";
+}
+
+export function scoreClassification(result: ClassificationResult): { score: number; reasons: string[] } {
+	const map: Record<ClassificationLabel, number> = {
+		safe: 0, spam: 20, suspicious: 30, bec: 45, phishing: 50,
+	};
+	const base = map[result.label];
+	// Scale slightly by confidence so low-confidence high-severity labels
+	// don't slam the score; high-confidence safe stays at zero.
+	const scaled = Math.round(base * (0.5 + 0.5 * result.confidence));
+	const reasons = result.label === "safe"
+		? []
+		: [`classifier: ${result.label} (${Math.round(result.confidence * 100)}%)`];
+	return { score: scaled, reasons };
+}

--- a/workers/security/index.ts
+++ b/workers/security/index.ts
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Synchronous security pipeline. Runs inline during `receiveEmail()` between
+ * the email being stored to INBOX and the agent auto-draft trigger. Returns
+ * a verdict; the caller decides whether to move to QUARANTINE.
+ *
+ * Staged so latency stays bounded:
+ *   1. Parse SPF/DKIM/DMARC from raw headers               (µs)
+ *   2. Sender reputation lookup (per-mailbox SQLite)        (ms)
+ *   3. URL extraction + homograph/shortener heuristics      (ms)
+ *   4. LLM classification (Workers AI, 5s timeout)          (seconds)
+ *   5. Aggregate verdict (pure scoring function)            (µs)
+ *   6. Persist verdict + URLs + sender reputation           (ms)
+ *
+ * Async deep-scan (attachment OCR, URL fetch, RDAP) is enqueued by the caller
+ * once `workers/intel/deep-scan.ts` is wired up — out of scope for this
+ * module so the sync path has no dependency on Queue bindings.
+ */
+
+import type { Env } from "../types";
+import { getMailboxStub } from "../lib/email-helpers";
+import { parseAuthResults } from "./auth";
+import { classifyEmail } from "./classification";
+import { extractUrls } from "./urls";
+import { aggregateVerdict, type FinalVerdict } from "./verdict";
+import { getSecuritySettings } from "./settings";
+import { checkUrlAgainstFeeds, type FeedMatch } from "../intel/feeds";
+import { evaluateTriage, type IntelMatchInfo } from "./triage";
+
+export interface RunPipelineInput {
+	env: Env;
+	mailboxId: string;
+	messageId: string;
+	parsedEmail: {
+		subject?: string;
+		from?: { address?: string };
+		html?: string;
+		text?: string;
+		headers?: unknown;
+	};
+}
+
+export interface PipelineResult {
+	/** Null means the pipeline was skipped (security disabled for this mailbox). */
+	verdict: FinalVerdict | null;
+	skipped: boolean;
+}
+
+export async function runSecurityPipeline(input: RunPipelineInput): Promise<PipelineResult> {
+	const { env, mailboxId, messageId, parsedEmail } = input;
+	const settings = await getSecuritySettings(env, mailboxId);
+	if (!settings.enabled) return { verdict: null, skipped: true };
+
+	const sender = (parsedEmail.from?.address || "").toLowerCase();
+	const bodyHtml = parsedEmail.html || parsedEmail.text || "";
+	const subject = parsedEmail.subject || "";
+
+	// Cheap signals first — all below run in parallel-friendly order and
+	// complete in milliseconds. The classifier LLM call is the expensive
+	// stage (seconds); the triage tier checks below let us skip it entirely
+	// for clear-cut cases.
+	const auth = parseAuthResults(parsedEmail.headers);
+	const urls = extractUrls(bodyHtml);
+
+	// Intel feed lookup — first confirmed hit wins. Kept early (pre-triage)
+	// so the hard-block tier can short-circuit on it.
+	let intelMatch: FeedMatch | null = null;
+	for (const u of urls) {
+		const m = await checkUrlAgainstFeeds(env, mailboxId, u.url).catch(() => null);
+		if (!m) continue;
+		// Prefer confirmed over bloom-only; stop as soon as we have a confirmed hit.
+		if (m.confirmed) { intelMatch = m; break; }
+		if (!intelMatch) intelMatch = m;
+	}
+	const intelForTriage: IntelMatchInfo | null = intelMatch?.confirmed
+		? { matched: true, feedId: intelMatch.feedId, value: intelMatch.value, confirmed: true }
+		: null;
+
+	const stub = getMailboxStub(env, mailboxId);
+	const reputation = sender ? await stub.getSenderReputation(sender) : null;
+
+	// Triage tiers — may short-circuit the pipeline before we ever touch the LLM.
+	// See workers/security/triage.ts for the rules and invariants.
+	const triaged = evaluateTriage({
+		sender,
+		auth,
+		reputation,
+		urls,
+		intelMatch: intelForTriage,
+		settings,
+	});
+	if (triaged) {
+		let verdict: FinalVerdict = { ...triaged.verdict, triage: triaged.tier };
+		// Learning mode still applies — even a hard-block is downgraded to tag.
+		if (settings.learning_mode && (verdict.action === "quarantine" || verdict.action === "block")) {
+			verdict = { ...verdict, action: "tag" };
+		}
+		await persistAll(env, mailboxId, messageId, sender, verdict, urls);
+		return { verdict, skipped: false };
+	}
+
+	// Full path: LLM classification + aggregation.
+	const classification = await classifyEmail(env.AI, { subject, sender, bodyHtml, auth });
+
+	let verdict = aggregateVerdict(
+		{ auth, classification, urls, reputation },
+		settings.thresholds,
+	);
+
+	// Intel-feed boost. Confirmed hit bumps score by 20; unconfirmed bloom-only
+	// hit bumps by 5 (low-signal — bloom FPR is configured at ~1%).
+	const intelBoost = intelMatch?.confirmed ? 20 : intelMatch ? 5 : 0;
+	if (intelBoost > 0 && intelMatch) {
+		const newScore = Math.min(100, verdict.score + intelBoost);
+		const thresh = settings.thresholds;
+		const action = newScore >= thresh.block ? "block"
+			: newScore >= thresh.quarantine ? "quarantine"
+			: newScore >= thresh.tag ? "tag"
+			: "allow";
+		const label = intelMatch.confirmed ? "threat-intel match" : "threat-intel match (unconfirmed)";
+		const reason = `${label} (${intelMatch.feedId}: ${intelMatch.value})`;
+		verdict = {
+			...verdict,
+			score: newScore,
+			action,
+			signals: [...verdict.signals, reason],
+			explanation: [...verdict.signals.slice(0, 2), reason].slice(0, 4).join("; "),
+		};
+	}
+
+	// Learning mode never quarantines/blocks — cap at "tag".
+	if (settings.learning_mode && (verdict.action === "quarantine" || verdict.action === "block")) {
+		verdict = { ...verdict, action: "tag" };
+	}
+
+	await persistAll(env, mailboxId, messageId, sender, verdict, urls);
+	return { verdict, skipped: false };
+}
+
+/**
+ * Persist verdict + URL rows + sender reputation update. Best-effort: each
+ * step catches its own errors so a single failure doesn't lose the verdict
+ * for the caller.
+ */
+async function persistAll(
+	env: Env,
+	mailboxId: string,
+	messageId: string,
+	sender: string,
+	verdict: FinalVerdict,
+	urls: ReturnType<typeof extractUrls>,
+) {
+	const stub = getMailboxStub(env, mailboxId);
+	try {
+		await stub.persistSecurityVerdict(messageId, {
+			verdict_json: JSON.stringify(verdict),
+			score: verdict.score,
+			explanation: verdict.explanation,
+		});
+	} catch (e) {
+		console.error("persistSecurityVerdict failed:", (e as Error).message);
+	}
+
+	if (urls.length > 0) {
+		try {
+			await stub.insertUrls(
+				messageId,
+				urls.map((u) => ({
+					url: u.url,
+					display_text: u.display_text ?? null,
+					is_homograph: u.is_homograph ? 1 : 0,
+					is_shortener: u.is_shortener ? 1 : 0,
+				})),
+			);
+		} catch (e) {
+			console.error("insertUrls failed:", (e as Error).message);
+		}
+	}
+
+	if (sender) {
+		try {
+			await stub.upsertSenderReputation(sender, verdict.score);
+		} catch (e) {
+			console.error("upsertSenderReputation failed:", (e as Error).message);
+		}
+	}
+}
+
+export type { FinalVerdict } from "./verdict";
+export type { AuthVerdict } from "./auth";
+export type { ClassificationResult } from "./classification";

--- a/workers/security/reputation.ts
+++ b/workers/security/reputation.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Per-sender reputation tracking. Stored on the mailbox DO so each mailbox
+ * has its own view (senders that are trusted by one user can be new/untrusted
+ * for another — correct behaviour for a personal inbox).
+ */
+
+export interface SenderReputation {
+	sender: string;
+	first_seen: string;
+	last_seen: string;
+	message_count: number;
+	avg_score: number;
+	flagged: boolean;
+}
+
+export function scoreReputation(rep: SenderReputation | null): { score: number; reasons: string[] } {
+	const reasons: string[] = [];
+	let score = 0;
+	if (!rep || rep.message_count === 0) {
+		score += 5;
+		reasons.push("first-time sender");
+		return { score, reasons };
+	}
+	if (rep.flagged) { score += 15; reasons.push("sender previously flagged"); }
+	if (rep.avg_score > 70) { score -= 5; }
+	return { score, reasons };
+}

--- a/workers/security/settings.ts
+++ b/workers/security/settings.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Mailbox-level security settings, stored inline in `mailboxes/{id}.json`.
+ *
+ * Read-only helper — writes go through the existing mailbox settings route.
+ * New fields are optional so older mailbox JSON files load cleanly.
+ */
+
+import type { Env } from "../types";
+import { DEFAULT_THRESHOLDS, type VerdictThresholds } from "./verdict";
+
+/**
+ * Business-hours definition for the off-hours scrutiny tier.
+ *
+ * This is a *scoring* input — it tilts marginal verdicts, never decides them
+ * alone. See `workers/security/time-rules.ts` for the rationale (BEC / wire
+ * fraud is correlated with off-hours delivery). The short-circuit triage
+ * layer is intentionally NOT wired to this signal: a trusted allowlisted
+ * sender emailing at 3 AM is still a legitimate email.
+ */
+export interface BusinessHours {
+	/** IANA timezone, e.g. `America/New_York`. Invalid values fall back to no contribution. */
+	timezone: string;
+	/** Inclusive start hour in 24h local time. 7 means 07:00 counts as in-hours. */
+	start_hour: number;
+	/** Exclusive end hour in 24h local time. 19 means 19:00 counts as out-of-hours. */
+	end_hour: number;
+	/** When true, Saturday and Sunday count as outside business hours regardless of the hour. */
+	weekdays_only: boolean;
+	/** Master switch so existing mailboxes opt-in explicitly. Defaults to false. */
+	boost_on_off_hours: boolean;
+}
+
+export interface MailboxSecuritySettings {
+	enabled: boolean;
+	thresholds: VerdictThresholds;
+	/** Learning mode: tag only, never auto-quarantine. */
+	learning_mode: boolean;
+	/** Exact sender addresses (lowercased) that short-circuit to allow when DMARC passes. */
+	allowlist_senders: string[];
+	/** Registrable domains (lowercased) that short-circuit to allow when DMARC passes. */
+	allowlist_domains: string[];
+	/** Enable the hard-allow triage tier. Requires DMARC pass — never allowlist alone. */
+	trusted_auto_allow: boolean;
+	/**
+	 * History-based hard-allow: if a sender has ≥ this many prior messages
+	 * with avg_score < 20 (and DMARC passes), auto-allow without running the
+	 * classifier. Set to 0 to disable history-based hard-allow.
+	 */
+	trusted_auto_allow_min_messages: number;
+	/** Enable the hard-block triage tier on confirmed intel-feed hits or flagged senders. */
+	intel_auto_block: boolean;
+	/**
+	 * Optional per-mailbox business-hours policy. When present and
+	 * `boost_on_off_hours` is true, mail received outside the configured window
+	 * gets a small verdict-score boost. See `time-rules.ts`.
+	 */
+	business_hours?: BusinessHours;
+}
+
+export const DEFAULT_SECURITY_SETTINGS: MailboxSecuritySettings = {
+	enabled: false, // opt-in — existing mailboxes are unaffected until the user flips this
+	thresholds: DEFAULT_THRESHOLDS,
+	learning_mode: false,
+	allowlist_senders: [],
+	allowlist_domains: [],
+	trusted_auto_allow: true,
+	trusted_auto_allow_min_messages: 10,
+	intel_auto_block: true,
+};
+
+export async function getSecuritySettings(
+	env: Env,
+	mailboxId: string,
+): Promise<MailboxSecuritySettings> {
+	try {
+		const obj = await env.BUCKET.get(`mailboxes/${mailboxId}.json`);
+		if (!obj) return DEFAULT_SECURITY_SETTINGS;
+		const json = (await obj.json()) as { security?: Partial<MailboxSecuritySettings> } | null;
+		const raw = json?.security ?? {};
+		const merged: MailboxSecuritySettings = {
+			...DEFAULT_SECURITY_SETTINGS,
+			...raw,
+			thresholds: { ...DEFAULT_THRESHOLDS, ...(raw.thresholds ?? {}) },
+			// Defensive normalisation: everything in allowlists is lowercased so
+			// comparisons at runtime don't need to repeat the case fold.
+			allowlist_senders: (raw.allowlist_senders ?? DEFAULT_SECURITY_SETTINGS.allowlist_senders).map((s) => s.toLowerCase()),
+			allowlist_domains: (raw.allowlist_domains ?? DEFAULT_SECURITY_SETTINGS.allowlist_domains).map((s) => s.toLowerCase()),
+			// business_hours: only materialise if the user supplied at least a timezone.
+			// `boost_on_off_hours` defaults to false so a partially specified block is inert.
+			business_hours: raw.business_hours && raw.business_hours.timezone
+				? {
+					timezone: raw.business_hours.timezone,
+					start_hour: raw.business_hours.start_hour ?? 7,
+					end_hour: raw.business_hours.end_hour ?? 19,
+					weekdays_only: raw.business_hours.weekdays_only ?? true,
+					boost_on_off_hours: raw.business_hours.boost_on_off_hours ?? false,
+				}
+				: undefined,
+		};
+		return merged;
+	} catch (e) {
+		console.error("getSecuritySettings failed:", (e as Error).message);
+		return DEFAULT_SECURITY_SETTINGS;
+	}
+}

--- a/workers/security/triage.ts
+++ b/workers/security/triage.ts
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Layered short-circuit triage. Evaluated BEFORE the LLM classifier so we
+ * can skip the expensive stage for obvious-safe or obvious-malicious mail.
+ *
+ * Two tiers:
+ *   1. Hard block — confirmed intel-feed match OR explicitly flagged sender.
+ *      Quarantines immediately; classifier never runs.
+ *   2. Hard allow — DMARC pass AND (explicit allowlist OR trusted history).
+ *      Returns allow immediately; classifier never runs.
+ *
+ * Hard-block wins over hard-allow: if someone compromises a trusted sender
+ * and sends a URL we already know is malicious, we'd rather quarantine.
+ *
+ * IMPORTANT INVARIANT: hard-allow REQUIRES DMARC pass. Allowlist alone is
+ * never sufficient — that would let anyone spoof the From address of a
+ * trusted domain. DMARC pass is the bind between the From header and the
+ * actual sending infrastructure.
+ */
+
+import type { AuthVerdict } from "./auth";
+import type { SenderReputation } from "./reputation";
+import type { ClassificationResult } from "./classification";
+import type { ExtractedUrl } from "./urls";
+import type { FinalVerdict, VerdictThresholds } from "./verdict";
+import type { MailboxSecuritySettings } from "./settings";
+
+export interface IntelMatchInfo {
+	matched: true;
+	feedId: string;
+	value: string;
+	confirmed: boolean;
+}
+
+export interface TriageInputs {
+	sender: string;
+	auth: AuthVerdict;
+	reputation: SenderReputation | null;
+	urls: ExtractedUrl[];
+	intelMatch: IntelMatchInfo | null;
+	settings: MailboxSecuritySettings;
+}
+
+export interface TriageResult {
+	verdict: FinalVerdict;
+	tier: "hard_block" | "hard_allow";
+	reason: string;
+}
+
+const SKIP_CLASSIFICATION: ClassificationResult = {
+	label: "safe",
+	confidence: 1.0,
+	reasoning: "classifier skipped by triage",
+};
+
+export function evaluateTriage(inputs: TriageInputs): TriageResult | null {
+	const { settings } = inputs;
+
+	// Tier 1: hard block — runs first so a compromised-but-allowlisted
+	// sender who's sending a known-bad URL still gets stopped.
+	if (settings.intel_auto_block) {
+		const block = evaluateHardBlock(inputs);
+		if (block) return block;
+	}
+
+	// Tier 2: hard allow — requires DMARC pass in ALL paths. See invariant above.
+	if (settings.trusted_auto_allow) {
+		const allow = evaluateHardAllow(inputs);
+		if (allow) return allow;
+	}
+
+	return null;
+}
+
+function evaluateHardBlock(inputs: TriageInputs): TriageResult | null {
+	const reasons: string[] = [];
+
+	if (inputs.reputation?.flagged) {
+		reasons.push(`sender flagged (${inputs.sender})`);
+	}
+	if (inputs.intelMatch?.confirmed) {
+		reasons.push(`confirmed intel hit (${inputs.intelMatch.feedId}: ${inputs.intelMatch.value})`);
+	}
+
+	if (reasons.length === 0) return null;
+
+	const verdict: FinalVerdict = {
+		action: "quarantine",
+		score: 100,
+		explanation: reasons.join("; "),
+		auth: inputs.auth,
+		classification: { ...SKIP_CLASSIFICATION, label: "phishing", reasoning: "classifier skipped by hard-block triage" },
+		signals: reasons,
+	};
+	return { verdict, tier: "hard_block", reason: reasons.join("; ") };
+}
+
+function evaluateHardAllow(inputs: TriageInputs): TriageResult | null {
+	// CRITICAL INVARIANT: require DMARC pass. Without it, anyone can spoof
+	// the From: address of a trusted domain.
+	if (inputs.auth.dmarc !== "pass") return null;
+
+	const senderMatch = inputs.settings.allowlist_senders.includes(inputs.sender);
+	const domain = inputs.sender.split("@")[1] ?? "";
+	const domainMatch = domain.length > 0 &&
+		(inputs.settings.allowlist_domains.includes(domain) ||
+			inputs.settings.allowlist_domains.some((d) => domain.endsWith("." + d)));
+
+	const reasons: string[] = [];
+	if (senderMatch) reasons.push(`sender on allowlist (${inputs.sender})`);
+	else if (domainMatch) reasons.push(`domain on allowlist (${domain})`);
+	else {
+		// History-based hard-allow: long-standing trusted sender.
+		const minMsgs = inputs.settings.trusted_auto_allow_min_messages;
+		const rep = inputs.reputation;
+		if (
+			minMsgs > 0 &&
+			rep &&
+			!rep.flagged &&
+			rep.message_count >= minMsgs &&
+			rep.avg_score < 20
+		) {
+			reasons.push(`trusted history (${rep.message_count} msgs, avg ${rep.avg_score.toFixed(0)})`);
+		} else {
+			return null;
+		}
+	}
+	reasons.push("DMARC pass");
+
+	const verdict: FinalVerdict = {
+		action: "allow",
+		score: 0,
+		explanation: reasons.join("; "),
+		auth: inputs.auth,
+		classification: SKIP_CLASSIFICATION,
+		signals: reasons,
+	};
+	return { verdict, tier: "hard_allow", reason: reasons.join("; ") };
+}

--- a/workers/security/urls.ts
+++ b/workers/security/urls.ts
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * URL extraction and synchronous heuristic scoring.
+ *
+ * Fetch-based enrichment (URL preview, redirect chain, RDAP) happens in the
+ * async deep-scan stage — see `workers/intel/deep-scan.ts`. Feed-based
+ * lookups (bloom filter against PhishDestroy/URLhaus lists) are applied by
+ * `workers/intel/feeds.ts` at the pipeline integration point.
+ */
+
+/** Domains whose typos are extremely high-value for phishers. */
+const HIGH_VALUE_DOMAINS = [
+	"google.com", "gmail.com", "googledrive.com", "googleusercontent.com",
+	"microsoft.com", "outlook.com", "office.com", "live.com", "microsoftonline.com",
+	"apple.com", "icloud.com",
+	"amazon.com", "amazon.co.uk", "amazonaws.com",
+	"paypal.com", "venmo.com", "zelle.com", "cashapp.com",
+	"facebook.com", "instagram.com", "meta.com", "whatsapp.com",
+	"dropbox.com", "box.com", "onedrive.com",
+	"adobe.com", "docusign.com", "docusign.net",
+	"github.com", "gitlab.com",
+	"linkedin.com", "twitter.com", "x.com",
+	"netflix.com", "spotify.com",
+	"bankofamerica.com", "chase.com", "wellsfargo.com", "citibank.com",
+	"hsbc.com", "barclays.com",
+	"cloudflare.com", "cloudflareaccess.com",
+];
+
+const SHORTENER_DOMAINS = new Set([
+	"bit.ly", "t.co", "tinyurl.com", "goo.gl", "ow.ly", "is.gd", "buff.ly",
+	"rebrand.ly", "cutt.ly", "shorturl.at", "rb.gy", "tiny.cc", "bl.ink",
+	"lnkd.in", "t.ly", "s.id", "v.gd", "qr.ae", "x.gd", "short.io",
+	"linktr.ee", "mcaf.ee", "trib.al", "dlvr.it",
+]);
+
+export interface ExtractedUrl {
+	url: string;
+	display_text?: string;
+	hostname: string;
+	is_homograph: boolean;
+	is_shortener: boolean;
+}
+
+const HREF_RE = /href\s*=\s*["']([^"']+)["']/gi;
+const BARE_URL_RE = /\bhttps?:\/\/[^\s<>"')]+/gi;
+const ANCHOR_RE = /<a\b[^>]*href\s*=\s*["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi;
+
+function stripTags(html: string): string {
+	return html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function safeHostname(url: string): string | null {
+	try {
+		const u = new URL(url);
+		return u.hostname.toLowerCase();
+	} catch {
+		return null;
+	}
+}
+
+/** Levenshtein distance — used for typo/homograph detection. */
+function levenshtein(a: string, b: string): number {
+	if (a === b) return 0;
+	const n = a.length, m = b.length;
+	if (n === 0) return m;
+	if (m === 0) return n;
+	let prev = new Array(m + 1);
+	let curr = new Array(m + 1);
+	for (let j = 0; j <= m; j++) prev[j] = j;
+	for (let i = 1; i <= n; i++) {
+		curr[0] = i;
+		for (let j = 1; j <= m; j++) {
+			const cost = a.charCodeAt(i - 1) === b.charCodeAt(j - 1) ? 0 : 1;
+			curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+		}
+		[prev, curr] = [curr, prev];
+	}
+	return prev[m];
+}
+
+/**
+ * Non-ASCII hostnames, bare punycode, or close Levenshtein matches to
+ * high-value domains are flagged as homographs. Legitimate mail practically
+ * never uses IDN hostnames; attackers use Cyrillic/Greek lookalikes.
+ */
+export function isHomographic(hostname: string): boolean {
+	for (let i = 0; i < hostname.length; i++) {
+		if (hostname.charCodeAt(i) > 127) return true;
+	}
+	if (hostname.includes("xn--")) return true;
+	for (const d of HIGH_VALUE_DOMAINS) {
+		if (hostname === d || hostname.endsWith("." + d)) return false;
+	}
+	const registrable = hostname.split(".").slice(-2).join(".");
+	for (const d of HIGH_VALUE_DOMAINS) {
+		const dist = levenshtein(registrable, d);
+		if (dist > 0 && dist <= 2) return true;
+	}
+	return false;
+}
+
+export function extractUrls(body: string | null | undefined, cap = 20): ExtractedUrl[] {
+	if (!body) return [];
+	const seen = new Set<string>();
+	const out: ExtractedUrl[] = [];
+
+	for (const match of body.matchAll(ANCHOR_RE)) {
+		if (out.length >= cap) break;
+		pushUrl(out, seen, match[1], stripTags(match[2]).slice(0, 200));
+	}
+	for (const match of body.matchAll(HREF_RE)) {
+		if (out.length >= cap) break;
+		pushUrl(out, seen, match[1]);
+	}
+	for (const match of body.matchAll(BARE_URL_RE)) {
+		if (out.length >= cap) break;
+		pushUrl(out, seen, match[0]);
+	}
+	return out;
+}
+
+function pushUrl(out: ExtractedUrl[], seen: Set<string>, rawUrl: string, display?: string) {
+	const hostname = safeHostname(rawUrl);
+	if (!hostname) return;
+	if (seen.has(rawUrl)) return;
+	seen.add(rawUrl);
+	const registrable = hostname.split(".").slice(-2).join(".");
+	out.push({
+		url: rawUrl,
+		display_text: display,
+		hostname,
+		is_homograph: isHomographic(hostname),
+		is_shortener: SHORTENER_DOMAINS.has(hostname) || SHORTENER_DOMAINS.has(registrable),
+	});
+}
+
+export function scoreUrls(urls: ExtractedUrl[]): { score: number; reasons: string[] } {
+	const reasons: string[] = [];
+	let score = 0;
+	const homograph = urls.find((u) => u.is_homograph);
+	if (homograph) { score += 20; reasons.push(`homograph URL (${homograph.hostname})`); }
+	const shortener = urls.find((u) => u.is_shortener);
+	if (shortener) { score += 5; reasons.push(`link shortener (${shortener.hostname})`); }
+	return { score, reasons };
+}

--- a/workers/security/verdict.ts
+++ b/workers/security/verdict.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Verdict aggregation — pure scoring function. No LLM call here.
+ *
+ * An LLM-final-judge was considered and rejected: it's opaque, adds latency
+ * per email, and makes the pipeline harder to audit for an open-source
+ * reference. The scoring function is deterministic given its inputs and
+ * users can tune thresholds in mailbox settings.
+ */
+
+import type { AuthVerdict } from "./auth";
+import type { ClassificationResult } from "./classification";
+import type { ExtractedUrl } from "./urls";
+import type { SenderReputation } from "./reputation";
+import { scoreAuth } from "./auth";
+import { scoreClassification } from "./classification";
+import { scoreUrls } from "./urls";
+import { scoreReputation } from "./reputation";
+
+export type VerdictAction = "allow" | "tag" | "quarantine" | "block";
+
+export interface FinalVerdict {
+	action: VerdictAction;
+	score: number;
+	explanation: string;
+	auth: AuthVerdict;
+	classification: ClassificationResult;
+	signals: string[];
+	/** If a triage tier short-circuited the pipeline, which one. */
+	triage?: "hard_allow" | "hard_block";
+}
+
+export interface VerdictInputs {
+	auth: AuthVerdict;
+	classification: ClassificationResult;
+	urls: ExtractedUrl[];
+	reputation: SenderReputation | null;
+}
+
+export interface VerdictThresholds {
+	tag: number;        // score >= this → tag
+	quarantine: number; // score >= this → quarantine
+	block: number;      // score >= this → block (reserved for SMTP-layer; treated as quarantine here)
+}
+
+export const DEFAULT_THRESHOLDS: VerdictThresholds = {
+	tag: 30,
+	quarantine: 60,
+	block: 80,
+};
+
+export function aggregateVerdict(
+	inputs: VerdictInputs,
+	thresholds: VerdictThresholds = DEFAULT_THRESHOLDS,
+): FinalVerdict {
+	const signals: string[] = [];
+	let score = 0;
+
+	const auth = scoreAuth(inputs.auth);
+	score += auth.score;
+	signals.push(...auth.reasons);
+
+	const cls = scoreClassification(inputs.classification);
+	score += cls.score;
+	signals.push(...cls.reasons);
+
+	const urls = scoreUrls(inputs.urls);
+	score += urls.score;
+	signals.push(...urls.reasons);
+
+	const rep = scoreReputation(inputs.reputation);
+	score += rep.score;
+	signals.push(...rep.reasons);
+
+	score = Math.max(0, Math.min(100, Math.round(score)));
+
+	let action: VerdictAction = "allow";
+	if (score >= thresholds.block) action = "block";
+	else if (score >= thresholds.quarantine) action = "quarantine";
+	else if (score >= thresholds.tag) action = "tag";
+
+	const explanation = signals.length > 0
+		? signals.slice(0, 4).join("; ")
+		: "no notable signals";
+
+	return {
+		action,
+		score,
+		explanation,
+		auth: inputs.auth,
+		classification: inputs.classification,
+		signals,
+	};
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -28,6 +28,20 @@
 			"preview_bucket_name": "agentic-inbox"
 		}
 	],
+	"kv_namespaces": [
+		{
+			"binding": "BLOOM_KV",
+			"id": "REPLACE_WITH_KV_NAMESPACE_ID",
+			"preview_id": "REPLACE_WITH_KV_NAMESPACE_ID"
+		}
+	],
+	"triggers": {
+		"crons": [
+			// Refresh threat-intel feeds hourly. Individual feeds respect their
+			// own refreshHours via ETag caching — the cron just wakes the worker.
+			"0 * * * *"
+		]
+	},
 	"ai": {
 		"binding": "AI"
 	},


### PR DESCRIPTION
## Summary

Adds an opt-in, community-driven email security layer on top of the existing agentic-inbox. Two pieces:

1. **Edge pipeline** (extends `agentic-inbox`) — per-mailbox inbound scanner that combines SPF/DKIM/DMARC, LLM classification (Workers AI), URL heuristics, threat-intel feed consumption, DMARC aggregate-report ingestion, and a TheHive-lite case workflow.
2. **Hub** (new `hub/` subproject) — MISP-compatible threat-intel hub with invite-based trust circles, API-key auth, trust-weighted aggregation, and a queue-backed LLM triage agent that suggests MISP taxonomy tags.

Everything is opt-in. Existing mailboxes are unchanged until `settings.security.enabled = true` is set in the mailbox R2 JSON.

## What's inside

### Security pipeline (`workers/security/`)
- `auth.ts` — SPF/DKIM/DMARC verdict extraction from `Authentication-Results` headers (handles IANA + Gmail + Microsoft variants).
- `urls.ts` — link extraction + synchronous homograph (non-ASCII / Levenshtein distance ≤2 from high-value domains) and shortener detection.
- `classification.ts` — Workers AI classifier call (`@cf/meta/llama-3.1-8b-instruct-fast`) with 5s timeout, Zod-shaped JSON verdict, fail-closed to `suspicious`.
- `reputation.ts` — per-sender rolling-average score tracking (on the mailbox DO).
- `verdict.ts` — deterministic scoring function mapping signals → `allow`/`tag`/`quarantine`/`block`. Thresholds configurable per mailbox. No LLM-final-judge — the scoring function is auditable.
- **`triage.ts` — layered short-circuit tiers**:
  - *Hard-block*: confirmed intel-feed hit OR flagged sender → quarantine immediately, LLM skipped.
  - *Hard-allow*: (sender/domain allowlist OR trusted history) **AND** DMARC pass → allow immediately, LLM skipped. DMARC pass is invariant — allowlist alone is never enough; that would undo exactly what DMARC exists to prevent.
- `settings.ts` — per-mailbox config schema with defaults designed so existing mailboxes behave identically until flipped.

### Threat intel (`workers/intel/`)
- `bloom.ts` — compact FNV-1a bloom filter with a `BLM1` binary header (stored in KV).
- `feeds.ts` — hourly cron refreshes configured feeds (default URLhaus + OpenPhish), builds a bloom + exact-match markers, exposes `checkUrlAgainstFeeds()` for the pipeline.
- `report.ts` + `misp-client.ts` — builds MISP events from locally-classified phish and posts to a configured hub.

### DMARC (`workers/dmarc/`)
- Detects RUA emails (sender / subject / attachment heuristics), gunzips via `DecompressionStream`, parses aggregate XML with a minimal hand-rolled tag extractor, stores per-source-IP stats.
- New React route `app/routes/dmarc.tsx` with a sending-sources table + recent-reports view.

### Cases (`workers/routes/cases.ts` + UI)
- CRUD + `/report-phish` shortcut that auto-extracts observables from an email, opens a local case, flags the sender, and optionally builds + posts a MISP event to the configured hub.
- UI: `ReportPhishButton` in the email toolbar, `cases.tsx` list view, `case-detail.tsx` with status transitions.

### Quarantine workflow
- New `Folders.QUARANTINE` constant, sidebar entry, migration `9_add_quarantine_folder`.
- `VerdictBadge` on email rows, `SecurityVerdictPanel` on the detail view (auth chips, classifier label, signals list, triage-tier pill).
- `Release to Inbox` action in the toolbar when viewing a quarantined email.

### Hub (`hub/` subproject)
- `src/routes/events.ts` — MISP-compatible `POST /events`, `GET /events/{uuid}`, `POST /events/restSearch` (subset).
- `src/routes/feeds.ts` — `GET /feeds/destroylist.txt` scoped by sharing group.
- `src/routes/orgs.ts` — invite-based signup: authenticated `POST /orgs/invite` + public `POST /orgs/accept`.
- `src/routes/sharing-groups.ts` — trust circles (MISP sharing-group semantics).
- `src/lib/auth.ts` — `Authorization: <key>` (MISP-native) or `Bearer` both supported; keys stored as sha256 hashes.
- `src/lib/aggregate.ts` — trust-weighted corroboration. Attributes promote to published feed at `score ≥ 2.0` AND `contributors ≥ 2` (both tunable).
- `src/agent/triage.ts` — Queue consumer that runs Workers AI to assign MISP taxonomy tags. **LLM output is intentionally non-load-bearing** — it cannot affect scoring or promotion, only tag text. That's the prompt-injection defense invariant.
- `migrations/0001_schema.sql` — orgs, sharing_groups, api_keys, invites, events, attributes, corroboration, tags.

### Schema migrations (edge)
- Migration `9_add_quarantine_folder`
- Migration `10_security_intel_dmarc_cases` — verdict columns on `emails` + `attachments`; new tables `urls`, `sender_reputation`, `intel_feed_state`, `dmarc_reports`, `dmarc_records`, `dmarc_sources`, `cases`, `case_emails`, `case_observables`.

## Why

The goal is an open-source reference for *agent-driven* email security that scales community intel (like MISP / PhishTank / PhishDestroy) into a per-user Cloudflare-native gateway. Two original-scope items — integrating Proxmox Mail Gateway and building attachment OCR — were ruled out during planning: PMG's deployment model clashes with Cloudflare Email Routing, and PDF/DOCX deep-scan hits Worker memory limits under load. Both are flagged as future work.

## What a reviewer should know

- **Opt-in**: Every new capability is gated by `mailboxes/{id}.json` settings. Default for new deployments is no behavioral change.
- **Hard-allow invariant**: `triage.ts` will never short-circuit to allow without DMARC pass. Allowlist alone is insufficient by design.
- **Hub prompt-injection defense**: The hub triage agent reads attacker-crafted event content; its LLM output controls *only* MISP tags, never scoring or promotion decisions.
- **Placeholders**: `wrangler.jsonc` ships with `REPLACE_WITH_KV_NAMESPACE_ID`; `hub/wrangler.jsonc` ships with `REPLACE_WITH_D1_DATABASE_ID`. Those are filled in at deploy time per the bootstrap steps in `hub/README.md`.
- **No tests yet** — a fixture-based pipeline test harness is scoped as a follow-up. `tsc -b` is green for both projects.
- **Deferred**: attachment deep-scan, URL fetch preview + RDAP, attachment-type gate tier, per-folder bypass tier, time-of-day scrutiny tier. Each has a scoped follow-up task.

## Test plan

- [ ] `npm install && npx tsc -b` passes in repo root
- [ ] `cd hub && npm install && npx tsc --noEmit` passes
- [ ] `npx wrangler kv namespace create BLOOM_KV` → paste id into `wrangler.jsonc`
- [ ] `cd hub && npx wrangler d1 create ais-hub` → paste id into `hub/wrangler.jsonc`; `npx wrangler d1 migrations apply ais-hub --remote`
- [ ] `npx wrangler queues create ais-hub-triage`
- [ ] Seed a bootstrap hub org + API key per `hub/README.md`
- [ ] On a test mailbox, set `settings.security.enabled = true`; send a phish-like email; confirm it lands in Quarantine with a verdict panel showing auth + classifier + signals
- [ ] Configure `settings.intel.hub.auto_report = true` with a hub key; click "Report as phish" on a test email; confirm `POST /events` lands on the hub and the case gains `hub_event_uuid`
- [ ] Drop a real Google DMARC aggregate report email into the mailbox; confirm `/mailbox/:id/dmarc` dashboard renders counts
- [ ] With `security.allowlist_senders` set + DMARC pass on the fixture, confirm the triage panel shows "allowlist fast-path" and no classifier call happened

🤖 Generated with [Claude Code](https://claude.com/claude-code)