### PR TITLE
Detect encrypted/password-protected archives in deep-scan

### DIFF
--- a/tests/intel/attachment-checks.test.ts
+++ b/tests/intel/attachment-checks.test.ts
@@ -1,9 +1,111 @@
 import { describe, expect, it } from "vitest";
 import {
 	aggregateAttachmentSignals,
+	detectEncryptedArchive,
 	finalExtension,
 	scoreAttachment,
 } from "../../workers/intel/attachment-checks";
+
+// ── byte-buffer helpers for the detectEncryptedArchive tests ────────────
+//
+// These construct minimal-but-valid archive prefixes by hand so the tests
+// don't depend on any compression library. We only need enough bytes for
+// the header-parsing code to reach an encryption-flag decision.
+
+/** Build a ZIP local-file-header with the given general-purpose flag. */
+function zipLocalHeader(gpFlag: number, prefix: Uint8Array = new Uint8Array(0)): Uint8Array {
+	const hdr = new Uint8Array(30 + 4); // 30-byte fixed header + 4-byte filename "test"
+	const view = new DataView(hdr.buffer);
+	view.setUint32(0, 0x04034b50, true); // signature
+	view.setUint16(4, 20, true); // version needed
+	view.setUint16(6, gpFlag, true); // general purpose flag
+	view.setUint16(8, 0, true); // compression method (stored)
+	view.setUint16(10, 0, true); // mod time
+	view.setUint16(12, 0, true); // mod date
+	view.setUint32(14, 0, true); // CRC-32
+	view.setUint32(18, 0, true); // compressed size
+	view.setUint32(22, 0, true); // uncompressed size
+	view.setUint16(26, 4, true); // filename length
+	view.setUint16(28, 0, true); // extra length
+	// "test" filename bytes
+	hdr[30] = 0x74; hdr[31] = 0x65; hdr[32] = 0x73; hdr[33] = 0x74;
+	const out = new Uint8Array(prefix.length + hdr.length);
+	out.set(prefix, 0);
+	out.set(hdr, prefix.length);
+	return out;
+}
+
+/**
+ * Build a RAR4 archive prefix (magic + MARK_HEAD + MAIN_HEAD) with the
+ * given main-header flags. MHD_PASSWORD is 0x0080 per the RAR technote
+ * and the unrar source (`#define MHD_PASSWORD 0x0080`).
+ */
+function rar4Prefix(mainFlags: number): Uint8Array {
+	const out = new Uint8Array(7 + 13);
+	// MARK_HEAD magic: `Rar!\x1a\x07\x00`
+	out.set([0x52, 0x61, 0x72, 0x21, 0x1a, 0x07, 0x00], 0);
+	// MAIN_HEAD block at offset 7: CRC(2) + TYPE(1) + FLAGS(2) + SIZE(2) + HighPosAV(2) + PosAV(4)
+	const view = new DataView(out.buffer);
+	view.setUint16(7, 0x0000, true); // CRC (not validated by our detector)
+	out[9] = 0x73; // HEAD_TYPE = MAIN_HEAD
+	view.setUint16(10, mainFlags, true); // HEAD_FLAGS
+	view.setUint16(12, 13, true); // HEAD_SIZE
+	view.setUint16(14, 0, true); // HighPosAV
+	view.setUint32(16, 0, true); // PosAV
+	return out;
+}
+
+describe("detectEncryptedArchive", () => {
+	it("returns false for a plain ZIP (GP flag bit 0 = 0)", () => {
+		expect(detectEncryptedArchive(zipLocalHeader(0x0000), "zip")).toBe(false);
+	});
+
+	it("returns true for an encrypted ZIP (GP flag bit 0 = 1)", () => {
+		expect(detectEncryptedArchive(zipLocalHeader(0x0001), "zip")).toBe(true);
+	});
+
+	it("returns true for a self-extracting (SFX) encrypted ZIP with an EXE stub prefix", () => {
+		// SFX archives prepend an EXE loader — the ZIP local-file-header
+		// signature is NOT at offset 0. The detector must scan for it.
+		const exeStub = new Uint8Array(2048);
+		for (let i = 0; i < exeStub.length; i++) exeStub[i] = (i * 7) & 0xff;
+		exeStub[0] = 0x4d; exeStub[1] = 0x5a; // "MZ" DOS header
+		expect(detectEncryptedArchive(zipLocalHeader(0x0001, exeStub), "zip")).toBe(true);
+	});
+
+	it("returns false for a RAR4 archive with no password", () => {
+		expect(detectEncryptedArchive(rar4Prefix(0x0000), "rar")).toBe(false);
+	});
+
+	it("returns true for a RAR4 archive with MHD_PASSWORD set", () => {
+		expect(detectEncryptedArchive(rar4Prefix(0x0080), "rar")).toBe(true);
+	});
+
+	it("returns false for very short / truncated buffers without throwing", () => {
+		expect(detectEncryptedArchive(new Uint8Array([1, 2, 3]), "zip")).toBe(false);
+		expect(detectEncryptedArchive(new Uint8Array([0x52, 0x61]), "rar")).toBe(false);
+	});
+
+	it("returns false for a buffer that contains no archive signature", () => {
+		const junk = new Uint8Array(1024);
+		for (let i = 0; i < junk.length; i++) junk[i] = 0x20;
+		expect(detectEncryptedArchive(junk, "zip")).toBe(false);
+		expect(detectEncryptedArchive(junk, "rar")).toBe(false);
+	});
+
+	it("returns false for 7z (header-encryption detection not implemented in v1)", () => {
+		// 7z signature is `7z\xBC\xAF\x27\x1C`. Header-encryption detection
+		// requires walking the StartHeader stream, which is deferred. We
+		// document the conservative behaviour: always return false rather
+		// than risk false-positives on legit 7z archives.
+		const sig = new Uint8Array([0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c, 0x00, 0x04, 0x00, 0x00]);
+		expect(detectEncryptedArchive(sig, "7z")).toBe(false);
+	});
+
+	it("returns false for non-archive extensions", () => {
+		expect(detectEncryptedArchive(zipLocalHeader(0x0001), "pdf")).toBe(false);
+	});
+});
 
 describe("finalExtension", () => {
 	it("returns lowercased extension", () => {
@@ -80,6 +182,39 @@ describe("scoreAttachment", () => {
 		const v = scoreAttachment({ filename: "invoice.pdf.exe", mimetype: "application/pdf", size: 0 });
 		expect(v.score).toBeLessThanOrEqual(100);
 		expect(v.score).toBeGreaterThanOrEqual(0);
+	});
+
+	it("flags encrypted_archive when the caller reports a positive content signal", () => {
+		const v = scoreAttachment(
+			{ filename: "payload.zip", mimetype: "application/zip", size: 10_000 },
+			{ encryptedArchive: true },
+		);
+		expect(v.flags).toContain("encrypted_archive");
+		expect(v.score).toBeGreaterThanOrEqual(25);
+	});
+
+	it("subsumes the bait-name nudge when an archive is also encrypted (avoids double-count)", () => {
+		// `invoice.zip` alone would trigger "suspicious_archive_name" (+5).
+		// When it is ALSO encrypted, the bigger signal wins and we skip the
+		// nudge so the reason string isn't redundant in the UI.
+		const v = scoreAttachment(
+			{ filename: "invoice.zip", mimetype: "application/zip", size: 10_000 },
+			{ encryptedArchive: true },
+		);
+		expect(v.flags).toContain("encrypted_archive");
+		expect(v.flags).not.toContain("suspicious_archive_name");
+	});
+
+	it("does not flag encrypted_archive when the signal is absent/false", () => {
+		const plain = scoreAttachment(
+			{ filename: "photos.zip", mimetype: "application/zip", size: 10_000 },
+			{ encryptedArchive: false },
+		);
+		expect(plain.flags).not.toContain("encrypted_archive");
+		const omitted = scoreAttachment(
+			{ filename: "photos.zip", mimetype: "application/zip", size: 10_000 },
+		);
+		expect(omitted.flags).not.toContain("encrypted_archive");
 	});
 });
 

--- a/workers/intel/attachment-checks.ts
+++ b/workers/intel/attachment-checks.ts
@@ -37,7 +37,20 @@ export type AttachmentFlag =
 	| "extension_mime_mismatch"
 	| "suspicious_archive_name"
 	| "executable_in_archive_name"
+	| "encrypted_archive"
 	| "zero_byte";
+
+/**
+ * Optional pre-computed content signals. `scoreAttachment` itself does NOT
+ * read bytes — it only inspects filename/MIME. Byte-level checks (e.g.
+ * detecting a password-protected ZIP via local-file-header GP flag) happen
+ * in the async deep-scan path where fetching bytes from R2 is affordable;
+ * the result is passed here so the verdict lives in one place.
+ */
+export interface AttachmentContentSignals {
+	/** True when `detectEncryptedArchive` found an encryption flag set. */
+	encryptedArchive?: boolean;
+}
 
 /** Always-block extensions. Executable on the user's OS or a script host. */
 const DANGEROUS_EXTENSIONS = new Set([
@@ -107,13 +120,23 @@ function penultimateExtension(filename: string): string {
 }
 
 /**
- * Score + flag a single attachment. Does NOT look at file contents.
+ * Score + flag a single attachment.
+ *
+ * This function itself does NOT read file contents — it only inspects the
+ * filename and declared MIME. Byte-level signals (like a password-protected
+ * ZIP detected via `detectEncryptedArchive`) are computed separately by the
+ * async deep-scan and handed in via `signals`. Keeping the content read
+ * out of this function lets the same code path serve both the sync pipeline
+ * (where we don't pay for R2 reads) and deep-scan.
  *
  * The score is a *contribution* to the email's overall suspicion score —
  * call sites decide how to weight it (the async deep-scan aggregates per
  * email, cap at 30 so attachments can't single-handedly quarantine).
  */
-export function scoreAttachment(info: AttachmentInfo): AttachmentVerdict {
+export function scoreAttachment(
+	info: AttachmentInfo,
+	signals?: AttachmentContentSignals,
+): AttachmentVerdict {
 	const flags: AttachmentFlag[] = [];
 	let score = 0;
 
@@ -154,6 +177,17 @@ export function scoreAttachment(info: AttachmentInfo): AttachmentVerdict {
 		score += 15;
 	}
 
+	// Content-level: encrypted archive (zip/rar/…). An encrypted archive
+	// delivered over email is a well-established malware delivery pattern
+	// (Emotet, Qakbot): the password arrives in the message body so the
+	// recipient can open it, while the encryption defeats antivirus
+	// scanning at the gateway. Scored between `macro_enabled_office` (20)
+	// and `dangerous_extension` (40) to reflect that risk.
+	if (signals?.encryptedArchive) {
+		flags.push("encrypted_archive");
+		score += 25;
+	}
+
 	// Archive whose filename mentions an executable payload. Cheap check
 	// that catches the common `invoice_exe.zip` or `report(exe).zip`
 	// spam/phish patterns without unpacking.
@@ -164,8 +198,14 @@ export function scoreAttachment(info: AttachmentInfo): AttachmentVerdict {
 		if (/(?:^|[^a-z0-9])(exe|scr|bat|cmd|vbs|js|ps1|hta|lnk)(?:[^a-z0-9]|$)/.test(lower)) {
 			flags.push("executable_in_archive_name");
 			score += 10;
-		} else if (/(?:^|[^a-z0-9])(invoice|receipt|payment|shipment|tracking)(?:[^a-z0-9]|$)/.test(lower)) {
+		} else if (
+			!signals?.encryptedArchive &&
+			/(?:^|[^a-z0-9])(invoice|receipt|payment|shipment|tracking)(?:[^a-z0-9]|$)/.test(lower)
+		) {
 			// Commercial-bait archive — not blocked, just nudged upward.
+			// Subsumed by the stronger `encrypted_archive` signal when both
+			// apply (e.g. `invoice.zip` that is password-protected); we skip
+			// the bait nudge so the reason string in the UI isn't redundant.
 			flags.push("suspicious_archive_name");
 			score += 5;
 		}
@@ -174,6 +214,131 @@ export function scoreAttachment(info: AttachmentInfo): AttachmentVerdict {
 	score = Math.max(0, Math.min(100, score));
 	const explanation = flags.slice(0, 3).join(", ") || "no notable signals";
 	return { score, flags, explanation };
+}
+
+// ── Content-based detection ────────────────────────────────────────
+//
+// These helpers DO read raw bytes and are called from the async deep-scan
+// with a size-capped buffer (the first ~32KB of the attachment). Kept here
+// so the flag that describes the outcome lives next to the detector that
+// produces it.
+
+/** Maximum bytes we'll scan looking for an archive signature. Guards against
+ *  runaway loops on large buffers and keeps the work proportional to what
+ *  the deep-scan actually fetches from R2. */
+const ARCHIVE_SCAN_WINDOW = 32 * 1024;
+
+/** Per-format minimum buffer lengths. Anything shorter can't carry enough
+ *  structure to decide safely. A ZIP local-file-header is 30 bytes fixed;
+ *  a RAR4 main header is 20 bytes past the 7-byte magic. */
+const ZIP_MIN_LEN = 30;
+const RAR4_MIN_LEN = 7 + 13;
+/** Lower bound below which any archive buffer is junk. */
+const ARCHIVE_MIN_LEN = Math.min(ZIP_MIN_LEN, RAR4_MIN_LEN);
+
+/**
+ * Detect whether an archive's header advertises encryption / password
+ * protection. Reads ONLY the bytes we have (caller typically passes a
+ * partial R2 read of 32KB) — never decrypts or decompresses.
+ *
+ * Supported:
+ *   - ZIP: local-file-header general-purpose flag bit 0. Scans the window
+ *     for the signature rather than assuming offset 0, so self-extracting
+ *     archives with an EXE stub prefix are still detected. NOTE: Central
+ *     Directory Encryption (PKZIP SES strong encryption) is NOT detected —
+ *     the CD lives at end-of-file which is outside our window. We accept
+ *     this false-negative rather than over-fetch.
+ *   - RAR4: MAIN_HEAD (HEAD_TYPE 0x73) MHD_PASSWORD flag bit 0x0080, AND
+ *     any file block (HEAD_TYPE 0x74) with LHD_PASSWORD bit 0x0004. Flag
+ *     values are per the RAR technote / unrar source.
+ *   - RAR5: not yet implemented — header record walking is deferred.
+ *     Returns false. (Parse failures on a RAR5-signature buffer are safe
+ *     false-negatives, not throws.)
+ *   - 7z: not implemented. Header encryption detection requires walking
+ *     SignatureHeader → StartHeader streams; deferred to avoid
+ *     false-positives on legitimate 7z archives.
+ *
+ * Never throws. A false-negative is strictly preferable to a false-positive
+ * here — we'd rather miss a malicious archive than block a legitimate one.
+ */
+export function detectEncryptedArchive(bytes: Uint8Array, ext: string): boolean {
+	if (!bytes || bytes.length < ARCHIVE_MIN_LEN) return false;
+	const lower = ext.toLowerCase();
+
+	if (lower === "zip") return detectEncryptedZip(bytes);
+	if (lower === "rar") return detectEncryptedRar(bytes);
+	// 7z and anything else: conservative false.
+	return false;
+}
+
+function detectEncryptedZip(bytes: Uint8Array): boolean {
+	if (bytes.length < ZIP_MIN_LEN) return false;
+	// Find the first local-file-header signature (0x04034b50, little-endian
+	// on disk => bytes 50 4B 03 04) within the scan window. SFX archives
+	// prepend a native executable stub, so we can't assume offset 0.
+	const limit = Math.min(bytes.length - 30, ARCHIVE_SCAN_WINDOW);
+	for (let i = 0; i <= limit; i++) {
+		if (
+			bytes[i] === 0x50 &&
+			bytes[i + 1] === 0x4b &&
+			bytes[i + 2] === 0x03 &&
+			bytes[i + 3] === 0x04
+		) {
+			// General-purpose bit flag is a 16-bit LE field at offset +6.
+			// Bit 0 = "file is encrypted" (PKZIP 2.0+). AES-encrypted zips
+			// use AE-x extra-field 0x9901 but STILL set bit 0, so this
+			// single check covers both classical and AES encryption for
+			// local-file-header encryption.
+			const gpFlag = bytes[i + 6] | (bytes[i + 7] << 8);
+			return (gpFlag & 0x0001) !== 0;
+		}
+	}
+	return false;
+}
+
+function detectEncryptedRar(bytes: Uint8Array): boolean {
+	if (bytes.length < RAR4_MIN_LEN) return false;
+	// RAR4 magic: `Rar!\x1a\x07\x00`. RAR5 magic ends with `\x01\x00`.
+	// We detect RAR4 specifically; RAR5 is deferred.
+	const magicRar4 = [0x52, 0x61, 0x72, 0x21, 0x1a, 0x07, 0x00];
+	for (let i = 0; i < magicRar4.length; i++) {
+		if (bytes[i] !== magicRar4[i]) return false;
+	}
+
+	// Walk the block headers. Each block begins with: CRC(2) TYPE(1) FLAGS(2)
+	// SIZE(2) and optionally ADD_SIZE(4) when FLAGS & LONG_BLOCK (0x8000).
+	// We stop after a bounded number of blocks or when SIZE looks invalid —
+	// this is a detector, not a parser, so giving up is always safe.
+	let offset = magicRar4.length;
+	const MAX_BLOCKS = 32;
+	for (let block = 0; block < MAX_BLOCKS && offset + 7 <= bytes.length; block++) {
+		const type = bytes[offset + 2];
+		const flags = bytes[offset + 3] | (bytes[offset + 4] << 8);
+		const size = bytes[offset + 5] | (bytes[offset + 6] << 8);
+
+		if (type === 0x73) {
+			// MAIN_HEAD — archive-level password flag.
+			if ((flags & 0x0080) !== 0) return true;
+		} else if (type === 0x74) {
+			// FILE_HEAD — per-file password flag.
+			if ((flags & 0x0004) !== 0) return true;
+		}
+
+		if (size < 7) return false; // malformed — stop rather than loop
+		let advance = size;
+		if ((flags & 0x8000) !== 0 && offset + 11 <= bytes.length) {
+			// LONG_BLOCK adds a 4-byte ADD_SIZE after HEAD_SIZE.
+			const addSize =
+				bytes[offset + 7] |
+				(bytes[offset + 8] << 8) |
+				(bytes[offset + 9] << 16) |
+				(bytes[offset + 10] << 24);
+			if (addSize > 0) advance += addSize;
+		}
+		if (advance <= 0 || advance > ARCHIVE_SCAN_WINDOW) return false;
+		offset += advance;
+	}
+	return false;
 }
 
 /**

--- a/workers/intel/deep-scan.ts
+++ b/workers/intel/deep-scan.ts
@@ -33,7 +33,12 @@ import { Folders } from "../../shared/folders";
 import { checkUrlAgainstFeeds } from "./feeds";
 import { lookupDomainAge, FRESH_DOMAIN_THRESHOLD_DAYS } from "./rdap";
 import { resolveUrl } from "./url-resolver";
-import { aggregateAttachmentSignals, scoreAttachment } from "./attachment-checks";
+import {
+	aggregateAttachmentSignals,
+	detectEncryptedArchive,
+	finalExtension,
+	scoreAttachment,
+} from "./attachment-checks";
 import { isHomographic } from "../security/urls";
 import { DEFAULT_THRESHOLDS } from "../security/verdict";
 
@@ -198,7 +203,16 @@ async function scanAttachments(
 	}>;
 	if (!rows.length) return { score: 0, reasons: [] };
 
-	const verdicts = rows.map((r) => ({ row: r, verdict: scoreAttachment(r) }));
+	// For archive attachments, fetch the first 32KB from R2 and run the
+	// header-level encryption detector. 32KB gives us room for self-
+	// extracting stubs (SFX zips prepend an EXE) and for RAR5 main headers
+	// that can sit after a prefix, without the cost of a full object read.
+	// Skipped for non-archives and for very small files where any "archive"
+	// is certainly junk.
+	const verdicts = await Promise.all(rows.map(async (r) => {
+		const signals = await detectArchiveSignals(env, emailId, r);
+		return { row: r, verdict: scoreAttachment(r, signals) };
+	}));
 	const agg = aggregateAttachmentSignals(verdicts.map((v) => v.verdict));
 
 	for (const { row, verdict } of verdicts) {
@@ -209,6 +223,41 @@ async function scanAttachments(
 	}
 
 	return { score: agg.score, reasons: agg.reasons };
+}
+
+/** Extensions for which we do a bounded R2 read to sniff encryption flags. */
+const ENCRYPTED_ARCHIVE_CHECK_EXTS = new Set(["zip", "rar", "7z"]);
+/** Size of the prefix we fetch from R2 for archive-header inspection. */
+const ARCHIVE_HEADER_READ_BYTES = 32 * 1024;
+/** Below this file size, any "archive" is certainly junk — skip the R2 read. */
+const ARCHIVE_MIN_FILE_SIZE = 100;
+
+/**
+ * Fetch enough bytes from the R2-stored attachment to decide whether the
+ * archive advertises encryption. Best-effort: any failure returns an empty
+ * signal object so attachment scoring can proceed without this input.
+ */
+async function detectArchiveSignals(
+	env: Env,
+	emailId: string,
+	row: { id: string; filename: string; size: number },
+): Promise<{ encryptedArchive?: boolean }> {
+	const ext = finalExtension(row.filename);
+	if (!ENCRYPTED_ARCHIVE_CHECK_EXTS.has(ext)) return {};
+	if (row.size < ARCHIVE_MIN_FILE_SIZE) return {};
+
+	const key = `attachments/${emailId}/${row.id}/${row.filename}`;
+	try {
+		const obj = await env.BUCKET.get(key, {
+			range: { offset: 0, length: ARCHIVE_HEADER_READ_BYTES },
+		});
+		if (!obj) return {};
+		const buf = new Uint8Array(await obj.arrayBuffer());
+		return { encryptedArchive: detectEncryptedArchive(buf, ext) };
+	} catch (e) {
+		console.error("deep-scan archive header read failed:", (e as Error).message);
+		return {};
+	}
 }
 
 // ── Internals ────────────────────────────────────────────────────

--- a/workers/security/attachments.ts
+++ b/workers/security/attachments.ts
@@ -194,7 +194,9 @@ export function scoreAttachments(
 //   [invoice.pdf]  → hardBlock=false, score 0
 //   [malware.ace] with custom_blocklist_extensions=["ace"] → hardBlock=true
 //
-// TODO(attachments): password-protected archive heuristic. zip/rar with a
-// very high ratio of unparseable content relative to size is a classic
-// malware-smuggling pattern, but we can't cleanly detect it without an
-// unzip implementation in the Worker — deferred alongside full deep-scan.
+// Content-based attachment signals (e.g. detecting a password-protected
+// ZIP/RAR via archive-header encryption flags) live in the async deep-scan,
+// not here. This sync module stays filename+MIME only so the hot receive
+// path never pays for an R2 read. See `detectEncryptedArchive` in
+// `workers/intel/attachment-checks.ts` and its call site in
+// `workers/intel/deep-scan.ts:scanAttachments`.


### PR DESCRIPTION
## Summary
- Closes the TODO at `workers/security/attachments.ts:197` — encrypted archives delivered over email are a well-known Emotet/Qakbot delivery pattern.
- New `detectEncryptedArchive(bytes, ext)` parses the first 32KB of an attachment (via R2 range read) to check ZIP general-purpose flag bit 0 and RAR4 MHD_PASSWORD/LHD_PASSWORD flags. RAR5 and 7z are deferred (conservative false).
- Runs in the **async deep-scan**, not the sync pipeline, so the hot receive path remains byte-free.
- `scoreAttachment` takes an optional `{encryptedArchive}` signal, adds +25 (between `macro_enabled_office` 20 and `dangerous_extension` 40), and suppresses the weaker `suspicious_archive_name` nudge to avoid duplicate reasons.
- SFX ZIPs (EXE stub prefix) are handled by scanning for the signature rather than assuming offset 0.

## Caveats (documented false-negatives)
- ZIP Central Directory Encryption (PKZIP SES) — CD lives at EOF, outside the 32KB window. Missing this is safer than over-fetching.
- RAR5 — header-record walking is non-trivial; deferred.
- 7z — header encryption detection needs StartHeader stream walking; deferred.

## Test plan
- [x] `npx vitest run tests/intel/attachment-checks.test.ts` — 30 tests, incl. hand-crafted ZIP/RAR byte buffers, SFX prefix, truncated junk.
- [x] `npx vitest run` — full suite 148/148 green.
- [x] `npx tsc -b` — clean.
- [ ] Staging smoke: send a real password-protected ZIP to a test mailbox, verify the verdict row picks up `encrypted_archive` and that the deep-scan log shows `+25`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)