### PR TITLE
feat(dashboard): real Operations dashboard wired to /dashboard endpoint — closes #56

### DIFF
--- a/app/queries/dashboard.ts
+++ b/app/queries/dashboard.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { useQuery } from "@tanstack/react-query";
+import api from "~/services/api";
+import type { DashboardSummary } from "~/types";
+import { queryKeys } from "./keys";
+
+export function useDashboardSummary(mailboxId: string | undefined) {
+	return useQuery<DashboardSummary>({
+		queryKey: mailboxId ? queryKeys.dashboard(mailboxId) : ["dashboard", "_disabled"],
+		queryFn: ({ signal }) =>
+			api.getDashboardSummary(mailboxId!, { signal }) as Promise<DashboardSummary>,
+		enabled: !!mailboxId,
+		staleTime: 30_000,
+	});
+}

--- a/app/queries/keys.ts
+++ b/app/queries/keys.ts
@@ -23,5 +23,6 @@ export const queryKeys = {
 		results: (mailboxId: string, query: string, page: number) =>
 			["search", mailboxId, query, page] as const,
 	},
+	dashboard: (mailboxId: string) => ["dashboard", mailboxId] as const,
 	config: ["config"] as const,
 };

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -2,71 +2,192 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { CompassIcon } from "@phosphor-icons/react";
+import { WarningIcon } from "@phosphor-icons/react";
+import { Loader } from "@cloudflare/kumo";
+import { Link, useParams } from "react-router";
 import Sparkline from "~/components/phishsoc/Sparkline";
+import { useDashboardSummary } from "~/queries/dashboard";
+import type { DashboardCase, DashboardSummary } from "~/types";
 
-const STUB_SPARK = [4, 6, 5, 8, 7, 9, 6, 11, 10, 14, 12, 9];
-
-// POC stub. Real dashboard needs aggregation endpoints (verdict mix, fleet
-// stats, pipeline snapshot) — not in scope for the preview branch.
 export default function DashboardRoute() {
+	const { mailboxId } = useParams<{ mailboxId: string }>();
+	const { data, isLoading, isError, refetch } = useDashboardSummary(mailboxId);
+
 	return (
 		<div className="px-6 md:px-10 py-8 max-w-[1280px] space-y-6">
+			<DashboardHeader />
+
+			{isLoading ? (
+				<div className="flex justify-center py-20">
+					<Loader size="lg" />
+				</div>
+			) : isError ? (
+				<DashboardError onRetry={() => refetch()} />
+			) : data ? (
+				<DashboardBody mailboxId={mailboxId!} data={data} />
+			) : null}
+		</div>
+	);
+}
+
+function DashboardHeader() {
+	return (
+		<div>
+			<div className="text-[11px] uppercase tracking-[0.08em] text-ink-3 mb-1">
+				Operations · last 24 hours
+			</div>
+			<h1 className="pp-serif text-[40px] leading-none text-ink mb-2">
+				Good morning.
+			</h1>
+			<p className="pp-serif text-[24px] leading-tight text-ink-3 max-w-2xl">
+				Here's what changed overnight.
+			</p>
+		</div>
+	);
+}
+
+function DashboardError({ onRetry }: { onRetry: () => void }) {
+	return (
+		<div className="pp-card p-6 flex items-start gap-3">
+			<span className="flex h-8 w-8 items-center justify-center rounded-full bg-paper-2 text-ink-3 shrink-0">
+				<WarningIcon size={18} />
+			</span>
 			<div>
-				<div className="text-[11px] uppercase tracking-[0.08em] text-ink-3 mb-1">
-					Operations · preview
+				<div className="text-[14px] font-medium text-ink mb-1">
+					Couldn't load the dashboard
 				</div>
-				<h1 className="pp-serif text-[40px] leading-none text-ink mb-2">
-					Good morning.
-				</h1>
-				<p className="pp-serif text-[24px] leading-tight text-ink-3 max-w-2xl">
-					Here's what changed overnight.
+				<p className="text-[12.5px] text-ink-3 leading-relaxed mb-2">
+					The dashboard endpoint didn't respond. Check the worker logs and retry.
 				</p>
-			</div>
-
-			<div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
-				{[
-					{ label: "Threats blocked · 24h", value: "—" },
-					{ label: "Open cases", value: "—" },
-					{ label: "Pipeline p50", value: "—" },
-					{ label: "Intel feed lift", value: "—" },
-				].map((k) => (
-					<div key={k.label} className="pp-card p-4">
-						<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-2">
-							{k.label}
-						</div>
-						<div className="flex items-end justify-between gap-2">
-							<div className="pp-serif text-[36px] leading-none text-ink">
-								{k.value}
-							</div>
-							<Sparkline values={STUB_SPARK} />
-						</div>
-					</div>
-				))}
-			</div>
-
-			<div
-				className="rounded-[14px] p-5 border flex items-start gap-3"
-				style={{
-					background: "var(--accent-tint)",
-					borderColor: "color-mix(in oklch, var(--accent) 25%, transparent)",
-				}}
-			>
-				<span className="flex h-8 w-8 items-center justify-center rounded-full bg-accent text-paper shrink-0">
-					<CompassIcon size={16} weight="fill" />
-				</span>
-				<div>
-					<div className="text-[13px] font-medium text-accent-ink mb-1">
-						Co-pilot briefing
-					</div>
-					<p className="text-[12.5px] text-accent-ink opacity-90 leading-relaxed">
-						Dashboard data lights up once we wire the aggregation endpoints
-						(verdict mix, fleet stats, pipeline snapshot). For the preview,
-						use the <span className="pp-mono">Cases</span> view to evaluate
-						the new visual language end-to-end.
-					</p>
-				</div>
+				<button
+					type="button"
+					onClick={onRetry}
+					className="text-[12px] underline text-accent hover:opacity-80"
+				>
+					Retry
+				</button>
 			</div>
 		</div>
 	);
+}
+
+function DashboardBody({
+	mailboxId,
+	data,
+}: { mailboxId: string; data: DashboardSummary }) {
+	return (
+		<>
+			<KpiGrid data={data} />
+
+			<div className="grid gap-4 lg:grid-cols-3">
+				<ThreatPressureCard values={data.threatPressure} />
+				<RecentCasesCard mailboxId={mailboxId} cases={data.recentCases} />
+			</div>
+		</>
+	);
+}
+
+interface Kpi {
+	label: string;
+	value: string;
+}
+
+function KpiGrid({ data }: { data: DashboardSummary }) {
+	const kpis: Kpi[] = [
+		{ label: "Threats blocked · 24h", value: String(data.threatsBlocked) },
+		{ label: "Open cases", value: String(data.openCases) },
+		{
+			label: "Pipeline success · 24h",
+			value:
+				data.pipelineSuccess === null
+					? "—"
+					: `${Math.round(data.pipelineSuccess * 100)}%`,
+		},
+		{
+			label: "Hub contributions · 24h",
+			value: String(data.hubContributions),
+		},
+	];
+
+	return (
+		<div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
+			{kpis.map((k) => (
+				<div key={k.label} className="pp-card p-4">
+					<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-2">
+						{k.label}
+					</div>
+					<div className="pp-serif text-[36px] leading-none text-ink">
+						{k.value}
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}
+
+function ThreatPressureCard({ values }: { values: number[] }) {
+	const total = values.reduce((a, b) => a + b, 0);
+	return (
+		<div className="pp-card p-5 lg:col-span-2 flex flex-col gap-3">
+			<div className="flex items-baseline justify-between gap-3">
+				<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3">
+					Threat pressure · 24h
+				</div>
+				<div className="text-[12px] text-ink-3">
+					{total} actioned
+				</div>
+			</div>
+			<Sparkline values={values} width={480} height={56} />
+			<p className="text-[11.5px] text-ink-3">
+				Per-2-hour count of emails the pipeline tagged, quarantined, or blocked.
+			</p>
+		</div>
+	);
+}
+
+function RecentCasesCard({
+	mailboxId,
+	cases,
+}: { mailboxId: string; cases: DashboardCase[] }) {
+	return (
+		<div className="pp-card p-5">
+			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-3">
+				Recent cases
+			</div>
+			{cases.length === 0 ? (
+				<p className="text-[12.5px] text-ink-3">No cases yet.</p>
+			) : (
+				<ul className="space-y-2">
+					{cases.map((c) => (
+						<li key={c.id}>
+							<Link
+								to={`/mailbox/${mailboxId}/cases/${c.id}`}
+								className="block group"
+							>
+								<div className="text-[13px] text-ink truncate group-hover:text-accent">
+									{c.title}
+								</div>
+								<div className="text-[11px] text-ink-3">
+									{c.status} · {formatRelative(c.updated_at)}
+								</div>
+							</Link>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}
+
+function formatRelative(iso: string): string {
+	const t = Date.parse(iso);
+	if (Number.isNaN(t)) return iso;
+	const diffMs = Date.now() - t;
+	const diffMin = Math.round(diffMs / 60_000);
+	if (diffMin < 1) return "just now";
+	if (diffMin < 60) return `${diffMin}m ago`;
+	const diffHr = Math.round(diffMin / 60);
+	if (diffHr < 24) return `${diffHr}h ago`;
+	const diffDay = Math.round(diffHr / 24);
+	return `${diffDay}d ago`;
 }

--- a/app/routes/mailbox-index.tsx
+++ b/app/routes/mailbox-index.tsx
@@ -4,6 +4,8 @@
 
 import { Navigate } from "react-router";
 
+// SOC framing: the dashboard is the default landing for a selected mailbox.
+// Inbox is still reachable via the topbar mailbox section.
 export default function MailboxIndexRoute() {
-  return <Navigate to="emails/inbox" replace />;
+  return <Navigate to="dashboard" replace />;
 }

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import type { Email, Folder, Mailbox } from "~/types";
+import type { DashboardSummary, Email, Folder, Mailbox } from "~/types";
 
 const REQUEST_TIMEOUT_MS = 30_000;
 
@@ -160,6 +160,10 @@ const api = {
 	// Search
 	searchEmails: (mailboxId: string, params: Record<string, string>) =>
 		get<EmailListResponse | Email[]>(`/api/v1/mailboxes/${mailboxId}/search`, { params }),
+
+	// Dashboard
+	getDashboardSummary: (mailboxId: string, opts?: { signal?: AbortSignal }) =>
+		get<DashboardSummary>(`/api/v1/mailboxes/${mailboxId}/dashboard`, { signal: opts?.signal }),
 };
 
 export default api;

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -126,3 +126,20 @@ export interface Folder {
 	name: string;
 	unreadCount: number;
 }
+
+export interface DashboardCase {
+	id: string;
+	title: string;
+	status: string;
+	updated_at: string;
+}
+
+export interface DashboardSummary {
+	now: string;
+	threatsBlocked: number;
+	openCases: number;
+	hubContributions: number;
+	pipelineSuccess: number | null;
+	threatPressure: number[];
+	recentCases: DashboardCase[];
+}

--- a/tests/frontend/dashboard.test.tsx
+++ b/tests/frontend/dashboard.test.tsx
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+import type { DashboardSummary } from "~/types";
+
+const refetch = vi.fn();
+let queryState: {
+	data: DashboardSummary | undefined;
+	isLoading: boolean;
+	isError: boolean;
+};
+
+vi.mock("~/queries/dashboard", () => ({
+	useDashboardSummary: () => ({ ...queryState, refetch }),
+}));
+
+import DashboardRoute from "~/routes/dashboard";
+import { renderWithProviders } from "./test-utils";
+
+function renderDashboard() {
+	return renderWithProviders(
+		<Routes>
+			<Route path="/mailbox/:mailboxId/dashboard" element={<DashboardRoute />} />
+		</Routes>,
+		{ initialEntries: ["/mailbox/m1/dashboard"] },
+	);
+}
+
+const populated: DashboardSummary = {
+	now: "2026-04-29T12:00:00Z",
+	threatsBlocked: 3,
+	openCases: 7,
+	hubContributions: 2,
+	pipelineSuccess: 0.92,
+	threatPressure: [0, 1, 0, 2, 1, 0, 3, 0, 0, 1, 0, 0],
+	recentCases: [
+		{ id: "c1", title: "Suspicious wire request", status: "open", updated_at: "2026-04-29T11:00:00Z" },
+		{ id: "c2", title: "Credential phish", status: "closed-tp", updated_at: "2026-04-29T08:00:00Z" },
+	],
+};
+
+describe("DashboardRoute", () => {
+	beforeEach(() => {
+		refetch.mockReset();
+	});
+
+	it("renders the loader while the query is pending", () => {
+		queryState = { data: undefined, isLoading: true, isError: false };
+		renderDashboard();
+		// The kumo Loader doesn't expose role=progressbar reliably, so assert by
+		// the presence of the header copy + absence of the KPI labels.
+		expect(screen.getByText(/good morning/i)).toBeInTheDocument();
+		expect(screen.queryByText(/threats blocked · 24h/i)).not.toBeInTheDocument();
+	});
+
+	it("renders error UI with a working retry when the query fails", async () => {
+		queryState = { data: undefined, isLoading: false, isError: true };
+		renderDashboard();
+		expect(screen.getByText(/couldn't load the dashboard/i)).toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+		expect(refetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders KPI values and recent cases when data is present", () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderDashboard();
+		expect(screen.getByText(/threats blocked · 24h/i)).toBeInTheDocument();
+		expect(screen.getByText("3")).toBeInTheDocument();
+		expect(screen.getByText("7")).toBeInTheDocument();
+		expect(screen.getByText("92%")).toBeInTheDocument();
+		expect(screen.getByText("2")).toBeInTheDocument();
+		expect(screen.getByText(/suspicious wire request/i)).toBeInTheDocument();
+		expect(screen.getByText(/credential phish/i)).toBeInTheDocument();
+	});
+
+	it("renders '—' for pipelineSuccess when no scans have run, and 'No cases yet.' when empty", () => {
+		queryState = {
+			data: {
+				now: populated.now,
+				threatsBlocked: 0,
+				openCases: 0,
+				hubContributions: 0,
+				pipelineSuccess: null,
+				threatPressure: new Array(12).fill(0),
+				recentCases: [],
+			},
+			isLoading: false,
+			isError: false,
+		};
+		renderDashboard();
+		expect(screen.getByText("—")).toBeInTheDocument();
+		expect(screen.getByText(/no cases yet/i)).toBeInTheDocument();
+	});
+
+	it("links each recent case to /mailbox/:id/cases/:caseId", () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderDashboard();
+		const link = screen.getByRole("link", { name: /suspicious wire request/i });
+		expect(link).toHaveAttribute("href", "/mailbox/m1/cases/c1");
+	});
+});

--- a/tests/lib/dashboard-aggregation.test.ts
+++ b/tests/lib/dashboard-aggregation.test.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, expect, it } from "vitest";
+import {
+	bucketThreatPressure,
+	pipelineSuccessRate,
+} from "../../workers/lib/dashboard-aggregation";
+
+const NOW = new Date("2026-04-29T12:00:00Z");
+
+function isoHoursAgo(hours: number): string {
+	return new Date(NOW.getTime() - hours * 60 * 60 * 1000).toISOString();
+}
+
+function row(date: string | null, action: string | null) {
+	return {
+		date,
+		security_verdict: action ? JSON.stringify({ action }) : null,
+	};
+}
+
+describe("bucketThreatPressure", () => {
+	it("returns 12 zero buckets when no rows are supplied", () => {
+		const buckets = bucketThreatPressure([], { now: NOW });
+		expect(buckets).toHaveLength(12);
+		expect(buckets.every((v) => v === 0)).toBe(true);
+	});
+
+	it("ignores allow verdicts and unparseable JSON", () => {
+		const rows = [
+			row(isoHoursAgo(1), "allow"),
+			{ date: isoHoursAgo(1), security_verdict: "not-json" },
+			row(isoHoursAgo(1), "block"),
+		];
+		const buckets = bucketThreatPressure(rows, { now: NOW });
+		expect(buckets.reduce((a, b) => a + b, 0)).toBe(1);
+	});
+
+	it("counts tag/quarantine/block verdicts", () => {
+		const rows = [
+			row(isoHoursAgo(0.5), "tag"),
+			row(isoHoursAgo(0.5), "quarantine"),
+			row(isoHoursAgo(0.5), "block"),
+		];
+		const buckets = bucketThreatPressure(rows, { now: NOW });
+		expect(buckets.reduce((a, b) => a + b, 0)).toBe(3);
+	});
+
+	it("places older rows in lower-index buckets, newer rows in higher", () => {
+		const rows = [
+			row(isoHoursAgo(23), "block"), // oldest, bucket 0
+			row(isoHoursAgo(0.5), "block"), // newest, bucket 11
+		];
+		const buckets = bucketThreatPressure(rows, { now: NOW });
+		expect(buckets[0]).toBe(1);
+		expect(buckets[11]).toBe(1);
+		expect(buckets.slice(1, 11).every((v) => v === 0)).toBe(true);
+	});
+
+	it("drops rows outside the 24h window", () => {
+		const rows = [
+			row(isoHoursAgo(25), "block"), // too old
+			row(isoHoursAgo(-1), "block"), // future
+			row(isoHoursAgo(2), "block"), // in window
+		];
+		const buckets = bucketThreatPressure(rows, { now: NOW });
+		expect(buckets.reduce((a, b) => a + b, 0)).toBe(1);
+	});
+
+	it("drops rows with unparseable dates", () => {
+		const rows = [
+			row("not-a-date", "block"),
+			row(null, "block"),
+			row(isoHoursAgo(1), "block"),
+		];
+		const buckets = bucketThreatPressure(rows, { now: NOW });
+		expect(buckets.reduce((a, b) => a + b, 0)).toBe(1);
+	});
+
+	it("honors a custom bucket count and window", () => {
+		const rows = [row(isoHoursAgo(0.25), "block")];
+		const buckets = bucketThreatPressure(rows, {
+			now: NOW,
+			bucketCount: 4,
+			windowHours: 1,
+		});
+		expect(buckets).toHaveLength(4);
+		expect(buckets[3]).toBe(1);
+	});
+});
+
+describe("pipelineSuccessRate", () => {
+	it("returns null when no runs are recorded", () => {
+		expect(pipelineSuccessRate({ completed: 0, failed: 0 })).toBeNull();
+	});
+
+	it("computes the success ratio when both buckets have counts", () => {
+		expect(pipelineSuccessRate({ completed: 9, failed: 1 })).toBeCloseTo(0.9);
+	});
+
+	it("returns 1 when nothing failed and 0 when everything failed", () => {
+		expect(pipelineSuccessRate({ completed: 5, failed: 0 })).toBe(1);
+		expect(pipelineSuccessRate({ completed: 0, failed: 3 })).toBe(0);
+	});
+});

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -1360,4 +1360,99 @@ export class MailboxDO extends DurableObject<Env> {
 		}>;
 		return rows;
 	}
+
+	/**
+	 * Aggregate the operations dashboard payload in one round-trip from the
+	 * UI. Each card lives in its own indexed query — see
+	 * `migrations.ts/11_dashboard_indexes` for the supporting indexes.
+	 *
+	 * Pipeline-success is derived from `emails.deep_scan_status` because we
+	 * don't yet log per-run latency; tracked as a follow-up. Hub
+	 * "contributions" is the local proxy `cases.shared_to_hub`; real
+	 * cross-org corroboration would require a hub-side query and is also
+	 * tracked separately.
+	 */
+	async getDashboardSummary(opts: { now?: string } = {}) {
+		const nowIso = opts.now ?? new Date().toISOString();
+		const dayAgoIso = new Date(
+			new Date(nowIso).getTime() - 24 * 60 * 60 * 1000,
+		).toISOString();
+
+		const threatsBlocked = (
+			this.db
+				.select({ count: sql<number>`COUNT(*)` })
+				.from(schema.cases)
+				.where(
+					and(
+						eq(schema.cases.status, "closed-tp"),
+						sql`${schema.cases.updated_at} >= ${dayAgoIso}`,
+					),
+				)
+				.get() ?? { count: 0 }
+		).count;
+
+		const openCases = (
+			this.db
+				.select({ count: sql<number>`COUNT(*)` })
+				.from(schema.cases)
+				.where(eq(schema.cases.status, "open"))
+				.get() ?? { count: 0 }
+		).count;
+
+		const hubContributions = (
+			this.db
+				.select({ count: sql<number>`COUNT(*)` })
+				.from(schema.cases)
+				.where(
+					and(
+						eq(schema.cases.shared_to_hub, 1),
+						sql`${schema.cases.updated_at} >= ${dayAgoIso}`,
+					),
+				)
+				.get() ?? { count: 0 }
+		).count;
+
+		const scanStatusRows = this.db
+			.select({
+				status: schema.emails.deep_scan_status,
+				count: sql<number>`COUNT(*)`,
+			})
+			.from(schema.emails)
+			.where(sql`${schema.emails.date} >= ${dayAgoIso}`)
+			.groupBy(schema.emails.deep_scan_status)
+			.all();
+		const completed = scanStatusRows.find((r) => r.status === "completed")?.count ?? 0;
+		const failed = scanStatusRows.find((r) => r.status === "failed")?.count ?? 0;
+
+		const verdictRows = this.db
+			.select({
+				date: schema.emails.date,
+				security_verdict: schema.emails.security_verdict,
+			})
+			.from(schema.emails)
+			.where(sql`${schema.emails.date} >= ${dayAgoIso}`)
+			.all();
+
+		const recentCases = this.db
+			.select({
+				id: schema.cases.id,
+				title: schema.cases.title,
+				status: schema.cases.status,
+				updated_at: schema.cases.updated_at,
+			})
+			.from(schema.cases)
+			.orderBy(desc(schema.cases.updated_at))
+			.limit(5)
+			.all();
+
+		return {
+			now: nowIso,
+			threatsBlocked,
+			openCases,
+			hubContributions,
+			pipelineScan: { completed, failed },
+			verdictRows,
+			recentCases,
+		};
+	}
 }

--- a/workers/durableObject/migrations.ts
+++ b/workers/durableObject/migrations.ts
@@ -286,4 +286,13 @@ export const mailboxMigrations: Migration[] = [
             CREATE INDEX IF NOT EXISTS idx_case_observables_case_id ON case_observables(case_id);
         `,
 	},
+	{
+		// Speeds up the dashboard aggregation queries that scan recent cases
+		// (`updated_at >= now-24h`) and order recent activity by `updated_at`.
+		// `idx_cases_status` is already in place from migration 10.
+		name: "11_dashboard_indexes",
+		sql: `
+            CREATE INDEX IF NOT EXISTS idx_cases_updated_at ON cases(updated_at);
+        `,
+	},
 ];

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -27,6 +27,10 @@ import { getSecuritySettings } from "./security/settings";
 import { isDmarcReport, ingestDmarcReport } from "./dmarc/ingest";
 import { dmarcRoutes } from "./routes/dmarc";
 import { caseRoutes } from "./routes/cases";
+import {
+	bucketThreatPressure,
+	pipelineSuccessRate,
+} from "./lib/dashboard-aggregation";
 
 type AppContext = Context<MailboxContext>;
 
@@ -131,6 +135,21 @@ app.get("/api/v1/mailboxes/:mailboxId", async (c) => {
 	const obj = await c.env.BUCKET.get(`mailboxes/${mailboxId}.json`);
 	if (!obj) return c.json({ error: "Not found" }, 404);
 	return c.json({ id: mailboxId, name: mailboxId, email: mailboxId, settings: await obj.json() });
+});
+
+app.get("/api/v1/mailboxes/:mailboxId/dashboard", async (c: AppContext) => {
+	const raw = await c.var.mailboxStub.getDashboardSummary();
+	const threatPressure = bucketThreatPressure(raw.verdictRows);
+	const pipelineSuccess = pipelineSuccessRate(raw.pipelineScan);
+	return c.json({
+		now: raw.now,
+		threatsBlocked: raw.threatsBlocked,
+		openCases: raw.openCases,
+		hubContributions: raw.hubContributions,
+		pipelineSuccess,
+		threatPressure,
+		recentCases: raw.recentCases,
+	});
 });
 
 // Realtime event stream. Browsers can't set custom headers on `new

--- a/workers/lib/dashboard-aggregation.ts
+++ b/workers/lib/dashboard-aggregation.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Pure helpers for the operations dashboard. Live outside the Durable Object
+ * so the bucketing + JSON-parsing logic is unit-testable without a
+ * runtime SQL surface — the DO `getDashboardSummary` method composes these
+ * with the SQL it owns.
+ */
+
+export type ThreatAction = "tag" | "quarantine" | "block";
+
+export interface VerdictBucketRow {
+	/** ISO 8601 timestamp from `emails.date`. */
+	date: string | null;
+	/** Raw `emails.security_verdict` cell — JSON-encoded `VerdictResult`. */
+	security_verdict: string | null;
+}
+
+/**
+ * Roll up recent emails into N equal-width time buckets, counting only
+ * threat-actioned verdicts (tag/quarantine/block — `allow` is dropped).
+ *
+ * Buckets are oldest-first, so `result[0]` is the oldest window and
+ * `result[N-1]` is the most recent. Rows outside the window or with
+ * unparseable verdict JSON are silently dropped.
+ */
+export function bucketThreatPressure(
+	rows: VerdictBucketRow[],
+	options: { now?: Date; bucketCount?: number; windowHours?: number } = {},
+): number[] {
+	const now = options.now ?? new Date();
+	const bucketCount = options.bucketCount ?? 12;
+	const windowHours = options.windowHours ?? 24;
+
+	const windowMs = windowHours * 60 * 60 * 1000;
+	const windowStart = now.getTime() - windowMs;
+	const bucketMs = windowMs / bucketCount;
+	const buckets = new Array<number>(bucketCount).fill(0);
+
+	for (const row of rows) {
+		if (!row.date || !row.security_verdict) continue;
+
+		const action = parseVerdictAction(row.security_verdict);
+		if (action !== "tag" && action !== "quarantine" && action !== "block") continue;
+
+		const t = Date.parse(row.date);
+		if (Number.isNaN(t)) continue;
+		if (t < windowStart || t > now.getTime()) continue;
+
+		const idx = Math.min(
+			Math.floor((t - windowStart) / bucketMs),
+			bucketCount - 1,
+		);
+		buckets[idx] += 1;
+	}
+
+	return buckets;
+}
+
+function parseVerdictAction(json: string): string | null {
+	try {
+		const parsed = JSON.parse(json) as { action?: unknown };
+		return typeof parsed.action === "string" ? parsed.action : null;
+	} catch {
+		return null;
+	}
+}
+
+export interface PipelineSuccessInput {
+	completed: number;
+	failed: number;
+}
+
+/**
+ * Compute the pipeline-success ratio over the deep-scan-status counts. Returns
+ * `null` when there's no data to report (UI surfaces an "—" placeholder rather
+ * than a misleading 0%).
+ */
+export function pipelineSuccessRate(input: PipelineSuccessInput): number | null {
+	const total = input.completed + input.failed;
+	if (total === 0) return null;
+	return input.completed / total;
+}


### PR DESCRIPTION
## Summary

- Replaces the dashboard POC stub (hardcoded sparkline, `—` placeholders) with a real Operations dashboard backed by a single `GET /api/v1/mailboxes/:mailboxId/dashboard` aggregation endpoint.
- Flips [`mailbox-index.tsx`](app/routes/mailbox-index.tsx) back to `Navigate to=\"dashboard\"` per the original intent of #21. The Shell already has a \"Mail review\" nav item linking to `/emails/inbox`, so the inbox stays one click away.
- Filed two follow-up issues (#71, #72) for the parts of the spec I scope-cut intentionally.

Closes #56.

## Cards (and how each is computed)

| Card | Source |
|------|--------|
| Threats blocked · 24h | `cases.status = 'closed-tp' AND updated_at >= now-24h` |
| Open cases | `cases.status = 'open'` |
| Pipeline success · 24h | `emails.deep_scan_status` rollup: completed / (completed + failed); `—` when zero |
| Hub contributions · 24h | `cases.shared_to_hub = 1 AND updated_at >= now-24h` |
| Threat pressure sparkline | 12 × 2-hour buckets of emails with verdict ∈ {tag, quarantine, block} |
| Recent cases | top 5 by `updated_at desc`, link to `/mailbox/:id/cases/:caseId` |

The bucketing + JSON parsing is in a pure helper [`workers/lib/dashboard-aggregation.ts`](workers/lib/dashboard-aggregation.ts) so it's unit-testable without a runtime SQL surface. The DO method [`getDashboardSummary`](workers/durableObject/index.ts) runs the queries and the route composes the helper.

## Spec deltas

The issue acceptance had three items I addressed differently:

1. **\"Pipeline p95 latency\" → \"Pipeline success · 24h\".** No `pipeline_runs` table exists, so honest p95 isn't computable today. Filed [#71](https://github.com/schmug/PhishSOC/issues/71) to instrument the pipeline with a runs table; that issue ships the original p95 card.
2. **\"Hub corroboration · 24h\" → \"Hub contributions · 24h\".** Real corroboration requires a hub-side query that adds a partial-failure mode to the dashboard load. Used the local proxy `cases.shared_to_hub` for v1. Filed [#72](https://github.com/schmug/PhishSOC/issues/72) to add the corroboration card behind a short-timeout hub call.
3. **\"Loader endpoint(s) under `app/routes/api.*`\".** That bullet describes a React Router resource-route convention; this stack runs the API in the worker, so the endpoint lives at `workers/index.ts:136`. Functionally equivalent.

**Auth scoping note.** Issue acceptance says \"mailbox-id must gate visibility.\" `requireMailbox` is path-only today (pre-existing per #27); this PR inherits that scope rather than fixing it. Tightening that boundary is its own piece of work.

## Migration

`11_dashboard_indexes` adds `idx_cases_updated_at` to keep the `updated_at >= now-24h` filters indexed. `idx_cases_status` already exists from migration 10. `idx_emails_date` already exists from migration 8.

## Test plan

- [x] `npm test` — 180 pass (was 165). 10 new unit tests for `bucketThreatPressure` + `pipelineSuccessRate`; 5 new frontend tests for `DashboardRoute` covering loading, error+retry, populated KPIs, the empty-card copy path, and case-link routing.
- [x] `npm run typecheck` — clean.
- [ ] Manual: deploy + verify the dashboard renders against a mailbox with real history. Will spot-check after preview deploys.

## Out of scope (per issue \"Out of scope\" + advisor review)

- Time-range picker beyond 24h.
- Per-user dashboard customization.
- Real p95 latency (→ #71) and real hub corroboration (→ #72).

🤖 Generated with [Claude Code](https://claude.com/claude-code)