### PR TITLE
ci: drop paths filters so required checks fire on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "LICENSE"
-      - "demo_app.png"
-      - ".github/dependabot.yml"
   push:
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "LICENSE"
-      - "demo_app.png"
-      - ".github/dependabot.yml"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,12 +3,6 @@ name: CodeQL
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "**/*.ts"
-      - "**/*.tsx"
-      - "**/*.js"
-      - "**/*.jsx"
-      - ".github/workflows/codeql.yml"
   push:
     branches: [main]
   schedule:


### PR DESCRIPTION
## Summary

Removes `paths-ignore` from `ci.yml` and `paths:` from `codeql.yml`, so the `Typecheck & Test` and `Analyze (javascript-typescript)` checks fire on every PR to `main`.

## Why

#35 added paths filters to skip CI on docs-only PRs (≈37s of CI saved per docs PR). After we layered branch protection on top — both checks required, `enforce_admins: true` — the optimization became a deadlock: a docs-only PR like #40 never triggers either workflow, the required checks stay pending forever, and even repo admins can't merge without disabling protection.

## Two ways to fix this

| | This PR (drop filters) | Ghost-check companion workflows |
|---|---|---|
| New files | 0 | 2 (`ci-skip.yml` + `codeql-skip.yml`) |
| Maintenance | none | every new required check needs a matching ghost; easy to forget |
| Failure mode | docs PR uses ~2 min of free CI | ghost workflow drifts out of sync, required check name silently doesn't match, PRs get stuck again |
| Behavior on real-code PRs | identical | identical |

The ghost-check pattern is the right answer when CI is genuinely expensive — large matrix builds, multi-hour test suites. For a 37-second `npm test` on a public repo with free Actions minutes, it's over-engineering with a real maintenance footgun. This is also what most large OSS projects (kubernetes, rust-lang, react, etc.) do for the same reason.

## Test plan

- [x] CI runs on this PR (modifies a workflow path that wasn't in `paths-ignore`)
- [ ] After merge, #40 (docs-only) gets a fresh CI + CodeQL run automatically
- [ ] After merge, the next Dependabot PR runs both required checks and can self-merge once green

## Notes for reviewer

- No source paths touched; only workflow `on:` blocks.
- The weekly CodeQL cron (`schedule: cron "27 6 * * 1"`) and `push: branches: [main]` triggers are unchanged.
- The `concurrency:` blocks already cancel superseded PR runs, so back-to-back doc edits won't pile up runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)