### PR TITLE
Wire attachment-type gate into pipeline scoring and settings merge

### DIFF
--- a/tests/security/triage.test.ts
+++ b/tests/security/triage.test.ts
@@ -180,3 +180,100 @@ describe("evaluateTriage — hard allow", () => {
 		expect(r.shortcircuit).toBeUndefined();
 	});
 });
+
+describe("evaluateTriage — attachment block", () => {
+	it("quarantines on an executable attachment under the default policy", () => {
+		const r = evaluateTriage({
+			...baseInputs,
+			sender: "whoever@example.com",
+			auth: dmarcFail,
+			reputation: null,
+			intelMatch: null,
+			settings: baseSettings,
+			attachments: [{ filename: "invoice.exe", mimetype: "application/pdf" }],
+		});
+		expect(r.shortcircuit?.tier).toBe("attachment_block");
+		expect(r.shortcircuit?.verdict.action).toBe("quarantine");
+		expect(r.shortcircuit?.verdict.score).toBe(100);
+		expect(r.shortcircuit?.reason).toContain(".exe");
+	});
+
+	it("preserves the double-extension trick: invoice.pdf.exe blocks on .exe", () => {
+		const r = evaluateTriage({
+			...baseInputs,
+			sender: "x@y.com",
+			auth: dmarcPass,
+			reputation: null,
+			intelMatch: null,
+			settings: baseSettings,
+			attachments: [{ filename: "invoice.pdf.exe", mimetype: "application/pdf" }],
+		});
+		expect(r.shortcircuit?.tier).toBe("attachment_block");
+	});
+
+	it("runs BEFORE hard-allow: allowlisted + DMARC-pass sender with .exe is still blocked", () => {
+		// Design invariant: account takeover or auto-forwarded malware should
+		// not be papered over by allowlist membership.
+		const r = evaluateTriage({
+			...baseInputs,
+			sender: "ceo@trusted.com",
+			auth: dmarcPass,
+			reputation: null,
+			intelMatch: null,
+			settings: { ...baseSettings, allowlist_senders: ["ceo@trusted.com"] },
+			attachments: [{ filename: "payroll.exe", mimetype: "application/octet-stream" }],
+		});
+		expect(r.shortcircuit?.tier).toBe("attachment_block");
+	});
+
+	it("does NOT short-circuit on safe attachments", () => {
+		const r = evaluateTriage({
+			...baseInputs,
+			sender: "x@y.com",
+			auth: dmarcFail,
+			reputation: null,
+			intelMatch: null,
+			settings: baseSettings,
+			attachments: [{ filename: "invoice.pdf", mimetype: "application/pdf" }],
+		});
+		expect(r.shortcircuit).toBeUndefined();
+	});
+
+	it("does NOT short-circuit on container/macro attachments (those only score)", () => {
+		// Default policy: container_action="score", macro_office_action="score".
+		// Neither category should cause a triage-level short-circuit.
+		const r = evaluateTriage({
+			...baseInputs,
+			sender: "x@y.com",
+			auth: dmarcFail,
+			reputation: null,
+			intelMatch: null,
+			settings: baseSettings,
+			attachments: [
+				{ filename: "report.iso", mimetype: "application/octet-stream" },
+				{ filename: "report.docm", mimetype: "application/vnd.ms-word.document.macroenabled.12" },
+			],
+		});
+		expect(r.shortcircuit).toBeUndefined();
+	});
+
+	it("custom_blocklist_extensions extends the block set (e.g. .ace)", () => {
+		const r = evaluateTriage({
+			...baseInputs,
+			sender: "x@y.com",
+			auth: dmarcFail,
+			reputation: null,
+			intelMatch: null,
+			settings: {
+				...baseSettings,
+				attachment_policy: {
+					...baseSettings.attachment_policy,
+					custom_blocklist_extensions: ["ace"],
+				},
+			},
+			attachments: [{ filename: "malware.ace", mimetype: "application/octet-stream" }],
+		});
+		expect(r.shortcircuit?.tier).toBe("attachment_block");
+		expect(r.shortcircuit?.reason).toContain(".ace");
+	});
+});

--- a/tests/security/verdict.test.ts
+++ b/tests/security/verdict.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { aggregateVerdict, DEFAULT_THRESHOLDS } from "../../workers/security/verdict";
+import { DEFAULT_ATTACHMENT_POLICY } from "../../workers/security/attachments";
 import type { AuthVerdict } from "../../workers/security/auth";
 import type { ClassificationResult } from "../../workers/security/classification";
 
@@ -73,6 +74,45 @@ describe("aggregateVerdict", () => {
 		});
 		expect(v.explanation.length).toBeGreaterThan(0);
 		expect(v.explanation).not.toBe("no notable signals");
+	});
+
+	it("adds +25 for a container-format attachment under the default policy", () => {
+		// Baseline uses DMARC-fail so score is positive before the attachment
+		// contribution — otherwise the [0,100] clamp masks the real delta.
+		const failAuth: AuthVerdict = { spf: "fail", dkim: "fail", dmarc: "fail" };
+		const common = { auth: failAuth, classification: safeClass, urls: [], reputation: null };
+		const without = aggregateVerdict(common);
+		const withIso = aggregateVerdict({
+			...common,
+			attachments: [{ filename: "installer.iso" }],
+			attachmentPolicy: DEFAULT_ATTACHMENT_POLICY,
+		});
+		expect(withIso.score - without.score).toBe(25);
+		expect(withIso.signals.some((s) => s.includes(".iso"))).toBe(true);
+	});
+
+	it("adds +15 for a macro-enabled Office attachment", () => {
+		const failAuth: AuthVerdict = { spf: "fail", dkim: "fail", dmarc: "fail" };
+		const common = { auth: failAuth, classification: safeClass, urls: [], reputation: null };
+		const without = aggregateVerdict(common);
+		const withDocm = aggregateVerdict({
+			...common,
+			attachments: [{ filename: "report.docm" }],
+			attachmentPolicy: DEFAULT_ATTACHMENT_POLICY,
+		});
+		expect(withDocm.score - without.score).toBe(15);
+	});
+
+	it("adds no score for an ordinary PDF attachment", () => {
+		const failAuth: AuthVerdict = { spf: "fail", dkim: "fail", dmarc: "fail" };
+		const common = { auth: failAuth, classification: safeClass, urls: [], reputation: null };
+		const without = aggregateVerdict(common);
+		const withPdf = aggregateVerdict({
+			...common,
+			attachments: [{ filename: "invoice.pdf" }],
+			attachmentPolicy: DEFAULT_ATTACHMENT_POLICY,
+		});
+		expect(withPdf.score).toBe(without.score);
 	});
 
 	it("respects custom thresholds", () => {

--- a/workers/security/index.ts
+++ b/workers/security/index.ts
@@ -146,7 +146,14 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 		: await classifyEmail(env.AI, { subject, sender, bodyHtml, auth });
 
 	let verdict = aggregateVerdict(
-		{ auth, classification, urls, reputation },
+		{
+			auth,
+			classification,
+			urls,
+			reputation,
+			attachments,
+			attachmentPolicy: settings.attachment_policy,
+		},
 		settings.thresholds,
 	);
 

--- a/workers/security/settings.ts
+++ b/workers/security/settings.ts
@@ -78,11 +78,13 @@ export interface MailboxSecuritySettings {
 	 */
 	folder_policies?: Record<string, FolderPolicy>;
 	/**
-	 * Attachment-type gate. When present, runs before hard-allow in triage
-	 * so a DMARC-passing allowlisted sender carrying an .exe still gets
-	 * quarantined. See `attachments.ts`.
+	 * Attachment-type gate. Runs before hard-allow in triage so a
+	 * DMARC-passing allowlisted sender carrying an .exe still gets
+	 * quarantined. Defaults are conservative-but-actionable: executables
+	 * hard-block, containers/macros only score. See `attachments.ts` for
+	 * the full rules.
 	 */
-	attachment_policy?: AttachmentPolicy;
+	attachment_policy: AttachmentPolicy;
 }
 
 /**
@@ -105,6 +107,7 @@ export const DEFAULT_SECURITY_SETTINGS: MailboxSecuritySettings = {
 	trusted_auto_allow: true,
 	trusted_auto_allow_min_messages: 10,
 	intel_auto_block: true,
+	attachment_policy: DEFAULT_ATTACHMENT_POLICY,
 };
 
 export async function getSecuritySettings(
@@ -136,6 +139,17 @@ export async function getSecuritySettings(
 					boost_on_off_hours: raw.business_hours.boost_on_off_hours ?? false,
 				}
 				: undefined,
+			// Merge attachment_policy field-by-field so a partially-specified user
+			// block (e.g. only `custom_blocklist_extensions`) doesn't silently
+			// drop the default actions back to "ignore" across the board.
+			attachment_policy: {
+				...DEFAULT_ATTACHMENT_POLICY,
+				...(raw.attachment_policy ?? {}),
+				custom_blocklist_extensions: (raw.attachment_policy?.custom_blocklist_extensions
+					?? DEFAULT_ATTACHMENT_POLICY.custom_blocklist_extensions)
+					.map((e) => e.trim().toLowerCase().replace(/^\./, ""))
+					.filter((e) => e.length > 0),
+			},
 		};
 		return merged;
 	} catch (e) {

--- a/workers/security/verdict.ts
+++ b/workers/security/verdict.ts
@@ -15,10 +15,12 @@ import type { AuthVerdict } from "./auth";
 import type { ClassificationResult } from "./classification";
 import type { ExtractedUrl } from "./urls";
 import type { SenderReputation } from "./reputation";
+import type { AttachmentLike, AttachmentPolicy } from "./attachments";
 import { scoreAuth } from "./auth";
 import { scoreClassification } from "./classification";
 import { scoreUrls } from "./urls";
 import { scoreReputation } from "./reputation";
+import { scoreAttachments } from "./attachments";
 
 export type VerdictAction = "allow" | "tag" | "quarantine" | "block";
 
@@ -38,6 +40,18 @@ export interface VerdictInputs {
 	classification: ClassificationResult;
 	urls: ExtractedUrl[];
 	reputation: SenderReputation | null;
+	/**
+	 * PostalMime-parsed attachment metadata. Only filename/mimetype is read;
+	 * the bodies already live in R2 by the time the pipeline runs.
+	 */
+	attachments?: AttachmentLike[];
+	/**
+	 * Attachment-type gate policy. When omitted or null, attachments
+	 * contribute no score here. Hard-blocks are handled by the triage tier
+	 * before aggregation; this hook only picks up the "score" contributions
+	 * (container/macro-office under the defaults).
+	 */
+	attachmentPolicy?: AttachmentPolicy | null;
 }
 
 export interface VerdictThresholds {
@@ -74,6 +88,17 @@ export function aggregateVerdict(
 	const rep = scoreReputation(inputs.reputation);
 	score += rep.score;
 	signals.push(...rep.reasons);
+
+	// Attachment-type gate. Hard-blocks are handled by the triage tier before
+	// we ever reach aggregation; here we only pick up the "score" action
+	// contributions (container / macro-office under the defaults). If a
+	// policy set `executable_action: "score"`, its contribution also lands
+	// here rather than short-circuiting.
+	if (inputs.attachmentPolicy && inputs.attachments && inputs.attachments.length > 0) {
+		const att = scoreAttachments(inputs.attachments, inputs.attachmentPolicy);
+		score += att.score;
+		signals.push(...att.reasons);
+	}
 
 	score = Math.max(0, Math.min(100, Math.round(score)));
 


### PR DESCRIPTION
## Summary
- `workers/security/attachments.ts` and the `attachment_block` triage tier shipped in #4 alongside folder-bypass, but the pipeline plumbing was only half-finished. This finishes the wiring.
- Adds `attachment_policy` to `DEFAULT_SECURITY_SETTINGS` with `DEFAULT_ATTACHMENT_POLICY` (executable: block, container: score, macro-office: score) so the tier actually fires on fresh mailboxes.
- `getSecuritySettings` now merges partial user policies field-by-field — a user supplying only `custom_blocklist_extensions` no longer clobbers the default actions back to undefined. The custom blocklist is additive-only, normalized to lowercased no-dot form.
- `aggregateVerdict` now threads `attachments` + `attachmentPolicy` through `VerdictInputs` and calls `scoreAttachments`, so container (+25) and macro-office (+15) contributions actually land in the final score. Hard-blocks continue to short-circuit in triage before aggregation.
- `workers/security/index.ts` passes `settings.attachment_policy` and the PostalMime attachment list through to both triage (existing) and aggregate (new).

## Design notes
- **Attachment-block runs BEFORE hard-allow.** A DMARC-passing allowlisted sender carrying an `.exe` is, by definition, no longer sending legitimate mail (account takeover, auto-forwarded malware). Tests lock this invariant in.
- **Classification is extension-only.** Mimetype on email attachments is whatever the sending client set and is trivially spoofed. Last extension wins (`invoice.pdf.exe` → `.exe`).
- **Custom blocklist is additive.** Users can expand what gets blocked but can never weaken executable defaults.

## Test plan
- [x] `npx vitest run` — 136 passed (was 127; +9 new)
- [x] `npx tsc -b` — clean
- [x] `cd hub && npx tsc --noEmit` — clean
- [x] Hand-traced cases verified via test:
  - `invoice.exe` → triage `attachment_block`, quarantine, score 100
  - `report.iso` → aggregate +25, no hard-block
  - `report.docm` → aggregate +15, no hard-block
  - `invoice.pdf` → no contribution
  - `malware.ace` with `custom_blocklist_extensions: ["ace"]` → triage `attachment_block`
  - `payroll.exe` from allowlisted+DMARC-pass sender → still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)