### PR TITLE
fix(ui): wire up shell search input + ⌘K shortcut (#80)

### DIFF
--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -11,7 +11,7 @@ import {
 	SunIcon,
 	TrayIcon,
 } from "@phosphor-icons/react";
-import type { ReactNode } from "react";
+import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
 import { NavLink, useNavigate, useParams } from "react-router";
 import { useUIStore } from "~/hooks/useUIStore";
 import { useMailbox, useMailboxes } from "~/queries/mailboxes";
@@ -78,6 +78,31 @@ export default function Shell({ children }: { children: ReactNode }) {
 	const orgInitial = (mailbox?.name || mailbox?.email || "?")[0]?.toUpperCase();
 
 	const base = mailboxId ? `/mailbox/${encodeURIComponent(mailboxId)}` : "";
+
+	const searchInputRef = useRef<HTMLInputElement>(null);
+	const [searchQuery, setSearchQuery] = useState("");
+
+	useEffect(() => {
+		// Cmd/Ctrl+K from anywhere focuses the search input.
+		const onKey = (e: KeyboardEvent) => {
+			if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+				e.preventDefault();
+				searchInputRef.current?.focus();
+				searchInputRef.current?.select();
+			}
+		};
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, []);
+
+	const handleSearchSubmit = (e: FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		const q = searchQuery.trim();
+		if (!q || !mailboxId) return;
+		navigate(
+			`/mailbox/${encodeURIComponent(mailboxId)}/search?q=${encodeURIComponent(q)}`,
+		);
+	};
 
 	return (
 		<div className="flex h-screen overflow-hidden bg-paper text-ink">
@@ -178,15 +203,22 @@ export default function Shell({ children }: { children: ReactNode }) {
 			{/* Main column. Topbar pinned, content scrolls. */}
 			<div className="flex-1 flex flex-col min-w-0">
 				<header className="flex items-center gap-3 h-[52px] px-4 md:px-6 border-b border-line bg-paper">
-					<div className="flex items-center gap-2 flex-1 max-w-xl">
+					<form
+						role="search"
+						onSubmit={handleSearchSubmit}
+						className="flex items-center gap-2 flex-1 max-w-xl"
+					>
 						<MagnifyingGlassIcon size={14} className="text-ink-3 shrink-0" />
 						<input
+							ref={searchInputRef}
 							type="search"
+							value={searchQuery}
+							onChange={(e) => setSearchQuery(e.target.value)}
 							className="flex-1 bg-transparent border-0 outline-none text-[13px] text-ink placeholder:text-ink-4"
-							placeholder="Search messages, indicators, cases…  ⌘K"
+							placeholder="Search emails…  ⌘K"
 							aria-label="Search"
 						/>
-					</div>
+					</form>
 					<div className="ml-auto flex items-center gap-1.5 shrink-0">
 						<button
 							type="button"

--- a/tests/frontend/shell-search.test.tsx
+++ b/tests/frontend/shell-search.test.tsx
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Route, Routes, useLocation } from "react-router";
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({
+		data: { id: "m1", email: "alice@acme.com", name: "Alice" },
+	}),
+	useMailboxes: () => ({
+		data: [{ id: "m1", email: "alice@acme.com", name: "Alice" }],
+	}),
+}));
+
+import Shell from "~/components/phishsoc/Shell";
+import { renderWithProviders } from "./test-utils";
+
+function LocationReporter() {
+	const loc = useLocation();
+	return (
+		<div data-testid="location">
+			{loc.pathname}
+			{loc.search}
+		</div>
+	);
+}
+
+function renderShell(initialEntries: string[] = ["/mailbox/m1/dashboard"]) {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/mailbox/:mailboxId/*"
+				element={
+					<Shell>
+						<LocationReporter />
+					</Shell>
+				}
+			/>
+		</Routes>,
+		{ initialEntries },
+	);
+}
+
+describe("Shell search", () => {
+	it("typing + Enter navigates to /mailbox/:id/search?q=…", async () => {
+		const user = userEvent.setup();
+		renderShell();
+		const input = screen.getByRole("searchbox", { name: /search/i });
+		await user.click(input);
+		await user.keyboard("invoice");
+		await user.keyboard("{Enter}");
+		expect(screen.getByTestId("location")).toHaveTextContent(
+			"/mailbox/m1/search?q=invoice",
+		);
+	});
+
+	it("URL-encodes special characters in the query", async () => {
+		const user = userEvent.setup();
+		renderShell();
+		const input = screen.getByRole("searchbox", { name: /search/i });
+		await user.click(input);
+		await user.type(input, "from:bob & jane");
+		await user.keyboard("{Enter}");
+		const location = screen.getByTestId("location").textContent ?? "";
+		// `&` must be percent-encoded so the rest of the query string isn't lost.
+		expect(location).toContain("/mailbox/m1/search?q=");
+		expect(location).toContain("%26");
+		expect(location).toContain("from%3Abob");
+	});
+
+	it("Enter on an empty input does not navigate", async () => {
+		const user = userEvent.setup();
+		renderShell();
+		const input = screen.getByRole("searchbox", { name: /search/i });
+		await user.click(input);
+		await user.keyboard("{Enter}");
+		expect(screen.getByTestId("location")).toHaveTextContent(
+			"/mailbox/m1/dashboard",
+		);
+	});
+
+	it("Cmd+K from anywhere focuses the search input", async () => {
+		const user = userEvent.setup();
+		renderShell();
+		const input = screen.getByRole("searchbox", { name: /search/i });
+		expect(document.activeElement).not.toBe(input);
+		await user.keyboard("{Meta>}k{/Meta}");
+		expect(document.activeElement).toBe(input);
+	});
+
+	it("Ctrl+K from anywhere focuses the search input", async () => {
+		const user = userEvent.setup();
+		renderShell();
+		const input = screen.getByRole("searchbox", { name: /search/i });
+		expect(document.activeElement).not.toBe(input);
+		await user.keyboard("{Control>}k{/Control}");
+		expect(document.activeElement).toBe(input);
+	});
+
+	it("placeholder copy doesn't promise more than the backend supports", () => {
+		renderShell();
+		const input = screen.getByRole("searchbox", { name: /search/i });
+		const placeholder = input.getAttribute("placeholder") ?? "";
+		// Backend only searches emails; should not promise indicators or cases.
+		expect(placeholder).not.toMatch(/indicator/i);
+		expect(placeholder).not.toMatch(/case/i);
+		expect(placeholder).toMatch(/email|message|search/i);
+	});
+});


### PR DESCRIPTION
## Summary

The global search input in `app/components/phishsoc/Shell.tsx` was rendering but wired to nothing — pressing Enter, typing, or `⌘K` all did nothing. The placeholder also promised the input could search "indicators, cases" but the backend at `/api/v1/mailboxes/:mailboxId/search` only searches emails. Filed and tracked in #80.

## What changed

- **Wrapped the input in a `<form role="search">` with an `onSubmit` handler.** Native form submit on Enter (works with IME composition, accessible by default). Navigates to `/mailbox/:id/search?q=<encoded>` only when the trimmed query is non-empty and a `mailboxId` is in scope. The destination route already accepts `?q=...` via `useSearchParams` and re-runs the search on key change — no route changes needed.
- **Added a global `Cmd+K` / `Ctrl+K` listener** in a `useEffect` on `window`. Focuses + selects the search input from any screen, matching the affordance the placeholder has been advertising since #21.
- **Updated placeholder copy** from `"Search messages, indicators, cases…  ⌘K"` to `"Search emails…  ⌘K"` so the chrome doesn't promise more than the backend delivers. (When the command-palette stretch from #80 lands and we can route to cases/hub from the input, we revisit.)

## Test plan

- [x] New `tests/frontend/shell-search.test.tsx` (6 tests) covering:
  - typing + Enter navigates to `/mailbox/:id/search?q=…`
  - special characters in the query are URL-encoded
  - Enter on empty input does not navigate
  - `Cmd+K` from anywhere focuses the search input
  - `Ctrl+K` from anywhere focuses the search input
  - placeholder copy doesn't promise indicators/cases
- [x] `npm test` — **202 passing**, 0 failing
- [x] `npm run typecheck` — clean
- [ ] Dev-server smoke: type query → Enter → results render with highlights; `⌘K` from cases/dashboard/hub focuses the input

## Out of scope (filed in #80 as stretch / follow-up)

- **Command-palette modal** that searches across emails AND can route to Cases / Hub / Settings — would be a separate PR. Until then, the placeholder is honest about being emails-only.
- **Mobile-specific search UX** — the input is reachable on mobile today (the topbar is not `hidden md:flex`); the modal/expanded mobile pattern can land with the broader mobile sweep in #81.

## Notes

- Used the worktree's own `node_modules` because the parent checkout's main is at #33 (pre-#70's jsdom dep). No package.json change.
- The `// in POC it just routes to the home picker.` comment on the org switcher and the `// Mobile collapse not in scope for POC.` comment on the sidebar are intentionally untouched — those are #84 and #81 territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)