### PR TITLE
fix(ui): wire pipeline status pill to dashboard data (#86)

### DIFF
--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -14,8 +14,43 @@ import {
 import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
 import { NavLink, useNavigate, useParams } from "react-router";
 import { useUIStore } from "~/hooks/useUIStore";
+import { useDashboardSummary } from "~/queries/dashboard";
 import { useMailbox, useMailboxes } from "~/queries/mailboxes";
 import Logo from "./Logo";
+
+type PipelineTone = "safe" | "suspect" | "danger" | "muted";
+
+interface PipelineState {
+	tone: PipelineTone;
+	label: string;
+	pulse: boolean;
+}
+
+// Map the dashboard summary's pipelineSuccess (0..1, or null) to a visible
+// pill state. Thresholds match the issue spec (#86): >=0.95 healthy, >=0.5
+// degraded, otherwise failing. Null/loading shows muted "No data" — never a
+// fake-green dot.
+function computePipelineState(
+	pipelineSuccess: number | null | undefined,
+): PipelineState {
+	if (pipelineSuccess == null) {
+		return { tone: "muted", label: "No data", pulse: false };
+	}
+	if (pipelineSuccess >= 0.95) {
+		return { tone: "safe", label: "Pipeline online", pulse: true };
+	}
+	if (pipelineSuccess >= 0.5) {
+		return { tone: "suspect", label: "Degraded", pulse: false };
+	}
+	return { tone: "danger", label: "Pipeline failing", pulse: false };
+}
+
+const PIPELINE_DOT_BG: Record<PipelineTone, string> = {
+	safe: "bg-safe",
+	suspect: "bg-suspect",
+	danger: "bg-danger",
+	muted: "bg-ink-4",
+};
 
 interface NavItemProps {
 	to: string;
@@ -78,6 +113,9 @@ export default function Shell({ children }: { children: ReactNode }) {
 	const orgInitial = (mailbox?.name || mailbox?.email || "?")[0]?.toUpperCase();
 
 	const base = mailboxId ? `/mailbox/${encodeURIComponent(mailboxId)}` : "";
+
+	const { data: dashboardSummary } = useDashboardSummary(mailboxId);
+	const pipelineState = computePipelineState(dashboardSummary?.pipelineSuccess);
 
 	const searchInputRef = useRef<HTMLInputElement>(null);
 	const [searchQuery, setSearchQuery] = useState("");
@@ -170,16 +208,36 @@ export default function Shell({ children }: { children: ReactNode }) {
 					)}
 				</nav>
 
-				{/* Pipeline status pill — static for POC; real data lands with the
-				    dashboard work. Kept in to anchor the visual language. */}
-				<div className="mx-3 mb-3 flex items-center gap-2 rounded-md border border-line bg-paper px-2.5 py-1.5">
-					<span className="relative flex h-2 w-2">
-						<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-safe opacity-60" />
-						<span className="relative inline-flex h-2 w-2 rounded-full bg-safe" />
-					</span>
-					<span className="text-[11px] text-ink-2">Pipeline online</span>
-					<span className="pp-mono text-[10.5px] text-ink-3 ml-auto">p50 —</span>
-				</div>
+				{/* Pipeline status pill. State derives from the dashboard summary's
+				    `pipelineSuccess` (#86). Real p50/p95 latency is tracked in #71
+				    and isn't surfaced here yet — the previous static "p50 —"
+				    placeholder was misleading and has been removed. */}
+				{mailboxId && (
+					<button
+						type="button"
+						role="status"
+						aria-live="polite"
+						aria-label={`Pipeline status: ${pipelineState.label}`}
+						onClick={() => navigate(`${base}/dashboard`)}
+						className="mx-3 mb-3 flex items-center gap-2 rounded-md border border-line bg-paper px-2.5 py-1.5 text-left hover:border-line-strong transition-colors"
+					>
+						<span className="relative flex h-2 w-2">
+							{pipelineState.pulse && (
+								<span
+									aria-hidden
+									className={`absolute inline-flex h-full w-full animate-ping rounded-full opacity-60 ${PIPELINE_DOT_BG[pipelineState.tone]}`}
+								/>
+							)}
+							<span
+								aria-hidden
+								className={`relative inline-flex h-2 w-2 rounded-full ${PIPELINE_DOT_BG[pipelineState.tone]}`}
+							/>
+						</span>
+						<span className="text-[11px] text-ink-2">
+							{pipelineState.label}
+						</span>
+					</button>
+				)}
 
 				<div className="border-t border-line px-3 py-2.5 flex items-center gap-2">
 					<div className="flex h-7 w-7 items-center justify-center rounded-full bg-accent-tint text-accent-ink text-[11px] font-medium">

--- a/tests/frontend/shell-pipeline-pill.test.tsx
+++ b/tests/frontend/shell-pipeline-pill.test.tsx
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Route, Routes, useLocation } from "react-router";
+import type { DashboardSummary } from "~/types";
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({
+		data: { id: "m1", email: "alice@acme.com", name: "Alice" },
+	}),
+	useMailboxes: () => ({
+		data: [{ id: "m1", email: "alice@acme.com", name: "Alice" }],
+	}),
+}));
+
+let queryState: {
+	data: DashboardSummary | undefined;
+	isLoading: boolean;
+	isError: boolean;
+};
+
+vi.mock("~/queries/dashboard", () => ({
+	useDashboardSummary: () => queryState,
+}));
+
+import Shell from "~/components/phishsoc/Shell";
+import { renderWithProviders } from "./test-utils";
+
+function makeSummary(pipelineSuccess: number | null): DashboardSummary {
+	return {
+		now: "2026-04-30T12:00:00Z",
+		threatsBlocked: 0,
+		openCases: 0,
+		hubContributions: 0,
+		pipelineSuccess,
+		threatPressure: [],
+		recentCases: [],
+	};
+}
+
+function LocationReporter() {
+	const loc = useLocation();
+	return <div data-testid="location">{loc.pathname}</div>;
+}
+
+function renderShell(initialEntries: string[] = ["/mailbox/m1/dashboard"]) {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/mailbox/:mailboxId/*"
+				element={
+					<Shell>
+						<LocationReporter />
+					</Shell>
+				}
+			/>
+		</Routes>,
+		{ initialEntries },
+	);
+}
+
+describe("Shell pipeline status pill", () => {
+	it("shows a 'Pipeline online' state when pipelineSuccess is high", () => {
+		queryState = {
+			data: makeSummary(0.98),
+			isLoading: false,
+			isError: false,
+		};
+		renderShell();
+		const pill = screen.getByRole("status", { name: /pipeline/i });
+		expect(pill).toHaveTextContent(/online/i);
+		expect(pill).not.toHaveTextContent(/degraded|failing|no data/i);
+	});
+
+	it("shows a 'Degraded' state when pipelineSuccess is mid", () => {
+		queryState = {
+			data: makeSummary(0.7),
+			isLoading: false,
+			isError: false,
+		};
+		renderShell();
+		const pill = screen.getByRole("status", { name: /pipeline/i });
+		expect(pill).toHaveTextContent(/degraded/i);
+		expect(pill).not.toHaveTextContent(/online|failing/i);
+	});
+
+	it("shows a 'Pipeline failing' state when pipelineSuccess is low", () => {
+		queryState = {
+			data: makeSummary(0.2),
+			isLoading: false,
+			isError: false,
+		};
+		renderShell();
+		const pill = screen.getByRole("status", { name: /pipeline/i });
+		expect(pill).toHaveTextContent(/failing/i);
+		expect(pill).not.toHaveTextContent(/online|degraded/i);
+	});
+
+	it("shows a 'No data' state when pipelineSuccess is null", () => {
+		queryState = {
+			data: makeSummary(null),
+			isLoading: false,
+			isError: false,
+		};
+		renderShell();
+		const pill = screen.getByRole("status", { name: /pipeline/i });
+		expect(pill).toHaveTextContent(/no data/i);
+		expect(pill).not.toHaveTextContent(/online|degraded|failing/i);
+	});
+
+	it("shows 'No data' while the query is loading (no fake green state)", () => {
+		queryState = { data: undefined, isLoading: true, isError: false };
+		renderShell();
+		const pill = screen.getByRole("status", { name: /pipeline/i });
+		expect(pill).not.toHaveTextContent(/online/i);
+	});
+
+	it("clicking the pill navigates to the mailbox dashboard", async () => {
+		queryState = {
+			data: makeSummary(0.98),
+			isLoading: false,
+			isError: false,
+		};
+		const user = userEvent.setup();
+		// Start somewhere other than /dashboard so we can observe the navigation.
+		renderShell(["/mailbox/m1/cases"]);
+		expect(screen.getByTestId("location")).toHaveTextContent(
+			"/mailbox/m1/cases",
+		);
+		const pill = screen.getByRole("status", { name: /pipeline/i });
+		await user.click(pill);
+		expect(screen.getByTestId("location")).toHaveTextContent(
+			"/mailbox/m1/dashboard",
+		);
+	});
+
+	it("does not render a fabricated p50 latency placeholder", () => {
+		queryState = {
+			data: makeSummary(0.98),
+			isLoading: false,
+			isError: false,
+		};
+		renderShell();
+		// The old static pill rendered "p50 —" with no real data behind it.
+		// Until pipeline-runs-table (#71) lands, the pill should not advertise
+		// a latency at all.
+		expect(screen.queryByText(/p50/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/p95/i)).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary

The pipeline status pill in `app/components/phishsoc/Shell.tsx` was statically green — always rendered "Pipeline online" with a hardcoded `p50 —`, regardless of actual pipeline state. A static-green health indicator is **worse than no indicator**: it actively misinforms an operator who glances at the chrome during an incident. Closes #86.

## What changed

- **State now derives from real data.** `useDashboardSummary` already returns `pipelineSuccess: number | null` from #73's dashboard endpoint. The pill maps that to four states:

  | `pipelineSuccess` | Tone | Label | Pulse |
  |---|---|---|---|
  | ≥ 0.95 | safe (green) | Pipeline online | yes |
  | ≥ 0.5 | suspect (yellow) | Degraded | no |
  | < 0.5 | danger (red) | Pipeline failing | no |
  | `null` / loading / error | muted (gray) | No data | no |

  Loading and error fall through to "No data" — never green. An outage during page load can't masquerade as healthy.

- **Pill is a button now.** Click navigates to `/mailbox/:id/dashboard` for context. `role="status"` + `aria-live="polite"` + descriptive `aria-label` so screen readers announce state changes.

- **Dropped the fake `p50 —` text.** No real latency data exists in `DashboardSummary` today; the placeholder was advertising something the chrome couldn't back. Real latency lands with #71 (pipeline runs table for real p95).

- **Pill only renders inside a mailbox context** (`mailboxId` truthy), matching the rest of the per-mailbox nav.

## Test plan

- [x] New `tests/frontend/shell-pipeline-pill.test.tsx` (7 tests):
  - all four state transitions (online/degraded/failing/no-data)
  - loading state shows muted "No data" — never green
  - clicking the pill navigates to the mailbox dashboard
  - no fabricated `p50` / `p95` latency text in any state
- [x] `npm test` — **209 passing**, 0 failing
- [x] `npm run typecheck` — clean
- [x] Dev-server smoke: navigated to `/mailbox/<test>/cases`, observed pill shows "No data" (correct — fresh local mailbox has no pipeline runs), clicking the pill navigated to `/mailbox/<test>/dashboard`. No "p50" text anywhere on the page.

## Out of scope

- **Real p50/p95 latency** in the pill — depends on #71's pipeline-runs table. When that lands, this pill can be extended to show "Pipeline online · p50 32ms" and similar.
- **Org-wide pipeline health** — today the pill is per-mailbox because `pipelineSuccess` is per-mailbox. The org-overview at `/` (#84) will need its own aggregate pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)