### PR TITLE
Harden Authentication-Results parsing; wire up off-hours scoring

### DIFF
--- a/tests/security/auth.test.ts
+++ b/tests/security/auth.test.ts
@@ -70,6 +70,61 @@ describe("parseAuthResults", () => {
 	});
 });
 
+describe("parseAuthResults — authserv-id gating", () => {
+	// The forgery threat: an attacker-controlled upstream mail server can
+	// inject its own Authentication-Results header claiming pass results
+	// before sending. Cloudflare Email Routing preserves such headers, so a
+	// parser that trusts any Authentication-Results header would accept
+	// forged verdicts. These tests pin the defensive behaviour.
+
+	it("ignores headers whose authserv-id is not on the trusted list", () => {
+		const v = parseAuthResults(
+			[
+				header("Authentication-Results", "attacker.example; spf=pass; dkim=pass; dmarc=pass"),
+				header("Authentication-Results", "mx.cloudflare.net; spf=fail; dkim=fail; dmarc=fail"),
+			],
+			{ trustedAuthservIds: ["mx.cloudflare.net"] },
+		);
+		expect(v).toMatchObject({ spf: "fail", dkim: "fail", dmarc: "fail", authservId: "mx.cloudflare.net", trusted: true });
+	});
+
+	it("matches trusted authserv-id as a dotted suffix", () => {
+		const v = parseAuthResults(
+			[header("Authentication-Results", "mx5.google.com; spf=pass; dkim=pass; dmarc=pass")],
+			{ trustedAuthservIds: ["google.com"] },
+		);
+		expect(v).toMatchObject({ spf: "pass", trusted: true });
+	});
+
+	it("returns all-none when no trusted header is present (prefers silence over forged-pass)", () => {
+		const v = parseAuthResults(
+			[header("Authentication-Results", "attacker.example; spf=pass; dkim=pass; dmarc=pass")],
+			{ trustedAuthservIds: ["mx.cloudflare.net"] },
+		);
+		expect(v).toEqual(emptyVerdict());
+	});
+
+	it("treats an empty trusted list as 'trust any' (back-compat)", () => {
+		const v = parseAuthResults(
+			[header("Authentication-Results", "anywhere; spf=pass; dkim=pass; dmarc=pass")],
+			{ trustedAuthservIds: [] },
+		);
+		expect(v).toMatchObject({ spf: "pass", dkim: "pass", dmarc: "pass" });
+	});
+
+	it("preserves 'first set wins' — legitimate dkim=none is not overwritten by later headers", () => {
+		// Regression: earlier versions used the string 'none' as both the
+		// value and the "not yet set" sentinel, so a first header with
+		// `dkim=none` let any subsequent header overwrite it — including
+		// an attacker-controlled one when gating was off.
+		const v = parseAuthResults([
+			header("Authentication-Results", "inner; spf=pass; dkim=none; dmarc=pass"),
+			header("Authentication-Results", "outer; spf=fail; dkim=pass; dmarc=fail"),
+		]);
+		expect(v).toMatchObject({ spf: "pass", dkim: "none", dmarc: "pass" });
+	});
+});
+
 describe("scoreAuth", () => {
 	it("scores a clean pass as a net-negative (credit)", () => {
 		const { score } = scoreAuth({ spf: "pass", dkim: "pass", dmarc: "pass" });

--- a/tests/security/time-rules.test.ts
+++ b/tests/security/time-rules.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { scoreOffHours } from "../../workers/security/time-rules";
+import type { BusinessHours } from "../../workers/security/settings";
+
+const NY: BusinessHours = {
+	timezone: "America/New_York",
+	start_hour: 9,
+	end_hour: 18,
+	weekdays_only: true,
+	boost_on_off_hours: true,
+};
+
+// 2026-04-20 (Monday) — chosen to avoid DST edges.
+const monday9amEt = new Date("2026-04-20T13:00:00Z"); // 09:00 New_York
+const monday3amEt = new Date("2026-04-20T07:00:00Z"); // 03:00 New_York
+const monday6pmEt = new Date("2026-04-20T22:00:00Z"); // 18:00 New_York (off)
+const saturday10amEt = new Date("2026-04-25T14:00:00Z"); // Sat 10:00 New_York
+
+describe("scoreOffHours", () => {
+	it("returns zero when business_hours is undefined", () => {
+		expect(scoreOffHours(undefined, monday3amEt)).toEqual({ score: 0, reasons: [] });
+	});
+
+	it("returns zero when boost_on_off_hours is false", () => {
+		expect(scoreOffHours({ ...NY, boost_on_off_hours: false }, monday3amEt)).toEqual({ score: 0, reasons: [] });
+	});
+
+	it("returns zero for email delivered inside business hours", () => {
+		expect(scoreOffHours(NY, monday9amEt).score).toBe(0);
+	});
+
+	it("boosts mail delivered outside the hour window on a weekday", () => {
+		const r = scoreOffHours(NY, monday3amEt);
+		expect(r.score).toBe(10);
+		expect(r.reasons[0]).toMatch(/outside business hours/);
+	});
+
+	it("treats end_hour as exclusive — 18:00 itself is off-hours", () => {
+		expect(scoreOffHours(NY, monday6pmEt).score).toBe(10);
+	});
+
+	it("flags weekend delivery when weekdays_only", () => {
+		const r = scoreOffHours(NY, saturday10amEt);
+		expect(r.score).toBe(10);
+		expect(r.reasons[0]).toMatch(/weekend/);
+	});
+
+	it("does not flag weekend delivery when weekdays_only is false", () => {
+		const r = scoreOffHours({ ...NY, weekdays_only: false }, saturday10amEt);
+		expect(r.score).toBe(0);
+	});
+
+	it("returns zero for an invalid timezone (conservative: missing signal is better than wrong signal)", () => {
+		const r = scoreOffHours({ ...NY, timezone: "Not/A/Real/Zone" }, monday3amEt);
+		expect(r.score).toBe(0);
+	});
+
+	it("handles a wrapped (night-shift) window", () => {
+		// 22:00 → 06:00. A 3 AM delivery falls inside the window → no boost.
+		const nightShift: BusinessHours = { ...NY, start_hour: 22, end_hour: 6, weekdays_only: false };
+		expect(scoreOffHours(nightShift, monday3amEt).score).toBe(0);
+	});
+});

--- a/workers/security/auth.ts
+++ b/workers/security/auth.ts
@@ -8,6 +8,19 @@
  * Cloudflare Email Routing preserves upstream auth headers and adds its own.
  * This parser handles the IANA-standard `Authentication-Results` format plus
  * the common Gmail and Microsoft variants.
+ *
+ * THREAT MODEL: An attacker who controls their own mail server can inject
+ * an `Authentication-Results` header claiming pass results for their own
+ * forged From address. Per RFC 8601 §5, receivers MUST validate the
+ * authserv-id against a trusted list before acting on the reported
+ * results. When `trusted_authserv_ids` is configured on the mailbox, only
+ * headers whose authserv-id appears in that list contribute to the verdict;
+ * all others are ignored.
+ *
+ * When no trusted list is configured we fall back to first-header-wins,
+ * which matches the behaviour pre-hardening. That's still exploitable if
+ * a forged header precedes the authentic one in the array, so operators
+ * are strongly encouraged to set the trusted list.
  */
 
 export type AuthResult =
@@ -25,6 +38,13 @@ export interface AuthVerdict {
 	dmarc: AuthResult;
 	/** The `authserv-id` that produced the verdict, if captured. */
 	authservId?: string;
+	/**
+	 * True when at least one header with a trusted authserv-id was found.
+	 * When `trusted_authserv_ids` is configured and no header matched, this
+	 * stays false and the verdict remains all-none — the aggregator treats
+	 * that as a strong suspicion signal.
+	 */
+	trusted?: boolean;
 }
 
 export function emptyVerdict(): AuthVerdict {
@@ -52,22 +72,59 @@ function findAuthHeaders(rawHeaders: unknown): string[] {
 
 const RESULT_RE = /(spf|dkim|dmarc)\s*=\s*(pass|fail|neutral|none|softfail|temperror|permerror)/gi;
 
-export function parseAuthResults(rawHeaders: unknown): AuthVerdict {
+function extractAuthservId(raw: string): string | undefined {
+	const firstToken = raw.split(";")[0]?.trim();
+	if (!firstToken || firstToken.includes("=")) return undefined;
+	return firstToken.toLowerCase();
+}
+
+export interface ParseAuthOptions {
+	/**
+	 * Lowercased list of trusted authserv-id values. When non-empty, only
+	 * `Authentication-Results` headers whose authserv-id is on this list
+	 * contribute to the verdict. Empty/unset means "trust any".
+	 */
+	trustedAuthservIds?: readonly string[];
+}
+
+/** Suffix-aware authserv-id match. `google.com` matches `mx.google.com`. */
+function matchesTrusted(authservId: string, trusted: readonly string[]): boolean {
+	for (const t of trusted) {
+		if (authservId === t) return true;
+		if (authservId.endsWith("." + t)) return true;
+	}
+	return false;
+}
+
+export function parseAuthResults(rawHeaders: unknown, options: ParseAuthOptions = {}): AuthVerdict {
 	const verdict = emptyVerdict();
 	const headerValues = findAuthHeaders(rawHeaders);
 	if (headerValues.length === 0) return verdict;
 
+	const trusted = options.trustedAuthservIds ?? [];
+	const gating = trusted.length > 0;
+
+	// Track which methods are already set so a legitimate `dkim=none` result
+	// doesn't leave the state indistinguishable from "not set" — which would
+	// otherwise let a subsequent (possibly forged) header overwrite it.
+	const set = { spf: false, dkim: false, dmarc: false };
+
 	for (const raw of headerValues) {
-		if (!verdict.authservId) {
-			const firstToken = raw.split(";")[0]?.trim();
-			if (firstToken && !firstToken.includes("=")) verdict.authservId = firstToken;
+		const authservId = extractAuthservId(raw);
+		if (gating) {
+			if (!authservId) continue;
+			if (!matchesTrusted(authservId, trusted)) continue;
 		}
+		if (!verdict.authservId && authservId) verdict.authservId = authservId;
+		if (!verdict.trusted) verdict.trusted = true;
+
 		for (const match of raw.matchAll(RESULT_RE)) {
 			const method = match[1].toLowerCase() as "spf" | "dkim" | "dmarc";
 			const result = match[2].toLowerCase() as AuthResult;
-			// First verdict wins if multiple Authentication-Results headers
-			// disagree — we trust the innermost (first-listed) authserv-id.
-			if (verdict[method] === "none") verdict[method] = result;
+			if (!set[method]) {
+				verdict[method] = result;
+				set[method] = true;
+			}
 		}
 	}
 	return verdict;

--- a/workers/security/index.ts
+++ b/workers/security/index.ts
@@ -29,6 +29,34 @@ import { aggregateVerdict, type FinalVerdict } from "./verdict";
 import { getSecuritySettings } from "./settings";
 import { checkUrlAgainstFeeds, type FeedMatch } from "../intel/feeds";
 import { evaluateTriage, type IntelMatchInfo } from "./triage";
+import { scoreOffHours } from "./time-rules";
+import type { VerdictThresholds } from "./verdict";
+
+/**
+ * Apply a post-aggregation score bump and recompute the action tier and
+ * explanation. Used for signals that only fire after the main verdict has
+ * been computed (intel feed hits, off-hours delivery).
+ */
+function applyBoost(
+	verdict: FinalVerdict,
+	boost: number,
+	reason: string,
+	thresholds: VerdictThresholds,
+): FinalVerdict {
+	const newScore = Math.min(100, verdict.score + boost);
+	const action: FinalVerdict["action"] = newScore >= thresholds.block ? "block"
+		: newScore >= thresholds.quarantine ? "quarantine"
+		: newScore >= thresholds.tag ? "tag"
+		: "allow";
+	const signals = [...verdict.signals, reason];
+	return {
+		...verdict,
+		score: newScore,
+		action,
+		signals,
+		explanation: signals.slice(0, 4).join("; "),
+	};
+}
 
 export interface RunPipelineInput {
 	env: Env;
@@ -62,7 +90,9 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 	// complete in milliseconds. The classifier LLM call is the expensive
 	// stage (seconds); the triage tier checks below let us skip it entirely
 	// for clear-cut cases.
-	const auth = parseAuthResults(parsedEmail.headers);
+	const auth = parseAuthResults(parsedEmail.headers, {
+		trustedAuthservIds: settings.trusted_authserv_ids,
+	});
 	const urls = extractUrls(bodyHtml);
 
 	// Intel feed lookup — first confirmed hit wins. Kept early (pre-triage)
@@ -114,21 +144,15 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 	// hit bumps by 5 (low-signal — bloom FPR is configured at ~1%).
 	const intelBoost = intelMatch?.confirmed ? 20 : intelMatch ? 5 : 0;
 	if (intelBoost > 0 && intelMatch) {
-		const newScore = Math.min(100, verdict.score + intelBoost);
-		const thresh = settings.thresholds;
-		const action = newScore >= thresh.block ? "block"
-			: newScore >= thresh.quarantine ? "quarantine"
-			: newScore >= thresh.tag ? "tag"
-			: "allow";
 		const label = intelMatch.confirmed ? "threat-intel match" : "threat-intel match (unconfirmed)";
 		const reason = `${label} (${intelMatch.feedId}: ${intelMatch.value})`;
-		verdict = {
-			...verdict,
-			score: newScore,
-			action,
-			signals: [...verdict.signals, reason],
-			explanation: [...verdict.signals.slice(0, 2), reason].slice(0, 4).join("; "),
-		};
+		verdict = applyBoost(verdict, intelBoost, reason, settings.thresholds);
+	}
+
+	// Off-hours boost. Small nudge (+10) so it can only tilt borderline verdicts.
+	const offHours = scoreOffHours(settings.business_hours);
+	if (offHours.score > 0) {
+		verdict = applyBoost(verdict, offHours.score, offHours.reasons[0], settings.thresholds);
 	}
 
 	// Learning mode never quarantines/blocks — cap at "tag".

--- a/workers/security/settings.ts
+++ b/workers/security/settings.ts
@@ -43,6 +43,17 @@ export interface MailboxSecuritySettings {
 	allowlist_senders: string[];
 	/** Registrable domains (lowercased) that short-circuit to allow when DMARC passes. */
 	allowlist_domains: string[];
+	/**
+	 * Lowercased list of trusted `authserv-id` values (e.g. `mx.cloudflare.net`,
+	 * `mx.google.com`). When set, only `Authentication-Results` headers from
+	 * these authserv-ids contribute to the DMARC/SPF/DKIM verdict — all others
+	 * are ignored. Prevents an attacker-controlled upstream from forging a
+	 * pass verdict by injecting their own `Authentication-Results` header.
+	 *
+	 * Empty list falls back to first-header-wins behaviour (insecure against
+	 * forgery). Operators should populate this list to match their mail path.
+	 */
+	trusted_authserv_ids: string[];
 	/** Enable the hard-allow triage tier. Requires DMARC pass — never allowlist alone. */
 	trusted_auto_allow: boolean;
 	/**
@@ -67,6 +78,7 @@ export const DEFAULT_SECURITY_SETTINGS: MailboxSecuritySettings = {
 	learning_mode: false,
 	allowlist_senders: [],
 	allowlist_domains: [],
+	trusted_authserv_ids: [],
 	trusted_auto_allow: true,
 	trusted_auto_allow_min_messages: 10,
 	intel_auto_block: true,
@@ -89,6 +101,7 @@ export async function getSecuritySettings(
 			// comparisons at runtime don't need to repeat the case fold.
 			allowlist_senders: (raw.allowlist_senders ?? DEFAULT_SECURITY_SETTINGS.allowlist_senders).map((s) => s.toLowerCase()),
 			allowlist_domains: (raw.allowlist_domains ?? DEFAULT_SECURITY_SETTINGS.allowlist_domains).map((s) => s.toLowerCase()),
+			trusted_authserv_ids: (raw.trusted_authserv_ids ?? DEFAULT_SECURITY_SETTINGS.trusted_authserv_ids).map((s) => s.toLowerCase()),
 			// business_hours: only materialise if the user supplied at least a timezone.
 			// `boost_on_off_hours` defaults to false so a partially specified block is inert.
 			business_hours: raw.business_hours && raw.business_hours.timezone

--- a/workers/security/time-rules.ts
+++ b/workers/security/time-rules.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Business-hours / off-hours scoring contribution.
+ *
+ * BEC and wire-fraud attempts are disproportionately delivered outside of
+ * the recipient's working hours (attacker presumes the CFO reading a wire
+ * request at 7pm on a Friday won't double-check with treasury). This module
+ * turns a mailbox-level `business_hours` setting into a small score nudge.
+ *
+ * DESIGN RULES:
+ *   - Scoring only. Never short-circuits the pipeline. The triage layer
+ *     deliberately ignores this signal — a legitimate sender emailing
+ *     at 3 AM is still legitimate mail and must remain allow-able.
+ *   - Off-hours boost is small (+10) so it can't single-handedly quarantine
+ *     a clean email; it nudges borderline verdicts over the threshold.
+ *   - Invalid timezone strings produce a zero contribution. We don't fail
+ *     open by assuming UTC or anything else — silent timezone misconfig
+ *     silently breaks the signal, which is the conservative default.
+ */
+
+import type { BusinessHours } from "./settings";
+
+export interface TimeRuleResult {
+	score: number;
+	reasons: string[];
+}
+
+/**
+ * `at` defaults to `new Date()` but is threaded as a parameter so tests can
+ * inject a fixed instant without mocking the global clock.
+ */
+export function scoreOffHours(
+	hours: BusinessHours | undefined,
+	at: Date = new Date(),
+): TimeRuleResult {
+	if (!hours || !hours.boost_on_off_hours) return { score: 0, reasons: [] };
+
+	const local = localDateParts(hours.timezone, at);
+	if (!local) return { score: 0, reasons: [] };
+
+	const { hour, weekday } = local;
+
+	// weekday in the Intl.DateTimeFormat output is 0=Sunday..6=Saturday
+	const isWeekend = weekday === 0 || weekday === 6;
+	if (hours.weekdays_only && isWeekend) {
+		return {
+			score: 10,
+			reasons: [`received on weekend (${hours.timezone})`],
+		};
+	}
+
+	const start = clampHour(hours.start_hour, 7);
+	const end = clampHour(hours.end_hour, 19);
+
+	// Range is inclusive-start, exclusive-end so `end_hour = 19` treats 19:00
+	// as off-hours. Handles wrapped windows (night-shift style, e.g. start=22,
+	// end=6) for completeness even though BEC signal goes the other way.
+	const inHours = start <= end
+		? hour >= start && hour < end
+		: hour >= start || hour < end;
+
+	if (inHours) return { score: 0, reasons: [] };
+	return {
+		score: 10,
+		reasons: [`received outside business hours (${String(hour).padStart(2, "0")}:00 ${hours.timezone})`],
+	};
+}
+
+function clampHour(v: number, fallback: number): number {
+	if (!Number.isFinite(v)) return fallback;
+	const i = Math.floor(v);
+	if (i < 0 || i > 23) return fallback;
+	return i;
+}
+
+interface LocalParts { hour: number; weekday: number; }
+
+function localDateParts(timezone: string, at: Date): LocalParts | null {
+	try {
+		const fmt = new Intl.DateTimeFormat("en-US", {
+			timeZone: timezone,
+			hour: "numeric",
+			hour12: false,
+			weekday: "short",
+		});
+		const parts = fmt.formatToParts(at);
+		let hour = NaN;
+		let weekdayName = "";
+		for (const p of parts) {
+			if (p.type === "hour") hour = parseInt(p.value, 10);
+			else if (p.type === "weekday") weekdayName = p.value;
+		}
+		// Intl formats midnight as either "0" or "24" across locales/runtimes; normalise.
+		if (hour === 24) hour = 0;
+		if (!Number.isFinite(hour)) return null;
+		const weekdayIndex = WEEKDAY_INDEX[weekdayName];
+		if (weekdayIndex === undefined) return null;
+		return { hour, weekday: weekdayIndex };
+	} catch {
+		return null;
+	}
+}
+
+const WEEKDAY_INDEX: Record<string, number> = {
+	Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6,
+};


### PR DESCRIPTION
Stacked on [#5](https://github.com/schmug/agentic-inbox/pull/5). Merge that first; this PR will auto-rebase against `main` when the base is retargeted.

## 1. Authentication-Results forgery hardening

An attacker-controlled upstream mail server can inject its own `Authentication-Results` header claiming pass results before sending. Cloudflare Email Routing preserves the header, so the previous parser — which accepted *any* `Authentication-Results` header without validating authserv-id — could be tricked into reporting DMARC=pass for a forged message, potentially triggering hard-allow triage.

**Two defensive changes in [auth.ts](workers/security/auth.ts):**

- **Per-mailbox `trusted_authserv_ids` setting.** When configured, only headers whose authserv-id matches (or is a dotted subdomain of) an entry on the list contribute to the verdict. Empty list preserves back-compat ``trust any'' behaviour so existing mailboxes aren't broken on upgrade.
- **Track per-method set-ness separately from the AuthResult value.** Previously the string ``none'' was both a valid result and the ``not yet set'' sentinel, so a legitimate first header with `dkim=none` allowed any later (possibly attacker-controlled) header to overwrite it.

## 2. Off-hours scoring (completes half-built feature)

The `business_hours` setting already existed in `MailboxSecuritySettings` but nothing consumed it, and the referenced `workers/security/time-rules.ts` didn't exist. Added the module with a small +10 off-hours boost, wired into the pipeline **after** aggregation so it can't short-circuit triage. Targets the BEC signal where wire-fraud asks disproportionately land outside working hours.

Also refactored the duplicated post-aggregation boost logic in [index.ts](workers/security/index.ts) into an `applyBoost()` helper so the intel and off-hours cases share a single code path.

## Test plan
- [x] `npm test` — 78/78 passing (14 new)
- [x] `npm run typecheck` — clean
- [ ] Recommend adding a README note steering operators to populate `trusted_authserv_ids` with their mail path's authserv-id (e.g. `mx.cloudflare.net`, `mx.google.com`) to get the full hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)