### PR TITLE
chore: add SECURITY.md, CODEOWNERS, PR template, and issue forms

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS - auto-requests review on touched paths.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+* @schmug

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Something is broken or behaving unexpectedly.
+title: "bug: <short summary>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please fill in what you can — partial reports are still useful.
+        For **security vulnerabilities**, do NOT use this form; use [private vulnerability reporting](https://github.com/schmug/PhishSOC/security/advisories) instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you observe? What did you expect instead?
+      placeholder: |
+        I tried to X and saw Y. I expected Z.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimum sequence of steps to trigger the bug.
+      placeholder: |
+        1. Deploy with `npm run deploy`
+        2. Send an email matching ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Best guess — maintainers will adjust.
+      options:
+        - Low — cosmetic / minor inconvenience
+        - Medium — feature impaired but workaround exists
+        - High — feature broken, no workaround
+        - Critical — data loss, auth bypass, or service down
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Commit / version
+      description: Output of `git rev-parse HEAD` or the deployed Worker version tag.
+      placeholder: "e.g. 1c34ef8 or v0.3.1"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / errors
+      description: Worker logs, browser console output, or stack traces. Redact secrets.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+        - label: This is not a security vulnerability (those go to private reporting).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/schmug/PhishSOC/security/advisories/new
+    about: Report security issues privately via GitHub Security Advisories — please do not open a public issue.
+  - name: Question / discussion
+    url: https://github.com/schmug/PhishSOC/discussions
+    about: For open-ended questions, ideas, or help requests.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature request
+description: Propose a new capability or a meaningful change to existing behavior.
+title: "feat: <short summary>"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user-facing or operational problem are you trying to solve?
+      placeholder: |
+        Today I have to X manually because ...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should PhishSOC do? Sketch the UX, API, or pipeline change.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why you'd pick this one.
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Area
+      multiple: true
+      options:
+        - Frontend (app/)
+        - Worker / API (workers/)
+        - Hub federation (hub/)
+        - Detection pipeline (SPF/DKIM/DMARC, URL, RDAP, LLM)
+        - AI agent / chat
+        - Deploy / wrangler config
+        - Docs
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+PhishSOC is a security tool. We treat vulnerability reports as a priority.
+
+## Reporting a vulnerability
+
+**Please do not file a public issue for security problems.** Use GitHub's private vulnerability reporting:
+
+1. Open the [Security tab](https://github.com/schmug/PhishSOC/security/advisories) on this repo.
+2. Click **Report a vulnerability**.
+3. Describe the issue, impact, and a minimum reproduction.
+
+We aim to acknowledge reports within 3 business days and to ship a fix or mitigation within 30 days for high-severity issues.
+
+## Scope
+
+In scope:
+
+- The PhishSOC Worker code in this repository (`app/`, `workers/`, `hub/`, `shared/`)
+- Authentication, authorization, and tenant-isolation boundaries
+- The phishing-detection pipeline (SPF/DKIM/DMARC parsing, URL/homograph/RDAP analysis, LLM classifier)
+- Any configuration in `wrangler.jsonc` that affects security posture
+
+Out of scope:
+
+- Issues in upstream dependencies — please report to the dependency directly; we will pick up fixes via Dependabot
+- Issues that require physical access to the operator's Cloudflare account
+- Findings that require disabling Cloudflare Access or running outside the documented deployment topology
+- Self-XSS, missing security headers without a demonstrated impact, and other low-severity report classes commonly rejected by major bug-bounty programs
+
+## Disclosure
+
+We prefer coordinated disclosure. After a fix ships and operators have had a reasonable window to upgrade, we will publish a GitHub Security Advisory crediting the reporter (unless anonymity is requested).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!--
+Thanks for the PR. Keep this template — reviewers scan for these sections.
+-->
+
+## Summary
+
+<!-- 1–3 bullets on what this PR changes. -->
+
+## Why
+
+<!-- The motivation: bug, spec, issue link, incident. Skip if obvious from Summary. -->
+
+## Test plan
+
+<!-- Checklist of how the change was verified. CI runs typecheck + tests automatically. -->
+
+- [ ] `npm run typecheck` passes locally
+- [ ] `npm test` passes locally
+- [ ] Manually exercised the affected flow (describe how)
+
+## Notes for reviewer
+
+<!-- Trade-offs, follow-ups, or anything not obvious from the diff. Optional. -->


### PR DESCRIPTION
## Summary

- `SECURITY.md` — routes vulnerability reports through GitHub's [private vulnerability reporting](https://github.com/schmug/PhishSOC/security/advisories), with scope/SLA/disclosure terms.
- `CODEOWNERS` — auto-requests review on every change.
- `pull_request_template.md` — locks in the **Summary / Why / Test plan / Notes** structure already used in #35.
- `ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml` — issue forms with required fields. `config.yml` disables blank issues and links security reports to the private advisory flow and questions to Discussions.

## Why

Pairs with the CI/CodeQL/Dependabot baseline in #35. With #35, the repo had no enforced PR/issue structure and no documented vuln-report channel — the `Report a vulnerability` button on the Security tab existed but wasn't pointed at by anything user-facing. As a security-positioning tool, this is table stakes.

## Test plan

- [ ] After merge, **Issues → New issue** shows only Bug / Feature forms (no blank-issue option) plus the contact links.
- [ ] **Security → Report a vulnerability** flow is reachable from `SECURITY.md`.
- [ ] Next PR opened against `main` auto-fills the new template and auto-requests review from `@schmug` via CODEOWNERS.

## Notes for reviewer

- Docs/config only. No source paths touched. CI still runs on this PR — `.github/SECURITY.md`, `.github/CODEOWNERS`, `.github/pull_request_template.md`, and `.github/ISSUE_TEMPLATE/**` are not in the `paths-ignore` block from #35.
- No file overlap with #35, so the two PRs can land in either order.
- This PR is part of a repo-hygiene pass that also applied (via `gh api`):
  - Updated repo description / homepage / 15 topics
  - Enabled Dependabot vulnerability alerts (now reporting **27 vulns: 6 high, 21 moderate** — worth a follow-up triage pass once #35's grouped Dependabot config starts opening PRs)
  - Enabled private vulnerability reporting
  - Branch protection on `main` requiring PR + the `Typecheck & Test` and `Analyze (javascript-typescript)` checks; admin-enforced; linear history; conversation resolution; no force pushes / deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)