### PR TITLE
PhishSOC UI: per-mailbox auto-draft toggle + agent model picker (PR C, closes #11)

### DIFF
--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -10,6 +10,7 @@ import { useFeedback } from "~/lib/feedback";
 import { useMailbox, useUpdateMailbox } from "~/queries/mailboxes";
 import { SecuritySettingsPanel } from "~/components/SecuritySettingsPanel";
 import type { SecuritySettings } from "~/types";
+import { TEXT_MODELS } from "shared/mailbox-settings";
 
 // Placeholder shown in the textarea when no custom prompt is set.
 // The authoritative default prompt lives in workers/agent/index.ts (DEFAULT_SYSTEM_PROMPT).
@@ -24,6 +25,9 @@ export default function SettingsRoute() {
 	const [displayName, setDisplayName] = useState("");
 	const [agentPrompt, setAgentPrompt] = useState("");
 	const [security, setSecurity] = useState<SecuritySettings | undefined>(undefined);
+	const [autoDraftEnabled, setAutoDraftEnabled] = useState(true);
+	const [modelChoice, setModelChoice] = useState<string>(TEXT_MODELS[0]);
+	const [customModel, setCustomModel] = useState("");
 	const [isSaving, setIsSaving] = useState(false);
 
 	useEffect(() => {
@@ -31,17 +35,42 @@ export default function SettingsRoute() {
 			setDisplayName(mailbox.settings?.fromName || mailbox.name || "");
 			setAgentPrompt(mailbox.settings?.agentSystemPrompt || "");
 			setSecurity(mailbox.settings?.security);
+
+			const behavior = mailbox.settings as
+				| { autoDraft?: { enabled?: boolean }; agentModel?: string }
+				| undefined;
+			const enabled = behavior?.autoDraft?.enabled;
+			setAutoDraftEnabled(enabled === undefined ? true : enabled);
+
+			const m = behavior?.agentModel ?? TEXT_MODELS[0];
+			if (TEXT_MODELS.includes(m as (typeof TEXT_MODELS)[number])) {
+				setModelChoice(m);
+				setCustomModel("");
+			} else {
+				setModelChoice("__custom__");
+				setCustomModel(m);
+			}
 		}
 	}, [mailbox]);
 
 	const handleSave = async () => {
 		if (!mailbox || !mailboxId) return;
+
+		const resolvedModel =
+			modelChoice === "__custom__" ? customModel.trim() : modelChoice;
+		if (resolvedModel && !resolvedModel.startsWith("@cf/")) {
+			feedback.error("Model must start with @cf/");
+			return;
+		}
+
 		setIsSaving(true);
 		const settings = {
 			...mailbox.settings,
 			fromName: displayName,
 			agentSystemPrompt: agentPrompt.trim() || undefined,
 			security,
+			autoDraft: { enabled: autoDraftEnabled },
+			agentModel: resolvedModel || TEXT_MODELS[0],
 		};
 		try {
 			await updateMailboxMutation.mutateAsync({ mailboxId, settings });
@@ -127,6 +156,58 @@ export default function SettingsRoute() {
 						The prompt is sent as the system message to the AI model.
 						It controls the agent's personality, writing style, and behavior rules.
 					</p>
+				</div>
+
+				{/* Behavior — auto-draft toggle + agent model picker */}
+				<div className="pp-card p-5">
+					<div className="text-sm font-medium text-ink mb-4">Behavior</div>
+
+					<label className="flex items-start justify-between gap-3 mb-5">
+						<span className="flex flex-col">
+							<span className="text-sm text-ink">Auto-draft replies</span>
+							<span className="text-xs text-ink-3 mt-1 max-w-md">
+								Generate a draft reply automatically when new mail arrives.
+								Drafts are never sent without explicit confirmation.
+							</span>
+						</span>
+						<input
+							type="checkbox"
+							checked={autoDraftEnabled}
+							onChange={(e) => setAutoDraftEnabled(e.target.checked)}
+							className="mt-1 h-4 w-4 accent-accent shrink-0"
+							aria-label="Auto-draft replies"
+						/>
+					</label>
+
+					<div>
+						<label htmlFor="agent-model-select" className="block text-sm text-ink mb-1.5">
+							Agent model
+						</label>
+						<select
+							id="agent-model-select"
+							value={modelChoice}
+							onChange={(e) => setModelChoice(e.target.value)}
+							className="w-full rounded-md border border-line bg-paper-2 px-3 py-2 text-sm text-ink focus:outline-none focus:ring-1 focus:ring-accent"
+						>
+							{TEXT_MODELS.map((m) => (
+								<option key={m} value={m}>{m}</option>
+							))}
+							<option value="__custom__">Custom…</option>
+						</select>
+						{modelChoice === "__custom__" && (
+							<input
+								type="text"
+								placeholder="@cf/your/model"
+								value={customModel}
+								onChange={(e) => setCustomModel(e.target.value)}
+								className="mt-2 w-full rounded-md border border-line bg-paper-2 px-3 py-2 text-sm text-ink placeholder:text-ink-3 focus:outline-none focus:ring-1 focus:ring-accent"
+							/>
+						)}
+						<p className="text-xs text-ink-3 mt-2">
+							Used for chat and auto-draft. Custom values must start with{" "}
+							<code className="pp-mono">@cf/</code>.
+						</p>
+					</div>
 				</div>
 
 				{/* Security */}

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -58,6 +58,10 @@ export default function SettingsRoute() {
 
 		const resolvedModel =
 			modelChoice === "__custom__" ? customModel.trim() : modelChoice;
+		if (modelChoice === "__custom__" && !resolvedModel) {
+			feedback.error("Custom model cannot be empty");
+			return;
+		}
 		if (resolvedModel && !resolvedModel.startsWith("@cf/")) {
 			feedback.error("Model must start with @cf/");
 			return;

--- a/shared/mailbox-settings.ts
+++ b/shared/mailbox-settings.ts
@@ -1,0 +1,32 @@
+// shared/mailbox-settings.ts
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { z } from "zod";
+
+/**
+ * Per-mailbox settings stored at R2 key `mailboxes/<mailboxId>.json`.
+ *
+ * The schema is intentionally lenient on the write side (passthrough) so
+ * future fields can land without coordinated frontend/backend deploys.
+ * Strict on the read side: every consumer that reads a typed field uses
+ * `MailboxSettings.parse(...)` which fills in defaults.
+ */
+export const MailboxSettings = z.object({
+  agentSystemPrompt: z.string().optional(),
+  autoDraft: z
+    .object({
+      enabled: z.boolean().default(true),
+    })
+    .default({ enabled: true }),
+  agentModel: z.string().default("@cf/moonshotai/kimi-k2.5"),
+}).passthrough();
+
+export type MailboxSettings = z.infer<typeof MailboxSettings>;
+
+/** The hand-curated list shown in the Settings model dropdown. The first
+ *  entry MUST match the default in MailboxSettings.agentModel above so an
+ *  unconfigured mailbox renders with a list option selected, not "Custom". */
+export const TEXT_MODELS = [
+  "@cf/moonshotai/kimi-k2.5",
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+] as const;

--- a/tests/agent/settings.test.ts
+++ b/tests/agent/settings.test.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, expect, it } from "vitest";
+import { MailboxSettings } from "../../shared/mailbox-settings";
+
+describe("MailboxSettings", () => {
+  it("defaults autoDraft.enabled to true when missing", () => {
+    const parsed = MailboxSettings.parse({});
+    expect(parsed.autoDraft.enabled).toBe(true);
+  });
+
+  it("defaults agentModel to the kimi entry when missing", () => {
+    const parsed = MailboxSettings.parse({});
+    expect(parsed.agentModel).toBe("@cf/moonshotai/kimi-k2.5");
+  });
+
+  it("respects an explicit disabled autoDraft", () => {
+    const parsed = MailboxSettings.parse({ autoDraft: { enabled: false } });
+    expect(parsed.autoDraft.enabled).toBe(false);
+  });
+
+  it("preserves arbitrary extra fields (passthrough)", () => {
+    const parsed = MailboxSettings.parse({ agentSystemPrompt: "Hi" });
+    expect(parsed.agentSystemPrompt).toBe("Hi");
+  });
+});

--- a/workers/agent/index.ts
+++ b/workers/agent/index.ts
@@ -30,6 +30,8 @@ import {
 	toolDiscardDraft,
 } from "../lib/tools";
 import { Folders, FOLDER_TOOL_DESCRIPTION, MOVE_FOLDER_TOOL_DESCRIPTION } from "../../shared/folders";
+import type { MailboxSettings } from "../../shared/mailbox-settings";
+import { getMailboxSettings } from "../lib/mailbox-settings";
 import type { Env } from "../types";
 
 // AI SDK v6 changed tool() overloads significantly. We define tools as plain
@@ -88,21 +90,12 @@ You can ONLY draft emails. You do NOT have the ability to send emails directly.
 Use discard_draft to delete drafts that the operator rejects or that are no longer needed.`;
 
 /**
- * Fetch the custom system prompt for a mailbox from its R2 settings.
- * Falls back to DEFAULT_SYSTEM_PROMPT if none is configured.
+ * Pick the custom system prompt from per-mailbox settings, or fall back
+ * to DEFAULT_SYSTEM_PROMPT if the field is absent or blank.
  */
-async function getSystemPrompt(env: Env, mailboxId: string): Promise<string> {
-	try {
-		const key = `mailboxes/${mailboxId}.json`;
-		const obj = await env.BUCKET.get(key);
-		if (obj) {
-			const settings = await obj.json<Record<string, unknown>>();
-			if (typeof settings.agentSystemPrompt === "string" && settings.agentSystemPrompt.trim()) {
-				return settings.agentSystemPrompt;
-			}
-		}
-	} catch {
-		// Fall through to default
+function resolveSystemPrompt(settings: MailboxSettings): string {
+	if (typeof settings.agentSystemPrompt === "string" && settings.agentSystemPrompt.trim()) {
+		return settings.agentSystemPrompt;
 	}
 	return DEFAULT_SYSTEM_PROMPT;
 }
@@ -278,10 +271,11 @@ export class EmailAgent extends AIChatAgent<any> {
 		const mailboxId = this.name;
 		const workersai = createWorkersAI({ binding: env.AI });
 		const tools = createEmailTools(env, mailboxId);
-		const systemPrompt = await getSystemPrompt(env, mailboxId);
+		const settings = await getMailboxSettings(env, mailboxId);
+		const systemPrompt = resolveSystemPrompt(settings);
 
 		const result = streamText({
-			model: workersai("@cf/moonshotai/kimi-k2.5"),
+			model: workersai(settings.agentModel as Parameters<typeof workersai>[0]),
 			system: systemPrompt,
 			messages: await convertToModelMessages(this.messages),
 			tools,
@@ -361,7 +355,8 @@ export class EmailAgent extends AIChatAgent<any> {
 		const env = this.env as Env;
 		const workersai = createWorkersAI({ binding: env.AI });
 		const tools = createEmailTools(env, emailData.mailboxId);
-		const systemPrompt = await getSystemPrompt(env, emailData.mailboxId);
+		const settings = await getMailboxSettings(env, emailData.mailboxId);
+		const systemPrompt = resolveSystemPrompt(settings);
 
 		// Pre-read the email and thread so the agent has full context
 		// without needing to waste tool calls discovering it
@@ -488,7 +483,7 @@ Based on the email content and thread context above, draft a reply using draft_r
 
 		try {
 			const result = await generateText({
-				model: workersai("@cf/moonshotai/kimi-k2.5"),
+				model: workersai(settings.agentModel as Parameters<typeof workersai>[0]),
 				system: systemPrompt,
 				messages: await convertToModelMessages(messages),
 				tools,

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -20,6 +20,7 @@ import { handleReplyEmail, handleForwardEmail } from "./routes/reply-forward";
 import { Folders } from "../shared/folders";
 import type { Env } from "./types";
 import { requireMailbox, type MailboxContext } from "./lib/mailbox";
+import { getMailboxSettings } from "./lib/mailbox-settings";
 import { runSecurityPipeline } from "./security";
 import { runDeepScan } from "./intel/deep-scan";
 import { getSecuritySettings } from "./security/settings";
@@ -596,6 +597,14 @@ async function receiveEmail(event: { raw: ReadableStream; rawSize: number }, env
 		} catch (e) {
 			console.error("deep-scan enqueue failed:", (e as Error).message);
 		}
+	}
+
+	// Auto-draft dispatch is gated on per-mailbox settings. The security
+	// pipeline above always runs; only the agent's onNewEmail fetch is
+	// skipped when the operator has disabled auto-draft for this mailbox.
+	const mailboxSettings = await getMailboxSettings(env, mailboxId);
+	if (!mailboxSettings.autoDraft.enabled) {
+		return;
 	}
 
 	const agentStub = env.EMAIL_AGENT.get(env.EMAIL_AGENT.idFromName(mailboxId));

--- a/workers/lib/mailbox-settings.ts
+++ b/workers/lib/mailbox-settings.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { MailboxSettings } from "../../shared/mailbox-settings";
+
+/**
+ * Read the per-mailbox settings blob from R2 and parse through the Zod
+ * schema (which fills in defaults for missing fields). Returns the
+ * defaults if the blob is missing or unreadable — never throws.
+ *
+ * The `env` shape is intentionally narrowed to `{ BUCKET: R2Bucket }` so
+ * this helper works in both Worker and Durable Object contexts.
+ */
+export async function getMailboxSettings(
+	env: { BUCKET: R2Bucket },
+	mailboxId: string,
+): Promise<MailboxSettings> {
+	try {
+		const obj = await env.BUCKET.get(`mailboxes/${mailboxId}.json`);
+		if (obj) {
+			const raw = await obj.json<Record<string, unknown>>();
+			return MailboxSettings.parse(raw);
+		}
+	} catch {
+		// Fall through to defaults — missing/malformed blob shouldn't break
+		// the auto-draft pipeline. Surfaces as default behavior.
+	}
+	return MailboxSettings.parse({});
+}


### PR DESCRIPTION
## Summary

Third and final PR continuing the PhishSOC UI rebrand. Stacks on top of [#60](https://github.com/schmug/PhishSOC/pull/60) (PR B). Merge order: PR A → PR B → PR C.

Closes upstream issue [#11](https://github.com/cloudflare/agentic-inbox/issues/11).

## Changes

### Schema + helper

- **`shared/mailbox-settings.ts`** — New Zod schema for the per-mailbox settings blob stored at R2 key `mailboxes/<id>.json`. Two new fields:
  - `autoDraft.enabled: boolean` — defaults to `true`. When `false`, inbound mail no longer triggers the agent's `onNewEmail` dispatch.
  - `agentModel: string` — defaults to `@cf/moonshotai/kimi-k2.5` (matches the model the agent currently hardcodes, so existing mailboxes are unaffected).
  - `passthrough()` preserves unknown fields so future fields can land without coordinated frontend/backend deploys.
- **`workers/lib/mailbox-settings.ts`** — `getMailboxSettings(env, mailboxId)` helper. Reads R2, parses through the schema, falls back to defaults on missing/malformed blob. Never throws.
- **`tests/agent/settings.test.ts`** — 4 schema tests (defaults, explicit override, passthrough). Test count 155 → 159.

### Backend wiring

- **`workers/index.ts`** — Calls `getMailboxSettings` before the auto-draft dispatch in `receiveEmail` and `return`s early when `autoDraft.enabled` is false. The gate sits after the security pipeline + deep-scan + new-email notification — only the agent dispatch is skipped.
- **`workers/agent/index.ts`** — Both `streamText` (chat) and `generateText` (auto-draft) read settings via `getMailboxSettings` and use `settings.agentModel`. The old `getSystemPrompt` function is deleted (only had callers in this file); replaced by a tiny `resolveSystemPrompt(settings)` helper that's used at both call sites. The `workersai(settings.agentModel as Parameters<typeof workersai>[0])` cast is required because the SDK's parameter type is a strict union — frontend validates the `@cf/` prefix client-side, so the runtime contract holds.

### Frontend UI

- **`app/routes/settings.tsx`** — New "Behavior" card between the existing "AI Agent Prompt" and "Security" sections.
  - Auto-draft toggle (checkbox, `accent-accent` brand color).
  - Agent model `<select>` populated from `TEXT_MODELS` (currently `@cf/moonshotai/kimi-k2.5` and `@cf/meta/llama-3.3-70b-instruct-fp8-fast`) plus a "Custom…" option that reveals a text input.
  - Save handler validates `@cf/` prefix and rejects empty custom values BEFORE flipping `isSaving` (so validation failure doesn't strand the loading state).
  - Hydrates from `mailbox.settings.autoDraft.enabled` (defaulting to true) and `mailbox.settings.agentModel` (defaulting to the first allowlist entry). Custom values that aren't in the allowlist hydrate as "Custom…" with the value pre-filled.

## Defaults preserve current behavior

- Existing mailboxes (whose stored settings blob has neither `autoDraft` nor `agentModel`) continue to auto-draft on the current Kimi model with no migration needed.
- The schema is `passthrough()` and write-side payloads spread `...mailbox.settings`, so legacy fields (`fromName`, `agentSystemPrompt`, `security`) round-trip unmodified.

## Out of scope (per upstream issue #11)

- Non–Workers AI providers (Anthropic / OpenAI via AI SDK adapters).
- Per-mailbox override of the injection scanner / draft verifier models in `workers/lib/ai.ts`.

## Follow-ups (separate issues)

- Dynamic Workers AI text-model list — replaces the hand-curated `TEXT_MODELS` array. Needs a `CLOUDFLARE_API_TOKEN` secret + KV cache.
- Frontend test infrastructure (jsdom + RTL) so settings UI behaviors can be asserted in tests, not only via manual smoke.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — **159 passing**, 0 failing (155 prior + 4 new schema tests)
- [ ] Manual: turn auto-draft off, send mail to the mailbox, confirm no draft is generated
- [ ] Manual: change model to llama-3.3, chat with the agent, confirm Workers AI dashboard shows the new model
- [ ] Manual: pick "Custom…", enter `gpt-4o`, save → expect "Model must start with @cf/" toast
- [ ] Manual: pick "Custom…", leave blank, save → expect "Custom model cannot be empty" toast
- [ ] Manual: pick "Custom…", enter `@cf/foo/bar`, save → expect success and persistence across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)