### PR TITLE
Add security pipeline tests; fix reputation sign + multi-TLD gaps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
 				"typescript": "^5.8.3",
 				"vite": "^6.3.3",
 				"vite-tsconfig-paths": "^5.1.4",
+				"vitest": "^4.1.4",
 				"wrangler": "^4.74.0"
 			}
 		},
@@ -3505,6 +3506,17 @@
 				"url": "https://github.com/sponsors/ueberdosis"
 			}
 		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
 		"node_modules/@types/debug": {
 			"version": "4.1.12",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3513,6 +3525,13 @@
 			"dependencies": {
 				"@types/ms": "*"
 			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/dompurify": {
 			"version": "3.0.5",
@@ -3660,6 +3679,133 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 20"
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+			"integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.4",
+				"@vitest/utils": "4.1.4",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+			"integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.4",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+			"integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+			"integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.4",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner/node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+			"integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.4",
+				"@vitest/utils": "4.1.4",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot/node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+			"integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+			"integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.4",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/accepts": {
@@ -3869,6 +4015,16 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"license": "Python-2.0"
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/babel-dead-code-elimination": {
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/babel-dead-code-elimination/-/babel-dead-code-elimination-1.0.12.tgz",
@@ -4048,6 +4204,16 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/character-entities": {
@@ -4701,6 +4867,16 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/etag": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -4748,6 +4924,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/express": {
@@ -6908,6 +7094,17 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT"
+		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -8011,6 +8208,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8031,6 +8235,13 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/statuses": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -8039,6 +8250,13 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/string-width": {
 			"version": "7.2.0",
@@ -8179,6 +8397,23 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+			"integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.15",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8193,6 +8428,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/toidentifier": {
@@ -9166,6 +9411,110 @@
 				}
 			}
 		},
+		"node_modules/vitest": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+			"integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.4",
+				"@vitest/mocker": "4.1.4",
+				"@vitest/pretty-format": "4.1.4",
+				"@vitest/runner": "4.1.4",
+				"@vitest/snapshot": "4.1.4",
+				"@vitest/spy": "4.1.4",
+				"@vitest/utils": "4.1.4",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.4",
+				"@vitest/browser-preview": "4.1.4",
+				"@vitest/browser-webdriverio": "4.1.4",
+				"@vitest/coverage-istanbul": "4.1.4",
+				"@vitest/coverage-v8": "4.1.4",
+				"@vitest/ui": "4.1.4",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/es-module-lexer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vitest/node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.8",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -9185,6 +9534,23 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/workerd": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
 	"type": "module",
 	"cloudflare": {
 		"label": "Agentic Inbox",
-		"products": ["Workers", "Durable Objects", "R2", "Workers AI"],
+		"products": [
+			"Workers",
+			"Durable Objects",
+			"R2",
+			"Workers AI"
+		],
 		"bindings": {
 			"DOMAINS": {
 				"description": "Your domain with [Email Routing](https://developers.cloudflare.com/email-routing/) enabled (e.g. `example.com`). After deploying, create a catch-all Email Routing rule pointing to this Worker."
@@ -18,6 +23,8 @@
 		"deploy": "npm run build && wrangler deploy",
 		"dev": "react-router dev",
 		"preview": "npm run build && vite preview",
+		"test": "vitest run",
+		"test:watch": "vitest",
 		"typecheck": "npm run cf-typegen && react-router typegen && tsc -b"
 	},
 	"dependencies": {
@@ -93,6 +100,7 @@
 		"typescript": "^5.8.3",
 		"vite": "^6.3.3",
 		"vite-tsconfig-paths": "^5.1.4",
+		"vitest": "^4.1.4",
 		"wrangler": "^4.74.0"
 	}
 }

--- a/tests/dmarc/parser.test.ts
+++ b/tests/dmarc/parser.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { parseDmarcXml } from "../../workers/dmarc/parser";
+
+const SAMPLE = `<?xml version="1.0" encoding="UTF-8"?>
+<feedback>
+  <report_metadata>
+    <org_name>google.com</org_name>
+    <email>noreply-dmarc-support@google.com</email>
+    <report_id>12345678901234567890</report_id>
+    <date_range>
+      <begin>1700000000</begin>
+      <end>1700086400</end>
+    </date_range>
+  </report_metadata>
+  <policy_published>
+    <domain>example.com</domain>
+    <adkim>r</adkim>
+    <aspf>r</aspf>
+    <p>reject</p>
+    <sp>reject</sp>
+    <pct>100</pct>
+  </policy_published>
+  <record>
+    <row>
+      <source_ip>203.0.113.1</source_ip>
+      <count>42</count>
+      <policy_evaluated>
+        <disposition>none</disposition>
+        <dkim>pass</dkim>
+        <spf>pass</spf>
+      </policy_evaluated>
+    </row>
+    <identifiers>
+      <header_from>example.com</header_from>
+    </identifiers>
+    <auth_results>
+      <dkim><domain>example.com</domain><result>pass</result></dkim>
+      <spf><domain>example.com</domain><result>pass</result></spf>
+    </auth_results>
+  </record>
+  <record>
+    <row>
+      <source_ip>198.51.100.42</source_ip>
+      <count>7</count>
+      <policy_evaluated>
+        <disposition>reject</disposition>
+        <dkim>fail</dkim>
+        <spf>fail</spf>
+      </policy_evaluated>
+    </row>
+    <identifiers>
+      <header_from>example.com</header_from>
+    </identifiers>
+  </record>
+</feedback>`;
+
+describe("parseDmarcXml", () => {
+	it("parses top-level metadata", () => {
+		const r = parseDmarcXml(SAMPLE);
+		expect(r.org_name).toBe("google.com");
+		expect(r.report_id).toBe("12345678901234567890");
+		expect(r.date_range_begin).toBe("1700000000");
+		expect(r.date_range_end).toBe("1700086400");
+		expect(r.policy_domain).toBe("example.com");
+		expect(r.policy_p).toBe("reject");
+	});
+
+	it("parses each <record> into a DmarcRecord", () => {
+		const r = parseDmarcXml(SAMPLE);
+		expect(r.records).toHaveLength(2);
+		expect(r.records[0]).toMatchObject({
+			source_ip: "203.0.113.1",
+			count: 42,
+			disposition: "none",
+			dkim_result: "pass",
+			spf_result: "pass",
+			header_from: "example.com",
+		});
+		expect(r.records[1]).toMatchObject({
+			source_ip: "198.51.100.42",
+			count: 7,
+			disposition: "reject",
+			dkim_result: "fail",
+			spf_result: "fail",
+		});
+	});
+
+	it("caps `count` at 1,000,000 to guard against crafted reports", () => {
+		const xml = `<feedback><record><row><source_ip>1.2.3.4</source_ip><count>999999999</count></row></record></feedback>`;
+		const r = parseDmarcXml(xml);
+		expect(r.records[0].count).toBeLessThanOrEqual(1_000_000);
+	});
+
+	it("returns count=0 when the value is malformed", () => {
+		const xml = `<feedback><record><row><source_ip>1.2.3.4</source_ip><count>abc</count></row></record></feedback>`;
+		const r = parseDmarcXml(xml);
+		expect(r.records[0].count).toBe(0);
+	});
+
+	it("drops records that lack a source_ip", () => {
+		const xml = `<feedback><record><row><count>10</count></row></record></feedback>`;
+		const r = parseDmarcXml(xml);
+		expect(r.records).toEqual([]);
+	});
+
+	it("handles empty <feedback/> without throwing", () => {
+		expect(() => parseDmarcXml("<feedback></feedback>")).not.toThrow();
+	});
+});

--- a/tests/intel/bloom.test.ts
+++ b/tests/intel/bloom.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+	addToBloom,
+	checkBloom,
+	createBloom,
+	deserializeBloom,
+	serializeBloom,
+} from "../../workers/intel/bloom";
+
+describe("bloom filter", () => {
+	it("finds values it was given", () => {
+		const b = createBloom(1000);
+		for (const v of ["a.example", "b.example", "https://c.example/x"]) addToBloom(b, v);
+		for (const v of ["a.example", "b.example", "https://c.example/x"]) expect(checkBloom(b, v)).toBe(true);
+	});
+
+	it("respects its own p=0.01 FPR on modest inputs", () => {
+		const b = createBloom(1000, 0.01);
+		const kept = new Set<string>();
+		for (let i = 0; i < 1000; i++) {
+			const v = `entry-${i}.example.com`;
+			kept.add(v);
+			addToBloom(b, v);
+		}
+		let falsePositives = 0;
+		const probes = 5000;
+		for (let i = 0; i < probes; i++) {
+			const v = `probe-${i}.unknown.example`;
+			if (kept.has(v)) continue;
+			if (checkBloom(b, v)) falsePositives++;
+		}
+		// 1% target with ~5000 probes leaves plenty of headroom; we assert a
+		// loose upper bound so small hash quirks don't flake the suite.
+		expect(falsePositives / probes).toBeLessThan(0.05);
+	});
+
+	it("round-trips through serialize/deserialize", () => {
+		const b = createBloom(500);
+		for (let i = 0; i < 100; i++) addToBloom(b, `v${i}`);
+		const serialized = serializeBloom(b);
+		const restored = deserializeBloom(serialized);
+		expect(restored).not.toBeNull();
+		for (let i = 0; i < 100; i++) expect(checkBloom(restored!, `v${i}`)).toBe(true);
+	});
+
+	it("rejects invalid magic bytes on deserialize", () => {
+		const bad = new Uint8Array(16);
+		expect(deserializeBloom(bad)).toBeNull();
+	});
+
+	it("rejects truncated input on deserialize", () => {
+		expect(deserializeBloom(new Uint8Array(4))).toBeNull();
+	});
+});

--- a/tests/security/auth.test.ts
+++ b/tests/security/auth.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { emptyVerdict, parseAuthResults, scoreAuth } from "../../workers/security/auth";
+
+function header(name: string, value: string) {
+	return { key: name, value };
+}
+
+describe("parseAuthResults", () => {
+	it("returns all-none when no Authentication-Results header present", () => {
+		expect(parseAuthResults([header("from", "a@b.com")])).toEqual(emptyVerdict());
+	});
+
+	it("returns all-none when rawHeaders is not an array", () => {
+		expect(parseAuthResults(null)).toEqual(emptyVerdict());
+		expect(parseAuthResults(undefined)).toEqual(emptyVerdict());
+		expect(parseAuthResults("not-an-array")).toEqual(emptyVerdict());
+	});
+
+	it("parses a standard gmail-style Authentication-Results header", () => {
+		const verdict = parseAuthResults([
+			header(
+				"Authentication-Results",
+				"mx.google.com; spf=pass smtp.mailfrom=example.com; dkim=pass header.d=example.com; dmarc=pass header.from=example.com",
+			),
+		]);
+		expect(verdict).toMatchObject({ spf: "pass", dkim: "pass", dmarc: "pass", authservId: "mx.google.com" });
+	});
+
+	it("captures softfail/fail/temperror/permerror", () => {
+		const verdict = parseAuthResults([
+			header(
+				"Authentication-Results",
+				"srv1; spf=softfail smtp.mailfrom=x; dkim=fail; dmarc=temperror",
+			),
+		]);
+		expect(verdict).toMatchObject({ spf: "softfail", dkim: "fail", dmarc: "temperror" });
+	});
+
+	it("is case-insensitive on header key and result values", () => {
+		const verdict = parseAuthResults([
+			header("AUTHENTICATION-RESULTS", "authserv-x; SPF=Pass; DKIM=Fail; DMARC=None"),
+		]);
+		expect(verdict).toMatchObject({ spf: "pass", dkim: "fail", dmarc: "none", authservId: "authserv-x" });
+	});
+
+	it("first-verdict-wins across duplicate Authentication-Results headers", () => {
+		// Multiple Authentication-Results headers can appear when mail traverses
+		// several verifiers. We trust the first (outermost-recorded) result so a
+		// downstream relay cannot override an upstream failure verdict.
+		const verdict = parseAuthResults([
+			header("Authentication-Results", "inner; spf=fail; dkim=fail; dmarc=fail"),
+			header("Authentication-Results", "outer; spf=pass; dkim=pass; dmarc=pass"),
+		]);
+		expect(verdict).toMatchObject({ spf: "fail", dkim: "fail", dmarc: "fail", authservId: "inner" });
+	});
+
+	it("ignores irrelevant headers", () => {
+		const verdict = parseAuthResults([
+			header("DKIM-Signature", "v=1; a=rsa-sha256; dkim=pass"),
+			header("Received-SPF", "pass"),
+		]);
+		expect(verdict).toEqual(emptyVerdict());
+	});
+
+	it("captures authserv-id when no method results are present", () => {
+		const verdict = parseAuthResults([
+			header("Authentication-Results", "auth.example.com; none"),
+		]);
+		expect(verdict.authservId).toBe("auth.example.com");
+	});
+});
+
+describe("scoreAuth", () => {
+	it("scores a clean pass as a net-negative (credit)", () => {
+		const { score } = scoreAuth({ spf: "pass", dkim: "pass", dmarc: "pass" });
+		expect(score).toBe(-10);
+	});
+
+	it("scores a DMARC fail as suspicious", () => {
+		const { score, reasons } = scoreAuth({ spf: "pass", dkim: "pass", dmarc: "fail" });
+		expect(score).toBeGreaterThanOrEqual(20);
+		expect(reasons.join(" ")).toMatch(/DMARC/i);
+	});
+
+	it("caps multi-fail contribution at 30 (before DMARC-pass credit)", () => {
+		const { score } = scoreAuth({ spf: "fail", dkim: "fail", dmarc: "fail" });
+		expect(score).toBe(30);
+	});
+
+	it("scores SPF softfail identically to SPF fail (treats both as suspicious)", () => {
+		const softfail = scoreAuth({ spf: "softfail", dkim: "none", dmarc: "none" });
+		const fail = scoreAuth({ spf: "fail", dkim: "none", dmarc: "none" });
+		expect(softfail.score).toBe(fail.score);
+	});
+
+	it("returns zero for all-none (no auth headers present)", () => {
+		const { score } = scoreAuth(emptyVerdict());
+		expect(score).toBe(0);
+	});
+});

--- a/tests/security/reputation.test.ts
+++ b/tests/security/reputation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { scoreReputation } from "../../workers/security/reputation";
+
+describe("scoreReputation", () => {
+	it("adds +5 suspicion for first-time senders (null reputation)", () => {
+		const { score, reasons } = scoreReputation(null);
+		expect(score).toBe(5);
+		expect(reasons.join(" ")).toMatch(/first-time/i);
+	});
+
+	it("adds +5 suspicion when message_count is 0", () => {
+		const { score } = scoreReputation({
+			sender: "a@b.com",
+			first_seen: "",
+			last_seen: "",
+			message_count: 0,
+			avg_score: 0,
+			flagged: false,
+		});
+		expect(score).toBe(5);
+	});
+
+	it("adds +15 suspicion for a previously flagged sender", () => {
+		const { score, reasons } = scoreReputation({
+			sender: "a@b.com",
+			first_seen: "",
+			last_seen: "",
+			message_count: 10,
+			avg_score: 50,
+			flagged: true,
+		});
+		expect(score).toBe(15);
+		expect(reasons.join(" ")).toMatch(/flagged/i);
+	});
+
+	it("returns zero for a trusted sender with long benign history", () => {
+		const { score, reasons } = scoreReputation({
+			sender: "a@b.com",
+			first_seen: "",
+			last_seen: "",
+			message_count: 100,
+			avg_score: 5,
+			flagged: false,
+		});
+		expect(score).toBe(0);
+		expect(reasons).toEqual([]);
+	});
+
+	it("adds suspicion (never subtracts) for a sender with consistently bad history", () => {
+		// Regression: earlier versions subtracted from the score when
+		// avg_score was high, which inverted the reputation signal —
+		// a sender that has reliably been malicious in the past looked
+		// *less* suspicious to the aggregator than an unknown sender.
+		const { score } = scoreReputation({
+			sender: "a@b.com",
+			first_seen: "",
+			last_seen: "",
+			message_count: 20,
+			avg_score: 80,
+			flagged: false,
+		});
+		expect(score).toBeGreaterThanOrEqual(0);
+	});
+});

--- a/tests/security/triage.test.ts
+++ b/tests/security/triage.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import { evaluateTriage } from "../../workers/security/triage";
+import { DEFAULT_SECURITY_SETTINGS } from "../../workers/security/settings";
+import type { AuthVerdict } from "../../workers/security/auth";
+
+const dmarcPass: AuthVerdict = { spf: "pass", dkim: "pass", dmarc: "pass" };
+const dmarcFail: AuthVerdict = { spf: "fail", dkim: "fail", dmarc: "fail" };
+
+const baseSettings = {
+	...DEFAULT_SECURITY_SETTINGS,
+	enabled: true,
+	trusted_auto_allow: true,
+	intel_auto_block: true,
+};
+
+describe("evaluateTriage — hard block", () => {
+	it("quarantines on confirmed intel hit regardless of sender trust", () => {
+		const r = evaluateTriage({
+			sender: "ceo@trusted.com",
+			auth: dmarcPass,
+			reputation: null,
+			urls: [],
+			intelMatch: { matched: true, feedId: "urlhaus", value: "bad.example", confirmed: true },
+			settings: { ...baseSettings, allowlist_senders: ["ceo@trusted.com"] },
+		});
+		expect(r?.tier).toBe("hard_block");
+		expect(r?.verdict.action).toBe("quarantine");
+	});
+
+	it("does NOT hard-block on unconfirmed (bloom-only) intel hit", () => {
+		// Bloom FPR is ~1% — we never act on an unconfirmed hit alone.
+		const r = evaluateTriage({
+			sender: "x@y.com",
+			auth: dmarcFail,
+			reputation: null,
+			urls: [],
+			intelMatch: { matched: true, feedId: "f", value: "v", confirmed: false },
+			settings: baseSettings,
+		});
+		expect(r).toBeNull();
+	});
+
+	it("hard-blocks a sender that's been flagged on this mailbox", () => {
+		const r = evaluateTriage({
+			sender: "x@y.com",
+			auth: dmarcPass,
+			reputation: {
+				sender: "x@y.com",
+				first_seen: "",
+				last_seen: "",
+				message_count: 2,
+				avg_score: 40,
+				flagged: true,
+			},
+			urls: [],
+			intelMatch: null,
+			settings: baseSettings,
+		});
+		expect(r?.tier).toBe("hard_block");
+	});
+
+	it("is disabled when intel_auto_block is off", () => {
+		const r = evaluateTriage({
+			sender: "x@y.com",
+			auth: dmarcFail,
+			reputation: null,
+			urls: [],
+			intelMatch: { matched: true, feedId: "urlhaus", value: "v", confirmed: true },
+			settings: { ...baseSettings, intel_auto_block: false },
+		});
+		expect(r).toBeNull();
+	});
+});
+
+describe("evaluateTriage — hard allow", () => {
+	it("requires DMARC pass even for an explicit allowlist match", () => {
+		// Critical invariant: allowlist alone is insufficient.
+		const r = evaluateTriage({
+			sender: "ceo@trusted.com",
+			auth: dmarcFail,
+			reputation: null,
+			urls: [],
+			intelMatch: null,
+			settings: { ...baseSettings, allowlist_senders: ["ceo@trusted.com"] },
+		});
+		expect(r).toBeNull();
+	});
+
+	it("allows on explicit sender allowlist + DMARC pass", () => {
+		const r = evaluateTriage({
+			sender: "ceo@trusted.com",
+			auth: dmarcPass,
+			reputation: null,
+			urls: [],
+			intelMatch: null,
+			settings: { ...baseSettings, allowlist_senders: ["ceo@trusted.com"] },
+		});
+		expect(r?.tier).toBe("hard_allow");
+		expect(r?.verdict.action).toBe("allow");
+	});
+
+	it("allows on explicit domain allowlist + DMARC pass (exact)", () => {
+		const r = evaluateTriage({
+			sender: "anyone@trusted.com",
+			auth: dmarcPass,
+			reputation: null,
+			urls: [],
+			intelMatch: null,
+			settings: { ...baseSettings, allowlist_domains: ["trusted.com"] },
+		});
+		expect(r?.tier).toBe("hard_allow");
+	});
+
+	it("allows subdomains of allowlisted domains", () => {
+		const r = evaluateTriage({
+			sender: "bot@mail.trusted.com",
+			auth: dmarcPass,
+			reputation: null,
+			urls: [],
+			intelMatch: null,
+			settings: { ...baseSettings, allowlist_domains: ["trusted.com"] },
+		});
+		expect(r?.tier).toBe("hard_allow");
+	});
+
+	it("allows on history-based trust when min_messages threshold met", () => {
+		const r = evaluateTriage({
+			sender: "colleague@work.com",
+			auth: dmarcPass,
+			reputation: {
+				sender: "colleague@work.com",
+				first_seen: "",
+				last_seen: "",
+				message_count: 50,
+				avg_score: 5,
+				flagged: false,
+			},
+			urls: [],
+			intelMatch: null,
+			settings: { ...baseSettings, trusted_auto_allow_min_messages: 10 },
+		});
+		expect(r?.tier).toBe("hard_allow");
+	});
+
+	it("does not history-allow a flagged sender even if message_count is high", () => {
+		const r = evaluateTriage({
+			sender: "colleague@work.com",
+			auth: dmarcPass,
+			reputation: {
+				sender: "colleague@work.com",
+				first_seen: "",
+				last_seen: "",
+				message_count: 100,
+				avg_score: 80,
+				flagged: true,
+			},
+			urls: [],
+			intelMatch: null,
+			settings: { ...baseSettings, trusted_auto_allow_min_messages: 10 },
+		});
+		// hard_block tier (because flagged) trumps hard_allow
+		expect(r?.tier).toBe("hard_block");
+	});
+
+	it("returns null (falls through to full pipeline) when neither tier applies", () => {
+		const r = evaluateTriage({
+			sender: "stranger@nowhere.com",
+			auth: dmarcPass,
+			reputation: null,
+			urls: [],
+			intelMatch: null,
+			settings: baseSettings,
+		});
+		expect(r).toBeNull();
+	});
+});

--- a/tests/security/urls.test.ts
+++ b/tests/security/urls.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+	extractUrls,
+	isHomographic,
+	scoreUrls,
+	type ExtractedUrl,
+} from "../../workers/security/urls";
+
+describe("extractUrls", () => {
+	it("returns [] for empty/null input", () => {
+		expect(extractUrls(null)).toEqual([]);
+		expect(extractUrls(undefined)).toEqual([]);
+		expect(extractUrls("")).toEqual([]);
+	});
+
+	it("extracts an anchor href and its visible display text", () => {
+		const urls = extractUrls('<a href="https://example.com/login">Click here</a>');
+		expect(urls).toHaveLength(1);
+		expect(urls[0]).toMatchObject({
+			url: "https://example.com/login",
+			display_text: "Click here",
+			hostname: "example.com",
+		});
+	});
+
+	it("extracts bare URLs from plain text", () => {
+		const urls = extractUrls("Visit https://example.com/path now.");
+		expect(urls.map((u) => u.url)).toContain("https://example.com/path");
+	});
+
+	it("de-duplicates URLs by exact match", () => {
+		const urls = extractUrls(
+			'<a href="https://a.com/x">a</a> and <a href="https://a.com/x">b</a>',
+		);
+		expect(urls).toHaveLength(1);
+	});
+
+	it("caps output at the configured limit", () => {
+		const body = Array.from({ length: 30 }, (_, i) => `https://example${i}.com`).join(" ");
+		expect(extractUrls(body, 10)).toHaveLength(10);
+	});
+
+	it("ignores garbage that does not parse as a URL", () => {
+		expect(extractUrls('<a href="javascript:void(0)">x</a>')).toEqual([]);
+		expect(extractUrls("not a url")).toEqual([]);
+	});
+
+	it("flags shorteners on extracted URLs", () => {
+		const urls = extractUrls("https://bit.ly/abc and https://tinyurl.com/xyz");
+		expect(urls.every((u) => u.is_shortener)).toBe(true);
+	});
+
+	it("strips HTML from display_text", () => {
+		const urls = extractUrls('<a href="https://example.com"><b>Click <i>here</i></b></a>');
+		expect(urls[0].display_text).toBe("Click here");
+	});
+});
+
+describe("isHomographic", () => {
+	it("flags non-ASCII hostnames", () => {
+		expect(isHomographic("раypal.com")).toBe(true); // Cyrillic 'р'
+		expect(isHomographic("münchen.example")).toBe(true);
+	});
+
+	it("flags bare punycode hostnames", () => {
+		expect(isHomographic("xn--paypa-7ve.com")).toBe(true);
+	});
+
+	it("does NOT flag exact matches or subdomains of high-value domains", () => {
+		expect(isHomographic("paypal.com")).toBe(false);
+		expect(isHomographic("mail.google.com")).toBe(false);
+		expect(isHomographic("accounts.google.com")).toBe(false);
+	});
+
+	it("flags typo-squats of high-value .com domains (Lev dist 1–2)", () => {
+		expect(isHomographic("paypa1.com")).toBe(true);
+		expect(isHomographic("g00gle.com")).toBe(true);
+		expect(isHomographic("anazon.com")).toBe(true);
+	});
+
+	it("does not flag unrelated third-party domains", () => {
+		expect(isHomographic("openai.com")).toBe(false);
+		expect(isHomographic("rust-lang.org")).toBe(false);
+	});
+
+	it("handles multi-label public suffixes (amazon.co.uk and lookalikes)", () => {
+		// Regression: earlier versions used last-2-labels as the registrable
+		// domain, so `amazom.co.uk` was compared against `co.uk` (and slipped
+		// through), and the real `amazon.co.uk` was fine only because of the
+		// exact/suffix early return. Lookalikes of brands that are NOT in the
+		// high-value list still go undetected — that's by design; we'd need a
+		// broader brand database to catch those.
+		expect(isHomographic("amazon.co.uk")).toBe(false);
+		expect(isHomographic("amazom.co.uk")).toBe(true);
+	});
+});
+
+describe("scoreUrls", () => {
+	it("returns zero when all URLs are clean", () => {
+		const urls: ExtractedUrl[] = [
+			{ url: "https://a.com", hostname: "a.com", is_homograph: false, is_shortener: false },
+		];
+		expect(scoreUrls(urls)).toEqual({ score: 0, reasons: [] });
+	});
+
+	it("scores a homograph URL at +20", () => {
+		const urls: ExtractedUrl[] = [
+			{ url: "https://paypa1.com", hostname: "paypa1.com", is_homograph: true, is_shortener: false },
+		];
+		expect(scoreUrls(urls).score).toBe(20);
+	});
+
+	it("scores a shortener at +5", () => {
+		const urls: ExtractedUrl[] = [
+			{ url: "https://bit.ly/x", hostname: "bit.ly", is_homograph: false, is_shortener: true },
+		];
+		expect(scoreUrls(urls).score).toBe(5);
+	});
+
+	it("stacks homograph + shortener", () => {
+		const urls: ExtractedUrl[] = [
+			{ url: "https://bit.ly/x", hostname: "bit.ly", is_homograph: false, is_shortener: true },
+			{ url: "https://paypa1.com", hostname: "paypa1.com", is_homograph: true, is_shortener: false },
+		];
+		expect(scoreUrls(urls).score).toBe(25);
+	});
+});

--- a/tests/security/verdict.test.ts
+++ b/tests/security/verdict.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { aggregateVerdict, DEFAULT_THRESHOLDS } from "../../workers/security/verdict";
+import type { AuthVerdict } from "../../workers/security/auth";
+import type { ClassificationResult } from "../../workers/security/classification";
+
+const cleanAuth: AuthVerdict = { spf: "pass", dkim: "pass", dmarc: "pass" };
+const safeClass: ClassificationResult = { label: "safe", confidence: 0.9, reasoning: "ok" };
+
+describe("aggregateVerdict", () => {
+	it("produces allow for a clean, trusted email", () => {
+		const v = aggregateVerdict({
+			auth: cleanAuth,
+			classification: safeClass,
+			urls: [],
+			reputation: {
+				sender: "a@b.com",
+				first_seen: "2026-01-01T00:00:00Z",
+				last_seen: "2026-01-01T00:00:00Z",
+				message_count: 5,
+				avg_score: 5,
+				flagged: false,
+			},
+		});
+		expect(v.action).toBe("allow");
+		expect(v.score).toBeLessThan(DEFAULT_THRESHOLDS.tag);
+	});
+
+	it("quarantines on high-confidence phishing + DMARC fail", () => {
+		const v = aggregateVerdict({
+			auth: { spf: "fail", dkim: "fail", dmarc: "fail" },
+			classification: { label: "phishing", confidence: 0.95, reasoning: "fake login" },
+			urls: [
+				{ url: "https://paypa1.com", hostname: "paypa1.com", is_homograph: true, is_shortener: false },
+			],
+			reputation: null,
+		});
+		expect(["quarantine", "block"]).toContain(v.action);
+		expect(v.score).toBeGreaterThanOrEqual(DEFAULT_THRESHOLDS.quarantine);
+		expect(v.signals.length).toBeGreaterThan(0);
+	});
+
+	it("clamps score to [0, 100]", () => {
+		const v = aggregateVerdict({
+			auth: { spf: "fail", dkim: "fail", dmarc: "fail" },
+			classification: { label: "phishing", confidence: 1 , reasoning: "" },
+			urls: [
+				{ url: "https://paypa1.com", hostname: "paypa1.com", is_homograph: true, is_shortener: true },
+			],
+			reputation: { sender: "x", first_seen: "", last_seen: "", message_count: 1, avg_score: 99, flagged: true },
+		}, DEFAULT_THRESHOLDS);
+		expect(v.score).toBeLessThanOrEqual(100);
+		expect(v.score).toBeGreaterThanOrEqual(0);
+	});
+
+	it("never returns negative scores even when all signals are benign", () => {
+		// A clean-auth email with no other signals gets -10 from scoreAuth;
+		// the aggregate must floor that at 0.
+		const v = aggregateVerdict({
+			auth: cleanAuth,
+			classification: safeClass,
+			urls: [],
+			reputation: null, // first-time sender adds +5, so this caps negative
+		});
+		expect(v.score).toBeGreaterThanOrEqual(0);
+	});
+
+	it("explanation surfaces the first few signals", () => {
+		const v = aggregateVerdict({
+			auth: { spf: "fail", dkim: "fail", dmarc: "fail" },
+			classification: { label: "phishing", confidence: 0.9, reasoning: "" },
+			urls: [],
+			reputation: null,
+		});
+		expect(v.explanation.length).toBeGreaterThan(0);
+		expect(v.explanation).not.toBe("no notable signals");
+	});
+
+	it("respects custom thresholds", () => {
+		const base = {
+			auth: cleanAuth,
+			classification: { label: "spam" as const, confidence: 0.9, reasoning: "" },
+			urls: [],
+			reputation: null,
+		};
+		const strict = aggregateVerdict(base, { tag: 5, quarantine: 10, block: 20 });
+		const lenient = aggregateVerdict(base, { tag: 90, quarantine: 95, block: 99 });
+		expect(strict.action).not.toBe("allow");
+		expect(lenient.action).toBe("allow");
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Vitest config for the security pipeline modules.
+ *
+ * These modules are pure functions — parsing, scoring, and aggregation —
+ * and don't need the Workers runtime to run. We deliberately scope tests
+ * to `tests/` so `vitest` doesn't try to pick up build output or vendored
+ * fixtures. Workers-runtime-specific modules (DO, R2, KV) stay un-unit-
+ * tested here; they're exercised via integration against `wrangler dev`.
+ */
+export default defineConfig({
+	test: {
+		include: ["tests/**/*.test.ts"],
+		environment: "node",
+		globals: false,
+		reporters: ["default"],
+	},
+});

--- a/workers/security/reputation.ts
+++ b/workers/security/reputation.ts
@@ -26,6 +26,13 @@ export function scoreReputation(rep: SenderReputation | null): { score: number; 
 		return { score, reasons };
 	}
 	if (rep.flagged) { score += 15; reasons.push("sender previously flagged"); }
-	if (rep.avg_score > 70) { score -= 5; }
+	// Consistently-bad history adds suspicion. The score here is a small
+	// nudge rather than a hard signal — the `flagged` branch above is the
+	// deliberate-action path; this catches senders whose verdicts have been
+	// piling up without anyone flipping the flag.
+	if (rep.avg_score > 70) {
+		score += 10;
+		reasons.push(`bad sender history (avg ${rep.avg_score.toFixed(0)})`);
+	}
 	return { score, reasons };
 }

--- a/workers/security/urls.ts
+++ b/workers/security/urls.ts
@@ -82,6 +82,33 @@ function levenshtein(a: string, b: string): number {
 }
 
 /**
+ * Small allow-list of second-level country-code TLDs. The Public Suffix List
+ * is the "correct" answer but pulling it in costs ~200KB of compiled data
+ * per Worker; this 20-entry list covers the domains that matter for the
+ * high-value-domain homograph check (so `amazom.co.uk` is compared against
+ * `amazon.co.uk` rather than the nonsensical `co.uk`).
+ */
+const MULTI_LABEL_PUBLIC_SUFFIXES = new Set([
+	"co.uk", "co.jp", "co.kr", "co.nz", "co.za", "co.in",
+	"com.au", "com.br", "com.cn", "com.mx", "com.sg", "com.tr", "com.ar",
+	"ac.uk", "gov.uk", "org.uk", "net.au", "org.au",
+]);
+
+/**
+ * Extract the registrable (eTLD+1) portion of a hostname, handling common
+ * multi-label suffixes so we compare like-for-like against HIGH_VALUE_DOMAINS.
+ */
+function registrableDomain(hostname: string): string {
+	const parts = hostname.split(".");
+	if (parts.length < 2) return hostname;
+	const last2 = parts.slice(-2).join(".");
+	if (parts.length >= 3 && MULTI_LABEL_PUBLIC_SUFFIXES.has(last2)) {
+		return parts.slice(-3).join(".");
+	}
+	return last2;
+}
+
+/**
  * Non-ASCII hostnames, bare punycode, or close Levenshtein matches to
  * high-value domains are flagged as homographs. Legitimate mail practically
  * never uses IDN hostnames; attackers use Cyrillic/Greek lookalikes.
@@ -94,7 +121,7 @@ export function isHomographic(hostname: string): boolean {
 	for (const d of HIGH_VALUE_DOMAINS) {
 		if (hostname === d || hostname.endsWith("." + d)) return false;
 	}
-	const registrable = hostname.split(".").slice(-2).join(".");
+	const registrable = registrableDomain(hostname);
 	for (const d of HIGH_VALUE_DOMAINS) {
 		const dist = levenshtein(registrable, d);
 		if (dist > 0 && dist <= 2) return true;
@@ -127,7 +154,7 @@ function pushUrl(out: ExtractedUrl[], seen: Set<string>, rawUrl: string, display
 	if (!hostname) return;
 	if (seen.has(rawUrl)) return;
 	seen.add(rawUrl);
-	const registrable = hostname.split(".").slice(-2).join(".");
+	const registrable = registrableDomain(hostname);
 	out.push({
 		url: rawUrl,
 		display_text: display,


### PR DESCRIPTION
## Summary
- Stands up a Vitest suite (64 tests) for the security-critical pure-function modules: auth parser, URL/homograph heuristics, verdict aggregation, triage, reputation, DMARC XML parser, bloom filter.
- Fixes **`scoreReputation`** — it was subtracting 5 when `avg_score > 70`, so a consistently malicious sender looked *less* suspicious to the aggregator than a first-time sender. Now adds +10 and attaches a reason string. (See `tests/security/reputation.test.ts` regression case.)
- Fixes **`isHomographic`** — it compared the last two labels as the registrable domain, so `amazom.co.uk` was checked against `co.uk` instead of `amazon.co.uk`. Adds a small multi-label public-suffix set and a `registrableDomain()` helper used by both the homograph check and the shortener check.

## Why this matters for "full-stack email security"
Before this PR, the entire scoring pipeline — the code that decides whether to allow, tag, or quarantine email — had zero tests. The two bugs above are the kind of thing a test suite catches on day one; without one, they shipped. Now we have a baseline so future changes to the scoring logic can't silently regress detection.

## Test plan
- [x] `npm test` — 64/64 passing
- [x] `npm run typecheck` — clean
- [ ] Integration: no behavior change for enabled mailboxes beyond the two fixes (verdict scores shift up for bad-history senders and for `amazom.co.uk`-style lookalikes, as intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)