### PR TITLE
Add hub test suite (aggregate, hash, auth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Click the button above to deploy to your Cloudflare account. The deploy flow wil
 - **Built-in AI agent** — Side panel with 9 email tools for reading, searching, drafting, and sending
 - **Auto-draft on new email** — Agent automatically reads inbound emails and generates draft replies, always requiring explicit confirmation before sending
 - **Configurable and persistent** — Custom system prompts per mailbox, persistent chat history, streaming markdown responses, and tool call visibility
+- **Security pipeline** — Opt-in SPF/DKIM/DMARC parsing, URL homograph detection, LLM classifier, sender reputation, threat-intel feed matching, and async deep-scan (redirect-chain resolution, RDAP domain age, attachment heuristics). See [Security](#security) below
 
 ## Stack
 
@@ -69,6 +70,69 @@ npm run deploy
 - [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/policies/access/) configured for deployed/shared environments (required in production)
 
 Any user who passes the shared Cloudflare Access policy can access all mailboxes in this app by design. This includes the MCP server at `/mcp` -- external AI tools (Claude Code, Cursor, etc.) connected via MCP can operate on any mailbox by passing a `mailboxId` parameter. There is no per-mailbox authorization; the Cloudflare Access policy is the single trust boundary.
+
+## Security
+
+The security pipeline is **opt-in per mailbox** — existing mailboxes are unaffected until you flip the toggle in **Settings → Security**. When enabled, every inbound email runs through a synchronous scoring pipeline (SPF/DKIM/DMARC parse → URL heuristics → LLM classifier → sender reputation → threat-intel feed match → aggregate verdict), then an async deep-scan stage layered on top.
+
+### Recommended configuration after enabling
+
+These two settings are the high-leverage ones. Both live in **Settings → Security**; both are empty by default for back-compat.
+
+#### 1. Trusted authentication servers
+
+Sets which `Authentication-Results` headers are trusted when computing the SPF/DKIM/DMARC verdict. Without this list populated, an attacker-controlled upstream mail server can inject a forged `Authentication-Results: attacker.example; spf=pass; dkim=pass; dmarc=pass` header and the parser will accept it.
+
+Populate with the authserv-id(s) that actually sit on your mail path. For a typical Cloudflare-routed setup:
+
+```
+mx.cloudflare.net
+```
+
+If your mail traverses a Google/Microsoft forwarder before Cloudflare, add those too (suffix match is supported — `google.com` covers `mx1.google.com`, `mx5.google.com`, etc.):
+
+```
+mx.cloudflare.net, google.com, outlook.com
+```
+
+#### 2. Business hours
+
+Optional. When enabled, mail delivered outside your working hours gets a small score nudge (+10) — BEC / wire-fraud requests disproportionately land at 3 AM and on weekends. The nudge can push a borderline verdict over the tag/quarantine threshold; it can never single-handedly quarantine an email on time alone (the triage layer deliberately ignores the signal for explicit allowlists and trusted history).
+
+Takes an IANA timezone plus an hour window:
+
+```
+Timezone: America/New_York
+Start:    09
+End:      18  (exclusive — 18:00 itself is off-hours)
+Weekends: flagged when weekdays_only is on
+```
+
+### Pipeline stages
+
+| Stage | Latency | Notes |
+| --- | --- | --- |
+| Auth header parse | µs | SPF/DKIM/DMARC from `Authentication-Results`; gated by trusted authserv-ids |
+| URL extract + homograph/shortener check | ms | Levenshtein vs a high-value-domain list |
+| Sender reputation | ms | Rolling avg score per mailbox; flagged-sender fast path |
+| Threat-intel bloom lookup | ms | Against [workers/intel/feeds.ts](workers/intel/feeds.ts) (URLhaus, PhishDestroy, configurable) |
+| Triage short-circuits | µs | Hard-block on confirmed intel / flagged sender; hard-allow on DMARC pass + allowlist or trusted history |
+| LLM classifier | seconds (5s cap) | Workers AI; fail-closed to `suspicious` on timeout |
+| Verdict aggregation | µs | Pure scoring function; thresholds configurable per mailbox |
+| Off-hours boost | µs | Optional, scoring-only |
+| **Async deep-scan** | seconds–tens-of-seconds | `ctx.waitUntil`; see below |
+
+### Async deep-scan
+
+Fires after the sync verdict is stored and only ever *tightens* the decision (sync `allow` → deep-scan `quarantine` is fine; reverse is not). Contribution capped at `+40` so it can't dominate the sync signal.
+
+- **Redirect-chain resolution** — follows `bit.ly`-style wrappers up to 5 hops so downstream checks see the real destination.
+- **RDAP domain age** — queries `rdap.org` for registration date. Domains <7d get +20, <30d get +10. Fails silently on flaky RDAP servers.
+- **Attachment heuristics** — dangerous extensions, macro-enabled Office, `.pdf.exe`-style double extensions, MIME/extension mismatches, archives that advertise a payload in the filename.
+
+### Threat-intel hub
+
+The [`hub/`](hub/) subdirectory is a MISP-compatible community threat-intel hub — mailboxes can push phishing reports (`workers/intel/report.ts`) and pull corroborated lists back via the destroylist feed. Trust-weighted so one org can't single-handedly promote its own intel.
 
 ## Architecture
 

--- a/hub/package-lock.json
+++ b/hub/package-lock.json
@@ -13,7 +13,10 @@
 			},
 			"devDependencies": {
 				"@cloudflare/workers-types": "^4.20250101.0",
+				"@types/better-sqlite3": "^7.6.13",
+				"better-sqlite3": "^12.9.0",
 				"typescript": "^5.5.0",
+				"vitest": "^4.1.4",
 				"wrangler": "^3.80.0"
 			}
 		},
@@ -152,10 +155,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -185,6 +188,23 @@
 			},
 			"peerDependencies": {
 				"esbuild": "*"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
@@ -459,6 +479,23 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@esbuild/netbsd-x64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
@@ -476,6 +513,23 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@esbuild/openbsd-x64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
@@ -491,6 +545,23 @@
 			],
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+			"integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
@@ -979,6 +1050,470 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.124.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+			"integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+			"integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+			"integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+			"integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+			"integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+			"integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+			"integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+			"integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+			"integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.9.2",
+				"@emnapi/runtime": "1.9.2",
+				"@napi-rs/wasm-runtime": "^1.1.3"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+			"integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+			"integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+			"integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/better-sqlite3": {
+			"version": "7.6.13",
+			"resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+			"integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~7.19.0"
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+			"integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.4",
+				"@vitest/utils": "4.1.4",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+			"integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+			"integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.4",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+			"integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.4",
+				"@vitest/utils": "4.1.4",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot/node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+			"integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+			"integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.4",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.14.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -1012,12 +1547,122 @@
 				"printable-characters": "^1.0.42"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/better-sqlite3": {
+			"version": "12.9.0",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+			"integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"bindings": "^1.5.0",
+				"prebuild-install": "^7.1.1"
+			},
+			"engines": {
+				"node": "20.x || 22.x || 23.x || 24.x || 25.x"
+			}
+		},
+		"node_modules/bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"node_modules/bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			}
+		},
 		"node_modules/blake3-wasm": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
 			"integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/color": {
 			"version": "4.2.3",
@@ -1068,6 +1713,13 @@
 				"simple-swizzle": "^0.2.2"
 			}
 		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/cookie": {
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -1085,6 +1737,32 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
 		"node_modules/defu": {
 			"version": "6.1.7",
 			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
@@ -1098,10 +1776,26 @@
 			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/esbuild": {
 			"version": "0.17.19",
@@ -1175,10 +1869,62 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/expand-template": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+			"dev": true,
+			"license": "(MIT OR WTFPL)",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/exsolve": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
 			"integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1208,6 +1954,13 @@
 				"source-map": "^0.6.1"
 			}
 		},
+		"node_modules/github-from-package": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/glob-to-regexp": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -1224,6 +1977,41 @@
 				"node": ">=16.9.0"
 			}
 		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/is-arrayish": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
@@ -1231,6 +2019,267 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true
+		},
+		"node_modules/lightningcss": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.32.0",
+				"lightningcss-darwin-arm64": "1.32.0",
+				"lightningcss-darwin-x64": "1.32.0",
+				"lightningcss-freebsd-x64": "1.32.0",
+				"lightningcss-linux-arm-gnueabihf": "1.32.0",
+				"lightningcss-linux-arm64-gnu": "1.32.0",
+				"lightningcss-linux-arm64-musl": "1.32.0",
+				"lightningcss-linux-x64-gnu": "1.32.0",
+				"lightningcss-linux-x64-musl": "1.32.0",
+				"lightningcss-win32-arm64-msvc": "1.32.0",
+				"lightningcss-win32-x64-msvc": "1.32.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
 		},
 		"node_modules/magic-string": {
 			"version": "0.25.9",
@@ -1253,6 +2302,19 @@
 			},
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/miniflare": {
@@ -1291,6 +2353,23 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/mustache": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
@@ -1301,12 +2380,72 @@
 				"mustache": "bin/mustache"
 			}
 		},
+		"node_modules/nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/napi-build-utils": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+			"integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/node-abi": {
+			"version": "3.89.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+			"integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/obug": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT"
+		},
 		"node_modules/ohash": {
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
 			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
 		},
 		"node_modules/path-to-regexp": {
 			"version": "6.3.0",
@@ -1322,12 +2461,166 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.10",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+			"integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/prebuild-install": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+			"integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+			"deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"detect-libc": "^2.0.0",
+				"expand-template": "^2.0.3",
+				"github-from-package": "0.0.0",
+				"minimist": "^1.2.3",
+				"mkdirp-classic": "^0.5.3",
+				"napi-build-utils": "^2.0.0",
+				"node-abi": "^3.3.0",
+				"pump": "^3.0.0",
+				"rc": "^1.2.7",
+				"simple-get": "^4.0.0",
+				"tar-fs": "^2.0.0",
+				"tunnel-agent": "^0.6.0"
+			},
+			"bin": {
+				"prebuild-install": "bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/printable-characters": {
 			"version": "1.0.42",
 			"resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
 			"integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
 			"dev": true,
 			"license": "Unlicense"
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dev": true,
+			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+			"dependencies": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"bin": {
+				"rc": "cli.js"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/rolldown": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+			"integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.124.0",
+				"@rolldown/pluginutils": "1.0.0-rc.15"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.0.0-rc.15",
+				"@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+				"@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+				"@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+			}
 		},
 		"node_modules/rollup-plugin-inject": {
 			"version": "3.0.2",
@@ -1362,13 +2655,33 @@
 				"estree-walker": "^0.6.1"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/semver": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
 			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
-			"optional": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -1417,6 +2730,60 @@
 				"@img/sharp-win32-x64": "0.33.5"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
 		"node_modules/simple-swizzle": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
@@ -1438,11 +2805,28 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/sourcemap-codec": {
 			"version": "1.4.8",
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
 			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
 			"deprecated": "Please use @jridgewell/sourcemap-codec instead",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1457,6 +2841,13 @@
 				"get-source": "^2.0.12"
 			}
 		},
+		"node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/stoppable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
@@ -1468,6 +2859,100 @@
 				"npm": ">=6"
 			}
 		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/tar-fs": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+			"integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+			"integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.16",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1475,6 +2960,19 @@
 			"dev": true,
 			"license": "0BSD",
 			"optional": true
+		},
+		"node_modules/tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
+			}
 		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
@@ -1510,6 +3008,13 @@
 				"node": ">=14.0"
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/unenv": {
 			"version": "2.0.0-rc.14",
 			"resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
@@ -1525,6 +3030,620 @@
 				"ufo": "^1.5.4"
 			}
 		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vitest": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+			"integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.4",
+				"@vitest/mocker": "4.1.4",
+				"@vitest/pretty-format": "4.1.4",
+				"@vitest/runner": "4.1.4",
+				"@vitest/snapshot": "4.1.4",
+				"@vitest/spy": "4.1.4",
+				"@vitest/utils": "4.1.4",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.4",
+				"@vitest/browser-preview": "4.1.4",
+				"@vitest/browser-webdriverio": "4.1.4",
+				"@vitest/coverage-istanbul": "4.1.4",
+				"@vitest/coverage-v8": "4.1.4",
+				"@vitest/ui": "4.1.4",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/android-arm": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/android-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/android-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-arm": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/win32-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@vitest/mocker": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+			"integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.4",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/vitest/node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/vitest/node_modules/vite": {
+			"version": "8.0.8",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+			"integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.4",
+				"postcss": "^8.5.8",
+				"rolldown": "1.0.0-rc.15",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.1.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/workerd": {
 			"version": "1.20250718.0",
 			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
@@ -1532,6 +3651,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"workerd": "bin/workerd"
 			},
@@ -1583,6 +3703,13 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/ws": {
 			"version": "8.18.0",

--- a/hub/package.json
+++ b/hub/package.json
@@ -6,6 +6,8 @@
 	"scripts": {
 		"dev": "wrangler dev",
 		"deploy": "wrangler deploy",
+		"test": "vitest run",
+		"test:watch": "vitest",
 		"typecheck": "wrangler types && tsc --noEmit",
 		"db:migrate:local": "wrangler d1 migrations apply ais-hub --local",
 		"db:migrate:remote": "wrangler d1 migrations apply ais-hub --remote"
@@ -16,7 +18,10 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20250101.0",
+		"@types/better-sqlite3": "^7.6.13",
+		"better-sqlite3": "^12.9.0",
 		"typescript": "^5.5.0",
+		"vitest": "^4.1.4",
 		"wrangler": "^3.80.0"
 	}
 }

--- a/hub/tests/helpers/d1.ts
+++ b/hub/tests/helpers/d1.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Minimal D1Database shim backed by better-sqlite3 for unit tests.
+ *
+ * Implements just the prepare/bind/first/all/run surface the hub code
+ * uses. This is NOT a general-purpose D1 emulator — do not reuse in
+ * production code. It exists so we can exercise the hub's SQL against
+ * a real SQLite without spinning up Miniflare for every test.
+ */
+
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { D1Database } from "@cloudflare/workers-types";
+
+interface PreparedLike {
+	bind(...args: unknown[]): PreparedLike;
+	first<T = unknown>(): Promise<T | null>;
+	all<T = unknown>(): Promise<{ results: T[] }>;
+	run(): Promise<{ meta: { changes: number; last_row_id?: number } }>;
+}
+
+export interface TestDb {
+	d1: D1Database;
+	raw: Database.Database;
+	close(): void;
+}
+
+const SCHEMA_PATH = resolve(__dirname, "../../migrations/0001_schema.sql");
+
+export function makeTestDb(): TestDb {
+	const raw = new Database(":memory:");
+	// Cloudflare D1 does NOT enforce foreign keys by default. Match that so
+	// tests exercise the same permissive behaviour production code relies on.
+	raw.pragma("foreign_keys = OFF");
+	const schema = readFileSync(SCHEMA_PATH, "utf-8");
+	// better-sqlite3's `exec` runs multiple statements; it is NOT child_process.
+	raw.exec(schema);
+
+	const d1 = {
+		prepare(sql: string): PreparedLike {
+			// better-sqlite3 expects `?N` placeholders to be passed as an
+			// object keyed by N (not a positional array, which is only for
+			// anonymous `?` markers). Convert the D1-style `bind(v1, v2, ...)`
+			// call into the object form so the same ?N can be reused within
+			// a single SQL statement without "too many parameters" errors.
+			let boundObj: Record<string, unknown> = {};
+			const stmt = raw.prepare(sql);
+			const api: PreparedLike = {
+				bind(...args: unknown[]) {
+					boundObj = {};
+					args.forEach((v, i) => {
+						boundObj[String(i + 1)] = normalizeBindValue(v);
+					});
+					return api;
+				},
+				async first<T = unknown>() {
+					return (stmt.get(boundObj) as T | undefined) ?? null;
+				},
+				async all<T = unknown>() {
+					return { results: stmt.all(boundObj) as T[] };
+				},
+				async run() {
+					const info = stmt.run(boundObj);
+					return {
+						meta: {
+							changes: info.changes,
+							last_row_id: Number(info.lastInsertRowid),
+						},
+					};
+				},
+			};
+			return api;
+		},
+	} as unknown as D1Database;
+
+	return { d1, raw, close: () => raw.close() };
+}
+
+/**
+ * better-sqlite3 rejects `undefined` bindings (they must be `null` to map to
+ * SQL NULL). D1 accepts either; normalise so call sites can be ergonomic.
+ */
+function normalizeBindValue(v: unknown): unknown {
+	if (v === undefined) return null;
+	if (typeof v === "boolean") return v ? 1 : 0;
+	return v;
+}

--- a/hub/tests/lib/aggregate.test.ts
+++ b/hub/tests/lib/aggregate.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	applyCorroboration,
+	getPromotedForSharingGroup,
+	PROMOTION_SCORE,
+	PROMOTION_CONTRIBUTORS,
+} from "../../src/lib/aggregate";
+import { makeTestDb, type TestDb } from "../helpers/d1";
+
+let db: TestDb;
+
+beforeEach(() => {
+	db = makeTestDb();
+});
+
+afterEach(() => {
+	db.close();
+});
+
+async function seedOrg(uuid: string, trust = 1.0) {
+	db.raw
+		.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, ?)`)
+		.run(uuid, `org-${uuid}`, trust);
+}
+
+async function seedSharingGroup(uuid: string) {
+	db.raw
+		.prepare(`INSERT INTO sharing_groups (uuid, name) VALUES (?, ?)`)
+		.run(uuid, `sg-${uuid}`);
+}
+
+async function corroborationFor(
+	sg: string | null,
+	type: string,
+	value: string,
+) {
+	return db.raw
+		.prepare(
+			`SELECT score, contributor_count
+			 FROM corroboration
+			 WHERE (sharing_group_uuid IS ? OR (sharing_group_uuid IS NULL AND ? IS NULL))
+			   AND attribute_type = ? AND value = ?`,
+		)
+		.get(sg, sg, type, value) as { score: number; contributor_count: number } | undefined;
+}
+
+describe("applyCorroboration", () => {
+	it("inserts a fresh corroboration row and credits the contributor's trust", async () => {
+		await seedOrg("org-A", 1.0);
+		await seedSharingGroup("sg-1");
+
+		await applyCorroboration(db.d1, {
+			event_uuid: "e1",
+			orgc_uuid: "org-A",
+			sharing_group_uuid: "sg-1",
+			attributes: [{ type: "url", value: "https://bad.example/phish" }],
+		});
+
+		const row = await corroborationFor("sg-1", "url", "https://bad.example/phish");
+		expect(row).toMatchObject({ score: 1, contributor_count: 1 });
+	});
+
+	it("does NOT double-count the same org contributing the same attribute twice", async () => {
+		// This is the core sybil/self-reinforcement defense: one org cannot
+		// single-handedly promote their own intel by re-submitting it.
+		await seedOrg("org-A", 1.0);
+		await seedSharingGroup("sg-1");
+
+		for (let i = 0; i < 5; i++) {
+			await applyCorroboration(db.d1, {
+				event_uuid: `e${i}`,
+				orgc_uuid: "org-A",
+				sharing_group_uuid: "sg-1",
+				attributes: [{ type: "url", value: "https://bad.example/phish" }],
+			});
+		}
+
+		const row = await corroborationFor("sg-1", "url", "https://bad.example/phish");
+		expect(row).toMatchObject({ score: 1, contributor_count: 1 });
+	});
+
+	it("accumulates distinct orgs' trust values", async () => {
+		await seedOrg("org-A", 1.0);
+		await seedOrg("org-B", 1.5);
+		await seedOrg("org-C", 0.5);
+		await seedSharingGroup("sg-1");
+
+		for (const org of ["org-A", "org-B", "org-C"]) {
+			await applyCorroboration(db.d1, {
+				event_uuid: `e-${org}`,
+				orgc_uuid: org,
+				sharing_group_uuid: "sg-1",
+				attributes: [{ type: "url", value: "https://bad.example" }],
+			});
+		}
+
+		const row = await corroborationFor("sg-1", "url", "https://bad.example");
+		expect(row?.contributor_count).toBe(3);
+		expect(row?.score).toBeCloseTo(3.0, 5);
+	});
+
+	it("ignores non-promotable attribute types (e.g. text, comment)", async () => {
+		await seedOrg("org-A", 1.0);
+		await seedSharingGroup("sg-1");
+
+		await applyCorroboration(db.d1, {
+			event_uuid: "e1",
+			orgc_uuid: "org-A",
+			sharing_group_uuid: "sg-1",
+			attributes: [
+				{ type: "comment", value: "looks phishy" },
+				{ type: "text", value: "see subject" },
+			],
+		});
+
+		// No row should have been created for the non-promotable types.
+		const row = await corroborationFor("sg-1", "comment", "looks phishy");
+		expect(row).toBeUndefined();
+	});
+
+	it("defaults unknown org to trust=1.0 (graceful-degradation for race conditions)", async () => {
+		// No seedOrg call — the org doesn't exist in the table yet. The
+		// aggregator should still fall back to trust=1.0 rather than skip.
+		await seedSharingGroup("sg-1");
+		await applyCorroboration(db.d1, {
+			event_uuid: "e1",
+			orgc_uuid: "org-ghost",
+			sharing_group_uuid: "sg-1",
+			attributes: [{ type: "url", value: "https://x.example" }],
+		});
+		const row = await corroborationFor("sg-1", "url", "https://x.example");
+		expect(row).toMatchObject({ score: 1, contributor_count: 1 });
+	});
+
+	it("isolates corroboration state between sharing groups", async () => {
+		await seedOrg("org-A", 1.0);
+		await seedOrg("org-B", 1.0);
+		await seedSharingGroup("sg-1");
+		await seedSharingGroup("sg-2");
+
+		// Both orgs submit the same value to sg-1; only org-A submits to sg-2.
+		for (const sg of ["sg-1", "sg-1", "sg-2"]) {
+			const org = sg === "sg-2" ? "org-A" : sg === "sg-1" ? "org-A" : "org-B";
+		}
+		await applyCorroboration(db.d1, {
+			event_uuid: "e1", orgc_uuid: "org-A", sharing_group_uuid: "sg-1",
+			attributes: [{ type: "url", value: "https://x.example" }],
+		});
+		await applyCorroboration(db.d1, {
+			event_uuid: "e2", orgc_uuid: "org-B", sharing_group_uuid: "sg-1",
+			attributes: [{ type: "url", value: "https://x.example" }],
+		});
+		await applyCorroboration(db.d1, {
+			event_uuid: "e3", orgc_uuid: "org-A", sharing_group_uuid: "sg-2",
+			attributes: [{ type: "url", value: "https://x.example" }],
+		});
+
+		const sg1 = await corroborationFor("sg-1", "url", "https://x.example");
+		const sg2 = await corroborationFor("sg-2", "url", "https://x.example");
+		expect(sg1?.contributor_count).toBe(2);
+		expect(sg2?.contributor_count).toBe(1);
+	});
+});
+
+describe("getPromotedForSharingGroup", () => {
+	it("returns only entries meeting both promotion thresholds", async () => {
+		await seedOrg("org-A", 1.0);
+		await seedOrg("org-B", 1.0);
+		await seedSharingGroup("sg-1");
+
+		// Below threshold: only one contributor.
+		await applyCorroboration(db.d1, {
+			event_uuid: "e1", orgc_uuid: "org-A", sharing_group_uuid: "sg-1",
+			attributes: [{ type: "url", value: "https://only-one.example" }],
+		});
+		// Meets both thresholds.
+		for (const org of ["org-A", "org-B"]) {
+			await applyCorroboration(db.d1, {
+				event_uuid: `e-${org}`, orgc_uuid: org, sharing_group_uuid: "sg-1",
+				attributes: [{ type: "url", value: "https://corroborated.example" }],
+			});
+		}
+
+		const promoted = await getPromotedForSharingGroup(db.d1, "sg-1");
+		expect(promoted).toHaveLength(1);
+		expect(promoted[0]).toMatchObject({
+			attribute_type: "url",
+			value: "https://corroborated.example",
+		});
+		expect(promoted[0].score).toBeGreaterThanOrEqual(PROMOTION_SCORE);
+		expect(promoted[0].contributor_count).toBeGreaterThanOrEqual(PROMOTION_CONTRIBUTORS);
+	});
+
+	it("does not promote a high-trust single contributor above the threshold score alone", async () => {
+		// Invariant: a single trusted org (e.g. trust=5) can NOT single-handedly
+		// promote an attribute to the destroylist even though their score alone
+		// crosses PROMOTION_SCORE — the contributor_count guard prevents it.
+		await seedOrg("org-whale", 5.0);
+		await seedSharingGroup("sg-1");
+		await applyCorroboration(db.d1, {
+			event_uuid: "e1", orgc_uuid: "org-whale", sharing_group_uuid: "sg-1",
+			attributes: [{ type: "url", value: "https://solo.example" }],
+		});
+		const promoted = await getPromotedForSharingGroup(db.d1, "sg-1");
+		expect(promoted).toEqual([]);
+	});
+
+	it("scopes promotion to the given sharing group", async () => {
+		await seedOrg("org-A", 1.0);
+		await seedOrg("org-B", 1.0);
+		await seedSharingGroup("sg-1");
+		await seedSharingGroup("sg-2");
+
+		for (const org of ["org-A", "org-B"]) {
+			await applyCorroboration(db.d1, {
+				event_uuid: `e-${org}`, orgc_uuid: org, sharing_group_uuid: "sg-1",
+				attributes: [{ type: "url", value: "https://sg1.example" }],
+			});
+		}
+
+		const sg1 = await getPromotedForSharingGroup(db.d1, "sg-1");
+		const sg2 = await getPromotedForSharingGroup(db.d1, "sg-2");
+		expect(sg1).toHaveLength(1);
+		expect(sg2).toHaveLength(0);
+	});
+});

--- a/hub/tests/lib/auth.test.ts
+++ b/hub/tests/lib/auth.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { webcrypto } from "node:crypto";
+import { Hono } from "hono";
+import { requireOrg, type HubContext } from "../../src/lib/auth";
+import { sha256 } from "../../src/lib/hash";
+import { makeTestDb, type TestDb } from "../helpers/d1";
+
+if (!(globalThis as any).crypto) (globalThis as any).crypto = webcrypto;
+
+let db: TestDb;
+
+beforeEach(() => {
+	db = makeTestDb();
+	// Seed org + api_key for tests.
+});
+
+afterEach(() => db.close());
+
+async function seedKey(key: string, orgUuid = "org-A", revoked = false) {
+	db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, ?)`).run(orgUuid, `name-${orgUuid}`, 1.0);
+	db.raw
+		.prepare(`INSERT INTO api_keys (key_hash, org_uuid, label, revoked) VALUES (?, ?, ?, ?)`)
+		.run(await sha256(key), orgUuid, "test", revoked ? 1 : 0);
+}
+
+function app() {
+	const a = new Hono<HubContext>();
+	a.use("*", requireOrg);
+	a.get("/whoami", (c) => c.json(c.get("org")));
+	return a;
+}
+
+const env = () => ({ DB: db.d1 } as unknown as Record<string, unknown>);
+
+describe("requireOrg", () => {
+	it("rejects requests with no Authorization header (401)", async () => {
+		const res = await app().fetch(new Request("http://x/whoami"), env());
+		expect(res.status).toBe(401);
+	});
+
+	it("rejects an unknown key (401)", async () => {
+		const res = await app().fetch(
+			new Request("http://x/whoami", { headers: { authorization: "Bearer unknown" } }),
+			env(),
+		);
+		expect(res.status).toBe(401);
+	});
+
+	it("accepts a valid bare key (MISP-style)", async () => {
+		await seedKey("good-key");
+		const res = await app().fetch(
+			new Request("http://x/whoami", { headers: { authorization: "good-key" } }),
+			env(),
+		);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({ uuid: "org-A", name: "name-org-A", trust: 1 });
+	});
+
+	it("accepts a valid Bearer-prefixed key", async () => {
+		await seedKey("good-key");
+		const res = await app().fetch(
+			new Request("http://x/whoami", { headers: { authorization: "Bearer good-key" } }),
+			env(),
+		);
+		expect(res.status).toBe(200);
+	});
+
+	it("rejects a revoked key", async () => {
+		await seedKey("revoked-key", "org-A", true);
+		const res = await app().fetch(
+			new Request("http://x/whoami", { headers: { authorization: "Bearer revoked-key" } }),
+			env(),
+		);
+		expect(res.status).toBe(401);
+	});
+
+	it("stores the sha256 of the key, not the key itself", async () => {
+		await seedKey("secret-key");
+		const stored = db.raw.prepare(`SELECT key_hash FROM api_keys`).all() as Array<{ key_hash: string }>;
+		const hash = await sha256("secret-key");
+		expect(stored[0].key_hash).toBe(hash);
+		expect(stored[0].key_hash).not.toBe("secret-key");
+	});
+});

--- a/hub/tests/lib/hash.test.ts
+++ b/hub/tests/lib/hash.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { webcrypto } from "node:crypto";
+import { generateSecret, sha256 } from "../../src/lib/hash";
+
+// Polyfill `crypto` (Web Crypto API) for Node test runtimes that don't expose
+// it on `globalThis`. Node ≥ 20 has it built in; older versions need the shim.
+if (!(globalThis as any).crypto) {
+	(globalThis as any).crypto = webcrypto;
+}
+
+describe("sha256", () => {
+	it("produces the known digest of the empty string", async () => {
+		// Well-known: sha256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+		expect(await sha256("")).toBe(
+			"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		);
+	});
+
+	it("produces the known digest of 'abc'", async () => {
+		expect(await sha256("abc")).toBe(
+			"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		);
+	});
+
+	it("is stable across calls (deterministic)", async () => {
+		const a = await sha256("claude");
+		const b = await sha256("claude");
+		expect(a).toBe(b);
+	});
+
+	it("produces distinct digests for distinct inputs", async () => {
+		const a = await sha256("claude");
+		const b = await sha256("Claude");
+		expect(a).not.toBe(b);
+	});
+
+	it("handles multi-byte UTF-8 correctly", async () => {
+		// Different strings must hash differently even if their lengths match
+		// when encoded as UTF-8.
+		const a = await sha256("café");
+		const b = await sha256("cafe");
+		expect(a).not.toBe(b);
+	});
+});
+
+describe("generateSecret", () => {
+	it("returns a 43-character base64url string (≈256 bits)", () => {
+		const s = generateSecret();
+		expect(s).toHaveLength(43);
+		expect(s).toMatch(/^[A-Za-z0-9_-]+$/);
+	});
+
+	it("returns a fresh value each call", () => {
+		// Birthday collision on 32 random bytes is astronomically unlikely;
+		// this is really just checking we're not accidentally returning a
+		// cached/constant value.
+		const secrets = new Set<string>();
+		for (let i = 0; i < 50; i++) secrets.add(generateSecret());
+		expect(secrets.size).toBe(50);
+	});
+});

--- a/hub/vitest.config.ts
+++ b/hub/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["tests/**/*.test.ts"],
+		environment: "node",
+	},
+});

--- a/tests/intel/attachment-checks.test.ts
+++ b/tests/intel/attachment-checks.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+	aggregateAttachmentSignals,
+	finalExtension,
+	scoreAttachment,
+} from "../../workers/intel/attachment-checks";
+
+describe("finalExtension", () => {
+	it("returns lowercased extension", () => {
+		expect(finalExtension("Report.PDF")).toBe("pdf");
+	});
+	it("returns empty for extensionless files", () => {
+		expect(finalExtension("LICENSE")).toBe("");
+	});
+	it("ignores trailing dots", () => {
+		expect(finalExtension("report.")).toBe("");
+	});
+	it("handles multi-dot filenames (last wins)", () => {
+		expect(finalExtension("archive.tar.gz")).toBe("gz");
+	});
+});
+
+describe("scoreAttachment", () => {
+	it("flags dangerous extensions aggressively", () => {
+		const v = scoreAttachment({ filename: "invoice.exe", mimetype: "application/octet-stream", size: 1024 });
+		expect(v.flags).toContain("dangerous_extension");
+		expect(v.score).toBeGreaterThanOrEqual(40);
+	});
+
+	it("flags macro-enabled Office docs", () => {
+		const v = scoreAttachment({ filename: "quarterly-report.docm", mimetype: "application/vnd.ms-word.document.macroEnabled.12", size: 2048 });
+		expect(v.flags).toContain("macro_enabled_office");
+	});
+
+	it("flags the classic invoice.pdf.exe double-extension pattern", () => {
+		const v = scoreAttachment({ filename: "invoice.pdf.exe", mimetype: "application/octet-stream", size: 512 });
+		expect(v.flags).toContain("dangerous_extension");
+		expect(v.flags).toContain("double_extension");
+	});
+
+	it("does not flag legitimate archives with `.tar.gz` as double-extension", () => {
+		const v = scoreAttachment({ filename: "release.tar.gz", mimetype: "application/gzip", size: 10_000 });
+		expect(v.flags).not.toContain("double_extension");
+	});
+
+	it("flags MIME/extension mismatches (pdf MIME with .exe extension)", () => {
+		const v = scoreAttachment({ filename: "contract.exe", mimetype: "application/pdf", size: 1_000 });
+		expect(v.flags).toContain("extension_mime_mismatch");
+		expect(v.flags).toContain("dangerous_extension");
+	});
+
+	it("does not flag well-known mime/ext matches", () => {
+		const v = scoreAttachment({ filename: "photo.png", mimetype: "image/png", size: 10_000 });
+		expect(v.flags).toEqual([]);
+		expect(v.score).toBe(0);
+	});
+
+	it("passes silently on MIME types we don't have a map for", () => {
+		const v = scoreAttachment({ filename: "data.bin", mimetype: "application/some-novel-type", size: 2000 });
+		expect(v.flags).not.toContain("extension_mime_mismatch");
+	});
+
+	it("flags archives whose filename advertises an executable", () => {
+		const v = scoreAttachment({ filename: "invoice_exe.zip", mimetype: "application/zip", size: 1000 });
+		expect(v.flags).toContain("executable_in_archive_name");
+	});
+
+	it("nudges commercial-bait archive names slightly", () => {
+		const v = scoreAttachment({ filename: "invoice-123.zip", mimetype: "application/zip", size: 1000 });
+		expect(v.flags).toContain("suspicious_archive_name");
+		expect(v.score).toBeLessThan(15);
+	});
+
+	it("flags zero-byte attachments", () => {
+		const v = scoreAttachment({ filename: "empty.pdf", mimetype: "application/pdf", size: 0 });
+		expect(v.flags).toContain("zero_byte");
+	});
+
+	it("clamps scores to the [0, 100] range", () => {
+		const v = scoreAttachment({ filename: "invoice.pdf.exe", mimetype: "application/pdf", size: 0 });
+		expect(v.score).toBeLessThanOrEqual(100);
+		expect(v.score).toBeGreaterThanOrEqual(0);
+	});
+});
+
+describe("aggregateAttachmentSignals", () => {
+	it("caps contribution at 30 so attachments can't dominate", () => {
+		const v = aggregateAttachmentSignals([
+			scoreAttachment({ filename: "a.exe", mimetype: "application/pdf", size: 0 }),
+			scoreAttachment({ filename: "b.docm", mimetype: "x", size: 0 }),
+		]);
+		expect(v.score).toBeLessThanOrEqual(30);
+	});
+
+	it("returns zero when every attachment is clean", () => {
+		const v = aggregateAttachmentSignals([
+			scoreAttachment({ filename: "photo.png", mimetype: "image/png", size: 10_000 }),
+		]);
+		expect(v.score).toBe(0);
+	});
+
+	it("de-duplicates repeated reasons across attachments", () => {
+		const v = aggregateAttachmentSignals([
+			scoreAttachment({ filename: "a.exe", mimetype: "application/octet-stream", size: 100 }),
+			scoreAttachment({ filename: "b.exe", mimetype: "application/octet-stream", size: 100 }),
+		]);
+		expect(v.reasons.length).toBeLessThanOrEqual(2);
+	});
+});

--- a/tests/intel/rdap.test.ts
+++ b/tests/intel/rdap.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+	FRESH_DOMAIN_THRESHOLD_DAYS,
+	lookupDomainAge,
+	parseRdapAge,
+	type RdapTransport,
+} from "../../workers/intel/rdap";
+
+const NOW = new Date("2026-04-18T12:00:00Z");
+
+function rdapBody(events: Array<{ eventAction: string; eventDate: string }>) {
+	return { events };
+}
+
+describe("parseRdapAge", () => {
+	it("returns age_days from the earliest registration event", () => {
+		const age = parseRdapAge(
+			rdapBody([
+				{ eventAction: "last changed", eventDate: "2026-04-01T00:00:00Z" },
+				{ eventAction: "registration", eventDate: "2022-01-01T00:00:00Z" },
+				{ eventAction: "registration", eventDate: "2020-06-15T00:00:00Z" }, // should win
+			]),
+			NOW,
+		);
+		expect(age?.registered_at).toBe("2020-06-15T00:00:00Z");
+		expect(age?.age_days).toBeGreaterThan(2000);
+		expect(age?.is_fresh).toBe(false);
+	});
+
+	it("flags domains registered within the fresh window", () => {
+		const age = parseRdapAge(
+			rdapBody([{ eventAction: "registration", eventDate: "2026-04-10T00:00:00Z" }]),
+			NOW,
+		);
+		expect(age?.age_days).toBeLessThan(FRESH_DOMAIN_THRESHOLD_DAYS);
+		expect(age?.is_fresh).toBe(true);
+	});
+
+	it("returns null when no registration event is present", () => {
+		const age = parseRdapAge(
+			rdapBody([{ eventAction: "last changed", eventDate: "2026-01-01T00:00:00Z" }]),
+			NOW,
+		);
+		expect(age).toBeNull();
+	});
+
+	it("returns null when the body is malformed / missing", () => {
+		expect(parseRdapAge(null)).toBeNull();
+		expect(parseRdapAge(undefined)).toBeNull();
+		expect(parseRdapAge({ events: "nope" as unknown as [] })).toBeNull();
+		expect(parseRdapAge({ events: [{ eventAction: "registration", eventDate: "not-a-date" }] })).toBeNull();
+	});
+});
+
+describe("lookupDomainAge", () => {
+	it("returns parsed age on 200 OK", async () => {
+		const transport: RdapTransport = async () => new Response(
+			JSON.stringify(rdapBody([{ eventAction: "registration", eventDate: "2020-01-01T00:00:00Z" }])),
+			{ status: 200, headers: { "content-type": "application/rdap+json" } },
+		);
+		const age = await lookupDomainAge("example.com", NOW, transport);
+		expect(age?.is_fresh).toBe(false);
+		expect(age?.age_days).toBeGreaterThan(2000);
+	});
+
+	it("returns null on non-200 responses (does not fail closed)", async () => {
+		const transport: RdapTransport = async () => new Response("not found", { status: 404 });
+		const age = await lookupDomainAge("bad.example", NOW, transport);
+		expect(age).toBeNull();
+	});
+
+	it("returns null when the transport throws (no network)", async () => {
+		const transport: RdapTransport = async () => { throw new Error("enetunreach"); };
+		const age = await lookupDomainAge("offline.example", NOW, transport);
+		expect(age).toBeNull();
+	});
+
+	it("returns null for an empty or missing domain", async () => {
+		expect(await lookupDomainAge("")).toBeNull();
+	});
+});

--- a/tests/intel/url-resolver.test.ts
+++ b/tests/intel/url-resolver.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { extractTitle, resolveUrl } from "../../workers/intel/url-resolver";
+
+/** Minimal fetch stub that plays back a scripted chain of responses by URL. */
+function stubFetch(chain: Record<string, Response>): typeof fetch {
+	return (async (input: string | URL | Request) => {
+		const url = typeof input === "string" ? input : (input as Request).url ?? String(input);
+		const res = chain[url];
+		if (!res) throw new Error(`unexpected URL: ${url}`);
+		return res;
+	}) as typeof fetch;
+}
+
+describe("extractTitle", () => {
+	it("pulls the first <title> from an HTML doc", () => {
+		expect(extractTitle("<html><title> Login </title></html>")).toBe("Login");
+	});
+	it("collapses whitespace and trims", () => {
+		expect(extractTitle("<html><title>\n  Sign\n  in\n</title></html>")).toBe("Sign in");
+	});
+	it("returns null when no title tag is present", () => {
+		expect(extractTitle("<html><body>no title</body></html>")).toBeNull();
+	});
+	it("caps at 200 chars", () => {
+		const long = "x".repeat(500);
+		expect(extractTitle(`<title>${long}</title>`)?.length).toBe(200);
+	});
+});
+
+describe("resolveUrl", () => {
+	it("follows a single 302 redirect to a new host and flags host_changed", async () => {
+		const fetchImpl = stubFetch({
+			"https://short.example/abc": new Response("", {
+				status: 302,
+				headers: { location: "https://target.example/phish" },
+			}),
+			"https://target.example/phish": new Response("<html><title>Sign in</title></html>", {
+				status: 200,
+				headers: { "content-type": "text/html" },
+			}),
+		});
+		const r = await resolveUrl("https://short.example/abc", fetchImpl);
+		expect(r?.resolved).toBe("https://target.example/phish");
+		expect(r?.host_changed).toBe(true);
+		expect(r?.title).toBe("Sign in");
+		expect(r?.hops).toBe(2);
+	});
+
+	it("truncates at the max redirect depth without following indefinitely", async () => {
+		// Build a 10-deep chain; MAX_REDIRECT_HOPS is 5.
+		const chain: Record<string, Response> = {};
+		for (let i = 0; i < 10; i++) {
+			chain[`https://hop${i}.example/`] = new Response("", {
+				status: 302,
+				headers: { location: `https://hop${i + 1}.example/` },
+			});
+		}
+		chain["https://hop10.example/"] = new Response("done", { status: 200 });
+		const r = await resolveUrl("https://hop0.example/", stubFetch(chain));
+		expect(r?.truncated).toBe(true);
+		expect(r?.hops).toBeLessThanOrEqual(5);
+	});
+
+	it("returns a result with final_status=0 when the fetch throws", async () => {
+		const fetchImpl = (async () => { throw new Error("offline"); }) as typeof fetch;
+		const r = await resolveUrl("https://offline.example", fetchImpl);
+		expect(r?.final_status).toBe(0);
+		expect(r?.resolved).toBe("https://offline.example");
+	});
+
+	it("does not change host when the redirect stays on the same domain", async () => {
+		const fetchImpl = stubFetch({
+			"https://same.example/a": new Response("", {
+				status: 302,
+				headers: { location: "https://same.example/b" },
+			}),
+			"https://same.example/b": new Response("ok", { status: 200 }),
+		});
+		const r = await resolveUrl("https://same.example/a", fetchImpl);
+		expect(r?.host_changed).toBe(false);
+	});
+
+	it("returns null for a URL that cannot be parsed", async () => {
+		const r = await resolveUrl("not a url");
+		expect(r).toBeNull();
+	});
+});

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -915,6 +915,76 @@ export class MailboxDO extends DurableObject<Env> {
 			.run();
 	}
 
+	/** Read all URL rows for a message — used by the async deep-scan stage. */
+	async getUrlsForEmail(emailId: string) {
+		return this.db
+			.select()
+			.from(schema.urls)
+			.where(eq(schema.urls.email_id, emailId))
+			.all();
+	}
+
+	async updateUrlScan(
+		urlId: string,
+		data: {
+			resolved_url?: string | null;
+			page_title?: string | null;
+			fetch_status?: string;
+			verdict?: string | null;
+		},
+	) {
+		this.db
+			.update(schema.urls)
+			.set(data)
+			.where(eq(schema.urls.id, urlId))
+			.run();
+	}
+
+	async getAttachmentsForEmail(emailId: string) {
+		return this.db
+			.select()
+			.from(schema.attachments)
+			.where(eq(schema.attachments.email_id, emailId))
+			.all();
+	}
+
+	async updateAttachmentScan(
+		attachmentId: string,
+		data: { scan_status: string; scan_verdict?: string | null },
+	) {
+		this.db
+			.update(schema.attachments)
+			.set(data)
+			.where(eq(schema.attachments.id, attachmentId))
+			.run();
+	}
+
+	async updateDeepScanStatus(emailId: string, status: string) {
+		this.db
+			.update(schema.emails)
+			.set({ deep_scan_status: status })
+			.where(eq(schema.emails.id, emailId))
+			.run();
+	}
+
+	/**
+	 * Read the currently-stored verdict blob so a deep-scan can layer its
+	 * findings onto the synchronous verdict without losing the earlier
+	 * signals. Returns the verdict JSON and the numeric score as stored.
+	 */
+	async getStoredVerdict(emailId: string) {
+		const row = this.db
+			.select({
+				verdict: schema.emails.security_verdict,
+				score: schema.emails.security_score,
+				explanation: schema.emails.security_explanation,
+			})
+			.from(schema.emails)
+			.where(eq(schema.emails.id, emailId))
+			.get();
+		return row ?? null;
+	}
+
 	async getSenderReputation(sender: string) {
 		const row = this.db
 			.select()

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -21,6 +21,8 @@ import { Folders } from "../shared/folders";
 import type { Env } from "./types";
 import { requireMailbox, type MailboxContext } from "./lib/mailbox";
 import { runSecurityPipeline } from "./security";
+import { runDeepScan } from "./intel/deep-scan";
+import { getSecuritySettings } from "./security/settings";
 import { isDmarcReport, ingestDmarcReport } from "./dmarc/ingest";
 import { dmarcRoutes } from "./routes/dmarc";
 import { caseRoutes } from "./routes/cases";
@@ -447,6 +449,31 @@ async function receiveEmail(event: { raw: ReadableStream; rawSize: number }, env
 		}
 	} catch (e) {
 		console.error("Security pipeline failed:", (e as Error).message);
+	}
+
+	// Async deep-scan. Runs AFTER the sync pipeline decision and only ever
+	// tightens the verdict (never downgrades). Enqueued via ctx.waitUntil
+	// so it doesn't block email receipt; failures are logged but don't
+	// propagate. Gated on the same `security.enabled` flag as the sync path.
+	if (securityVerdict) {
+		try {
+			const settings = await getSecuritySettings(env, mailboxId);
+			ctx.waitUntil(
+				runDeepScan({ env, mailboxId, emailId: messageId, thresholds: settings.thresholds })
+					.then(
+						(r) => {
+							if (r.added_score > 0) {
+								console.log(
+									`deep-scan ${messageId}: +${r.added_score} → ${r.final_action} (${r.reasons.slice(0, 3).join("; ")})`,
+								);
+							}
+						},
+						(e) => console.error("deep-scan failed:", (e as Error).message),
+					),
+			);
+		} catch (e) {
+			console.error("deep-scan enqueue failed:", (e as Error).message);
+		}
 	}
 
 	const agentStub = env.EMAIL_AGENT.get(env.EMAIL_AGENT.idFromName(mailboxId));

--- a/workers/intel/attachment-checks.ts
+++ b/workers/intel/attachment-checks.ts
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Filename / MIME-type heuristics for email attachments.
+ *
+ * These checks are PURE — no I/O, no Workers bindings — so they can be
+ * exercised from vitest without mocks and called from both the sync
+ * pipeline (for the extension/MIME mismatch, which is cheap) and the
+ * async deep-scan (for the full multi-signal verdict).
+ *
+ * They do NOT replace antivirus. They catch the low-hanging-fruit delivery
+ * patterns that malware authors have used for decades: risky extensions,
+ * extension/MIME mismatches, and double-extensions designed to hide the
+ * dangerous part behind a friendlier-looking suffix.
+ */
+
+export interface AttachmentInfo {
+	filename: string;
+	mimetype: string;
+	size: number;
+}
+
+export interface AttachmentVerdict {
+	/** 0..100 — higher is more suspicious. */
+	score: number;
+	flags: AttachmentFlag[];
+	/** Short human-readable explanation, at most 3 flags joined. */
+	explanation: string;
+}
+
+export type AttachmentFlag =
+	| "dangerous_extension"
+	| "macro_enabled_office"
+	| "double_extension"
+	| "extension_mime_mismatch"
+	| "suspicious_archive_name"
+	| "executable_in_archive_name"
+	| "zero_byte";
+
+/** Always-block extensions. Executable on the user's OS or a script host. */
+const DANGEROUS_EXTENSIONS = new Set([
+	// Windows executables
+	"exe", "scr", "com", "pif", "cpl", "msi", "msp", "mst", "bat", "cmd",
+	"vbs", "vbe", "js", "jse", "wsf", "wsh", "ps1", "psm1", "hta", "lnk",
+	"reg", "scf", "jar", "application", "gadget",
+	// macOS-y
+	"dmg", "pkg", "command", "app",
+	// Linux-y that are sometimes sent as attachments
+	"deb", "rpm",
+	// Installer scripts
+	"appx", "appxbundle",
+]);
+
+/** Office formats that support macros — not blocked, but high scrutiny. */
+const MACRO_OFFICE_EXTENSIONS = new Set([
+	"docm", "dotm", "xlsm", "xltm", "xlam", "pptm", "potm", "ppam", "ppsm", "sldm",
+]);
+
+/** Archive formats — flagged when their filename advertises an executable inside. */
+const ARCHIVE_EXTENSIONS = new Set(["zip", "rar", "7z", "tar", "gz", "tgz", "iso", "img"]);
+
+/**
+ * Canonical mime-type → set of acceptable extensions.
+ * Used for mismatch detection, not allow-listing. Missing entries mean
+ * "don't assert a match" rather than "reject unseen types".
+ */
+const MIME_EXT_MAP: Record<string, string[]> = {
+	"application/pdf": ["pdf"],
+	"image/png": ["png"],
+	"image/jpeg": ["jpg", "jpeg"],
+	"image/gif": ["gif"],
+	"image/webp": ["webp"],
+	"image/svg+xml": ["svg"],
+	"text/plain": ["txt", "log", "md"],
+	"text/html": ["html", "htm"],
+	"text/csv": ["csv"],
+	"application/zip": ["zip"],
+	"application/x-rar-compressed": ["rar"],
+	"application/x-7z-compressed": ["7z"],
+	"application/msword": ["doc"],
+	"application/vnd.openxmlformats-officedocument.wordprocessingml.document": ["docx"],
+	"application/vnd.ms-excel": ["xls"],
+	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ["xlsx"],
+	"application/vnd.ms-powerpoint": ["ppt"],
+	"application/vnd.openxmlformats-officedocument.presentationml.presentation": ["pptx"],
+};
+
+/** Final extension (lowercased), or empty string if none. */
+export function finalExtension(filename: string): string {
+	const clean = filename.toLowerCase().trim();
+	const idx = clean.lastIndexOf(".");
+	if (idx < 0 || idx === clean.length - 1) return "";
+	return clean.slice(idx + 1);
+}
+
+/** Second-to-last extension, used to detect `.pdf.exe` disguises. */
+function penultimateExtension(filename: string): string {
+	const clean = filename.toLowerCase().trim();
+	const last = clean.lastIndexOf(".");
+	if (last <= 0) return "";
+	const stem = clean.slice(0, last);
+	const prev = stem.lastIndexOf(".");
+	if (prev < 0) return "";
+	return stem.slice(prev + 1);
+}
+
+/**
+ * Score + flag a single attachment. Does NOT look at file contents.
+ *
+ * The score is a *contribution* to the email's overall suspicion score —
+ * call sites decide how to weight it (the async deep-scan aggregates per
+ * email, cap at 30 so attachments can't single-handedly quarantine).
+ */
+export function scoreAttachment(info: AttachmentInfo): AttachmentVerdict {
+	const flags: AttachmentFlag[] = [];
+	let score = 0;
+
+	const last = finalExtension(info.filename);
+	const prev = penultimateExtension(info.filename);
+	const mime = info.mimetype.toLowerCase();
+
+	if (info.size === 0) {
+		flags.push("zero_byte");
+		score += 5; // weak signal, but zero-byte attachments are rarely legitimate
+	}
+
+	if (DANGEROUS_EXTENSIONS.has(last)) {
+		flags.push("dangerous_extension");
+		score += 40;
+	}
+
+	if (MACRO_OFFICE_EXTENSIONS.has(last)) {
+		flags.push("macro_enabled_office");
+		score += 20;
+	}
+
+	// Classic "invoice.pdf.exe" / "report.docx.js" — penultimate extension
+	// is a common "safe" one while the final is dangerous. Flag both on
+	// dangerous final and on mismatched penultimate.
+	if (prev && isLikelyPenultimateCover(prev) && last !== prev) {
+		flags.push("double_extension");
+		score += 15;
+	}
+
+	// MIME/extension mismatch: declared MIME says one thing, filename
+	// extension says another. We only flag when the MIME is one we have
+	// a canonical mapping for — missing map entries pass silently so we
+	// don't flood on exotic-but-valid types.
+	const expected = MIME_EXT_MAP[mime];
+	if (expected && last && !expected.includes(last)) {
+		flags.push("extension_mime_mismatch");
+		score += 15;
+	}
+
+	// Archive whose filename mentions an executable payload. Cheap check
+	// that catches the common `invoice_exe.zip` or `report(exe).zip`
+	// spam/phish patterns without unpacking.
+	if (ARCHIVE_EXTENSIONS.has(last)) {
+		const lower = info.filename.toLowerCase();
+		// Allow underscore/dot/dash/parens as segment separators, not just
+		// \b (which treats `_exe` as a single word).
+		if (/(?:^|[^a-z0-9])(exe|scr|bat|cmd|vbs|js|ps1|hta|lnk)(?:[^a-z0-9]|$)/.test(lower)) {
+			flags.push("executable_in_archive_name");
+			score += 10;
+		} else if (/(?:^|[^a-z0-9])(invoice|receipt|payment|shipment|tracking)(?:[^a-z0-9]|$)/.test(lower)) {
+			// Commercial-bait archive — not blocked, just nudged upward.
+			flags.push("suspicious_archive_name");
+			score += 5;
+		}
+	}
+
+	score = Math.max(0, Math.min(100, score));
+	const explanation = flags.slice(0, 3).join(", ") || "no notable signals";
+	return { score, flags, explanation };
+}
+
+/**
+ * Per-email aggregation: roll up individual attachment verdicts into a
+ * single score capped at 30 so attachments can contribute meaningfully
+ * to quarantine but never dominate the aggregate on their own.
+ */
+export function aggregateAttachmentSignals(
+	verdicts: AttachmentVerdict[],
+): { score: number; flags: AttachmentFlag[]; reasons: string[] } {
+	const flags = new Set<AttachmentFlag>();
+	const reasons: string[] = [];
+	let highest = 0;
+	for (const v of verdicts) {
+		for (const f of v.flags) flags.add(f);
+		if (v.score > highest) highest = v.score;
+		if (v.flags.length > 0) reasons.push(`attachment: ${v.explanation}`);
+	}
+	return {
+		score: Math.min(30, highest),
+		flags: [...flags],
+		// De-duplicated explanation lines, capped at a couple entries for brevity.
+		reasons: dedupe(reasons).slice(0, 2),
+	};
+}
+
+function dedupe(items: string[]): string[] {
+	return [...new Set(items)];
+}
+
+/**
+ * Penultimate extensions that get abused as "cover" in double-extension
+ * tricks. Constrained to common document / media types — we don't want
+ * legitimate files like `archive.tar.gz` to flag.
+ */
+function isLikelyPenultimateCover(ext: string): boolean {
+	return ["pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "txt", "jpg", "jpeg", "png"].includes(ext);
+}

--- a/workers/intel/deep-scan.ts
+++ b/workers/intel/deep-scan.ts
@@ -1,0 +1,247 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Async deep-scan orchestrator.
+ *
+ * Runs AFTER the synchronous security pipeline has stored its verdict
+ * and decided allow/tag/quarantine. Deep-scan adds higher-latency signals
+ * that would have dominated the sync-path budget:
+ *
+ *   - Redirect-chain resolution for every URL (up to 5 hops)
+ *   - RDAP age lookup for each new hostname
+ *   - Attachment extension / MIME / macro heuristics
+ *
+ * If the combined deep-scan signals push the verdict across a higher
+ * threshold (e.g. from `tag` to `quarantine`) we upgrade the verdict and
+ * move the email to the QUARANTINE folder. We never DOWNgrade — sync
+ * decisions are load-bearing (the user may already have seen the email)
+ * so the deep-scan only tightens.
+ *
+ * The orchestrator is best-effort: every external call is wrapped so a
+ * single failure (flaky RDAP server, unreachable URL) never aborts the
+ * scan for the other signals. `deep_scan_status` ends as either
+ * `completed` or `failed` and the stored verdict is always internally
+ * consistent.
+ */
+
+import type { Env } from "../types";
+import type { FinalVerdict, VerdictThresholds } from "../security/verdict";
+import { getMailboxStub } from "../lib/email-helpers";
+import { Folders } from "../../shared/folders";
+import { checkUrlAgainstFeeds } from "./feeds";
+import { lookupDomainAge, FRESH_DOMAIN_THRESHOLD_DAYS } from "./rdap";
+import { resolveUrl } from "./url-resolver";
+import { aggregateAttachmentSignals, scoreAttachment } from "./attachment-checks";
+import { isHomographic } from "../security/urls";
+import { DEFAULT_THRESHOLDS } from "../security/verdict";
+
+export interface DeepScanInput {
+	env: Env;
+	mailboxId: string;
+	emailId: string;
+	thresholds?: VerdictThresholds;
+}
+
+export interface DeepScanResult {
+	added_score: number;
+	reasons: string[];
+	final_action: FinalVerdict["action"] | "unchanged";
+}
+
+/**
+ * Cap on score that deep-scan can add on top of the sync verdict. Keeping
+ * this bounded means operators can tune the sync thresholds independently
+ * of deep-scan sensitivity, and one flaky signal can't single-handedly
+ * quarantine on its own.
+ */
+const DEEP_SCAN_MAX_ADD = 40;
+
+export async function runDeepScan(input: DeepScanInput): Promise<DeepScanResult> {
+	const { env, mailboxId, emailId } = input;
+	const thresholds = input.thresholds ?? DEFAULT_THRESHOLDS;
+	const stub = getMailboxStub(env, mailboxId);
+
+	const stored = await stub.getStoredVerdict(emailId).catch(() => null);
+	// No sync verdict stored — either the pipeline was disabled or errored.
+	// Deep-scan still runs for URL/attachment persistence but can't layer
+	// a score increment onto a missing base verdict.
+	const baseVerdict = parseVerdict(stored?.verdict);
+
+	const reasons: string[] = [];
+	let added = 0;
+
+	try {
+		const urlDelta = await scanUrls(env, mailboxId, emailId);
+		added += urlDelta.score;
+		reasons.push(...urlDelta.reasons);
+	} catch (e) {
+		console.error("deep-scan URL stage failed:", (e as Error).message);
+	}
+
+	try {
+		const attDelta = await scanAttachments(env, mailboxId, emailId);
+		added += attDelta.score;
+		reasons.push(...attDelta.reasons);
+	} catch (e) {
+		console.error("deep-scan attachment stage failed:", (e as Error).message);
+	}
+
+	added = Math.min(DEEP_SCAN_MAX_ADD, added);
+
+	let finalAction: FinalVerdict["action"] | "unchanged" = "unchanged";
+	if (baseVerdict && added > 0) {
+		const newScore = Math.min(100, (stored?.score ?? baseVerdict.score) + added);
+		const newAction = actionForScore(newScore, thresholds);
+		const upgraded = tierIndex(newAction) > tierIndex(baseVerdict.action);
+		if (upgraded) {
+			const upgradedVerdict: FinalVerdict = {
+				...baseVerdict,
+				score: newScore,
+				action: newAction,
+				signals: [...baseVerdict.signals, ...reasons],
+				explanation: dedupe([
+					...baseVerdict.signals.slice(0, 2),
+					...reasons,
+				]).slice(0, 4).join("; "),
+			};
+			await stub.persistSecurityVerdict(emailId, {
+				verdict_json: JSON.stringify(upgradedVerdict),
+				score: newScore,
+				explanation: upgradedVerdict.explanation,
+			}).catch(() => {});
+			if (newAction === "quarantine" || newAction === "block") {
+				await stub.moveEmail(emailId, Folders.QUARANTINE).catch(() => {});
+			}
+			finalAction = newAction;
+		}
+	}
+
+	await stub.updateDeepScanStatus(emailId, "completed").catch(() => {});
+	return { added_score: added, reasons, final_action: finalAction };
+}
+
+async function scanUrls(
+	env: Env,
+	mailboxId: string,
+	emailId: string,
+): Promise<{ score: number; reasons: string[] }> {
+	const stub = getMailboxStub(env, mailboxId);
+	const urls = await stub.getUrlsForEmail(emailId);
+	if (!urls.length) return { score: 0, reasons: [] };
+
+	const reasons: string[] = [];
+	let score = 0;
+	// Track checked hostnames so RDAP isn't hit repeatedly for the same domain.
+	const seenHosts = new Set<string>();
+
+	for (const row of urls) {
+		const urlRow = row as unknown as { id: string; url: string };
+		const resolved = await resolveUrl(urlRow.url).catch(() => null);
+		const finalUrl = resolved?.resolved ?? urlRow.url;
+		const urlVerdict: string[] = [];
+
+		if (resolved?.host_changed) {
+			urlVerdict.push("redirect_host_change");
+			score += 10;
+		}
+		if (resolved?.truncated) {
+			urlVerdict.push("redirect_chain_too_long");
+			score += 5;
+		}
+
+		const host = safeHost(finalUrl);
+		if (host && !seenHosts.has(host)) {
+			seenHosts.add(host);
+			if (isHomographic(host)) {
+				urlVerdict.push("resolved_homograph");
+				score += 15;
+			}
+			const age = await lookupDomainAge(host).catch(() => null);
+			if (age?.is_fresh) {
+				urlVerdict.push(`domain_age_${age.age_days}d`);
+				score += age.age_days < 7 ? 20 : 10;
+			}
+			const feedMatch = await checkUrlAgainstFeeds(env, mailboxId, finalUrl).catch(() => null);
+			if (feedMatch?.confirmed) {
+				urlVerdict.push(`intel_match:${feedMatch.feedId}`);
+				score += 20;
+			}
+		}
+
+		await stub.updateUrlScan(urlRow.id, {
+			resolved_url: finalUrl,
+			page_title: resolved?.title ?? null,
+			fetch_status: resolved ? "completed" : "failed",
+			verdict: urlVerdict.length > 0 ? urlVerdict.join(",") : null,
+		}).catch(() => {});
+
+		if (urlVerdict.length > 0) {
+			reasons.push(`URL ${host ?? urlRow.url}: ${urlVerdict.join(",")}`);
+		}
+	}
+
+	// Cap URL contribution so a particularly nasty-looking link can't
+	// single-handedly burn the whole deep-scan budget.
+	return { score: Math.min(30, score), reasons };
+}
+
+async function scanAttachments(
+	env: Env,
+	mailboxId: string,
+	emailId: string,
+): Promise<{ score: number; reasons: string[] }> {
+	const stub = getMailboxStub(env, mailboxId);
+	const rows = (await stub.getAttachmentsForEmail(emailId)) as unknown as Array<{
+		id: string; filename: string; mimetype: string; size: number;
+	}>;
+	if (!rows.length) return { score: 0, reasons: [] };
+
+	const verdicts = rows.map((r) => ({ row: r, verdict: scoreAttachment(r) }));
+	const agg = aggregateAttachmentSignals(verdicts.map((v) => v.verdict));
+
+	for (const { row, verdict } of verdicts) {
+		await stub.updateAttachmentScan(row.id, {
+			scan_status: "completed",
+			scan_verdict: JSON.stringify(verdict),
+		}).catch(() => {});
+	}
+
+	return { score: agg.score, reasons: agg.reasons };
+}
+
+// ── Internals ────────────────────────────────────────────────────
+
+interface StoredVerdict { verdict: string | null; score: number | null; }
+
+function parseVerdict(raw: string | null | undefined): FinalVerdict | null {
+	if (!raw) return null;
+	try { return JSON.parse(raw) as FinalVerdict; } catch { return null; }
+}
+
+function actionForScore(score: number, thresholds: VerdictThresholds): FinalVerdict["action"] {
+	if (score >= thresholds.block) return "block";
+	if (score >= thresholds.quarantine) return "quarantine";
+	if (score >= thresholds.tag) return "tag";
+	return "allow";
+}
+
+function tierIndex(action: FinalVerdict["action"]): number {
+	switch (action) {
+		case "allow": return 0;
+		case "tag": return 1;
+		case "quarantine": return 2;
+		case "block": return 3;
+	}
+}
+
+function safeHost(url: string): string | null {
+	try { return new URL(url).hostname.toLowerCase(); } catch { return null; }
+}
+
+function dedupe(items: string[]): string[] {
+	return [...new Set(items)];
+}
+
+export type { StoredVerdict };

--- a/workers/intel/rdap.ts
+++ b/workers/intel/rdap.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * RDAP domain registration-age lookup.
+ *
+ * Phishing domains are overwhelmingly fresh — registered days before the
+ * campaign and burned within weeks. Domain age is therefore one of the
+ * highest-signal-per-dollar checks available. We use https://rdap.org/ as
+ * the top-level router; it handles TLD-specific RDAP server discovery.
+ *
+ * The HTTP call is isolated behind `rdapFetch` so tests can inject a fake
+ * transport without touching the network.
+ */
+
+/**
+ * Minimum domain age (in days) to consider "aged"; below this we flag the
+ * domain as fresh-registration suspicious. Chosen at 30 because typical
+ * phishing infrastructure turnover is 1–14 days and legitimate corporate
+ * domains are virtually always much older.
+ */
+export const FRESH_DOMAIN_THRESHOLD_DAYS = 30;
+
+export interface DomainAge {
+	registered_at: string; // ISO-8601
+	age_days: number;
+	is_fresh: boolean;
+}
+
+export type RdapTransport = (url: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Returns domain age info, or `null` when lookup fails for any reason
+ * (network, non-200, missing registration event, unparseable date).
+ * Never throws — callers treat missing age info as "no signal", not
+ * "fail closed", because RDAP providers are rate-limited and flaky and
+ * we don't want false positives on their bad days.
+ */
+export async function lookupDomainAge(
+	domain: string,
+	now: Date = new Date(),
+	fetchImpl: RdapTransport = fetch,
+): Promise<DomainAge | null> {
+	if (!domain) return null;
+	// Strip any leading subdomains and trailing dot; RDAP is keyed by
+	// the registrable (eTLD+1) plus any registrar-accepted subdomain.
+	const canonical = domain.toLowerCase().replace(/\.$/, "");
+
+	let res: Response;
+	try {
+		res = await fetchImpl(`https://rdap.org/domain/${encodeURIComponent(canonical)}`, {
+			// 10s upper bound — the deep-scan budget per email can't be dominated
+			// by a slow RDAP server.
+			signal: AbortSignal.timeout(10_000),
+			headers: { accept: "application/rdap+json, application/json" },
+		});
+	} catch {
+		return null;
+	}
+	if (!res.ok) return null;
+
+	let body: unknown;
+	try {
+		body = await res.json();
+	} catch {
+		return null;
+	}
+	return parseRdapAge(body, now);
+}
+
+/**
+ * Extract the earliest "registration" event date from an RDAP payload.
+ * Exposed for tests; callers should prefer `lookupDomainAge`.
+ */
+export function parseRdapAge(body: unknown, now: Date = new Date()): DomainAge | null {
+	if (!body || typeof body !== "object") return null;
+	const events = (body as { events?: Array<{ eventAction?: unknown; eventDate?: unknown }> }).events;
+	if (!Array.isArray(events)) return null;
+	let earliest: number | null = null;
+	let earliestIso: string | null = null;
+	for (const ev of events) {
+		if (!ev || typeof ev !== "object") continue;
+		if (ev.eventAction !== "registration") continue;
+		if (typeof ev.eventDate !== "string") continue;
+		const ts = Date.parse(ev.eventDate);
+		if (!Number.isFinite(ts)) continue;
+		if (earliest === null || ts < earliest) {
+			earliest = ts;
+			earliestIso = ev.eventDate;
+		}
+	}
+	if (earliest === null || earliestIso === null) return null;
+	const ageMs = now.getTime() - earliest;
+	const age_days = Math.floor(ageMs / 86_400_000);
+	return {
+		registered_at: earliestIso,
+		age_days,
+		is_fresh: age_days >= 0 && age_days < FRESH_DOMAIN_THRESHOLD_DAYS,
+	};
+}

--- a/workers/intel/url-resolver.ts
+++ b/workers/intel/url-resolver.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Follow a URL's redirect chain and surface the final URL + page title.
+ *
+ * The synchronous pipeline only sees the URL as it appears in the email.
+ * Many phishing links use short-URLs or tracking redirectors that hop
+ * through several hosts before landing on the credential-theft page. By
+ * resolving the final hostname we let downstream heuristics (homograph,
+ * intel-feed match) operate on the actual destination.
+ *
+ * The `fetchImpl` parameter is there so tests can avoid touching the
+ * network; production callers use the global `fetch`.
+ */
+
+export const MAX_REDIRECT_HOPS = 5;
+export const RESOLVE_TIMEOUT_MS = 8000;
+
+export interface ResolvedUrl {
+	original: string;
+	resolved: string;
+	hops: number;
+	/** Trimmed `<title>` from the final GET, if any. Capped at 200 chars. */
+	title: string | null;
+	/** Set when the chain exits the starting hostname — a strong anti-phishing tell. */
+	host_changed: boolean;
+	/** HTTP status of the final response; 0 when the fetch failed. */
+	final_status: number;
+	/** True when the chain stopped because of MAX_REDIRECT_HOPS. */
+	truncated: boolean;
+}
+
+export async function resolveUrl(
+	rawUrl: string,
+	fetchImpl: typeof fetch = fetch,
+): Promise<ResolvedUrl | null> {
+	const startHost = safeHost(rawUrl);
+	if (!startHost) return null;
+
+	const result: ResolvedUrl = {
+		original: rawUrl,
+		resolved: rawUrl,
+		hops: 0,
+		title: null,
+		host_changed: false,
+		final_status: 0,
+		truncated: false,
+	};
+
+	// First, do a HEAD-follow chain with manual redirect handling so we can
+	// count hops and surface the hostname change. We'd use `redirect: "follow"`
+	// on fetch but that hides the intermediate Location headers we want to
+	// count.
+	let current = rawUrl;
+	for (let i = 0; i <= MAX_REDIRECT_HOPS; i++) {
+		if (i === MAX_REDIRECT_HOPS) {
+			result.truncated = true;
+			break;
+		}
+		let res: Response;
+		try {
+			res = await fetchImpl(current, {
+				method: "GET",
+				redirect: "manual",
+				signal: AbortSignal.timeout(RESOLVE_TIMEOUT_MS),
+				headers: {
+					// Many phishing redirectors refuse to emit Location without a
+					// recognisable browser UA. Use a generic one.
+					"user-agent": "Mozilla/5.0 (compatible; AgenticInboxSecurity/1.0)",
+				},
+			});
+		} catch {
+			result.final_status = 0;
+			result.resolved = current;
+			break;
+		}
+		result.hops = i + 1;
+		result.final_status = res.status;
+		if (res.status >= 300 && res.status < 400) {
+			const loc = res.headers.get("location");
+			if (!loc) break;
+			const next = absolutize(current, loc);
+			if (!next) break;
+			current = next;
+			continue;
+		}
+		result.resolved = current;
+		// Only bother extracting a title on HTML-ish responses.
+		const ct = res.headers.get("content-type") || "";
+		if (ct.toLowerCase().includes("html")) {
+			try {
+				const text = (await res.text()).slice(0, 200_000);
+				result.title = extractTitle(text);
+			} catch {
+				// ignore body read failures — we have the URL already
+			}
+		}
+		break;
+	}
+
+	const endHost = safeHost(result.resolved);
+	result.host_changed = !!endHost && endHost !== startHost;
+	return result;
+}
+
+function absolutize(base: string, loc: string): string | null {
+	try {
+		return new URL(loc, base).toString();
+	} catch {
+		return null;
+	}
+}
+
+function safeHost(url: string): string | null {
+	try {
+		return new URL(url).hostname.toLowerCase();
+	} catch {
+		return null;
+	}
+}
+
+const TITLE_RE = /<title\b[^>]*>([\s\S]*?)<\/title>/i;
+
+export function extractTitle(html: string): string | null {
+	const match = html.match(TITLE_RE);
+	if (!match) return null;
+	return match[1]
+		.replace(/\s+/g, " ")
+		.trim()
+		.slice(0, 200) || null;
+}


### PR DESCRIPTION
Stacked on [#7](https://github.com/schmug/agentic-inbox/pull/7).

## Why
`hub/` had zero tests despite hosting the trust-weighted corroboration logic that decides what shows up on the destroylist feed — a decision that directly shapes what threats downstream Agentic Inbox mailboxes act on. Untested security-critical code is a liability we should close.

## What
Stands up vitest + a minimal in-memory D1 adapter backed by better-sqlite3 (`foreign_keys OFF` to match Cloudflare D1 defaults; `?N` placeholders translated to object-keyed binds).

### Aggregate tests
- **Sybil resistance**: one org cannot single-handedly promote intel by resubmitting the same attribute, even with a high trust multiplier. `contributor_count` guard is the invariant.
- Trust accumulation across distinct orgs.
- Non-promotable attribute types (comment, text) are ignored.
- Sharing-group isolation between tenants.
- Promotion thresholds scope to the requested sharing group.

### Hash tests
- `sha256` produces the known digests of `""` and `"abc"`; deterministic; distinct inputs yield distinct digests; multi-byte UTF-8 handled.
- `generateSecret` returns 43-char base64url (~256 bits) and is collision-free across 50 samples.

### Auth tests
- Rejects missing/unknown/revoked keys with 401.
- Accepts both bare-key (MISP convention) and `Bearer`-prefixed forms.
- Confirms the DB stores `sha256(key)`, not the key itself.

## Test plan
- [x] `cd hub && npm test` — 22/22
- [ ] Recommend adding `hub` to CI so the suite runs on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)