### PR TITLE
Add foreground new-mail notifications via per-mailbox WebSocket

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -3,19 +3,64 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 import { Button, Input, Tooltip } from "@cloudflare/kumo";
-import { GearSixIcon, ListIcon, MagnifyingGlassIcon, RobotIcon, XIcon } from "@phosphor-icons/react";
+import {
+	BellIcon,
+	BellSlashIcon,
+	GearSixIcon,
+	ListIcon,
+	MagnifyingGlassIcon,
+	RobotIcon,
+	XIcon,
+} from "@phosphor-icons/react";
 import { type KeyboardEvent, useEffect, useState } from "react";
 import { useLocation, useNavigate, useParams, useSearchParams } from "react-router";
 import { useUIStore } from "~/hooks/useUIStore";
 
+type NotificationStatus = "unsupported" | "default" | "granted" | "denied";
+
+function readNotificationStatus(): NotificationStatus {
+	if (typeof window === "undefined" || typeof Notification === "undefined") {
+		return "unsupported";
+	}
+	return Notification.permission as NotificationStatus;
+}
+
 export default function Header() {
 	const [searchQuery, setSearchQuery] = useState("");
 	const [isSearchExpanded, setIsSearchExpanded] = useState(false);
+	const [notifStatus, setNotifStatus] = useState<NotificationStatus>("unsupported");
 	const { mailboxId } = useParams<{ mailboxId: string }>();
 	const navigate = useNavigate();
 	const location = useLocation();
 	const [searchParams] = useSearchParams();
 	const { toggleSidebar, toggleAgentPanel, isAgentPanelOpen } = useUIStore();
+
+	// Read on mount only. The Permissions API would let us watch for revocation
+	// in real time but Safari's support is uneven and a stale "granted" badge
+	// is harmless — the OS still controls actual delivery.
+	useEffect(() => {
+		setNotifStatus(readNotificationStatus());
+	}, []);
+
+	const requestNotifications = async () => {
+		if (typeof Notification === "undefined") return;
+		try {
+			const result = await Notification.requestPermission();
+			setNotifStatus(result as NotificationStatus);
+		} catch {
+			// Older Safari throws on the promise form. Ignore — the user can
+			// re-enable via browser settings if it falls through.
+		}
+	};
+
+	const notifTooltip = (() => {
+		switch (notifStatus) {
+			case "granted": return "Desktop notifications enabled";
+			case "denied": return "Notifications blocked — enable in browser settings";
+			case "default": return "Enable desktop notifications";
+			default: return "Notifications not supported in this browser";
+		}
+	})();
 
 	// Sync search input with URL query param so it stays populated
 	const urlQuery = searchParams.get("q") || "";
@@ -119,6 +164,22 @@ export default function Header() {
 			)}
 
 			<div className="flex items-center gap-1 ml-auto shrink-0">
+				{notifStatus !== "unsupported" && (
+					<Tooltip content={notifTooltip} side="bottom" asChild>
+						<Button
+							variant={notifStatus === "granted" ? "secondary" : "ghost"}
+							shape="square"
+							icon={
+								notifStatus === "denied"
+									? <BellSlashIcon size={20} />
+									: <BellIcon size={20} weight={notifStatus === "granted" ? "fill" : "regular"} />
+							}
+							onClick={requestNotifications}
+							disabled={notifStatus === "granted" || notifStatus === "denied"}
+							aria-label={notifTooltip}
+						/>
+					</Tooltip>
+				)}
 				<Tooltip content={isAgentPanelOpen ? "Hide agent panel" : "Show agent panel"} side="bottom" asChild>
 					<Button
 						variant={isAgentPanelOpen ? "secondary" : "ghost"}

--- a/app/hooks/useMailboxEvents.ts
+++ b/app/hooks/useMailboxEvents.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { useEffect } from "react";
+
+export interface MailboxEvent {
+	type: "new-email";
+	id: string;
+	folder: string;
+}
+
+/**
+ * Subscribe to a mailbox's realtime event stream. Auth piggybacks on the
+ * Cloudflare Access cookie attached to same-origin WebSocket upgrades.
+ *
+ * Reconnects with simple jittered backoff. Backoff resets on a successful
+ * `open`; component unmount or a `mailboxId` change closes the socket and
+ * cancels any pending reconnect.
+ */
+export function useMailboxEvents(
+	mailboxId: string | undefined,
+	onEvent: (event: MailboxEvent) => void,
+) {
+	useEffect(() => {
+		if (!mailboxId) return;
+		if (typeof window === "undefined") return;
+
+		let ws: WebSocket | null = null;
+		let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+		let attempt = 0;
+		let cancelled = false;
+
+		const url = (() => {
+			const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+			return `${proto}//${window.location.host}/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/events`;
+		})();
+
+		const connect = () => {
+			if (cancelled) return;
+			ws = new WebSocket(url);
+
+			ws.addEventListener("open", () => {
+				attempt = 0;
+			});
+
+			ws.addEventListener("message", (e) => {
+				if (typeof e.data !== "string") return;
+				try {
+					const parsed = JSON.parse(e.data) as MailboxEvent;
+					if (parsed && parsed.type === "new-email") onEvent(parsed);
+				} catch {
+					// Ignore malformed frames.
+				}
+			});
+
+			ws.addEventListener("close", () => {
+				if (cancelled) return;
+				attempt += 1;
+				// 1s, 2s, 4s, ... capped at 30s, with up to 1s of jitter.
+				const base = Math.min(30_000, 1_000 * 2 ** Math.min(attempt - 1, 5));
+				const delay = base + Math.random() * 1_000;
+				reconnectTimer = setTimeout(connect, delay);
+			});
+		};
+
+		connect();
+
+		return () => {
+			cancelled = true;
+			if (reconnectTimer) clearTimeout(reconnectTimer);
+			if (ws && ws.readyState <= WebSocket.OPEN) ws.close();
+		};
+	}, [mailboxId, onEvent]);
+}

--- a/app/routes/email-list.tsx
+++ b/app/routes/email-list.tsx
@@ -176,10 +176,13 @@ export default function EmailListRoute() {
 		[folder, page],
 	);
 
+	// Live updates arrive via the per-mailbox WebSocket subscription mounted
+	// in `app/routes/mailbox.tsx`, which invalidates this query on each new
+	// email. The manual refresh button below remains as an explicit fallback.
 	const {
 		data: emailData,
 		isFetching: isRefreshing,
-	} = useEmails(mailboxId, params, { refetchInterval: 30_000 });
+	} = useEmails(mailboxId, params);
 
 	const emails = emailData?.emails ?? [];
 	const totalCount = emailData?.totalCount ?? 0;

--- a/app/routes/mailbox.tsx
+++ b/app/routes/mailbox.tsx
@@ -2,13 +2,17 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef } from "react";
 import { Outlet, useParams } from "react-router";
+import { Folders } from "shared/folders";
 import AgentSidebar from "~/components/AgentSidebar";
 import ComposeEmail from "~/components/ComposeEmail";
 import Header from "~/components/Header";
 import Sidebar from "~/components/Sidebar";
+import { type MailboxEvent, useMailboxEvents } from "~/hooks/useMailboxEvents";
 import { useMailbox } from "~/queries/mailboxes";
+import { queryKeys } from "~/queries/keys";
 import { useUIStore } from "~/hooks/useUIStore";
 
 export default function MailboxRoute() {
@@ -16,6 +20,7 @@ export default function MailboxRoute() {
 	// Prefetch mailbox data for child components
 	useMailbox(mailboxId);
 	const prevMailboxIdRef = useRef<string | undefined>(undefined);
+	const queryClient = useQueryClient();
 	const {
 		isSidebarOpen,
 		closeSidebar,
@@ -23,6 +28,33 @@ export default function MailboxRoute() {
 		closePanel,
 		closeComposeModal,
 	} = useUIStore();
+
+	const handleMailboxEvent = useCallback(
+		(event: MailboxEvent) => {
+			if (!mailboxId || event.type !== "new-email") return;
+			queryClient.invalidateQueries({ queryKey: ["emails", mailboxId] });
+			queryClient.invalidateQueries({ queryKey: queryKeys.folders.list(mailboxId) });
+
+			// Quarantined / blocked mail still invalidates so the list updates
+			// for users browsing Quarantine, but never raises a desktop toast.
+			if (event.folder !== Folders.INBOX) return;
+			if (typeof Notification === "undefined") return;
+			if (Notification.permission !== "granted") return;
+			if (typeof document !== "undefined" && document.visibilityState === "visible") return;
+
+			try {
+				new Notification("New email", {
+					body: mailboxId,
+					tag: event.id, // dedupe across multiple tabs viewing the same mailbox
+					icon: "/favicon.svg",
+				});
+			} catch {
+				// Some browsers throw if invoked outside a service worker; ignore.
+			}
+		},
+		[mailboxId, queryClient],
+	);
+	useMailboxEvents(mailboxId, handleMailboxEvent);
 
 	useEffect(() => {
 		if (

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -110,6 +110,42 @@ export class MailboxDO extends DurableObject<Env> {
 		applyMigrations(this.ctx.storage.sql, mailboxMigrations, this.ctx.storage);
 	}
 
+	// ── Realtime event stream (WebSocket, hibernation API) ─────────
+	//
+	// Foreground "new mail" notifications. Clients open a WebSocket via
+	// `GET /api/v1/mailboxes/:id/events` (see workers/index.ts) and the
+	// inbound email handler calls `notifyNewEmail` after the sync security
+	// verdict so quarantined mail doesn't surface as a desktop notification.
+
+	async fetch(request: Request): Promise<Response> {
+		if (request.headers.get("Upgrade") !== "websocket") {
+			return new Response("Expected WebSocket upgrade", { status: 426 });
+		}
+		const pair = new WebSocketPair();
+		const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+		this.ctx.acceptWebSocket(server);
+		return new Response(null, { status: 101, webSocket: client });
+	}
+
+	async webSocketMessage(_ws: WebSocket, _msg: ArrayBuffer | string) {
+		// Server-push only; ignore anything the client sends.
+	}
+
+	async webSocketClose(ws: WebSocket, code: number, _reason: string, _wasClean: boolean) {
+		try { ws.close(code, "closing"); } catch { /* already closed */ }
+	}
+
+	async webSocketError(_ws: WebSocket, _err: unknown) {
+		// Hibernation API requires the handler; nothing to do.
+	}
+
+	async notifyNewEmail(emailId: string, folderId: string) {
+		const payload = JSON.stringify({ type: "new-email", id: emailId, folder: folderId });
+		for (const ws of this.ctx.getWebSockets()) {
+			try { ws.send(payload); } catch { /* dead socket — hibernation will GC */ }
+		}
+	}
+
 	// ── Email CRUD (Drizzle) ───────────────────────────────────────
 
 	async getEmails(options: GetEmailsOptions = {}) {

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -132,6 +132,18 @@ app.get("/api/v1/mailboxes/:mailboxId", async (c) => {
 	return c.json({ id: mailboxId, name: mailboxId, email: mailboxId, settings: await obj.json() });
 });
 
+// Realtime event stream. Browsers can't set custom headers on `new
+// WebSocket()`, so auth piggybacks on the `cf-access-jwt-assertion` header
+// the CF Access edge injects on all origin requests (including Upgrade)
+// when the user's session is valid. The `*` middleware in workers/app.ts
+// validates that header before this route is reached.
+app.get("/api/v1/mailboxes/:mailboxId/events", async (c) => {
+	if (c.req.header("Upgrade") !== "websocket") {
+		return c.text("Expected WebSocket upgrade", 426);
+	}
+	return c.var.mailboxStub.fetch(c.req.raw);
+});
+
 app.put("/api/v1/mailboxes/:mailboxId", async (c) => {
 	const mailboxId = c.req.param("mailboxId")!;
 	const { settings } = (await c.req.json()) as { settings: Record<string, unknown> };
@@ -543,6 +555,22 @@ async function receiveEmail(event: { raw: ReadableStream; rawSize: number }, env
 		}
 	} catch (e) {
 		console.error("Security pipeline failed:", (e as Error).message);
+	}
+
+	// Foreground notification fanout. Pass the *final* folder so connected
+	// clients can suppress desktop notifications for mail that was
+	// quarantined/blocked by the sync verdict — surfacing a notification for
+	// a phishing email that just vanished into Quarantine is worse than
+	// silence. Deep-scan can still tighten the verdict later, but that
+	// happens out-of-band and does not retract the notification.
+	const finalFolder =
+		securityVerdict?.action === "quarantine" || securityVerdict?.action === "block"
+			? Folders.QUARANTINE
+			: Folders.INBOX;
+	try {
+		await stub.notifyNewEmail(messageId, finalFolder);
+	} catch (e) {
+		console.error("notifyNewEmail failed:", (e as Error).message);
 	}
 
 	// Async deep-scan. Runs AFTER the sync pipeline decision and only ever


### PR DESCRIPTION
## Summary

Replaces the 30-second inbox poll with a server-pushed event channel so new mail surfaces immediately and can raise a desktop notification when the tab is hidden. Foundation for the eventual PWA + Web Push path; works on any browser that supports the Notification API.

## What changed

- **`MailboxDO`** now handles WebSocket upgrades via the hibernation API (`fetch` / `webSocketMessage` / `webSocketClose` / `webSocketError`) and exposes `notifyNewEmail(emailId, folder)` for fanout to all attached sockets.
- **`GET /api/v1/mailboxes/:mailboxId/events`** — new route, gated by the existing CF Access `*` middleware and `requireMailbox`. Forwards the upgrade to the DO stub.
- **`receiveEmail` fanout** runs *after* the sync security verdict and passes the final folder, so mail that lands in `QUARANTINE` never surfaces as a desktop toast. Deep-scan can still tighten the verdict later but does not retract notifications.
- **`useMailboxEvents` hook** — opens the WS, reconnects with jittered exponential backoff (1s → 30s cap), tears down on unmount or `mailboxId` change.
- **`mailbox.tsx`** subscribes for the session, invalidates `emails` + `folders` queries on every event, and fires `new Notification` only when (a) the folder is `INBOX`, (b) `Notification.permission === "granted"`, and (c) the tab is hidden. The notification is tagged by `emailId` so multiple tabs viewing the same mailbox don't double-notify.
- **`email-list.tsx`** drops the 30s `refetchInterval` — push handles it.
- **`Header.tsx`** gains a bell with `default` → click to request, `granted` → solid + disabled, `denied` → slashed bell, `unsupported` → hidden.

## What this does not do

- No service worker → closed-tab and iOS Safari delivery still don't fire. That's the Web Push / PWA work tracked separately.
- The focused tab is intentionally silent (list updates but no OS toast). Drop the `visibilityState === \"visible\"` guard in `app/routes/mailbox.tsx` if you'd rather it always ding.

## Reviewer notes

Two things deserve a real-environment check:

1. **CF Access on WebSocket upgrades.** Browsers can't set custom headers on `new WebSocket()`, so this relies on the CF edge injecting `cf-access-jwt-assertion` on the upgrade — the standard behavior, but binary in prod (works or every connection 403s). Confirm with one browser test through the Access-protected deploy. Fallback if it fails: short-lived signed token via query param.
2. **End-to-end fanout** can't be exercised in local dev (no way to invoke the worker's `email()` handler). The two-domain test in [README.md](../blob/main/README.md#two-domain-end-to-end-test) is the smallest reproduction.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 155 pre-existing tests pass
- [x] Dev server boots; `/api/v1/config` reachable
- [x] `curl` to `/events` without `Upgrade` → `426 Upgrade Required`
- [x] Real WS upgrade returns `101 Switching Protocols`; Node `ws` client receives `open` and the socket holds open (Hono passes `Response.webSocket` through; DO accepts via hibernation)
- [ ] Two-domain inbound smoke: send mailbox A → mailbox B with B's tab hidden, confirm the OS notification fires and the inbox list updates without a manual refresh
- [ ] CF Access verification on the deployed Worker (real browser, not curl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)