### PR TITLE
ci: add baseline GitHub checks (CI, CodeQL, Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+    groups:
+      tiptap:
+        patterns:
+          - "@tiptap/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "react-router"
+          - "@react-router/*"
+      cloudflare:
+        patterns:
+          - "@cloudflare/*"
+          - "wrangler"
+          - "workers-ai-provider"
+      dev-dependencies:
+        dependency-type: development
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@cloudflare/*"
+          - "wrangler"
+          - "@types/react*"
+      production-dependencies:
+        dependency-type: production
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@tiptap/*"
+          - "@cloudflare/*"
+          - "react"
+          - "react-dom"
+          - "react-router"
+          - "@react-router/*"
+          - "workers-ai-provider"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE"
+      - "demo_app.png"
+      - ".github/dependabot.yml"
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE"
+      - "demo_app.png"
+      - ".github/dependabot.yml"
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Typecheck & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.ts"
+      - "**/*.tsx"
+      - "**/*.js"
+      - "**/*.jsx"
+      - ".github/workflows/codeql.yml"
+  push:
+    branches: [main]
+  schedule:
+    - cron: "27 6 * * 1"
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/app/hooks/useUIStore.ts
+++ b/app/hooks/useUIStore.ts
@@ -166,7 +166,7 @@ export const useUIStore = create<UIState>((set, get) => ({
 		set({ theme });
 	},
 	toggleTheme: () => {
-		const theme = get().theme === "dark" ? "light" : "dark";
+		const theme: Theme = get().theme === "dark" ? "light" : "dark";
 		const next = { ...pickPrefs(get()), theme };
 		savePrefs(next);
 		set({ theme });


### PR DESCRIPTION
## Summary

Adds three baseline checks under `.github/` chosen to be useful without burning Actions minutes:

- **`ci.yml`** — `npm run typecheck` + `npm test` on PRs to `main` and pushes to `main`. Single Ubuntu/Node 20 runner, npm cache, 15-min timeout, `paths-ignore` for docs-only changes, concurrency that cancels superseded **PR** runs but preserves main-branch runs.
- **`codeql.yml`** — `javascript-typescript` scan with the `security-and-quality` query suite. Runs on JS/TS PR diffs, pushes to `main`, and a weekly Monday cron (`27 6 * * 1`). 20-min timeout.
- **`dependabot.yml`** — Weekly grouped npm + actions updates. Tiptap (~25 packages), react/react-router, and Cloudflare/wrangler are grouped so we get ~5 PRs/week instead of 30+. Caps: 5 npm + 3 actions PRs open.

## Why

The repo had no `.github/` directory — every PR was merging unverified, and there was no scheduled security scan or dependency hygiene.

Minimum-cost choices:
- No matrix (single Node version)
- No separate `build` job — `typecheck` covers compile-time correctness; `deploy` runs locally, so we don't pay twice
- `paths-ignore` on docs-only changes
- `cancel-in-progress` only on PR events, so a `main` push is never half-completed when the next push lands

## Test plan

- [ ] First PR after merge runs `verify` job and `Analyze` job
- [ ] Confirm `npm ci` resolves with current `package-lock.json` on Node 20
- [ ] Confirm `npm run typecheck` and `npm test` pass on a fresh runner
- [ ] After merge to `main`, watch for the first weekly Dependabot PR (Monday 07:00 UTC) to confirm grouping behaves as configured
- [ ] Confirm CodeQL weekly cron runs the following Monday

## Notes for reviewer

- If you want lint as well, there's no `lint` script in `package.json` today — happy to add ESLint config + a `lint` job in a follow-up PR if desired.
- If Cloudflare Workers compatibility wants Node 22, swap `node-version: 20` → `22` in `ci.yml`. I picked 20 as the current LTS; the project doesn't pin an `engines` field.