### PR TITLE
PhishSOC UI: loading & error states (PR B, closes #19)

### DIFF
--- a/app/components/AgentPanel.tsx
+++ b/app/components/AgentPanel.tsx
@@ -23,6 +23,7 @@ import { useParams } from "react-router";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useUIStore } from "~/hooks/useUIStore";
+import { useFeedback } from "~/lib/feedback";
 import type { UIMessage } from "ai";
 
 const TOOL_LABELS: Record<string, { label: string; icon: React.ReactNode }> = {
@@ -306,10 +307,17 @@ function AgentChatConnected({
 	const inputRef = useRef<HTMLTextAreaElement>(null);
 	const [inputValue, setInputValue] = useState("");
 	const { startCompose } = useUIStore();
+	const feedback = useFeedback();
 
 	const agent = useAgent({ agent: "EmailAgent", name: mailboxId });
 	const { messages, sendMessage, status, setMessages, stop } =
-		useAgentChat({ agent });
+		useAgentChat({
+			agent,
+			onError: (error) => {
+				console.error("agent chat error:", error);
+				feedback.error("Agent request failed. Try again.");
+			},
+		});
 	const isStreaming = status === "streaming" || status === "submitted";
 
 	useEffect(() => {

--- a/app/components/EmailPanel.tsx
+++ b/app/components/EmailPanel.tsx
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { useKumoToastManager } from "@cloudflare/kumo";
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router";
 import { Folders } from "shared/folders";
@@ -11,6 +10,7 @@ import EmailPanelHeader from "~/components/email-panel/EmailPanelHeader";
 import EmailPanelToolbar from "~/components/email-panel/EmailPanelToolbar";
 import SingleMessageView from "~/components/email-panel/SingleMessageView";
 import ThreadMessage from "~/components/email-panel/ThreadMessage";
+import { useFeedback } from "~/lib/feedback";
 import { splitEmailList, toEmailListValue } from "~/lib/utils";
 import api from "~/services/api";
 import { useDeleteEmail, useEmail, useMoveEmail, useReplyToEmail, useSendEmail, useThreadReplies, useUpdateEmail } from "~/queries/emails";
@@ -45,7 +45,7 @@ export default function EmailPanel({ emailId }: { emailId: string }) {
 		data?: Mailbox;
 	};
 	const { closePanel, startCompose } = useUIStore();
-	const toastManager = useKumoToastManager();
+	const feedback = useFeedback();
 	const [isSending, setIsSending] = useState(false);
 	const [sourceViewEmail, setSourceViewEmail] = useState<Email | null>(null);
 	const [expandedMessages, setExpandedMessages] = useState<Set<string>>(new Set());
@@ -87,9 +87,9 @@ export default function EmailPanel({ emailId }: { emailId: string }) {
 
 	if (!email) return <EmailPanelSkeleton />;
 
-	const toggleStar = () => { if (mailboxId) updateEmail.mutate({ mailboxId, id: email.id, data: { starred: !email.starred } }); };
-	const handleMove = (folderId: string) => { if (mailboxId) { moveEmailMut.mutate({ mailboxId, id: email.id, folderId }); closePanel(); } };
-	const handleDelete = () => { if (mailboxId) { if (!window.confirm("Are you sure you want to delete this email?")) return; deleteEmailMut.mutate({ mailboxId, id: email.id }); closePanel(); } };
+	const toggleStar = () => { if (mailboxId) updateEmail.mutate({ mailboxId, id: email.id, data: { starred: !email.starred } }, { onError: () => feedback.error("Couldn't update email.") }); };
+	const handleMove = (folderId: string) => { if (mailboxId) { moveEmailMut.mutate({ mailboxId, id: email.id, folderId }, { onError: () => feedback.error("Couldn't move email.") }); closePanel(); } };
+	const handleDelete = () => { if (mailboxId) { if (!window.confirm("Are you sure you want to delete this email?")) return; deleteEmailMut.mutate({ mailboxId, id: email.id }, { onError: () => feedback.error("Couldn't delete email.") }); closePanel(); } };
 
 	const handleEditDraft = (draftMsg?: Email) => {
 		const target = draftMsg || email;
@@ -101,8 +101,8 @@ export default function EmailPanel({ emailId }: { emailId: string }) {
 		const target = draftMsg || email;
 		if (!mailboxId) return;
 		if (!window.confirm("Discard this draft?")) return;
-		deleteEmailMut.mutate({ mailboxId, id: target.id });
-		toastManager.add({ title: "Draft discarded" });
+		deleteEmailMut.mutate({ mailboxId, id: target.id }, { onError: () => feedback.error("Couldn't delete email.") });
+		feedback.info("Draft discarded");
 		if (target.id === emailId) closePanel();
 	};
 
@@ -112,9 +112,9 @@ export default function EmailPanel({ emailId }: { emailId: string }) {
 		setIsSending(true);
 		try {
 			if (!target.recipient || !target.subject) { try { const fresh = await api.getEmail(mailboxId, target.id) as Email; if (fresh) target = fresh; } catch {} }
-			if (!target.recipient) { toastManager.add({ title: "Cannot send: no recipient set on this draft.", variant: "error" }); return; }
+			if (!target.recipient) { feedback.error("Cannot send: no recipient set on this draft."); return; }
 			const toRecipients = splitEmailList(target.recipient);
-			if (toRecipients.length === 0) { toastManager.add({ title: "Cannot send: no valid recipient set on this draft.", variant: "error" }); return; }
+			if (toRecipients.length === 0) { feedback.error("Cannot send: no valid recipient set on this draft."); return; }
 			const fromName = currentMailbox.settings?.fromName || currentMailbox.name;
 			const from = fromName && fromName !== currentMailbox.email ? { email: currentMailbox.email, name: fromName } : currentMailbox.email;
 			const originalEmail = target.in_reply_to ? allMessages.find((msg) => msg.id === target.in_reply_to) : undefined;
@@ -129,11 +129,11 @@ export default function EmailPanel({ emailId }: { emailId: string }) {
 			};
 			if (originalEmail) await replyMut.mutateAsync({ mailboxId, emailId: originalEmail.id, email: emailData }); else await sendEmailMut.mutateAsync({ mailboxId, email: emailData });
 			await deleteEmailMut.mutateAsync({ mailboxId, id: target.id });
-			toastManager.add({ title: "Email sent!" });
+			feedback.success("Email sent!");
 			if (isDraftFolder) closePanel();
 		} catch (err) {
 			const message = (err instanceof Error ? err.message : null) || "Failed to send email.";
-			toastManager.add({ title: message, variant: "error" });
+			feedback.error(message);
 		} finally { setIsSending(false); }
 	};
 
@@ -163,11 +163,14 @@ export default function EmailPanel({ emailId }: { emailId: string }) {
 				onToggleStar={toggleStar}
 				onToggleRead={() => {
 					if (mailboxId) {
-						updateEmail.mutate({
-							mailboxId,
-							id: email.id,
-							data: { read: !email.read },
-						});
+						updateEmail.mutate(
+							{
+								mailboxId,
+								id: email.id,
+								data: { read: !email.read },
+							},
+							{ onError: () => feedback.error("Couldn't update email.") },
+						);
 					}
 				}}
 				onMove={handleMove}

--- a/app/components/ReportPhishButton.tsx
+++ b/app/components/ReportPhishButton.tsx
@@ -2,10 +2,11 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { Button, Tooltip, useKumoToastManager } from "@cloudflare/kumo";
+import { Button, Tooltip } from "@cloudflare/kumo";
 import { ShieldWarningIcon } from "@phosphor-icons/react";
 import { useNavigate } from "react-router";
 import { useState } from "react";
+import { useFeedback } from "~/lib/feedback";
 
 /**
  * Convert an email into a local case and (future milestones) push anonymized
@@ -20,7 +21,7 @@ export default function ReportPhishButton({
 	emailId: string;
 }) {
 	const navigate = useNavigate();
-	const toast = useKumoToastManager();
+	const feedback = useFeedback();
 	const [pending, setPending] = useState(false);
 
 	const handle = async () => {
@@ -37,10 +38,10 @@ export default function ReportPhishButton({
 			);
 			if (!res.ok) throw new Error(await res.text());
 			const data = (await res.json()) as { caseId?: string };
-			toast.add({ title: "Phish reported", description: "A case was opened." });
+			feedback.success("Phish reported — a case was opened.");
 			if (data.caseId) navigate(`/mailbox/${encodeURIComponent(mailboxId)}/cases/${data.caseId}`);
 		} catch (e) {
-			toast.add({ title: "Report failed", description: (e as Error).message, variant: "error" });
+			feedback.error(`Report failed: ${(e as Error).message}`);
 		} finally {
 			setPending(false);
 		}

--- a/app/hooks/useComposeForm.ts
+++ b/app/hooks/useComposeForm.ts
@@ -2,8 +2,8 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { useKumoToastManager } from "@cloudflare/kumo";
 import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { useFeedback } from "~/lib/feedback";
 import {
 	buildQuotedReplyBlock,
 	escapeHtml,
@@ -163,7 +163,7 @@ function buildInitialComposeFields(
 }
 
 export function useComposeForm(mailboxId?: string, _folder?: string) {
-	const toastManager = useKumoToastManager();
+	const feedback = useFeedback();
 	const { composeOptions, closePanel, closeCompose } = useUIStore();
 	const { data: currentMailbox } = useMailbox(mailboxId);
 	const sendEmailMutation = useSendEmail();
@@ -222,12 +222,12 @@ export function useComposeForm(mailboxId?: string, _folder?: string) {
 				thread_id: composeOptions.originalEmail?.thread_id || composeOptions.draftEmail?.thread_id || undefined,
 				draft_id: composeOptions.draftEmail?.id || undefined,
 			} });
-			toastManager.add({ title: "Draft saved!" });
+			feedback.success("Draft saved!");
 		}
 		catch (err: unknown) {
 			const message = (err instanceof Error ? err.message : null) || "Failed to save draft.";
 			setError(message);
-			toastManager.add({ title: message, variant: "error" });
+			feedback.error(message);
 		}
 		finally { setIsSavingDraft(false); }
 	};
@@ -250,15 +250,15 @@ export function useComposeForm(mailboxId?: string, _folder?: string) {
 			text: htmlToPlainText(body),
 		};
 		const draftId = composeOptions.draftEmail?.id; const mode = composeOptions.mode; const originalId = composeOptions.originalEmail?.id || composeOptions.draftEmail?.in_reply_to;
-		setIsSending(true); toastManager.add({ title: "Sending email..." });
+		setIsSending(true); feedback.info("Sending email...");
 		try {
 			if ((mode === "reply" || mode === "reply-all") && originalId) await replyMutation.mutateAsync({ mailboxId, emailId: originalId, email: emailData });
 			else if (mode === "forward" && originalId) await forwardMutation.mutateAsync({ mailboxId, emailId: originalId, email: emailData });
 			else await sendEmailMutation.mutateAsync({ mailboxId, email: emailData });
 			if (draftId) deleteEmailMutation.mutate({ mailboxId, id: draftId });
-			toastManager.add({ title: "Email sent!" });
+			feedback.success("Email sent!");
 			onClose();
-		} catch (err: unknown) { const message = (err instanceof Error ? err.message : null) || "Failed to send email."; setError(message); toastManager.add({ title: message, variant: "error" }); }
+		} catch (err: unknown) { const message = (err instanceof Error ? err.message : null) || "Failed to send email."; setError(message); feedback.error(message); }
 		finally { setIsSending(false); }
 	};
 

--- a/app/lib/feedback.ts
+++ b/app/lib/feedback.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { useKumoToastManager } from "@cloudflare/kumo";
+
+/**
+ * Thin wrapper over kumo's toast manager so call sites don't need to
+ * remember the {variant: "error"} shape. The hook is the only API — use
+ * the returned object's methods inside event handlers / effects.
+ */
+export function useFeedback() {
+  const toasts = useKumoToastManager();
+  return {
+    error: (title: string) => toasts.add({ title, variant: "error" }),
+    success: (title: string) => toasts.add({ title }),
+    info: (title: string) => toasts.add({ title }),
+  };
+}

--- a/app/routes/case-detail.tsx
+++ b/app/routes/case-detail.tsx
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { useKumoToastManager } from "@cloudflare/kumo";
 import {
 	ArrowLeftIcon,
 	BriefcaseIcon,
@@ -15,6 +14,7 @@ import { Link, useParams } from "react-router";
 import ScoreRing from "~/components/phishsoc/ScoreRing";
 import VerdictPill from "~/components/phishsoc/VerdictPill";
 import { statusLabel, statusTone } from "~/components/phishsoc/verdict";
+import { useFeedback } from "~/lib/feedback";
 
 interface CaseEmail { case_id: string; email_id: string; }
 interface CaseObservable { id: string; kind: string; value: string; }
@@ -52,7 +52,7 @@ function relativeAge(iso: string): string {
 
 export default function CaseDetailRoute() {
 	const { mailboxId, caseId } = useParams<{ mailboxId: string; caseId: string }>();
-	const toast = useKumoToastManager();
+	const feedback = useFeedback();
 	const [data, setData] = useState<CaseRecord | null>(null);
 	const [loading, setLoading] = useState(true);
 
@@ -86,7 +86,7 @@ export default function CaseDetailRoute() {
 				body: JSON.stringify({ status }),
 			},
 		);
-		toast.add({ title: "Case updated" });
+		feedback.success("Case updated");
 		await load();
 	};
 

--- a/app/routes/email-list.tsx
+++ b/app/routes/email-list.tsx
@@ -24,6 +24,7 @@ import { Folders } from "shared/folders";
 import { formatListDate } from "shared/dates";
 import MailboxSplitView from "~/components/MailboxSplitView";
 import VerdictBadge from "~/components/VerdictBadge";
+import { useFeedback } from "~/lib/feedback";
 import { getSnippetText } from "~/lib/utils";
 import {
 	useDeleteEmail,
@@ -166,6 +167,7 @@ export default function EmailListRoute() {
 	const updateEmail = useUpdateEmail();
 	const markThreadRead = useMarkThreadRead();
 	const deleteEmail = useDeleteEmail();
+	const feedback = useFeedback();
 
 	const params = useMemo(
 		() => ({
@@ -214,11 +216,14 @@ export default function EmailListRoute() {
 		e.preventDefault();
 		e.stopPropagation();
 		if (mailboxId)
-			updateEmail.mutate({
-				mailboxId,
-				id: email.id,
-				data: { starred: !email.starred },
-			});
+			updateEmail.mutate(
+				{
+					mailboxId,
+					id: email.id,
+					data: { starred: !email.starred },
+				},
+				{ onError: () => feedback.error("Couldn't update email.") },
+			);
 	};
 
 	const handleDelete = (e: React.MouseEvent, emailId: string) => {
@@ -227,7 +232,10 @@ export default function EmailListRoute() {
 		if (mailboxId) {
 			const confirmed = window.confirm("Are you sure you want to delete this email?");
 			if (!confirmed) return;
-			deleteEmail.mutate({ mailboxId, id: emailId });
+			deleteEmail.mutate(
+				{ mailboxId, id: emailId },
+				{ onError: () => feedback.error("Couldn't delete email.") },
+			);
 			if (selectedEmailId === emailId) closePanel();
 		}
 	};
@@ -253,16 +261,22 @@ export default function EmailListRoute() {
 		selectEmail(email.id);
 		if (mailboxId && hasUnread(email)) {
 			if (email.thread_id && email.thread_count && email.thread_count > 1) {
-				markThreadRead.mutate({
-					mailboxId,
-					threadId: email.thread_id,
-				});
+				markThreadRead.mutate(
+					{
+						mailboxId,
+						threadId: email.thread_id,
+					},
+					{ onError: () => feedback.error("Couldn't mark thread read.") },
+				);
 			} else {
-				updateEmail.mutate({
-					mailboxId,
-					id: email.id,
-					data: { read: true },
-				});
+				updateEmail.mutate(
+					{
+						mailboxId,
+						id: email.id,
+						data: { read: true },
+					},
+					{ onError: () => feedback.error("Couldn't update email.") },
+				);
 			}
 		}
 	};
@@ -425,11 +439,14 @@ export default function EmailListRoute() {
 													onClick={(e) => {
 														e.stopPropagation();
 														if (mailboxId)
-															updateEmail.mutate({
-																mailboxId,
-																id: email.id,
-																data: { read: !email.read },
-															});
+															updateEmail.mutate(
+																{
+																	mailboxId,
+																	id: email.id,
+																	data: { read: !email.read },
+																},
+																{ onError: () => feedback.error("Couldn't update email.") },
+															);
 													}}
 													aria-label={email.read ? "Mark unread" : "Mark read"}
 												/>

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -10,13 +10,13 @@ import {
 	Loader,
 	Select,
 	Text,
-	useKumoToastManager,
 } from "@cloudflare/kumo";
 import { EnvelopeIcon, PlusIcon, TrashIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { type FormEvent, useEffect, useRef, useState } from "react";
 import { Link as RouterLink } from "react-router";
 import Logo from "~/components/phishsoc/Logo";
+import { useFeedback } from "~/lib/feedback";
 import api from "~/services/api";
 import {
 	useCreateMailbox,
@@ -30,7 +30,7 @@ export function meta() {
 }
 
 export default function HomeRoute() {
-	const toastManager = useKumoToastManager();
+	const feedback = useFeedback();
 	const { data: mailboxes = [], refetch: refetchMailboxes, isFetched: mailboxesFetched } = useMailboxes();
 	const createMailbox = useCreateMailbox();
 	const deleteMailbox = useDeleteMailbox();
@@ -102,7 +102,7 @@ export default function HomeRoute() {
 		setIsCreating(true);
 		try {
 			await createMailbox.mutateAsync({ email, name });
-			toastManager.add({ title: "Mailbox created successfully!" });
+			feedback.success("Mailbox created successfully!");
 			setIsCreateOpen(false);
 			setNewPrefix("");
 			setNewName("");
@@ -119,11 +119,11 @@ export default function HomeRoute() {
 		setIsDeleting(true);
 		try {
 			await deleteMailbox.mutateAsync(mailboxToDelete.id);
-			toastManager.add({ title: "Mailbox deleted" });
+			feedback.info("Mailbox deleted");
 			setIsDeleteOpen(false);
 			setMailboxToDelete(null);
 		} catch {
-			toastManager.add({ title: "Failed to delete mailbox", variant: "error" });
+			feedback.error("Failed to delete mailbox");
 		} finally {
 			setIsDeleting(false);
 		}

--- a/app/routes/search-results.tsx
+++ b/app/routes/search-results.tsx
@@ -73,7 +73,15 @@ export default function SearchResultsRoute() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [isError]);
 
-	const handleRowClick = (email: Email) => { selectEmail(email.id); if (!email.read && mailboxId) updateEmail.mutate({ mailboxId, id: email.id, data: { read: true } }); };
+	const handleRowClick = (email: Email) => {
+		selectEmail(email.id);
+		if (!email.read && mailboxId) {
+			updateEmail.mutate(
+				{ mailboxId, id: email.id, data: { read: true } },
+				{ onError: () => feedback.error("Couldn't update email.") },
+			);
+		}
+	};
 	const folderDisplayName = (name: string | null | undefined): string => { if (!name) return ""; const map: Record<string, string> = { inbox: "Inbox", sent: "Sent", draft: "Drafts", archive: "Archive", trash: "Trash", quarantine: "Quarantine" }; return map[name.toLowerCase()] || name; };
 
 	return (

--- a/app/routes/search-results.tsx
+++ b/app/routes/search-results.tsx
@@ -2,11 +2,12 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { Badge, Button, Loader, Pagination, Tooltip } from "@cloudflare/kumo";
+import { Badge, Button, Pagination, Tooltip } from "@cloudflare/kumo";
 import { ArrowLeftIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 import MailboxSplitView from "~/components/MailboxSplitView";
+import { useFeedback } from "~/lib/feedback";
 import { formatListDate, getSnippetText } from "~/lib/utils";
 import { useUpdateEmail } from "~/queries/emails";
 import { useSearchEmails, SEARCH_PAGE_SIZE } from "~/queries/search";
@@ -55,7 +56,7 @@ export default function SearchResultsRoute() {
 		closePanel();
 	}, [closePanel, searchChanged, searchKey]);
 
-	const { data: searchData, isLoading } = useSearchEmails(
+	const { data: searchData, isLoading, isError } = useSearchEmails(
 		mailboxId,
 		urlQuery,
 		currentPage,
@@ -63,6 +64,14 @@ export default function SearchResultsRoute() {
 	const results = searchData?.results ?? [];
 	const totalCount = searchData?.totalCount ?? 0;
 	const isPanelOpen = selectedEmailId !== null || isComposing;
+
+	const feedback = useFeedback();
+	useEffect(() => {
+		if (isError) feedback.error("Search failed. Try again.");
+		// feedback identity changes every render (returns a fresh object), so we
+		// gate the effect on isError alone to avoid spamming toasts.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [isError]);
 
 	const handleRowClick = (email: Email) => { selectEmail(email.id); if (!email.read && mailboxId) updateEmail.mutate({ mailboxId, id: email.id, data: { read: true } }); };
 	const folderDisplayName = (name: string | null | undefined): string => { if (!name) return ""; const map: Record<string, string> = { inbox: "Inbox", sent: "Sent", draft: "Drafts", archive: "Archive", trash: "Trash", quarantine: "Quarantine" }; return map[name.toLowerCase()] || name; };
@@ -78,7 +87,23 @@ export default function SearchResultsRoute() {
 					<div className="min-w-0 flex-1"><h1 className="pp-serif text-ink truncate">Search Results</h1>{!isLoading && <span className="text-sm text-ink-3">{totalCount} result{totalCount !== 1 ? "s" : ""}{urlQuery ? ` for "${urlQuery}"` : ""}</span>}</div>
 				</div>
 				<div className="flex-1 overflow-y-auto">
-					{isLoading ? <div className="flex justify-center py-16"><Loader size="lg" /></div> : results.length === 0 ? (
+					{isLoading ? (
+						<div className="divide-y divide-line">
+							{Array.from({ length: 5 }).map((_, i) => (
+								<div key={i} className="flex items-center gap-3 px-4 py-2.5 md:px-5 md:py-3 animate-pulse">
+									<div className="w-2.5 shrink-0" />
+									<div className="flex-1 min-w-0">
+										<div className="flex items-center gap-2">
+											<div className="h-3 w-24 rounded bg-paper-3" />
+											<div className="h-3 flex-1 rounded bg-paper-3" />
+											<div className="h-3 w-12 rounded bg-paper-3 ml-auto" />
+										</div>
+										<div className="h-2.5 w-3/4 rounded bg-paper-3 mt-2" />
+									</div>
+								</div>
+							))}
+						</div>
+					) : results.length === 0 ? (
 						<div className="flex flex-col items-center justify-center py-24 px-6 text-center">
 							<div className="mb-4"><MagnifyingGlassIcon size={48} weight="thin" className="text-ink-3" /></div>
 							<h3 className="text-base font-semibold text-ink mb-1.5">No results found</h3>

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -2,10 +2,11 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { Badge, Button, Input, Loader, useKumoToastManager } from "@cloudflare/kumo";
+import { Badge, Button, Input, Loader } from "@cloudflare/kumo";
 import { RobotIcon, ArrowCounterClockwiseIcon } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router";
+import { useFeedback } from "~/lib/feedback";
 import { useMailbox, useUpdateMailbox } from "~/queries/mailboxes";
 import { SecuritySettingsPanel } from "~/components/SecuritySettingsPanel";
 import type { SecuritySettings } from "~/types";
@@ -16,7 +17,7 @@ const PROMPT_PLACEHOLDER = `You are an email assistant that helps manage this in
 
 export default function SettingsRoute() {
 	const { mailboxId } = useParams<{ mailboxId: string }>();
-	const toastManager = useKumoToastManager();
+	const feedback = useFeedback();
 	const { data: mailbox } = useMailbox(mailboxId);
 	const updateMailboxMutation = useUpdateMailbox();
 
@@ -44,12 +45,9 @@ export default function SettingsRoute() {
 		};
 		try {
 			await updateMailboxMutation.mutateAsync({ mailboxId, settings });
-			toastManager.add({ title: "Settings saved!" });
+			feedback.success("Settings saved!");
 		} catch {
-			toastManager.add({
-				title: "Failed to save settings",
-				variant: "error",
-			});
+			feedback.error("Failed to save settings");
 		} finally {
 			setIsSaving(false);
 		}


### PR DESCRIPTION
## Summary

Second of three PRs continuing the PhishSOC UI rebrand. Stacks on top of [#59](https://github.com/schmug/PhishSOC/pull/59) (PR A — base branch is set accordingly; merge after PR A).

Closes upstream issue [#19](https://github.com/cloudflare/agentic-inbox/issues/19).

## Changes

- **New:** `app/lib/feedback.ts` — thin wrapper over kumo's `useKumoToastManager` exposing `{ error(title), success(title), info(title) }`. Hides the `{ variant: "error" }` shape behind a typed API. After this PR, `useKumoToastManager` is imported only by the helper itself.
- **Migrated:** every direct `toastManager.add(...)` site in `app/` (8 files: `EmailPanel.tsx`, `useComposeForm.ts`, `ReportPhishButton.tsx`, `home.tsx`, `settings.tsx`, `case-detail.tsx`, etc.) to use the helper. ~25 call sites total.
- **Error toasts on mutations:**
  - `AgentPanel.tsx` — `useAgentChat({ agent, onError: ... })` so chat failures surface via toast (previously silent).
  - `EmailPanel.tsx` — fire-and-forget `toggleStar`/`handleMove`/`handleDelete`/`handleDeleteDraft`/`onToggleRead` mutations now pass `onError` callbacks.
  - `email-list.tsx` — same pattern for the 5 inline `updateEmail`/`deleteEmail`/`markThreadRead` fire-and-forget mutations.
  - `search-results.tsx` — row-click mark-as-read mutation also wired with onError (fix from review).
- **Skeletons:**
  - `search-results.tsx` — replaced single `<Loader>` with a 5-row `animate-pulse` skeleton matching the search-result row layout.
  - `email-list.tsx` already had `EmailListSkeleton` (line 92, rendered when `isLoading`) — left untouched, no double work.
- **Search error toast:** `useSearchEmails`'s `isError` watched in a `useEffect` → `feedback.error("Search failed. Try again.")`.

## Non-goals

- No conversion of `useComposeForm`'s hand-rolled `isSending` to a TanStack `.isPending` (would be a structural refactor).
- No changes to mutation hook factories in `app/queries/*` (per-call `onError` keeps the diff localized).
- No frontend test infrastructure (jsdom/RTL) — this PR validates via typecheck + manual smoke. Filed as a follow-up.

## Known follow-ups (filed as separate issues)

1. **`useFeedback` returns a fresh object each render** — `search-results.tsx` uses `eslint-disable-next-line react-hooks/exhaustive-deps` with an explanatory comment to gate the error effect on `[isError]` only. A future memoization pass could remove the comment.
2. **Frontend test infrastructure (jsdom/RTL)** would let us assert mutation `isPending` UX in tests, not just by manual smoke.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 155 passing, 0 failing
- [x] `grep -rn 'useKumoToastManager\\|toastManager\\.add\\|toast\\.add' app/` returns only `app/lib/feedback.ts`
- [ ] Manual: throttle network in DevTools, trigger each mutation (move, delete, mark-read, star, send compose, agent chat send), confirm error toast appears
- [ ] Manual: load search and email-list with throttled network, confirm skeletons render then content

🤖 Generated with [Claude Code](https://claude.com/claude-code)