### PR TITLE
Hub: inbound MISP sync from upstream peer instances

### DIFF
--- a/hub/README.md
+++ b/hub/README.md
@@ -17,6 +17,7 @@ This is not a full MISP implementation. Adopters needing complete MISP functiona
 | `POST` | `/orgs/invite` | API key | Issues one-time token, optionally binds to a sharing group. |
 | `POST` | `/orgs/accept` | (public) | Redeems token; returns new `api_key` (shown once). |
 | `GET` | `/orgs/me` | API key | Authenticated org. |
+| `POST` `GET` `DELETE` | `/admin/peers[/:uuid]` | `HUB_ADMIN_KEY` | Inbound MISP peer config (see [Inbound MISP Sync](#inbound-misp-sync)). |
 
 ## Auth
 
@@ -65,8 +66,53 @@ npx wrangler d1 execute ais-hub --remote --command "
 - Event visibility is enforced on read via `orgc_uuid` + `sharing_group_uuid` checks — no tenant can read another tenant's non-shared events.
 - Prompt-injection defense for the triage agent: the LLM only controls tags, not scores or promotions.
 
+## Inbound MISP Sync
+
+The hub can pull events from upstream MISP-compatible instances on the 5-minute cron and fold them into local corroboration. This is operator-only — there is no per-org subscription model in v1.
+
+### Configuring a peer
+
+Set `HUB_ADMIN_KEY` as a Worker secret:
+
+```
+wrangler secret put HUB_ADMIN_KEY
+```
+
+Set the peer's API key as a separate secret. The name you choose is what you pass to the admin route as `api_key_secret_name`:
+
+```
+wrangler secret put PEER_CIRCL_KEY
+```
+
+Then create the peer config:
+
+```bash
+curl -X POST https://your-hub.example/admin/peers \
+  -H "Authorization: $HUB_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "CIRCL",
+    "contact": "noc@circl.lu",
+    "base_url": "https://misp.circl.lu",
+    "api_key_secret_name": "PEER_CIRCL_KEY",
+    "default_sharing_group_uuid": "<existing-sg-uuid>",
+    "default_trust": 0.5,
+    "tag_include": "tlp:white\ntlp:green"
+  }'
+```
+
+`default_sharing_group_uuid` is required. Pulled events become visible to members of that sharing group; without it events would orphan to the synthetic peer org which has no human callers.
+
+### Promotion semantics
+
+Pulled-only intel does **not** solo-promote to the destroylist. The synthetic peer org counts as one contributor; promotion still requires `PROMOTION_CONTRIBUTORS = 2`. CIRCL's IoCs only land on the destroylist after at least one local org independently reports the same value. This is intentional sybil resistance — a compromised upstream cannot single-handedly push entries into your published feed. To boost a trusted peer's intel faster, raise its `default_trust` so it contributes more score per corroboration.
+
+### Loop prevention
+
+Events whose `orgc_uuid` matches a local org are skipped on pull. This handles the case where we previously published to the upstream and now see it coming back. Provenance is recorded on `events.source_peer_uuid` for forward-compat with outbound sync.
+
 ## Future work
 
 - STIX 2.1 export on `/events/{uuid}` (content negotiation).
-- Server-to-server sync with real MISP instances (`/events/index`, `/servers/pull`).
+- Outbound push sync to real MISP instances (separate `outbound_peers` config; reuses the `peers` shared-identity table).
 - Per-attribute confidence decay over time (cron already wired; logic TBD).

--- a/hub/README.md
+++ b/hub/README.md
@@ -107,6 +107,8 @@ curl -X POST https://your-hub.example/admin/peers \
 
 Pulled-only intel does **not** solo-promote to the destroylist. The synthetic peer org counts as one contributor; promotion still requires `PROMOTION_CONTRIBUTORS = 2`. CIRCL's IoCs only land on the destroylist after at least one local org independently reports the same value. This is intentional sybil resistance — a compromised upstream cannot single-handedly push entries into your published feed. To boost a trusted peer's intel faster, raise its `default_trust` so it contributes more score per corroboration.
 
+For local-org reports to count as corroboration of pulled intel, they must be posted to the same sharing group configured as `default_sharing_group_uuid` on the peer. Corroboration rows are keyed on `(sharing_group_uuid, attribute_type, value)`, so reports landing in a different group (or `NULL`) form a separate row and never combine.
+
 ### Loop prevention
 
 Events whose `orgc_uuid` matches a local org are skipped on pull. This handles the case where we previously published to the upstream and now see it coming back. Provenance is recorded on `events.source_peer_uuid` for forward-compat with outbound sync.

--- a/hub/migrations/0002_inbound_sync.sql
+++ b/hub/migrations/0002_inbound_sync.sql
@@ -1,0 +1,46 @@
+-- Copyright (c) 2026 Cloudflare, Inc.
+-- Licensed under the Apache 2.0 license found in the LICENSE file or at:
+--     https://opensource.org/licenses/Apache-2.0
+
+-- Shared identity for any external party we exchange intel with. Inbound and
+-- outbound peer configs both reference this so that a single party with
+-- bidirectional flows is recognisable as one entity.
+CREATE TABLE peers (
+    uuid TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    contact TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- One row per upstream MISP instance we PULL from. The synthetic_org_uuid
+-- references a local `orgs` row created at the same time as this peer; that
+-- org is the contributor used in corroboration math and is never a caller
+-- (no api_keys row is created for it).
+CREATE TABLE inbound_peers (
+    uuid TEXT PRIMARY KEY,
+    peer_uuid TEXT NOT NULL,
+    base_url TEXT NOT NULL,
+    api_key_secret_name TEXT NOT NULL,
+    synthetic_org_uuid TEXT NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    -- ISO-8601 watermark. NULL = full backfill on first run.
+    last_pulled_ts TEXT,
+    last_error TEXT,
+    -- Dual purpose: failure backoff AND soft cron lock. Cron skips peers
+    -- whose next_retry_at is in the future.
+    next_retry_at TEXT,
+    -- Required at admin-create time. NULL would orphan events to the
+    -- synthetic org which has no human callers.
+    default_sharing_group_uuid TEXT NOT NULL,
+    -- Newline-separated tag patterns. Empty/NULL means no filtering.
+    tag_include TEXT,
+    tag_exclude TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (peer_uuid) REFERENCES peers(uuid) ON DELETE CASCADE,
+    FOREIGN KEY (synthetic_org_uuid) REFERENCES orgs(uuid)
+);
+CREATE INDEX idx_inbound_peers_next_retry ON inbound_peers(next_retry_at);
+
+-- Provenance on events. NULL = locally authored via POST /events.
+ALTER TABLE events ADD COLUMN source_peer_uuid TEXT;
+CREATE INDEX idx_events_source_peer ON events(source_peer_uuid);

--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -4,6 +4,19 @@
 
 /**
  * AIS community hub — MISP-compatible reporting & feed distribution.
+ *
+ * This is an open-source reference implementation, not a full MISP server.
+ * Supported surface:
+ *   POST   /events
+ *   GET    /events/{uuid}
+ *   POST   /events/restSearch
+ *   GET    /feeds/destroylist.txt
+ *   GET    /sharing_groups
+ *   POST   /sharing_groups
+ *   POST   /orgs/invite    (authenticated — existing org invites another)
+ *   POST   /orgs/accept    (public — consumes an invite token, creates org + key)
+ *   GET    /orgs/me
+ *   *      /admin/*        (operator-only — gated by HUB_ADMIN_KEY)
  */
 
 import { Hono } from "hono";
@@ -22,8 +35,8 @@ app.get("/", (c) => c.text("AIS Hub — MISP-compatible threat-intel sharing. Se
 
 app.route("/events", eventRoutes);
 app.route("/feeds", feedRoutes);
-app.route("/orgs", orgAcceptApp);
-app.route("/orgs", orgRoutes);
+app.route("/orgs", orgAcceptApp); // public /orgs/accept
+app.route("/orgs", orgRoutes);    // authed /orgs/me, /orgs/invite
 app.route("/sharing_groups", sharingGroupRoutes);
 app.route("/admin", adminRoutes);
 

--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -4,18 +4,6 @@
 
 /**
  * AIS community hub — MISP-compatible reporting & feed distribution.
- *
- * This is an open-source reference implementation, not a full MISP server.
- * Supported surface:
- *   POST   /events
- *   GET    /events/{uuid}
- *   POST   /events/restSearch
- *   GET    /feeds/destroylist.txt
- *   GET    /sharing_groups
- *   POST   /sharing_groups
- *   POST   /orgs/invite    (authenticated — existing org invites another)
- *   POST   /orgs/accept    (public — consumes an invite token, creates org + key)
- *   GET    /orgs/me
  */
 
 import { Hono } from "hono";
@@ -23,7 +11,9 @@ import { eventRoutes } from "./routes/events";
 import { feedRoutes } from "./routes/feeds";
 import { orgRoutes, orgAcceptApp } from "./routes/orgs";
 import { sharingGroupRoutes } from "./routes/sharing-groups";
+import { adminRoutes } from "./routes/admin";
 import { consumeTriageBatch } from "./agent/triage";
+import { runInboundSync } from "./lib/sync";
 import type { Env, TriageMessage } from "./types";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -32,9 +22,10 @@ app.get("/", (c) => c.text("AIS Hub — MISP-compatible threat-intel sharing. Se
 
 app.route("/events", eventRoutes);
 app.route("/feeds", feedRoutes);
-app.route("/orgs", orgAcceptApp); // public /orgs/accept
-app.route("/orgs", orgRoutes);    // authed /orgs/me, /orgs/invite
+app.route("/orgs", orgAcceptApp);
+app.route("/orgs", orgRoutes);
 app.route("/sharing_groups", sharingGroupRoutes);
+app.route("/admin", adminRoutes);
 
 export default {
 	fetch: app.fetch,
@@ -42,8 +33,6 @@ export default {
 		await consumeTriageBatch(batch, env);
 	},
 	async scheduled(_event: ScheduledController, env: Env, ctx: ExecutionContext) {
-		// Placeholder for periodic re-scoring/cleanup work. Aggregation is
-		// fully event-driven right now; leave a hook for decay/retention later.
-		ctx.waitUntil(Promise.resolve());
+		ctx.waitUntil(runInboundSync(env));
 	},
 };

--- a/hub/src/lib/admin-auth.ts
+++ b/hub/src/lib/admin-auth.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { createMiddleware } from "hono/factory";
+import type { Env } from "../types";
+
+export type AdminContext = { Bindings: Env };
+
+/**
+ * Single-secret admin gate. Compares the request token against `HUB_ADMIN_KEY`
+ * (a Worker secret). Used for inbound-peer CRUD and other operator-only
+ * surfaces. We do not log the supplied token; on mismatch we return 401
+ * without revealing whether the resource exists.
+ */
+export const requireAdmin = createMiddleware<AdminContext>(async (c, next) => {
+	const expected = c.env.HUB_ADMIN_KEY;
+	if (!expected) return c.json({ error: "admin not configured" }, 401);
+
+	const header = c.req.header("authorization") ?? c.req.header("Authorization");
+	if (!header) return c.json({ error: "missing authorization" }, 401);
+	const token = header.startsWith("Bearer ") ? header.slice(7).trim() : header.trim();
+
+	if (!constantTimeEqual(token, expected)) {
+		return c.json({ error: "invalid admin token" }, 401);
+	}
+	await next();
+});
+
+function constantTimeEqual(a: string, b: string): boolean {
+	if (a.length !== b.length) return false;
+	let mismatch = 0;
+	for (let i = 0; i < a.length; i++) {
+		mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	}
+	return mismatch === 0;
+}

--- a/hub/src/lib/sync.ts
+++ b/hub/src/lib/sync.ts
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Inbound MISP sync. Pulls events from configured peers via
+ * POST /events/restSearch, UPSERTs them into the local DB, and credits
+ * corroboration to a synthetic per-peer org.
+ *
+ * Watermark semantics: query timestamp >= last_pulled_ts, advance to
+ * max(timestamp seen) at end of run. This handles the multi-event-same-
+ * timestamp case that '>' would lose. UPSERT makes the boundary overlap
+ * a no-op for corroboration math.
+ */
+
+import type { Env } from "../types";
+import { applyCorroboration } from "./aggregate";
+
+export interface InboundPeerRow {
+	uuid: string;
+	peer_uuid: string;
+	base_url: string;
+	api_key_secret_name: string;
+	synthetic_org_uuid: string;
+	enabled: number;
+	last_pulled_ts: string | null;
+	last_error: string | null;
+	next_retry_at: string | null;
+	default_sharing_group_uuid: string;
+	tag_include: string | null;
+	tag_exclude: string | null;
+}
+
+interface UpstreamEvent {
+	Event: {
+		uuid: string;
+		info: string;
+		date: string;
+		timestamp: string;
+		analysis?: string;
+		threat_level_id?: string;
+		distribution?: string;
+		orgc_uuid?: string;
+		Tag?: Array<{ name: string }>;
+		Attribute?: Array<{
+			uuid?: string;
+			type: string;
+			category: string;
+			value: string;
+			to_ids?: boolean | 0 | 1;
+			comment?: string;
+		}>;
+	};
+}
+
+const MAX_PAGES = 100;
+const PAGE_SIZE = 200;
+const SOFT_LOCK_MINUTES = 4;
+const FAILURE_BACKOFF_MINUTES = 10;
+
+export interface PullResult {
+	events_pulled: number;
+	events_skipped: number;
+	events_filtered: number;
+	error: string | null;
+}
+
+export async function pullFromPeer(env: Env, peer: InboundPeerRow): Promise<PullResult> {
+	// Take the soft lock so an overlapping cron skips this peer.
+	const softLockUntil = new Date(Date.now() + SOFT_LOCK_MINUTES * 60_000).toISOString();
+	await env.DB
+		.prepare(`UPDATE inbound_peers SET next_retry_at = ?1 WHERE uuid = ?2`)
+		.bind(softLockUntil, peer.uuid)
+		.run();
+
+	const apiKey = (env as unknown as Record<string, string>)[peer.api_key_secret_name];
+	if (!apiKey) {
+		return finishWithError(env, peer, `secret ${peer.api_key_secret_name} not bound`);
+	}
+
+	// Fetch local org UUIDs once for loop prevention.
+	const localOrgs = await env.DB.prepare(`SELECT uuid FROM orgs`).all<{ uuid: string }>();
+	const localOrgSet = new Set((localOrgs.results ?? []).map((r) => r.uuid));
+	// The synthetic org represents the peer; allow it through.
+	localOrgSet.delete(peer.synthetic_org_uuid);
+
+	const tagInclude = (peer.tag_include ?? "").split("\n").map((s) => s.trim()).filter(Boolean);
+	const tagExclude = (peer.tag_exclude ?? "").split("\n").map((s) => s.trim()).filter(Boolean);
+
+	let pulled = 0, skipped = 0, filtered = 0;
+	let maxTs = peer.last_pulled_ts ?? "0";
+
+	for (let page = 1; page <= MAX_PAGES; page++) {
+		const events = await fetchPage(peer, apiKey, peer.last_pulled_ts, page);
+		if (events === null) {
+			return finishWithError(env, peer, `upstream returned non-OK on page ${page}`);
+		}
+		if (events.length === 0) break;
+
+		for (const e of events) {
+			const ev = e.Event;
+			if (!ev?.uuid || !ev.timestamp) { skipped++; continue; }
+			if (ev.orgc_uuid && localOrgSet.has(ev.orgc_uuid)) { skipped++; continue; }
+			if (!passesTagFilter(ev.Tag, tagInclude, tagExclude)) { filtered++; continue; }
+
+			await upsertEvent(env, peer, e);
+			await applyCorroboration(env.DB, {
+				event_uuid: ev.uuid,
+				orgc_uuid: peer.synthetic_org_uuid,
+				sharing_group_uuid: peer.default_sharing_group_uuid,
+				attributes: (ev.Attribute ?? []).map((a) => ({ type: a.type, value: a.value })),
+			});
+			if (ev.timestamp > maxTs) maxTs = ev.timestamp;
+			pulled++;
+		}
+
+	}
+
+	await env.DB
+		.prepare(
+			`UPDATE inbound_peers
+			 SET last_pulled_ts = ?1, last_error = NULL, next_retry_at = NULL
+			 WHERE uuid = ?2`,
+		)
+		.bind(maxTs, peer.uuid)
+		.run();
+
+	return { events_pulled: pulled, events_skipped: skipped, events_filtered: filtered, error: null };
+}
+
+async function fetchPage(
+	peer: InboundPeerRow,
+	apiKey: string,
+	since: string | null,
+	page: number,
+): Promise<UpstreamEvent[] | null> {
+	const body: Record<string, unknown> = {
+		returnFormat: "json",
+		limit: PAGE_SIZE,
+		page,
+	};
+	if (since) body.timestamp = since; // >= semantics on the upstream side
+
+	const res = await fetch(`${peer.base_url.replace(/\/$/, "")}/events/restSearch`, {
+		method: "POST",
+		headers: {
+			"Authorization": apiKey,
+			"Accept": "application/json",
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(body),
+		signal: AbortSignal.timeout(15_000),
+	}).catch(() => null);
+
+	if (!res || !res.ok) return null;
+	const json = (await res.json().catch(() => null)) as { response?: UpstreamEvent[] } | UpstreamEvent[] | null;
+	if (Array.isArray(json)) return json;
+	return json?.response ?? [];
+}
+
+function passesTagFilter(
+	tags: Array<{ name: string }> | undefined,
+	include: string[],
+	exclude: string[],
+): boolean {
+	const names = new Set((tags ?? []).map((t) => t.name));
+	if (exclude.length > 0 && exclude.some((t) => names.has(t))) return false;
+	if (include.length > 0 && !include.some((t) => names.has(t))) return false;
+	return true;
+}
+
+/**
+ * UPSERT one event. INSERT OR REPLACE for the events row; for attributes we
+ * delete then re-insert because attribute UUIDs may shift on upstream edits.
+ *
+ * NOTE: this intentionally does NOT reuse the POST /events route's plain
+ * INSERT — sync needs idempotency on re-pull, the public route needs strict
+ * UUID conflict rejection.
+ */
+async function upsertEvent(env: Env, peer: InboundPeerRow, e: UpstreamEvent) {
+	const ev = e.Event;
+	await env.DB.batch([
+		env.DB
+			.prepare(
+				`INSERT OR REPLACE INTO events
+				   (uuid, orgc_uuid, sharing_group_uuid, info, date, timestamp,
+				    distribution, analysis, threat_level_id, event_json, source_peer_uuid)
+				 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)`,
+			)
+			.bind(
+				ev.uuid,
+				peer.synthetic_org_uuid,             // attribution → synthetic peer org
+				peer.default_sharing_group_uuid,
+				ev.info,
+				ev.date,
+				ev.timestamp,
+				ev.distribution ?? "1",
+				ev.analysis ?? "0",
+				ev.threat_level_id ?? "2",
+				JSON.stringify(e),
+				peer.uuid,
+			),
+		env.DB.prepare(`DELETE FROM attributes WHERE event_uuid = ?1`).bind(ev.uuid),
+	]);
+
+	if (ev.Attribute && ev.Attribute.length > 0) {
+		await env.DB.batch(
+			ev.Attribute.map((a) =>
+				env.DB
+					.prepare(
+						`INSERT INTO attributes (uuid, event_uuid, type, category, value, to_ids, comment)
+						 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)`,
+					)
+					.bind(
+						a.uuid ?? crypto.randomUUID(),
+						ev.uuid,
+						a.type,
+						a.category,
+						a.value,
+						a.to_ids === true || a.to_ids === 1 ? 1 : 0,
+						a.comment ?? null,
+					),
+			),
+		);
+	}
+}
+
+async function finishWithError(env: Env, peer: InboundPeerRow, message: string): Promise<PullResult> {
+	const backoff = new Date(Date.now() + FAILURE_BACKOFF_MINUTES * 60_000).toISOString();
+	await env.DB
+		.prepare(`UPDATE inbound_peers SET last_error = ?1, next_retry_at = ?2 WHERE uuid = ?3`)
+		.bind(message.slice(0, 500), backoff, peer.uuid)
+		.run();
+	return { events_pulled: 0, events_skipped: 0, events_filtered: 0, error: message };
+}
+
+/** Cron entry — iterate eligible peers, pull each. */
+export async function runInboundSync(env: Env): Promise<void> {
+	const now = new Date().toISOString();
+	const rows = await env.DB
+		.prepare(
+			`SELECT * FROM inbound_peers
+			 WHERE enabled = 1
+			   AND (next_retry_at IS NULL OR next_retry_at < ?1)`,
+		)
+		.bind(now)
+		.all<InboundPeerRow>();
+	for (const peer of rows.results ?? []) {
+		try {
+			await pullFromPeer(env, peer);
+		} catch (err) {
+			console.error(`pullFromPeer ${peer.uuid} threw:`, (err as Error).message);
+		}
+	}
+}

--- a/hub/src/lib/sync.ts
+++ b/hub/src/lib/sync.ts
@@ -138,6 +138,11 @@ async function fetchPage(
 		returnFormat: "json",
 		limit: PAGE_SIZE,
 		page,
+		// Explicit ASC ordering. MISP restSearch order is undefined without
+		// this; with DESC default a deep first-backfill (>MAX_PAGES * PAGE_SIZE
+		// events) would advance the watermark past unprocessed older events
+		// and never come back for them.
+		order: "Event.timestamp ASC",
 	};
 	if (since) body.timestamp = since; // >= semantics on the upstream side
 

--- a/hub/src/routes/admin.ts
+++ b/hub/src/routes/admin.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Operator-only admin routes (gated by HUB_ADMIN_KEY).
+ *
+ * /peers          POST   create an inbound peer (also creates peer + synthetic org)
+ *                 GET    list inbound peers
+ * /peers/:uuid    DELETE remove an inbound peer (cascade-removes peers row)
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { requireAdmin, type AdminContext } from "../lib/admin-auth";
+
+export const adminRoutes = new Hono<AdminContext>();
+
+adminRoutes.use("*", requireAdmin);
+
+const CreatePeerSchema = z.object({
+	name: z.string().min(1).max(200),
+	contact: z.string().max(500).optional(),
+	base_url: z.string().url().max(2000),
+	api_key_secret_name: z.string().min(1).max(200),
+	// Required non-NULL: pulled events default to this group's visibility.
+	default_sharing_group_uuid: z.string().uuid(),
+	default_trust: z.number().min(0).max(10).default(0.5),
+	tag_include: z.string().max(4000).optional(),
+	tag_exclude: z.string().max(4000).optional(),
+});
+
+adminRoutes.post("/peers", async (c) => {
+	const parsed = CreatePeerSchema.safeParse(await c.req.json().catch(() => null));
+	if (!parsed.success) return c.json({ error: parsed.error.flatten() }, 400);
+	const body = parsed.data;
+
+	// Sharing group must exist.
+	const sg = await c.env.DB
+		.prepare(`SELECT 1 FROM sharing_groups WHERE uuid = ?1`)
+		.bind(body.default_sharing_group_uuid)
+		.first();
+	if (!sg) return c.json({ error: "default_sharing_group_uuid not found" }, 400);
+
+	const peerUuid = crypto.randomUUID();
+	const inboundUuid = crypto.randomUUID();
+	const syntheticOrgUuid = crypto.randomUUID();
+
+	await c.env.DB.batch([
+		c.env.DB
+			.prepare(`INSERT INTO peers (uuid, name, contact) VALUES (?1, ?2, ?3)`)
+			.bind(peerUuid, body.name, body.contact ?? null),
+		c.env.DB
+			.prepare(`INSERT INTO orgs (uuid, name, contact, trust) VALUES (?1, ?2, ?3, ?4)`)
+			.bind(syntheticOrgUuid, `peer:${body.name}`, body.contact ?? null, body.default_trust),
+		c.env.DB
+			.prepare(
+				`INSERT INTO inbound_peers
+				   (uuid, peer_uuid, base_url, api_key_secret_name, synthetic_org_uuid,
+				    default_sharing_group_uuid, tag_include, tag_exclude)
+				 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)`,
+			)
+			.bind(
+				inboundUuid, peerUuid, body.base_url, body.api_key_secret_name,
+				syntheticOrgUuid, body.default_sharing_group_uuid,
+				body.tag_include ?? null, body.tag_exclude ?? null,
+			),
+		c.env.DB
+			.prepare(
+				`INSERT INTO sharing_group_orgs (sharing_group_uuid, org_uuid, role) VALUES (?1, ?2, 'member')`,
+			)
+			.bind(body.default_sharing_group_uuid, syntheticOrgUuid),
+	]);
+
+	return c.json(
+		{ inbound_peer_uuid: inboundUuid, peer_uuid: peerUuid, synthetic_org_uuid: syntheticOrgUuid },
+		201,
+	);
+});
+
+adminRoutes.get("/peers", async (c) => {
+	const rows = await c.env.DB
+		.prepare(
+			`SELECT ib.uuid, p.name, p.contact, ib.base_url, ib.api_key_secret_name,
+			        ib.enabled, ib.last_pulled_ts, ib.last_error, ib.next_retry_at,
+			        ib.default_sharing_group_uuid, ib.tag_include, ib.tag_exclude,
+			        ib.synthetic_org_uuid
+			 FROM inbound_peers ib JOIN peers p ON p.uuid = ib.peer_uuid
+			 ORDER BY p.name`,
+		)
+		.all();
+	return c.json({ peers: rows.results ?? [] });
+});
+
+adminRoutes.delete("/peers/:uuid", async (c) => {
+	const uuid = c.req.param("uuid");
+	const ib = await c.env.DB
+		.prepare(`SELECT peer_uuid, synthetic_org_uuid FROM inbound_peers WHERE uuid = ?1`)
+		.bind(uuid)
+		.first<{ peer_uuid: string; synthetic_org_uuid: string }>();
+	if (!ib) return c.json({ error: "not found" }, 404);
+	await c.env.DB.batch([
+		c.env.DB.prepare(`DELETE FROM inbound_peers WHERE uuid = ?1`).bind(uuid),
+		c.env.DB.prepare(`DELETE FROM peers WHERE uuid = ?1`).bind(ib.peer_uuid),
+		// Synthetic org is preserved; the events table FK references it. We
+		// soft-orphan rather than risk dangling refs. Operator can delete it
+		// manually if no events remain.
+	]);
+	return new Response(null, { status: 204 });
+});

--- a/hub/src/types.ts
+++ b/hub/src/types.ts
@@ -6,6 +6,7 @@ export interface Env {
 	DB: D1Database;
 	AI: Ai;
 	TRIAGE_QUEUE: Queue<TriageMessage>;
+	HUB_ADMIN_KEY: string;
 }
 
 export interface TriageMessage {

--- a/hub/tests/helpers/d1.ts
+++ b/hub/tests/helpers/d1.ts
@@ -76,8 +76,25 @@ export function makeTestDb(): TestDb {
 						},
 					};
 				},
-			};
+				// Expose boundObj for use in batch().
+				_getBoundObj() { return boundObj; },
+				_getStmt() { return stmt; },
+			} as PreparedLike & { _getBoundObj(): Record<string, unknown>; _getStmt(): ReturnType<Database.Database["prepare"]> };
 			return api;
+		},
+		async batch(statements: PreparedLike[]): Promise<{ results: unknown[] }[]> {
+			// Run all statements inside a single SQLite transaction to emulate
+			// D1's atomic batch semantics. Each statement returns a result object.
+			const results: { results: unknown[] }[] = [];
+			const txn = raw.transaction(() => {
+				for (const stmt of statements) {
+					const s = stmt as PreparedLike & { _getBoundObj(): Record<string, unknown>; _getStmt(): ReturnType<Database.Database["prepare"]> };
+					const info = s._getStmt().run(s._getBoundObj());
+					results.push({ results: [{ changes: info.changes, last_row_id: Number(info.lastInsertRowid) }] });
+				}
+			});
+			txn();
+			return results;
 		},
 	} as unknown as D1Database;
 

--- a/hub/tests/helpers/d1.ts
+++ b/hub/tests/helpers/d1.ts
@@ -12,7 +12,7 @@
  */
 
 import Database from "better-sqlite3";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
 import type { D1Database } from "@cloudflare/workers-types";
 
@@ -29,16 +29,20 @@ export interface TestDb {
 	close(): void;
 }
 
-const SCHEMA_PATH = resolve(__dirname, "../../migrations/0001_schema.sql");
+const MIGRATIONS_DIR = resolve(__dirname, "../../migrations");
 
 export function makeTestDb(): TestDb {
 	const raw = new Database(":memory:");
 	// Cloudflare D1 does NOT enforce foreign keys by default. Match that so
 	// tests exercise the same permissive behaviour production code relies on.
 	raw.pragma("foreign_keys = OFF");
-	const schema = readFileSync(SCHEMA_PATH, "utf-8");
-	// better-sqlite3's `exec` runs multiple statements; it is NOT child_process.
-	raw.exec(schema);
+	// Apply migrations in lexical order (0001, 0002, ...). better-sqlite3's
+	// `exec` runs multiple statements in a single SQL string.
+	const files = readdirSync(MIGRATIONS_DIR).filter((f) => f.endsWith(".sql")).sort();
+	for (const f of files) {
+		const migrationSql = readFileSync(resolve(MIGRATIONS_DIR, f), "utf-8");
+		raw.exec(migrationSql);
+	}
 
 	const d1 = {
 		prepare(sql: string): PreparedLike {

--- a/hub/tests/lib/admin-auth.test.ts
+++ b/hub/tests/lib/admin-auth.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { requireAdmin, type AdminContext } from "../../src/lib/admin-auth";
+
+function makeApp(adminKey: string) {
+	const app = new Hono<AdminContext>();
+	app.use("*", requireAdmin);
+	app.get("/", (c) => c.json({ ok: true }));
+	return (init?: RequestInit) =>
+		app.request("/", init, { HUB_ADMIN_KEY: adminKey } as never);
+}
+
+describe("requireAdmin", () => {
+	it("rejects requests with no Authorization header", async () => {
+		const res = await makeApp("secret-key")();
+		expect(res.status).toBe(401);
+	});
+
+	it("rejects requests with the wrong key", async () => {
+		const res = await makeApp("secret-key")({
+			headers: { Authorization: "wrong-key" },
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it("rejects when HUB_ADMIN_KEY is empty (operator misconfiguration)", async () => {
+		const res = await makeApp("")({ headers: { Authorization: "anything" } });
+		expect(res.status).toBe(401);
+	});
+
+	it("accepts the bare key form", async () => {
+		const res = await makeApp("secret-key")({
+			headers: { Authorization: "secret-key" },
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it("accepts the Bearer form", async () => {
+		const res = await makeApp("secret-key")({
+			headers: { Authorization: "Bearer secret-key" },
+		});
+		expect(res.status).toBe(200);
+	});
+});

--- a/hub/tests/lib/sync.test.ts
+++ b/hub/tests/lib/sync.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { pullFromPeer, type InboundPeerRow } from "../../src/lib/sync";
+import { makeTestDb, type TestDb } from "../helpers/d1";
+import type { Env } from "../../src/types";
+
+let db: TestDb;
+let env: Env;
+
+beforeEach(() => {
+	db = makeTestDb();
+	env = {
+		DB: db.d1,
+		AI: {} as Ai,
+		TRIAGE_QUEUE: { send: async () => {} } as never,
+		HUB_ADMIN_KEY: "admin",
+		PEER_KEY_TEST: "upstream-key",
+	} as Env & Record<string, string>;
+	// Seed sharing group + synthetic org.
+	db.raw.prepare(`INSERT INTO sharing_groups (uuid, name) VALUES (?, ?)`)
+		.run("sg-1", "sg");
+	db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, ?)`)
+		.run("synth-org", "peer:test", 0.5);
+	db.raw.prepare(`INSERT INTO sharing_group_orgs (sharing_group_uuid, org_uuid) VALUES (?, ?)`)
+		.run("sg-1", "synth-org");
+	db.raw.prepare(`INSERT INTO peers (uuid, name) VALUES (?, ?)`).run("peer-1", "test");
+	db.raw
+		.prepare(
+			`INSERT INTO inbound_peers
+			 (uuid, peer_uuid, base_url, api_key_secret_name, synthetic_org_uuid,
+			  default_sharing_group_uuid)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+		)
+		.run("ib-1", "peer-1", "https://upstream.test", "PEER_KEY_TEST", "synth-org", "sg-1");
+});
+
+afterEach(() => {
+	db.close();
+	vi.unstubAllGlobals();
+});
+
+function getPeer(): InboundPeerRow {
+	return db.raw
+		.prepare(`SELECT * FROM inbound_peers WHERE uuid = 'ib-1'`)
+		.get() as InboundPeerRow;
+}
+
+function mockUpstream(pages: Array<unknown[]>) {
+	let call = 0;
+	const fetchMock = vi.fn(async () => {
+		const events = pages[call] ?? [];
+		call++;
+		return new Response(JSON.stringify({ response: events }), {
+			status: 200, headers: { "Content-Type": "application/json" },
+		});
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+const sampleEvent = (uuid: string, ts: string, attrs: Array<{ type: string; value: string }> = [
+	{ type: "url", value: `https://bad.example/${uuid}` },
+]) => ({
+	Event: {
+		uuid, info: `evt ${uuid}`, date: "2026-04-26", timestamp: ts,
+		analysis: "0", threat_level_id: "2", distribution: "1",
+		orgc_uuid: "upstream-org",
+		Attribute: attrs.map((a) => ({
+			uuid: crypto.randomUUID(), type: a.type, category: "Network activity",
+			value: a.value, to_ids: 1,
+		})),
+	},
+});
+
+describe("pullFromPeer", () => {
+	it("inserts events, attributes, applies corroboration, advances watermark", async () => {
+		mockUpstream([
+			[sampleEvent("11111111-1111-1111-1111-111111111111", "1700000000")],
+			[],
+		]);
+		const result = await pullFromPeer(env, getPeer());
+		expect(result.events_pulled).toBe(1);
+		expect(result.error).toBeNull();
+
+		const ev = db.raw.prepare(`SELECT source_peer_uuid FROM events WHERE uuid = ?`)
+			.get("11111111-1111-1111-1111-111111111111") as { source_peer_uuid: string };
+		expect(ev.source_peer_uuid).toBe("ib-1");
+
+		const corr = db.raw.prepare(
+			`SELECT score, contributor_count FROM corroboration
+			 WHERE attribute_type = 'url' AND value = 'https://bad.example/11111111-1111-1111-1111-111111111111'`,
+		).get() as { score: number; contributor_count: number };
+		expect(corr.score).toBeCloseTo(0.5, 5);
+		expect(corr.contributor_count).toBe(1);
+
+		const after = getPeer();
+		expect(after.last_pulled_ts).toBe("1700000000");
+	});
+
+	it("is idempotent on re-pull — same event does not double-count", async () => {
+		const ev1 = sampleEvent("22222222-2222-2222-2222-222222222222", "1700000100");
+		mockUpstream([[ev1], []]);
+		await pullFromPeer(env, getPeer());
+
+		mockUpstream([[ev1], []]);
+		await pullFromPeer(env, getPeer());
+
+		const corr = db.raw.prepare(
+			`SELECT score, contributor_count FROM corroboration
+			 WHERE attribute_type = 'url'`,
+		).get() as { score: number; contributor_count: number };
+		expect(corr.score).toBeCloseTo(0.5, 5);
+		expect(corr.contributor_count).toBe(1);
+	});
+
+	it("skips events whose orgc_uuid matches a local org (loop prevention)", async () => {
+		db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, ?)`)
+			.run("local-org", "us", 1.0);
+		const ev = sampleEvent("33333333-3333-3333-3333-333333333333", "1700000200");
+		ev.Event.orgc_uuid = "local-org";
+		mockUpstream([[ev], []]);
+
+		const result = await pullFromPeer(env, getPeer());
+		expect(result.events_pulled).toBe(0);
+		expect(result.events_skipped).toBe(1);
+		const count = db.raw.prepare(`SELECT count(*) as n FROM events`).get() as { n: number };
+		expect(count.n).toBe(0);
+	});
+
+	it("ingests both events when two share a timestamp across pages (>= watermark)", async () => {
+		const ev1 = sampleEvent("44444444-4444-4444-4444-444444444444", "1700000300", [
+			{ type: "url", value: "https://a.example" },
+		]);
+		const ev2 = sampleEvent("55555555-5555-5555-5555-555555555555", "1700000300", [
+			{ type: "url", value: "https://b.example" },
+		]);
+		mockUpstream([[ev1], [ev2], []]);
+		const result = await pullFromPeer(env, getPeer());
+		expect(result.events_pulled).toBe(2);
+
+		mockUpstream([[ev1, ev2], []]);
+		await pullFromPeer(env, getPeer());
+		const corrA = db.raw.prepare(
+			`SELECT contributor_count FROM corroboration WHERE value = 'https://a.example'`,
+		).get() as { contributor_count: number };
+		expect(corrA.contributor_count).toBe(1);
+	});
+
+	it("drops events excluded by tag_exclude", async () => {
+		db.raw.prepare(`UPDATE inbound_peers SET tag_exclude = 'tlp:red' WHERE uuid = 'ib-1'`).run();
+		const ev = sampleEvent("66666666-6666-6666-6666-666666666666", "1700000400");
+		(ev.Event as Record<string, unknown>).Tag = [{ name: "tlp:red" }];
+		mockUpstream([[ev], []]);
+		const result = await pullFromPeer(env, getPeer());
+		expect(result.events_pulled).toBe(0);
+		expect(result.events_filtered).toBe(1);
+	});
+
+	it("on upstream 500: records last_error, schedules retry, does NOT advance watermark", async () => {
+		const fetchMock = vi.fn(async () =>
+			new Response("upstream broken", { status: 500 })
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		db.raw.prepare(`UPDATE inbound_peers SET last_pulled_ts = '1699999999' WHERE uuid = 'ib-1'`).run();
+
+		const result = await pullFromPeer(env, getPeer());
+		expect(result.error).not.toBeNull();
+		const after = getPeer();
+		expect(after.last_pulled_ts).toBe("1699999999");
+		expect(after.last_error).toMatch(/non-OK|500/);
+		expect(after.next_retry_at).toBeTruthy();
+	});
+
+	it("re-pull replaces the event row when upstream edits it", async () => {
+		const ev = sampleEvent("77777777-7777-7777-7777-777777777777", "1700000500");
+		ev.Event.info = "original";
+		mockUpstream([[ev], []]);
+		await pullFromPeer(env, getPeer());
+
+		ev.Event.info = "edited upstream";
+		ev.Event.timestamp = "1700000600";
+		mockUpstream([[ev], []]);
+		await pullFromPeer(env, getPeer());
+
+		const stored = db.raw.prepare(`SELECT info FROM events WHERE uuid = ?`)
+			.get("77777777-7777-7777-7777-777777777777") as { info: string };
+		expect(stored.info).toBe("edited upstream");
+	});
+});

--- a/hub/tests/lib/sync.test.ts
+++ b/hub/tests/lib/sync.test.ts
@@ -187,3 +187,29 @@ describe("pullFromPeer", () => {
 		expect(stored.info).toBe("edited upstream");
 	});
 });
+
+import { runInboundSync } from "../../src/lib/sync";
+
+describe("runInboundSync", () => {
+	it("skips peers whose next_retry_at is in the future", async () => {
+		const future = new Date(Date.now() + 60_000).toISOString();
+		db.raw.prepare(`UPDATE inbound_peers SET next_retry_at = ? WHERE uuid = 'ib-1'`).run(future);
+		const fetchMock = vi.fn(async () =>
+			new Response(JSON.stringify({ response: [] }), { status: 200 })
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await runInboundSync(env);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("skips peers with enabled=0", async () => {
+		db.raw.prepare(`UPDATE inbound_peers SET enabled = 0 WHERE uuid = 'ib-1'`).run();
+		const fetchMock = vi.fn(async () =>
+			new Response(JSON.stringify({ response: [] }), { status: 200 })
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		await runInboundSync(env);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});

--- a/hub/tests/routes/admin.test.ts
+++ b/hub/tests/routes/admin.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { adminRoutes } from "../../src/routes/admin";
+import { makeTestDb, type TestDb } from "../helpers/d1";
+import type { Env } from "../../src/types";
+
+let db: TestDb;
+let env: Env;
+
+beforeEach(() => {
+	db = makeTestDb();
+	env = {
+		DB: db.d1,
+		AI: {} as Ai,
+		TRIAGE_QUEUE: { send: async () => {} } as never,
+		HUB_ADMIN_KEY: "admin-secret",
+	};
+	// Seed a sharing group that admin routes can reference.
+	db.raw.prepare(`INSERT INTO sharing_groups (uuid, name) VALUES (?, ?)`)
+		.run("sg-1", "default-sg");
+});
+
+afterEach(() => db.close());
+
+function appReq(path: string, init?: RequestInit) {
+	const app = new Hono<{ Bindings: Env }>();
+	app.route("/admin", adminRoutes);
+	return app.request(`/admin${path}`, init, env as never);
+}
+
+const adminAuth = { Authorization: "admin-secret" };
+
+describe("POST /admin/peers", () => {
+	it("rejects unauthenticated requests", async () => {
+		const res = await appReq("/peers", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name: "x", base_url: "https://x", default_sharing_group_uuid: "sg-1", api_key_secret_name: "K" }),
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it("rejects when default_sharing_group_uuid is missing", async () => {
+		const res = await appReq("/peers", {
+			method: "POST",
+			headers: { ...adminAuth, "Content-Type": "application/json" },
+			body: JSON.stringify({ name: "x", base_url: "https://x.example", api_key_secret_name: "K" }),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("rejects when the referenced sharing group does not exist", async () => {
+		const res = await appReq("/peers", {
+			method: "POST",
+			headers: { ...adminAuth, "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: "x", base_url: "https://x.example", api_key_secret_name: "K",
+				default_sharing_group_uuid: "00000000-0000-0000-0000-000000000099",
+			}),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("creates peer + inbound_peer + synthetic org atomically", async () => {
+		// Replace the seeded sg-1 with a uuid-shaped value to satisfy zod.
+		db.raw.prepare(`DELETE FROM sharing_groups`).run();
+		db.raw.prepare(`INSERT INTO sharing_groups (uuid, name) VALUES (?, ?)`)
+			.run("00000000-0000-0000-0000-000000000001", "default-sg");
+
+		const res = await appReq("/peers", {
+			method: "POST",
+			headers: { ...adminAuth, "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: "CIRCL", contact: "noc@circl.lu",
+				base_url: "https://misp.circl.lu",
+				api_key_secret_name: "PEER_CIRCL_KEY",
+				default_sharing_group_uuid: "00000000-0000-0000-0000-000000000001",
+				default_trust: 0.5,
+				tag_include: "tlp:white\ntlp:green",
+			}),
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json() as { inbound_peer_uuid: string; synthetic_org_uuid: string };
+		expect(body.inbound_peer_uuid).toMatch(/^[0-9a-f-]{36}$/);
+		expect(body.synthetic_org_uuid).toMatch(/^[0-9a-f-]{36}$/);
+
+		const peer = db.raw.prepare(`SELECT * FROM peers WHERE name = ?`).get("CIRCL");
+		expect(peer).toBeDefined();
+		const ib = db.raw.prepare(`SELECT * FROM inbound_peers WHERE uuid = ?`).get(body.inbound_peer_uuid) as { tag_include: string; default_sharing_group_uuid: string };
+		expect(ib.tag_include).toBe("tlp:white\ntlp:green");
+		expect(ib.default_sharing_group_uuid).toBe("00000000-0000-0000-0000-000000000001");
+		const org = db.raw.prepare(`SELECT * FROM orgs WHERE uuid = ?`).get(body.synthetic_org_uuid) as { trust: number };
+		expect(org.trust).toBe(0.5);
+		// Synthetic org has no api_key — never authenticates.
+		const keyCount = db.raw.prepare(`SELECT count(*) as n FROM api_keys WHERE org_uuid = ?`).get(body.synthetic_org_uuid) as { n: number };
+		expect(keyCount.n).toBe(0);
+	});
+});
+
+describe("GET /admin/peers", () => {
+	it("lists configured inbound peers", async () => {
+		db.raw.prepare(`DELETE FROM sharing_groups`).run();
+		db.raw.prepare(`INSERT INTO sharing_groups (uuid, name) VALUES (?, ?)`)
+			.run("00000000-0000-0000-0000-000000000001", "default-sg");
+
+		await appReq("/peers", {
+			method: "POST",
+			headers: { ...adminAuth, "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: "p1", base_url: "https://p1.example", api_key_secret_name: "K1",
+				default_sharing_group_uuid: "00000000-0000-0000-0000-000000000001",
+			}),
+		});
+		const res = await appReq("/peers", { headers: adminAuth });
+		expect(res.status).toBe(200);
+		const body = await res.json() as { peers: Array<{ name: string; base_url: string }> };
+		expect(body.peers).toHaveLength(1);
+		expect(body.peers[0].name).toBe("p1");
+		expect(body.peers[0].base_url).toBe("https://p1.example");
+	});
+});
+
+describe("DELETE /admin/peers/:uuid", () => {
+	it("removes the inbound_peers row and cascades the peers row", async () => {
+		db.raw.prepare(`DELETE FROM sharing_groups`).run();
+		db.raw.prepare(`INSERT INTO sharing_groups (uuid, name) VALUES (?, ?)`)
+			.run("00000000-0000-0000-0000-000000000001", "default-sg");
+
+		const create = await appReq("/peers", {
+			method: "POST",
+			headers: { ...adminAuth, "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: "p1", base_url: "https://p1.example", api_key_secret_name: "K1",
+				default_sharing_group_uuid: "00000000-0000-0000-0000-000000000001",
+			}),
+		});
+		const { inbound_peer_uuid } = await create.json() as { inbound_peer_uuid: string };
+
+		const res = await appReq(`/peers/${inbound_peer_uuid}`, {
+			method: "DELETE", headers: adminAuth,
+		});
+		expect(res.status).toBe(204);
+		const ib = db.raw.prepare(`SELECT count(*) as n FROM inbound_peers`).get() as { n: number };
+		expect(ib.n).toBe(0);
+	});
+});


### PR DESCRIPTION
Closes #19.

## Summary

- Adds `pullFromPeer` + `runInboundSync` to the AIS hub: every 5 minutes, the hub pulls events from configured upstream MISP-compatible peers, UPSERTs them with watermark-based idempotency, and credits corroboration to a synthetic per-peer org.
- Adds operator-only `/admin/peers` CRUD gated by a single `HUB_ADMIN_KEY` Worker secret. No new role model; admin auth is decoupled from per-org auth.
- Adds the `peers` shared-identity table (referenced by inbound configs now, future outbound configs later) and a `events.source_peer_uuid` provenance column.

## Design highlights (worth reading the issue)

Issue #19 has the full rationale. Key constraints baked into the implementation:

- **Synthetic-org attribution** — pulled events all credit one synthetic org per peer, regardless of upstream `orgc_uuid`. Sybil resistance: a compromised upstream can't bypass the single-org corroboration cap.
- **Pulled-only intel does NOT solo-promote** — needs at least one local-org corroboration. README documents this caveat.
- **Watermark uses `>=` with end-of-run max** — events sharing timestamps across page boundaries don't get lost.
- **Loop prevention** — events whose `orgc_uuid` matches a local org are skipped (we previously pushed it).
- **`next_retry_at` dual-purpose** — soft cron lock at run start + failure backoff. Single column.
- **`order: \"Event.timestamp ASC\"` explicit** — MISP's restSearch order is undefined otherwise; deep first backfills could lose events.

## Out of scope (intentional)

Outbound push, per-org peer subscriptions, STIX export, retroactive trust changes, multi-sharing-group routing per peer. All called out in the README and the issue.

## Test plan

- [x] All 42 hub tests pass (9 new sync tests, 6 new admin route tests, 5 new admin-auth tests, 22 pre-existing)
- [x] `npm run typecheck` clean
- [ ] After merge: configure a real upstream peer (e.g., a CIRCL-style instance) via `wrangler secret put HUB_ADMIN_KEY` + `POST /admin/peers` and watch a cron tick land events
- [ ] Verify watermark advances on success and stays put on upstream 500 (already covered by unit tests but worth confirming in a live deploy)
- [ ] Confirm `default_trust` set at admin-create time shows up in `corroboration.score` for pulled events

🤖 Generated with [Claude Code](https://claude.com/claude-code)