### PR TITLE
feat(hub): wire hub screen to /api/v1/.../hub proxy endpoints — closes #57

### DIFF
--- a/app/queries/hub.ts
+++ b/app/queries/hub.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { useQuery } from "@tanstack/react-query";
+import api from "~/services/api";
+import type {
+	HubContributionsResponse,
+	HubDestroylistResponse,
+	HubSharingGroupsResponse,
+} from "~/types";
+import { queryKeys } from "./keys";
+
+// Hub data doesn't change minute-to-minute — keep it warm for a minute so
+// switching between panels in the same screen doesn't refetch.
+const STALE_MS = 60_000;
+
+export function useHubContributions(mailboxId: string | undefined) {
+	return useQuery<HubContributionsResponse>({
+		queryKey: mailboxId
+			? queryKeys.hub.contributions(mailboxId)
+			: ["hub", "_disabled", "contributions"],
+		queryFn: ({ signal }) =>
+			api.getHubContributions(mailboxId!, { signal }) as Promise<HubContributionsResponse>,
+		enabled: !!mailboxId,
+		staleTime: STALE_MS,
+	});
+}
+
+export function useHubDestroylist(mailboxId: string | undefined) {
+	return useQuery<HubDestroylistResponse>({
+		queryKey: mailboxId
+			? queryKeys.hub.destroylist(mailboxId)
+			: ["hub", "_disabled", "destroylist"],
+		queryFn: ({ signal }) =>
+			api.getHubDestroylist(mailboxId!, { signal }) as Promise<HubDestroylistResponse>,
+		enabled: !!mailboxId,
+		staleTime: STALE_MS,
+	});
+}
+
+export function useHubSharingGroups(mailboxId: string | undefined) {
+	return useQuery<HubSharingGroupsResponse>({
+		queryKey: mailboxId
+			? queryKeys.hub.sharingGroups(mailboxId)
+			: ["hub", "_disabled", "sharing-groups"],
+		queryFn: ({ signal }) =>
+			api.getHubSharingGroups(mailboxId!, { signal }) as Promise<HubSharingGroupsResponse>,
+		enabled: !!mailboxId,
+		staleTime: STALE_MS,
+	});
+}

--- a/app/queries/keys.ts
+++ b/app/queries/keys.ts
@@ -24,5 +24,10 @@ export const queryKeys = {
 			["search", mailboxId, query, page] as const,
 	},
 	dashboard: (mailboxId: string) => ["dashboard", mailboxId] as const,
+	hub: {
+		contributions: (mailboxId: string) => ["hub", mailboxId, "contributions"] as const,
+		destroylist: (mailboxId: string) => ["hub", mailboxId, "destroylist"] as const,
+		sharingGroups: (mailboxId: string) => ["hub", mailboxId, "sharing-groups"] as const,
+	},
 	config: ["config"] as const,
 };

--- a/app/routes/hub.tsx
+++ b/app/routes/hub.tsx
@@ -2,37 +2,265 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { GraphIcon } from "@phosphor-icons/react";
+import { GearSixIcon, GraphIcon, WarningIcon } from "@phosphor-icons/react";
+import { Loader } from "@cloudflare/kumo";
+import type { ReactNode } from "react";
+import { Link, useParams } from "react-router";
+import {
+	useHubContributions,
+	useHubDestroylist,
+	useHubSharingGroups,
+} from "~/queries/hub";
+import type {
+	HubContribution,
+	HubContributionsResponse,
+	HubDestroylistResponse,
+	HubSharingGroup,
+	HubSharingGroupsResponse,
+} from "~/types";
 
-// POC stub. Real hub needs feed sync endpoints + indicator stream — out of
-// scope for the preview branch.
 export default function HubRoute() {
+	const { mailboxId } = useParams<{ mailboxId: string }>();
+	const contributions = useHubContributions(mailboxId);
+	const destroylist = useHubDestroylist(mailboxId);
+	const sharingGroups = useHubSharingGroups(mailboxId);
+
+	// All three endpoints share the same `configured: false` state. If any
+	// reports unconfigured, the whole screen renders the setup hint —
+	// individual panels never disagree about whether the hub is wired up.
+	const anyUnconfigured =
+		contributions.data?.configured === false ||
+		destroylist.data?.configured === false ||
+		sharingGroups.data?.configured === false;
+
 	return (
 		<div className="px-6 md:px-10 py-8 max-w-[1280px] space-y-6">
-			<div>
-				<div className="text-[11px] uppercase tracking-[0.08em] text-ink-3 mb-1">
-					Community defense
-				</div>
-				<h1 className="pp-serif text-[40px] leading-none text-ink mb-2">
-					Threat-intel hub
-				</h1>
-				<p className="text-[13px] text-ink-3 max-w-2xl">
-					Pull corroborated indicators from MISP-compatible feeds. Push your
-					own confirmed phishing back. Trust-weighted so one org can't
-					single-handedly promote its own finding.
-				</p>
-			</div>
+			<HubHeader />
 
-			<div className="pp-card p-10 flex flex-col items-center text-center gap-3">
-				<span className="flex h-12 w-12 items-center justify-center rounded-full bg-paper-2 text-ink-3">
-					<GraphIcon size={22} />
-				</span>
-				<div className="pp-serif text-[20px] text-ink">Hub coming soon</div>
-				<p className="text-[12.5px] text-ink-3 max-w-md leading-relaxed">
-					This screen will show subscribed feeds, indicator stream, sharing
-					groups, and contribution stats once the hub backend lands.
-				</p>
+			{anyUnconfigured ? (
+				<NotConfiguredHint mailboxId={mailboxId} />
+			) : (
+				<div className="grid gap-4 lg:grid-cols-2">
+					<ContributionsPanel query={contributions} />
+					<DestroylistPanel query={destroylist} />
+					<SharingGroupsPanel query={sharingGroups} />
+				</div>
+			)}
+		</div>
+	);
+}
+
+function HubHeader() {
+	return (
+		<div>
+			<div className="text-[11px] uppercase tracking-[0.08em] text-ink-3 mb-1">
+				Community defense
+			</div>
+			<h1 className="pp-serif text-[40px] leading-none text-ink mb-2">
+				Threat-intel hub
+			</h1>
+			<p className="text-[13px] text-ink-3 max-w-2xl">
+				Pull corroborated indicators from MISP-compatible feeds. Push your
+				own confirmed phishing back. Trust-weighted so one org can't
+				single-handedly promote its own finding.
+			</p>
+		</div>
+	);
+}
+
+function NotConfiguredHint({ mailboxId }: { mailboxId: string | undefined }) {
+	return (
+		<div className="pp-card p-10 flex flex-col items-center text-center gap-3">
+			<span className="flex h-12 w-12 items-center justify-center rounded-full bg-paper-2 text-ink-3">
+				<GraphIcon size={22} />
+			</span>
+			<div className="pp-serif text-[20px] text-ink">Hub not configured</div>
+			<p className="text-[12.5px] text-ink-3 max-w-md leading-relaxed">
+				Connect this mailbox to a MISP-compatible hub to see your
+				contributions, the corroborated destroylist, and the sharing groups
+				you belong to.
+			</p>
+			{mailboxId ? (
+				<Link
+					to={`/mailbox/${mailboxId}/settings`}
+					className="inline-flex items-center gap-1.5 text-[12px] text-accent hover:opacity-80 underline"
+				>
+					<GearSixIcon size={14} /> Open settings
+				</Link>
+			) : null}
+		</div>
+	);
+}
+
+interface PanelShellProps {
+	title: string;
+	children: ReactNode;
+	footnote?: string;
+}
+
+function PanelShell({ title, children, footnote }: PanelShellProps) {
+	return (
+		<div className="pp-card p-5 flex flex-col gap-3">
+			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3">
+				{title}
+			</div>
+			{children}
+			{footnote ? (
+				<p className="text-[11.5px] text-ink-3 mt-auto">{footnote}</p>
+			) : null}
+		</div>
+	);
+}
+
+function PanelLoader() {
+	return (
+		<div className="flex justify-center py-6">
+			<Loader size="base" />
+		</div>
+	);
+}
+
+function PanelError({ onRetry }: { onRetry: () => void }) {
+	return (
+		<div className="flex items-start gap-2 text-[12.5px] text-ink-3">
+			<WarningIcon size={14} className="mt-[2px] shrink-0" />
+			<div>
+				Couldn't reach the hub.{" "}
+				<button
+					type="button"
+					onClick={onRetry}
+					className="underline text-accent hover:opacity-80"
+				>
+					Retry
+				</button>
 			</div>
 		</div>
 	);
+}
+
+function ContributionsPanel({
+	query,
+}: { query: ReturnType<typeof useHubContributions> }) {
+	return (
+		<PanelShell
+			title="My contributions"
+			footnote="The 25 most recent events your org pushed to the hub."
+		>
+			{renderListPanel<HubContributionsResponse, HubContribution>({
+				query,
+				extract: (envelope) => (envelope.configured ? envelope.data : []),
+				empty:
+					"No contributions yet — report a phish to push your first event.",
+				render: (events) => (
+					<ul className="space-y-2">
+						{events.map((e) => (
+							<li key={e.uuid} className="flex flex-col">
+								<div className="text-[13px] text-ink truncate">{e.info}</div>
+								<div className="text-[11px] text-ink-3">
+									{e.date} · {e.attribute_count} attribute
+									{e.attribute_count === 1 ? "" : "s"}
+									{e.sharing_group_uuid ? " · shared" : " · own org only"}
+								</div>
+							</li>
+						))}
+					</ul>
+				),
+			})}
+		</PanelShell>
+	);
+}
+
+function DestroylistPanel({
+	query,
+}: { query: ReturnType<typeof useHubDestroylist> }) {
+	return (
+		<PanelShell
+			title="Destroylist preview"
+			footnote="Promoted indicators visible to this org across all sharing groups it belongs to."
+		>
+			{renderListPanel<HubDestroylistResponse, string>({
+				query,
+				extract: (envelope) => (envelope.configured ? envelope.data.values : []),
+				empty: "Destroylist is empty for this org's visibility.",
+				render: (values) => (
+					<>
+						<div className="text-[12px] text-ink-3 mb-2">
+							{values.length} indicator{values.length === 1 ? "" : "s"}
+						</div>
+						<ul className="space-y-1 max-h-72 overflow-y-auto pp-mono text-[12px]">
+							{values.slice(0, 100).map((v) => (
+								<li key={v} className="text-ink truncate">
+									{v}
+								</li>
+							))}
+						</ul>
+						{values.length > 100 ? (
+							<div className="text-[11px] text-ink-3 mt-2">
+								+ {values.length - 100} more
+							</div>
+						) : null}
+					</>
+				),
+			})}
+		</PanelShell>
+	);
+}
+
+function SharingGroupsPanel({
+	query,
+}: { query: ReturnType<typeof useHubSharingGroups> }) {
+	return (
+		<PanelShell title="Sharing groups">
+			{renderListPanel<HubSharingGroupsResponse, HubSharingGroup>({
+				query,
+				extract: (envelope) =>
+					envelope.configured ? envelope.data.groups : [],
+				empty:
+					"This org isn't a member of any sharing groups yet. Ask your hub admin for an invite.",
+				render: (groups) => (
+					<ul className="space-y-2">
+						{groups.map((g) => (
+							<li key={g.uuid} className="flex flex-col">
+								<div className="text-[13px] text-ink">{g.name}</div>
+								{g.description ? (
+									<div className="text-[11px] text-ink-3 truncate">
+										{g.description}
+									</div>
+								) : null}
+								{g.role ? (
+									<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mt-0.5">
+										{g.role}
+									</div>
+								) : null}
+							</li>
+						))}
+					</ul>
+				),
+			})}
+		</PanelShell>
+	);
+}
+
+interface ListPanelArgs<TResp, TItem> {
+	query: {
+		data?: TResp;
+		isLoading: boolean;
+		isError: boolean;
+		refetch: () => void;
+	};
+	extract: (resp: TResp) => TItem[];
+	empty: string;
+	render: (items: TItem[]) => ReactNode;
+}
+
+function renderListPanel<TResp, TItem>(args: ListPanelArgs<TResp, TItem>) {
+	const { query, extract, empty, render } = args;
+	if (query.isLoading) return <PanelLoader />;
+	if (query.isError) return <PanelError onRetry={() => query.refetch()} />;
+	if (!query.data) return null;
+	const items = extract(query.data);
+	if (items.length === 0) {
+		return <p className="text-[12.5px] text-ink-3">{empty}</p>;
+	}
+	return render(items);
 }

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -2,7 +2,15 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import type { DashboardSummary, Email, Folder, Mailbox } from "~/types";
+import type {
+	DashboardSummary,
+	Email,
+	Folder,
+	HubContributionsResponse,
+	HubDestroylistResponse,
+	HubSharingGroupsResponse,
+	Mailbox,
+} from "~/types";
 
 const REQUEST_TIMEOUT_MS = 30_000;
 
@@ -164,6 +172,20 @@ const api = {
 	// Dashboard
 	getDashboardSummary: (mailboxId: string, opts?: { signal?: AbortSignal }) =>
 		get<DashboardSummary>(`/api/v1/mailboxes/${mailboxId}/dashboard`, { signal: opts?.signal }),
+
+	// Hub
+	getHubContributions: (mailboxId: string, opts?: { signal?: AbortSignal }) =>
+		get<HubContributionsResponse>(`/api/v1/mailboxes/${mailboxId}/hub/contributions`, {
+			signal: opts?.signal,
+		}),
+	getHubDestroylist: (mailboxId: string, opts?: { signal?: AbortSignal }) =>
+		get<HubDestroylistResponse>(`/api/v1/mailboxes/${mailboxId}/hub/destroylist`, {
+			signal: opts?.signal,
+		}),
+	getHubSharingGroups: (mailboxId: string, opts?: { signal?: AbortSignal }) =>
+		get<HubSharingGroupsResponse>(`/api/v1/mailboxes/${mailboxId}/hub/sharing-groups`, {
+			signal: opts?.signal,
+		}),
 };
 
 export default api;

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -143,3 +143,30 @@ export interface DashboardSummary {
 	threatPressure: number[];
 	recentCases: DashboardCase[];
 }
+
+export interface HubContribution {
+	uuid: string;
+	info: string;
+	date: string;
+	timestamp: string;
+	sharing_group_uuid?: string;
+	attribute_count: number;
+}
+
+export interface HubSharingGroup {
+	uuid: string;
+	name: string;
+	description?: string;
+	role?: string;
+}
+
+/**
+ * Every hub UI endpoint returns this envelope. `configured: false` is the
+ * normal state for a mailbox without `intel.hub` set; the UI renders one
+ * "Configure hub credentials" panel and stops querying.
+ */
+export type HubEnvelope<T> = { configured: true; data: T } | { configured: false };
+
+export type HubContributionsResponse = HubEnvelope<HubContribution[]>;
+export type HubDestroylistResponse = HubEnvelope<{ values: string[]; count: number }>;
+export type HubSharingGroupsResponse = HubEnvelope<{ groups: HubSharingGroup[] }>;

--- a/tests/frontend/hub.test.tsx
+++ b/tests/frontend/hub.test.tsx
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+import type {
+	HubContributionsResponse,
+	HubDestroylistResponse,
+	HubSharingGroupsResponse,
+} from "~/types";
+
+interface QueryStub<T> {
+	data?: T;
+	isLoading: boolean;
+	isError: boolean;
+	refetch: () => void;
+}
+
+const refetch = vi.fn();
+
+let contributionsState: QueryStub<HubContributionsResponse>;
+let destroylistState: QueryStub<HubDestroylistResponse>;
+let sharingGroupsState: QueryStub<HubSharingGroupsResponse>;
+
+vi.mock("~/queries/hub", () => ({
+	useHubContributions: () => contributionsState,
+	useHubDestroylist: () => destroylistState,
+	useHubSharingGroups: () => sharingGroupsState,
+}));
+
+import HubRoute from "~/routes/hub";
+import { renderWithProviders } from "./test-utils";
+
+function renderHub() {
+	return renderWithProviders(
+		<Routes>
+			<Route path="/mailbox/:mailboxId/hub" element={<HubRoute />} />
+		</Routes>,
+		{ initialEntries: ["/mailbox/m1/hub"] },
+	);
+}
+
+function configured<T>(data: T): QueryStub<{ configured: true; data: T }> {
+	return {
+		data: { configured: true, data },
+		isLoading: false,
+		isError: false,
+		refetch,
+	};
+}
+
+const unconfigured = (): QueryStub<{ configured: false }> => ({
+	data: { configured: false },
+	isLoading: false,
+	isError: false,
+	refetch,
+});
+
+describe("HubRoute", () => {
+	beforeEach(() => {
+		refetch.mockReset();
+	});
+
+	it("renders the not-configured hint with a settings link when any panel is unconfigured", () => {
+		contributionsState = unconfigured();
+		destroylistState = unconfigured();
+		sharingGroupsState = unconfigured();
+		renderHub();
+		expect(screen.getByText(/hub not configured/i)).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /open settings/i }),
+		).toHaveAttribute("href", "/mailbox/m1/settings");
+		expect(screen.queryByText(/my contributions/i)).not.toBeInTheDocument();
+	});
+
+	it("renders all three panels with real data when configured", () => {
+		contributionsState = configured([
+			{
+				uuid: "e1",
+				info: "Phish targeting finance",
+				date: "2026-04-29",
+				timestamp: "1714389600",
+				attribute_count: 4,
+				sharing_group_uuid: "sg1",
+			},
+		]);
+		destroylistState = configured({
+			values: ["bad.example.com", "evil.example.org"],
+			count: 2,
+		});
+		sharingGroupsState = configured({
+			groups: [
+				{ uuid: "sg1", name: "Trusted retailers", role: "member" },
+				{ uuid: "sg2", name: "Healthcare ISAC", description: "shared sigs" },
+			],
+		});
+
+		renderHub();
+
+		expect(screen.getByText(/my contributions/i)).toBeInTheDocument();
+		expect(screen.getByText(/phish targeting finance/i)).toBeInTheDocument();
+		expect(screen.getByText(/4 attributes · shared/i)).toBeInTheDocument();
+
+		expect(screen.getByText(/destroylist preview/i)).toBeInTheDocument();
+		expect(screen.getByText("bad.example.com")).toBeInTheDocument();
+		expect(screen.getByText("evil.example.org")).toBeInTheDocument();
+		expect(screen.getByText(/2 indicators/i)).toBeInTheDocument();
+
+		// Match the uppercased panel title exactly so the destroylist
+		// footnote ("…across all sharing groups…") doesn't collide.
+		expect(screen.getByText(/^sharing groups$/i)).toBeInTheDocument();
+		expect(screen.getByText(/trusted retailers/i)).toBeInTheDocument();
+		expect(screen.getByText(/healthcare isac/i)).toBeInTheDocument();
+	});
+
+	it("shows a per-panel error with a working retry when one panel fails", async () => {
+		contributionsState = {
+			data: undefined,
+			isLoading: false,
+			isError: true,
+			refetch,
+		};
+		destroylistState = configured({ values: [], count: 0 });
+		sharingGroupsState = configured({ groups: [] });
+
+		renderHub();
+
+		expect(screen.getByText(/couldn't reach the hub/i)).toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+		expect(refetch).toHaveBeenCalledTimes(1);
+
+		// Other configured-but-empty panels render their own empty copy.
+		expect(screen.getByText(/destroylist is empty/i)).toBeInTheDocument();
+		expect(
+			screen.getByText(/isn't a member of any sharing groups/i),
+		).toBeInTheDocument();
+	});
+
+	it("renders the loader while a panel's query is pending", () => {
+		contributionsState = {
+			data: undefined,
+			isLoading: true,
+			isError: false,
+			refetch,
+		};
+		destroylistState = configured({ values: [], count: 0 });
+		sharingGroupsState = configured({ groups: [] });
+		renderHub();
+		// Configured panels still render their headers; the loading panel
+		// shows neither its empty copy nor any populated rows.
+		expect(screen.getByText(/my contributions/i)).toBeInTheDocument();
+		expect(
+			screen.queryByText(/no contributions yet/i),
+		).not.toBeInTheDocument();
+	});
+});

--- a/tests/intel/misp-client.test.ts
+++ b/tests/intel/misp-client.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MispClient } from "../../workers/intel/misp-client";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+	fetchMock.mockReset();
+	vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+const baseCfg = { baseUrl: "https://hub.example.com", apiKey: "secret" };
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+		...init,
+	});
+}
+
+function textResponse(body: string, init: ResponseInit = {}) {
+	return new Response(body, {
+		status: 200,
+		headers: { "Content-Type": "text/plain" },
+		...init,
+	});
+}
+
+describe("MispClient.searchEvents", () => {
+	it("POSTs /events/restSearch with the auth header and unwraps `response`", async () => {
+		fetchMock.mockResolvedValue(
+			jsonResponse({
+				response: [{ Event: { uuid: "u1", info: "phish", date: "2026-04-29", timestamp: "1" } }],
+			}),
+		);
+		const client = new MispClient(baseCfg);
+		const events = await client.searchEvents({ limit: 5 });
+
+		expect(events).toHaveLength(1);
+		expect(events[0].Event.uuid).toBe("u1");
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe("https://hub.example.com/events/restSearch");
+		expect((init as RequestInit).method).toBe("POST");
+		const headers = (init as RequestInit).headers as Record<string, string>;
+		expect(headers.Authorization).toBe("secret");
+		const body = JSON.parse((init as RequestInit).body as string);
+		expect(body).toMatchObject({ returnFormat: "json", limit: 5 });
+	});
+
+	it("returns an empty array on non-2xx", async () => {
+		fetchMock.mockResolvedValue(jsonResponse({}, { status: 401 }));
+		const client = new MispClient(baseCfg);
+		expect(await client.searchEvents()).toEqual([]);
+	});
+});
+
+describe("MispClient.listSharingGroups", () => {
+	it("GETs /sharing_groups and unwraps `sharing_groups`", async () => {
+		fetchMock.mockResolvedValue(
+			jsonResponse({
+				sharing_groups: [{ uuid: "sg1", name: "Trusted", role: "member" }],
+			}),
+		);
+		const client = new MispClient(baseCfg);
+		const groups = await client.listSharingGroups();
+
+		expect(groups).toEqual([{ uuid: "sg1", name: "Trusted", role: "member" }]);
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe("https://hub.example.com/sharing_groups");
+		expect((init as RequestInit).method).toBeUndefined();
+	});
+
+	it("returns [] when the hub returns 401", async () => {
+		fetchMock.mockResolvedValue(jsonResponse({}, { status: 401 }));
+		const client = new MispClient(baseCfg);
+		expect(await client.listSharingGroups()).toEqual([]);
+	});
+});
+
+describe("MispClient.fetchDestroyList", () => {
+	it("strips comments + blanks and returns ordered values", async () => {
+		fetchMock.mockResolvedValue(
+			textResponse("# header\nbad.example.com\n\n# group\nbadder.example.com\n"),
+		);
+		const client = new MispClient(baseCfg);
+		const list = await client.fetchDestroyList();
+		expect(list).toEqual(["bad.example.com", "badder.example.com"]);
+	});
+
+	it("appends ?sharing_group=… when scoped to one group", async () => {
+		fetchMock.mockResolvedValue(textResponse(""));
+		const client = new MispClient(baseCfg);
+		await client.fetchDestroyList({ sharingGroup: "sg-uuid" });
+		expect(fetchMock.mock.calls[0][0]).toBe(
+			"https://hub.example.com/feeds/destroylist.txt?sharing_group=sg-uuid",
+		);
+	});
+
+	it("returns [] on 403 and never retries against the unscoped endpoint", async () => {
+		// Hub returns 403 when the org isn't a member of the requested
+		// sharing group (feeds.ts). The client must not silently widen the
+		// request to the unscoped destroylist — that would leak indicators
+		// the caller isn't entitled to see.
+		fetchMock.mockResolvedValue(textResponse("forbidden", { status: 403 }));
+		const client = new MispClient(baseCfg);
+		const list = await client.fetchDestroyList({ sharingGroup: "sg-not-a-member" });
+		expect(list).toEqual([]);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -27,6 +27,7 @@ import { getSecuritySettings } from "./security/settings";
 import { isDmarcReport, ingestDmarcReport } from "./dmarc/ingest";
 import { dmarcRoutes } from "./routes/dmarc";
 import { caseRoutes } from "./routes/cases";
+import { hubUiRoutes } from "./routes/hub-ui";
 import {
 	bucketThreatPressure,
 	pipelineSuccessRate,
@@ -98,6 +99,7 @@ app.use("/api/v1/mailboxes/:mailboxId/*", requireMailbox);
 
 app.route("/api/v1/mailboxes/:mailboxId/dmarc", dmarcRoutes);
 app.route("/api/v1/mailboxes/:mailboxId/cases", caseRoutes);
+app.route("/api/v1/mailboxes/:mailboxId/hub", hubUiRoutes);
 
 app.get("/api/v1/config", (c) => {
 	const domainsRaw = c.env.DOMAINS || "";

--- a/workers/intel/misp-client.ts
+++ b/workers/intel/misp-client.ts
@@ -39,13 +39,88 @@ export class MispClient {
 		return json?.Event?.uuid ? { uuid: json.Event.uuid } : null;
 	}
 
-	async fetchDestroyList(): Promise<string[]> {
-		const res = await fetch(`${this.cfg.baseUrl.replace(/\/$/, "")}/feeds/destroylist.txt`, {
-			headers: { "Authorization": this.cfg.apiKey, "Accept": "text/plain" },
-			signal: AbortSignal.timeout(10000),
-		});
+	async fetchDestroyList(opts: { sharingGroup?: string } = {}): Promise<string[]> {
+		const params = opts.sharingGroup
+			? `?sharing_group=${encodeURIComponent(opts.sharingGroup)}`
+			: "";
+		const res = await fetch(
+			`${this.cfg.baseUrl.replace(/\/$/, "")}/feeds/destroylist.txt${params}`,
+			{
+				headers: { "Authorization": this.cfg.apiKey, "Accept": "text/plain" },
+				signal: AbortSignal.timeout(10000),
+			},
+		);
 		if (!res.ok) return [];
 		const body = await res.text();
 		return body.split(/\r?\n/).map((s) => s.trim()).filter((s) => s && !s.startsWith("#"));
 	}
+
+	/**
+	 * MISP `/events/restSearch`. Returns events as the upstream JSON shape
+	 * (`{ Event: { uuid, info, ... } }`); callers that need a flat row should
+	 * project before rendering.
+	 */
+	async searchEvents(opts: {
+		type?: string;
+		value?: string;
+		limit?: number;
+		page?: number;
+	} = {}): Promise<MispEventEnvelope[]> {
+		const res = await fetch(
+			`${this.cfg.baseUrl.replace(/\/$/, "")}/events/restSearch`,
+			{
+				method: "POST",
+				headers: {
+					"Authorization": this.cfg.apiKey,
+					"Accept": "application/json",
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ returnFormat: "json", ...opts }),
+				signal: AbortSignal.timeout(10000),
+			},
+		);
+		if (!res.ok) return [];
+		const json = (await res.json().catch(() => null)) as
+			| { response?: MispEventEnvelope[] }
+			| null;
+		return json?.response ?? [];
+	}
+
+	/** Sharing groups the authenticated org belongs to. */
+	async listSharingGroups(): Promise<HubSharingGroup[]> {
+		const res = await fetch(
+			`${this.cfg.baseUrl.replace(/\/$/, "")}/sharing_groups`,
+			{
+				headers: {
+					"Authorization": this.cfg.apiKey,
+					"Accept": "application/json",
+				},
+				signal: AbortSignal.timeout(10000),
+			},
+		);
+		if (!res.ok) return [];
+		const json = (await res.json().catch(() => null)) as
+			| { sharing_groups?: HubSharingGroup[] }
+			| null;
+		return json?.sharing_groups ?? [];
+	}
+}
+
+export interface MispEventEnvelope {
+	Event: {
+		uuid: string;
+		info: string;
+		date: string;
+		timestamp: string;
+		orgc_uuid?: string;
+		sharing_group_uuid?: string;
+		Attribute?: Array<{ type: string; value: string; comment?: string }>;
+	};
+}
+
+export interface HubSharingGroup {
+	uuid: string;
+	name: string;
+	description?: string;
+	role?: string;
 }

--- a/workers/lib/hub-config.ts
+++ b/workers/lib/hub-config.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Per-mailbox MISP-compatible hub configuration. Stored under `intel.hub` in
+ * `mailboxes/<mailboxId>.json` (R2). The API key itself is NOT stored in R2 —
+ * the JSON only carries the secret *name* via `api_key_secret_name`, and the
+ * worker resolves it from `c.env` at call time. That way an org can rotate
+ * its key without rewriting mailbox JSON.
+ */
+
+export interface HubConfig {
+	url: string;
+	org_uuid: string;
+	api_key_secret_name: string;
+	default_sharing_group_uuid?: string;
+	auto_report?: boolean;
+}
+
+/** Returns the hub config for a mailbox, or null when none is set. */
+export async function loadHubConfig(
+	bucket: R2Bucket,
+	mailboxId: string,
+): Promise<HubConfig | null> {
+	const obj = await bucket.get(`mailboxes/${mailboxId}.json`);
+	if (!obj) return null;
+	const json = (await obj.json().catch(() => null)) as
+		| { intel?: { hub?: unknown } }
+		| null;
+	const raw = json?.intel?.hub;
+	if (!raw || typeof raw !== "object") return null;
+	const cfg = raw as Partial<HubConfig>;
+	if (!cfg.url || !cfg.org_uuid || !cfg.api_key_secret_name) return null;
+	return {
+		url: cfg.url,
+		org_uuid: cfg.org_uuid,
+		api_key_secret_name: cfg.api_key_secret_name,
+		default_sharing_group_uuid: cfg.default_sharing_group_uuid,
+		auto_report: cfg.auto_report ?? false,
+	};
+}
+
+/**
+ * Resolve a hub config + the live API key. Returns null if either the config
+ * is missing or the named secret is unset on `env`. Callers that need the
+ * "configured but unhealthy" distinction should branch on which side returned
+ * null — for the read-only hub UI we treat both as "not configured" so the
+ * empty state has one shape.
+ */
+export async function loadHubCredentials(
+	env: Record<string, unknown>,
+	bucket: R2Bucket,
+	mailboxId: string,
+): Promise<{ cfg: HubConfig; apiKey: string } | null> {
+	const cfg = await loadHubConfig(bucket, mailboxId);
+	if (!cfg) return null;
+	const apiKey = env[cfg.api_key_secret_name];
+	if (typeof apiKey !== "string" || !apiKey) return null;
+	return { cfg, apiKey };
+}

--- a/workers/routes/cases.ts
+++ b/workers/routes/cases.ts
@@ -20,6 +20,7 @@ import { extractUrls } from "../security/urls";
 import { stripHtmlToText } from "../lib/email-helpers";
 import { buildMispEvent } from "../intel/report";
 import { MispClient } from "../intel/misp-client";
+import { loadHubConfig } from "../lib/hub-config";
 
 export const caseRoutes = new Hono<MailboxContext>();
 
@@ -112,10 +113,10 @@ caseRoutes.post("/report-phish", async (c) => {
 	try {
 		const mailboxId = c.req.param("mailboxId");
 		if (mailboxId) {
-			const hub = await loadHubSettings(c.env.BUCKET, mailboxId);
+			const hub = await loadHubConfig(c.env.BUCKET, mailboxId);
 			if (hub?.auto_report) {
 				const apiKey = (c.env as unknown as Record<string, string | undefined>)[hub.api_key_secret_name];
-				if (apiKey && hub.url && hub.org_uuid) {
+				if (apiKey) {
 					const event = await buildMispEvent({
 						orgUuid: hub.org_uuid,
 						sharingGroupUuid: hub.default_sharing_group_uuid,
@@ -144,23 +145,3 @@ caseRoutes.post("/report-phish", async (c) => {
 
 	return c.json({ caseId: id, hubEventUuid: hubUuid }, 201);
 });
-
-async function loadHubSettings(
-	bucket: R2Bucket,
-	mailboxId: string,
-): Promise<{
-	url: string;
-	org_uuid: string;
-	api_key_secret_name: string;
-	auto_report: boolean;
-	default_sharing_group_uuid?: string;
-} | null> {
-	const obj = await bucket.get(`mailboxes/${mailboxId}.json`);
-	if (!obj) return null;
-	try {
-		const json = (await obj.json()) as { intel?: { hub?: unknown } } | null;
-		return (json?.intel?.hub as ReturnType<typeof loadHubSettings> extends Promise<infer T> ? T : never) ?? null;
-	} catch {
-		return null;
-	}
-}

--- a/workers/routes/hub-ui.ts
+++ b/workers/routes/hub-ui.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Read-only worker proxy for the threat-intel hub UI. The browser can't talk
+ * to the hub directly because the hub API key lives as a worker secret —
+ * these routes resolve the per-mailbox `intel.hub` config, read the secret
+ * by name from `c.env`, and forward the call.
+ *
+ * Each endpoint follows the same shape: a 200 with `{ configured: false }`
+ * when this mailbox has no hub config, otherwise the parsed payload.
+ * Picking 200 (not 412) because a mailbox without hub credentials is the
+ * normal idle state, not an error — the UI renders one empty-state panel
+ * regardless of which call you made.
+ *
+ * Mounted under `/api/v1/mailboxes/:mailboxId/hub`. The shared `requireMailbox`
+ * middleware applied at the parent path enforces the mailbox-id existence
+ * check; visibility scoping is the same path-only check the rest of the
+ * mailbox-scoped API uses today (see #27).
+ */
+
+import { Hono } from "hono";
+import type { MailboxContext } from "../lib/mailbox";
+import { MispClient } from "../intel/misp-client";
+import { loadHubCredentials } from "../lib/hub-config";
+
+export const hubUiRoutes = new Hono<MailboxContext>();
+
+interface ConfiguredResponse<T> {
+	configured: true;
+	data: T;
+}
+interface UnconfiguredResponse {
+	configured: false;
+}
+
+/**
+ * Returns `{ configured: false }` for any of: missing mailboxId, no
+ * `intel.hub` block in the mailbox JSON, or the named secret unset on
+ * `c.env`. The UI renders one empty state regardless of which side is
+ * missing, so the helper collapses all three into the same shape.
+ */
+async function withHubClient<T>(
+	c: import("hono").Context<MailboxContext>,
+	mailboxId: string | undefined,
+	fn: (client: MispClient, orgUuid: string) => Promise<T>,
+): Promise<ConfiguredResponse<T> | UnconfiguredResponse> {
+	if (!mailboxId) return { configured: false };
+	const creds = await loadHubCredentials(
+		c.env as unknown as Record<string, unknown>,
+		c.env.BUCKET,
+		mailboxId,
+	);
+	if (!creds) return { configured: false };
+	const client = new MispClient({ baseUrl: creds.cfg.url, apiKey: creds.apiKey });
+	const data = await fn(client, creds.cfg.org_uuid);
+	return { configured: true, data };
+}
+
+hubUiRoutes.get("/contributions", async (c) => {
+	const mailboxId = c.req.param("mailboxId");
+	const result = await withHubClient(c, mailboxId, async (client) => {
+		const events = await client.searchEvents({ limit: 25 });
+		// Project to a flat shape the UI can render without knowing about MISP.
+		return events.map((e) => ({
+			uuid: e.Event.uuid,
+			info: e.Event.info,
+			date: e.Event.date,
+			timestamp: e.Event.timestamp,
+			sharing_group_uuid: e.Event.sharing_group_uuid,
+			attribute_count: e.Event.Attribute?.length ?? 0,
+		}));
+	});
+	return c.json(result);
+});
+
+hubUiRoutes.get("/destroylist", async (c) => {
+	const mailboxId = c.req.param("mailboxId");
+	const sharingGroup = c.req.query("sharing_group") ?? undefined;
+	const result = await withHubClient(c, mailboxId, async (client) => {
+		const values = await client.fetchDestroyList({ sharingGroup });
+		return { values, count: values.length };
+	});
+	return c.json(result);
+});
+
+hubUiRoutes.get("/sharing-groups", async (c) => {
+	const mailboxId = c.req.param("mailboxId");
+	const result = await withHubClient(c, mailboxId, async (client) => {
+		const groups = await client.listSharingGroups();
+		return { groups };
+	});
+	return c.json(result);
+});


### PR DESCRIPTION
## Summary

- Replaces the \"Hub coming soon\" placeholder at [`app/routes/hub.tsx`](app/routes/hub.tsx) with three real panels (My contributions / Destroylist preview / Sharing groups), each backed by a worker proxy endpoint.
- Browser can't talk to the hub directly (API key is a worker secret), so the proxy at `/api/v1/mailboxes/:mailboxId/hub/*` resolves per-mailbox `intel.hub` config and forwards.
- Cut the invite flow to a follow-up — filed as [#74](https://github.com/schmug/PhishSOC/issues/74). The copy-once token UX deserves its own focused PR.

Closes #57.

## Architecture

| Endpoint | Hub call | UI panel |
|----------|----------|----------|
| `GET .../hub/contributions` | `POST /events/restSearch` | My contributions |
| `GET .../hub/destroylist` | `GET /feeds/destroylist.txt` | Destroylist preview |
| `GET .../hub/sharing-groups` | `GET /sharing_groups` | Sharing groups |

Every endpoint returns `{ configured: true, data }` or `{ configured: false }`. \"Not configured\" is the normal idle state for a mailbox without `intel.hub` set, not an error — picking 200+envelope (not 412) means the UI renders one empty-state hint regardless of which call you made.

## Cleanup

- New helper [`workers/lib/hub-config.ts`](workers/lib/hub-config.ts) with `loadHubConfig` + `loadHubCredentials`. The inline `loadHubSettings` from [`workers/routes/cases.ts`](workers/routes/cases.ts) is deleted in favor of it.
- `MispClient` gained `searchEvents`, `listSharingGroups`, and a scoped variant of `fetchDestroyList({ sharingGroup })`.

## Sharing-group visibility

Enforced server-side by the hub:
- [`hub/src/routes/feeds.ts:31-36`](hub/src/routes/feeds.ts) returns 403 to non-members on a scoped destroylist request.
- [`hub/src/routes/events.ts:168-172`](hub/src/routes/events.ts) filters `restSearch` by `sharing_group_orgs` membership.
- [`hub/src/routes/sharing-groups.ts:13-23`](hub/src/routes/sharing-groups.ts) only returns groups the org belongs to.

This PR adds a `MispClient` test asserting the client doesn't silently widen a 403'd scoped destroylist request to the unscoped endpoint — closes the \"verify in tests\" bullet from the acceptance.

## Spec deltas

- **Invite flow → #74.** The acceptance lists \"Invite flow: button → modal → \`POST /orgs/invite\` → show one-time token + copy button\" as one of six bullets. Cut for scope and review-surface reasons; copy-once UX needs careful clipboard fallback + secure-display affordances.
- **Auth scoping** of the proxy endpoints inherits the same path-only `requireMailbox` check the rest of the worker uses today (pre-existing per #27, not changed here).

## Test plan

- [x] `npm test` — 191 pass (was 180). New: 7 `MispClient` tests + 4 `HubRoute` frontend tests.
- [x] `npm run typecheck` — clean.
- [ ] Manual: deploy + verify against a real hub. Will spot-check after preview deploys.

## Out of scope

- Invite flow (→ #74).
- Per-attribute drilldown — separate UI, see issue body.
- Manual trust-score adjustments (operator-only via SQL today, fine to leave there).
- STIX 2.1 export UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)