### PR TITLE
Sync upstream cloudflare/agentic-inbox into fork

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,3 +1,3 @@
-# Cloudflare Access (required in production)
+# Cloudflare Access (required in production). TEAM_DOMAIN may be the base Access URL or the full /cdn-cgi/access/certs URL.
 POLICY_AUD=your-access-policy-audience-tag
 TEAM_DOMAIN=https://your-team.cloudflareaccess.com

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Click the button above to deploy to your Cloudflare account. The deploy flow wil
 
 ### Troubleshooting Access
 
-1. If you see `Invalid or expired Access token`, that usually means `POLICY_AUD` or `TEAM_DOMAIN` secrets are incorrect. 
-   * Resolution: turn Access off and back on for the Worker to get the Access modal again with the variables, then reset your Worker secrets to the latest `POLICY_AUD` and `TEAM_DOMAIN` values shown there.
-2. If you see `Cloudflare Access must be configured in production`, this application is intentionally enforcing Cloudflare Access so your inbox is not exposed to anyone on the internet. 
+1. If you see `Invalid or expired Access token`, that usually means `POLICY_AUD` or `TEAM_DOMAIN` secrets are incorrect.
+   * Resolution: [turn Access off and back on for the Worker to get the Access modal again](https://developers.cloudflare.com/changelog/post/2025-10-03-one-click-access-for-workers/), then reset your Worker secrets to the latest `POLICY_AUD` and `TEAM_DOMAIN` values shown there.
+2. If you see `Cloudflare Access must be configured in production`, this application is intentionally enforcing Cloudflare Access so your inbox is not exposed to anyone on the internet.
    * Resolution: enable Access using [one-click Cloudflare Access for Workers](https://developers.cloudflare.com/changelog/post/2025-10-03-one-click-access-for-workers/), then set the `POLICY_AUD` and `TEAM_DOMAIN` Worker secrets from the modal values.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Click the button above to deploy to your Cloudflare account. The deploy flow wil
 1. **Set up Email Routing** -- In the Cloudflare dashboard, go to your domain > Email Routing and create a catch-all rule that forwards to this Worker
 2. **Enable Email Service** -- The worker needs the `send_email` binding to send outbound emails. See [Email Service docs](https://developers.cloudflare.com/email-routing/email-workers/send-email-workers/)
 3. **Create a mailbox** -- Visit your deployed app and create a mailbox for any address on your domain (e.g. `hello@example.com`)
-4. **Configure Cloudflare Access** -- Enable [one-click Cloudflare Access](https://developers.cloudflare.com/changelog/post/2025-10-03-one-click-access-for-workers/) on your Worker under Settings > Domains & Routes. The modal will show your `POLICY_AUD` and `TEAM_DOMAIN` values. **You must set these are secrets for your Worker.**
+4. **Configure Cloudflare Access** -- Enable [one-click Cloudflare Access](https://developers.cloudflare.com/changelog/post/2025-10-03-one-click-access-for-workers/) on your Worker under Settings > Domains & Routes. The modal will show your `POLICY_AUD` and `TEAM_DOMAIN` values. `TEAM_DOMAIN` can be either your Access team URL or the full `.../cdn-cgi/access/certs` URL. **You must set these as secrets for your Worker.**
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -14,18 +14,19 @@ Read the blog post to learn more about Cloudflare Email Service and how to use i
 
 ## How to setup
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/agentic-inbox)
+**Important**: Clicking the 'Deploy to Cloudflare' button is only one part of the setup. You must follow the **After deploying** steps as well. For a full step-by-step guide with screenshots, refer to this comment: 
+https://github.com/cloudflare/agentic-inbox/issues/4#issuecomment-4269118513
 
-Click the button above to deploy to your Cloudflare account. The deploy flow will automatically provision R2, Durable Objects, and Workers AI. You'll be prompted for:
+### To set up
 
-- **DOMAINS** -- your domain with Email Routing enabled (e.g. `example.com`)
+1. Deploy to Cloudflare. The deploy flow will automatically provision R2, Durable Objects, and Workers AI. You'll be prompted for **DOMAINS**, which is the domain (yourdomain.com) you want to receive emails for (email@yourdomain.com).
 
-### After deploying
+     [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/agentic-inbox)
 
-1. **Set up Email Routing** -- In the Cloudflare dashboard, go to your domain > Email Routing and create a catch-all rule that forwards to this Worker
-2. **Enable Email Service** -- The worker needs the `send_email` binding to send outbound emails. See [Email Service docs](https://developers.cloudflare.com/email-routing/email-workers/send-email-workers/)
-3. **Create a mailbox** -- Visit your deployed app and create a mailbox for any address on your domain (e.g. `hello@example.com`)
-4. **Configure Cloudflare Access** -- Enable [one-click Cloudflare Access](https://developers.cloudflare.com/changelog/post/2025-10-03-one-click-access-for-workers/) on your Worker under Settings > Domains & Routes. The modal will show your `POLICY_AUD` and `TEAM_DOMAIN` values. `TEAM_DOMAIN` can be either your Access team URL or the full `.../cdn-cgi/access/certs` URL. **You must set these as secrets for your Worker.**
+2. **Configure Cloudflare Access** -- Enable [one-click Cloudflare Access](https://developers.cloudflare.com/changelog/post/2025-10-03-one-click-access-for-workers/) on your Worker under Settings > Domains & Routes. The modal will show your `POLICY_AUD` and `TEAM_DOMAIN` values. `TEAM_DOMAIN` can be either your Access team URL or the full `.../cdn-cgi/access/certs` URL. **You must set these as secrets for your Worker.**
+3. **Set up Email Routing** -- In the Cloudflare dashboard, go to your domain > Email Routing and create a catch-all rule that forwards to this Worker
+4. **Enable Email Service** -- The worker needs the `send_email` binding to send outbound emails. See [Email Service docs](https://developers.cloudflare.com/email-routing/email-workers/send-email-workers/)
+5. **Create a mailbox** -- Visit your deployed app and create a mailbox for any address on your domain (e.g. `hello@example.com`)
 
 ### Troubleshooting Access
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Click the button above to deploy to your Cloudflare account. The deploy flow wil
 3. **Create a mailbox** -- Visit your deployed app and create a mailbox for any address on your domain (e.g. `hello@example.com`)
 4. **Configure Cloudflare Access** -- Enable [one-click Cloudflare Access](https://developers.cloudflare.com/changelog/post/2025-10-03-one-click-access-for-workers/) on your Worker under Settings > Domains & Routes. The modal will show your `POLICY_AUD` and `TEAM_DOMAIN` values. `TEAM_DOMAIN` can be either your Access team URL or the full `.../cdn-cgi/access/certs` URL. **You must set these as secrets for your Worker.**
 
+### Troubleshooting Access
+
+1. If you see `Invalid or expired Access token`, that usually means `POLICY_AUD` or `TEAM_DOMAIN` secrets are incorrect. 
+   * Resolution: turn Access off and back on for the Worker to get the Access modal again with the variables, then reset your Worker secrets to the latest `POLICY_AUD` and `TEAM_DOMAIN` values shown there.
+2. If you see `Cloudflare Access must be configured in production`, this application is intentionally enforcing Cloudflare Access so your inbox is not exposed to anyone on the internet. 
+   * Resolution: enable Access using [one-click Cloudflare Access for Workers](https://developers.cloudflare.com/changelog/post/2025-10-03-one-click-access-for-workers/), then set the `POLICY_AUD` and `TEAM_DOMAIN` Worker secrets from the modal values.
+
 ## Features
 
 - **Full email client** — Send and receive emails via Cloudflare Email Routing with a rich text composer, reply/forward threading, folder organization, search, and attachments

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -28,6 +28,17 @@ const requestHandler = createRequestHandler(
 	import.meta.env.MODE,
 );
 
+function getAccessUrls(teamDomain: string) {
+	const certsPath = "/cdn-cgi/access/certs";
+	const teamUrl = new URL(teamDomain);
+	const issuer = teamUrl.origin;
+	const certsUrl = teamUrl.pathname.endsWith(certsPath)
+		? teamUrl
+		: new URL(certsPath, issuer);
+
+	return { issuer, certsUrl };
+}
+
 // Main app that wraps the API and adds React Router fallback
 const app = new Hono<{ Bindings: Env }>();
 
@@ -54,11 +65,10 @@ app.use("*", async (c, next) => {
 	}
 
 	try {
-		const JWKS = createRemoteJWKSet(
-			new URL(`${TEAM_DOMAIN}/cdn-cgi/access/certs`),
-		);
+		const { issuer, certsUrl } = getAccessUrls(TEAM_DOMAIN);
+		const JWKS = createRemoteJWKSet(certsUrl);
 		await jwtVerify(token, JWKS, {
-			issuer: TEAM_DOMAIN,
+			issuer,
 			audience: POLICY_AUD,
 		});
 	} catch {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,6 +11,7 @@
 	],
 	"vars": {
 		// Production deploys must also define POLICY_AUD and TEAM_DOMAIN.
+		// TEAM_DOMAIN may be the base Access URL or the full /cdn-cgi/access/certs URL.
 		// The worker now fails closed outside local development if Access is not configured.
 		"DOMAINS": "example.com",
 		"EMAIL_ADDRESSES": []


### PR DESCRIPTION
## Summary
- Merges upstream `cloudflare/agentic-inbox` main (commits `0d8e52e..48039bb`) into our fork
- Picks up the **TEAM_DOMAIN cert-URL fix** (`workers/app.ts`): now accepts either the base Access URL or the full `.../cdn-cgi/access/certs` URL
- Pulls in upstream's README restructuring + new **Troubleshooting Access** section
- Auto-merge handled `workers/app.ts`, `wrangler.jsonc`, and `.dev.vars.example` cleanly; README conflict resolved by keeping upstream's setup-flow rewrite while preserving our multi-domain `DOMAINS` note and the `Security pipeline` feature bullet

## Test plan
- [x] `npm run typecheck` passes
- [ ] Manual: deploy and verify Access JWT validation still works with both `TEAM_DOMAIN` formats (base URL and full certs URL)
- [ ] Spot-check rendered README on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)