### PR TITLE
Clean up DO state and R2 blobs on mailbox delete

### DIFF
--- a/tests/lib/attachments.test.ts
+++ b/tests/lib/attachments.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { attachmentObjectKey } from "../../workers/lib/attachments";
+
+/**
+ * The R2 key layout is load-bearing: the mailbox-delete reap
+ * (`workers/index.ts:reapMailbox`) reconstructs every key from
+ * `(email_id, attachment_id, filename)` triples pulled out of the
+ * Durable Object. If the write path and the read/delete path ever
+ * drift apart, deletes become silent no-ops and blobs orphan in R2
+ * forever. These tests pin the format in exactly one place.
+ */
+describe("attachmentObjectKey", () => {
+	it("uses the attachments/<emailId>/<attachmentId>/<filename> layout", () => {
+		expect(attachmentObjectKey("email-1", "att-1", "report.pdf")).toBe(
+			"attachments/email-1/att-1/report.pdf",
+		);
+	});
+
+	it("preserves whatever filename the caller supplies", () => {
+		// Filenames are sanitized at the write boundary (storeAttachments
+		// and the email-receive path). This helper trusts its inputs so
+		// read-side reconstruction matches byte-for-byte.
+		const weird = "spaces and.dots.zip";
+		expect(attachmentObjectKey("e", "a", weird)).toBe(`attachments/e/a/${weird}`);
+	});
+
+	it("round-trips: prefix + three segments separated by slashes", () => {
+		const key = attachmentObjectKey("E", "A", "f.bin");
+		expect(key.startsWith("attachments/")).toBe(true);
+		expect(key.split("/")).toEqual(["attachments", "E", "A", "f.bin"]);
+	});
+});

--- a/workers/agent/index.ts
+++ b/workers/agent/index.ts
@@ -577,4 +577,15 @@ Based on the email content and thread context above, draft a reply using draft_r
 			return { status: "error", error: (e as Error).message };
 		}
 	}
+
+	/**
+	 * Wipe ALL agent state for this mailbox. Used by the mailbox-delete
+	 * flow to clear conversation history and any AIChatAgent-managed
+	 * internal storage. Safe because each mailbox has its own DO — the
+	 * namespace uses `idFromName(mailboxId)` so this never touches state
+	 * for any other mailbox.
+	 */
+	async reset(): Promise<void> {
+		await this.ctx.storage.deleteAll();
+	}
 }

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -10,6 +10,7 @@ import * as schema from "../db/schema";
 import { Folders } from "../../shared/folders";
 import type { Env } from "../types";
 import { applyMigrations, mailboxMigrations } from "./migrations";
+import { attachmentObjectKey } from "../lib/attachments";
 
 /**
  * SQL expression to normalize email subjects by stripping common
@@ -957,6 +958,48 @@ export class MailboxDO extends DurableObject<Env> {
 			.set(data)
 			.where(eq(schema.attachments.id, attachmentId))
 			.run();
+	}
+
+	/**
+	 * Enumerate every attachment's R2 object key (`attachments/{email_id}/{id}/{filename}`)
+	 * so the mailbox-delete flow can reap R2 blobs before wiping this DO.
+	 *
+	 * Key construction happens HERE rather than at the caller so the caller
+	 * can't mishandle the `filename` field. Filenames are already sanitized
+	 * at receive time (`workers/index.ts` strips path separators and control
+	 * characters before ever storing to R2), so this mirrors that format.
+	 *
+	 * v1 returns everything in a single array. A long-lived mailbox can
+	 * hold thousands of attachments — still fine here because SQLite-in-DO
+	 * is local and the caller batches deletes downstream. If a mailbox
+	 * ever reaches hundreds of thousands of rows, add cursor-based paging.
+	 */
+	async listAllAttachmentKeys(): Promise<string[]> {
+		const rows = this.db
+			.select({
+				id: schema.attachments.id,
+				email_id: schema.attachments.email_id,
+				filename: schema.attachments.filename,
+			})
+			.from(schema.attachments)
+			.all();
+		return rows.map((r) => attachmentObjectKey(r.email_id, r.id, r.filename));
+	}
+
+	/**
+	 * Wipe ALL state for this mailbox DO. Used by the mailbox-delete flow.
+	 *
+	 * `ctx.storage.deleteAll()` clears SQLite *and* any KV-style storage
+	 * under this DO. The next inbound method call reconstructs the DO:
+	 * the constructor re-runs migrations on the empty DB, leaving a fresh
+	 * mailbox identical to one that never existed.
+	 *
+	 * Callers MUST have already drained external storage (R2 blobs) before
+	 * calling this, because the attachment table is the only place those
+	 * keys are enumerated.
+	 */
+	async reset(): Promise<void> {
+		await this.ctx.storage.deleteAll();
 	}
 
 	async updateDeepScanStatus(emailId: string, status: string) {

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -7,7 +7,7 @@ import { cors } from "hono/cors";
 import PostalMime from "postal-mime";
 import { z } from "zod";
 import { sendEmail } from "./email-sender";
-import { storeAttachments, type StoredAttachment } from "./lib/attachments";
+import { attachmentObjectKey, storeAttachments, type StoredAttachment } from "./lib/attachments";
 import {
 	validateSender,
 	SenderValidationError,
@@ -145,9 +145,66 @@ app.delete("/api/v1/mailboxes/:mailboxId", async (c) => {
 	const mailboxId = c.req.param("mailboxId")!;
 	const key = `mailboxes/${mailboxId}.json`;
 	if (!(await c.env.BUCKET.head(key))) return c.json({ error: "Not found" }, 404);
-	await c.env.BUCKET.delete(key); // TODO: also delete DO data and R2 attachment blobs
+
+	// Settings-first delete. Removing the settings JSON makes the mailbox
+	// invisible to every list/get endpoint immediately, and a DELETE retry
+	// after partial failure is now idempotent: the next `head()` returns
+	// null and we 404 cleanly. The heavier reap (R2 attachments + DO wipe)
+	// runs in the background via waitUntil — orphaned rows/blobs are a
+	// cleanup cost, never a correctness bug.
+	await c.env.BUCKET.delete(key);
+	c.executionCtx.waitUntil(reapMailbox(c.env, mailboxId));
 	return c.body(null, 204);
 });
+
+/** Upper bound on R2 delete batch size. The Workers R2 binding accepts up
+ *  to 1000 keys per call, but each call still consumes subrequest budget —
+ *  100 keeps us well inside both the per-request subrequest cap and
+ *  `reapMailbox`'s overall budget on mailboxes with long history. */
+const R2_DELETE_BATCH = 100;
+
+/**
+ * Best-effort cleanup for a deleted mailbox. Every step is isolated in its
+ * own try/catch so a partial failure (e.g. the DO being unreachable for a
+ * few seconds) never cancels the remaining steps. None of these errors
+ * propagate to the user — the settings JSON was already removed so the
+ * mailbox is effectively gone from the product's point of view.
+ */
+async function reapMailbox(env: Env, mailboxId: string): Promise<void> {
+	const mbStub = env.MAILBOX.get(env.MAILBOX.idFromName(mailboxId));
+	const agentStub = env.EMAIL_AGENT.get(env.EMAIL_AGENT.idFromName(mailboxId));
+
+	// 1. Enumerate attachment keys BEFORE the DO wipe. After deleteAll(),
+	//    the attachments table is the only place these keys live, so we
+	//    must list them first or accept orphans in R2 forever.
+	let keys: string[] = [];
+	try {
+		keys = await (mbStub as any).listAllAttachmentKeys();
+	} catch (e) {
+		console.error(`reapMailbox(${mailboxId}): listAllAttachmentKeys failed:`, (e as Error).message);
+	}
+
+	// 2. Batched R2 deletes. Each batch is its own try/catch so one failed
+	//    chunk doesn't abandon the rest — the alternative is leaving the
+	//    bulk of the blobs stranded because the first batch tripped a
+	//    transient error.
+	for (let i = 0; i < keys.length; i += R2_DELETE_BATCH) {
+		try {
+			await env.BUCKET.delete(keys.slice(i, i + R2_DELETE_BATCH));
+		} catch (e) {
+			console.error(`reapMailbox(${mailboxId}): R2 batch delete failed at offset ${i}:`, (e as Error).message);
+		}
+	}
+
+	// 3. Wipe both DOs. Safe to do after the R2 reap because neither
+	//    bucket read nor bucket delete depended on DO state at this point.
+	await (mbStub as any).reset().catch(
+		(e: Error) => console.error(`reapMailbox(${mailboxId}): mailbox DO reset failed:`, e.message),
+	);
+	await (agentStub as any).reset().catch(
+		(e: Error) => console.error(`reapMailbox(${mailboxId}): agent DO reset failed:`, e.message),
+	);
+}
 
 // -- Emails ---------------------------------------------------------
 
@@ -254,7 +311,7 @@ app.delete("/api/v1/mailboxes/:mailboxId/emails/:id", async (c: AppContext) => {
 	const id = c.req.param("id")!;
 	const attachments = await c.var.mailboxStub.deleteEmail(id);
 	if (attachments === null) return c.json({ error: "Not found" }, 404);
-	if (attachments.length > 0) await c.env.BUCKET.delete(attachments.map((att: any) => `attachments/${id}/${att.id}/${att.filename}`));
+	if (attachments.length > 0) await c.env.BUCKET.delete(attachments.map((att: any) => attachmentObjectKey(id, att.id, att.filename)));
 	return c.body(null, 204);
 });
 
@@ -353,7 +410,7 @@ app.get("/api/v1/mailboxes/:mailboxId/emails/:emailId/attachments/:attachmentId"
 	const attachmentId = c.req.param("attachmentId")!;
 	const attachment = await c.var.mailboxStub.getAttachment(attachmentId);
 	if (!attachment) return c.json({ error: "Attachment not found" }, 404);
-	const obj = await c.env.BUCKET.get(`attachments/${emailId}/${attachmentId}/${attachment.filename}`);
+	const obj = await c.env.BUCKET.get(attachmentObjectKey(emailId, attachmentId, attachment.filename));
 	if (!obj) return c.json({ error: "Attachment file not found" }, 404);
 	const headers = new Headers();
 	headers.set("Content-Type", attachment.mimetype);
@@ -410,7 +467,7 @@ async function receiveEmail(event: { raw: ReadableStream; rawSize: number }, env
 		for (const att of parsedEmail.attachments) {
 			const attId = crypto.randomUUID();
 			const filename = (att.filename || "untitled").replace(/[\/\\:*?"<>|\x00-\x1f]/g, "_");
-			await env.BUCKET.put(`attachments/${messageId}/${attId}/${filename}`, att.content);
+			await env.BUCKET.put(attachmentObjectKey(messageId, attId, filename), att.content);
 			attachmentData.push({ id: attId, email_id: messageId, filename, mimetype: att.mimeType,
 				size: typeof att.content === "string" ? att.content.length : att.content.byteLength,
 				content_id: att.contentId || null, disposition: att.disposition || "attachment" });

--- a/workers/lib/attachments.ts
+++ b/workers/lib/attachments.ts
@@ -19,6 +19,28 @@ export interface StoredAttachment {
 }
 
 /**
+ * Canonical R2 key for an attachment blob. All read/write/delete sites
+ * should funnel through this helper so the layout is defined in exactly
+ * one place — the mailbox-delete reap in particular relies on being able
+ * to reconstruct every key from `(email_id, attachment_id, filename)`
+ * triples stored in the DO.
+ *
+ * The `filename` segment is NOT re-sanitized here. Callers that accept
+ * user input (inbound email, API uploads) already strip path separators
+ * and control characters at the write boundary (`storeAttachments` below
+ * and the receive path in `workers/index.ts`); applying a second
+ * transformation here would introduce a mismatch between write and
+ * read keys.
+ */
+export function attachmentObjectKey(
+	emailId: string,
+	attachmentId: string,
+	filename: string,
+): string {
+	return `attachments/${emailId}/${attachmentId}/${filename}`;
+}
+
+/**
  * Store base64-encoded attachments to R2 and return metadata for the DO.
  */
 export async function storeAttachments(
@@ -39,7 +61,7 @@ export async function storeAttachments(
 		const attachmentId = crypto.randomUUID();
 		// Sanitize filename to prevent path traversal in R2 keys
 		const safeFilename = (att.filename || "untitled").replace(/[\/\\:*?"<>|\x00-\x1f]/g, "_");
-		const key = `attachments/${emailId}/${attachmentId}/${safeFilename}`;
+		const key = attachmentObjectKey(emailId, attachmentId, safeFilename);
 		const binaryStr = atob(att.content);
 		const bytes = Uint8Array.from(binaryStr, (c) => c.charCodeAt(0));
 		await bucket.put(key, bytes);


### PR DESCRIPTION
## Summary
- Closes the TODO at `workers/index.ts:148`. Deleting a mailbox previously removed only the settings JSON, leaving every email row, folder, sender-reputation entry, DMARC report, attachment blob, and agent chat history behind. Recreating the same address inherited all of it.
- New flow: settings JSON deleted **first** (mailbox becomes invisible immediately, retries are idempotent), then `reapMailbox` runs in `executionCtx.waitUntil` — endpoint returns 204 without waiting.
- `reapMailbox` lists R2 keys via a new DO method `listAllAttachmentKeys()`, batch-deletes them (100/batch to stay under R2 binding + subrequest caps), then calls `reset()` on both `MailboxDO` and `EmailAgent` (new methods; `ctx.storage.deleteAll()`).
- Every step isolated in its own try/catch so one transient failure doesn't abandon the rest. Failures logged, never bubbled.

## Bonus cleanup
Consolidated the R2 attachment-key format into a single helper `attachmentObjectKey(emailId, attachmentId, filename)` shared by the 5 sites that previously inlined `` `attachments/${emailId}/${attId}/${filename}` ``. Added unit tests to pin the layout — without this, a drift between the write path and the new read path in the reap would silently orphan blobs.

## Safety notes
- Cloudflare Access JWT middleware (`workers/app.ts:36`) covers this endpoint — destructive action is not exposed unauthed.
- `EmailAgent` DOs are per-mailbox via `idFromName(mailboxId)`, so `reset()` only touches this mailbox's state.
- `v1` lists all attachment keys into one array. Fine for typical mailboxes; cursor pagination noted as a follow-up if a mailbox ever reaches hundreds of thousands of rows.

## Test plan
- [x] `npx vitest run` — 139 tests, incl. new `tests/lib/attachments.test.ts` pinning the R2 key format.
- [x] `npx tsc -b` — clean.
- [ ] Staging smoke: create mailbox → send email with attachment → DELETE → confirm 204, confirm `GET /:id` → 404 immediately, confirm R2 attachment key is gone, confirm recreating the same address gives an empty inbox (not old emails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)