### PR TITLE
feat(ui): mobile nav drawer + responsive breakpoint sweep (#81)

### DIFF
--- a/app/components/MailboxSplitView.tsx
+++ b/app/components/MailboxSplitView.tsx
@@ -2,9 +2,11 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+import { CaretLeftIcon } from "@phosphor-icons/react";
 import type { ReactNode } from "react";
 import ComposePanel from "~/components/ComposePanel";
 import EmailPanel from "~/components/EmailPanel";
+import { useUIStore } from "~/hooks/useUIStore";
 
 interface MailboxSplitViewProps {
 	selectedEmailId: string | null;
@@ -18,6 +20,19 @@ export default function MailboxSplitView({
 	children,
 }: MailboxSplitViewProps) {
 	const isPanelOpen = selectedEmailId !== null || isComposing;
+	const { closePanel, closeCompose } = useUIStore();
+
+	// Mobile back-to-list returns from the detail/compose pane to the list.
+	// Compose has its own close path that restores the previously-selected
+	// email; for plain "email selected" we just clear the panel.
+	const handleBackToList = () => {
+		if (isComposing) {
+			closeCompose();
+			if (!selectedEmailId) closePanel();
+		} else {
+			closePanel();
+		}
+	};
 
 	return (
 		<div className="flex h-full">
@@ -32,6 +47,17 @@ export default function MailboxSplitView({
 			</div>
 			{isPanelOpen && (
 				<div className="flex-1 flex flex-col min-w-0 overflow-hidden w-full md:w-auto">
+					{/* Mobile-only back affordance. The desktop EmailPanelToolbar back
+					    button is only visible at md+; on phones the list is hidden so
+					    this row is the only escape back to the inbox. */}
+					<button
+						type="button"
+						onClick={handleBackToList}
+						className="md:hidden flex items-center gap-1 px-4 h-10 border-b border-line bg-paper text-[13px] text-ink-2 hover:text-ink"
+					>
+						<CaretLeftIcon size={14} />
+						Back to list
+					</button>
 					{isComposing && !selectedEmailId ? (
 						<ComposePanel />
 					) : isComposing && selectedEmailId ? (

--- a/app/components/SecuritySettingsPanel.tsx
+++ b/app/components/SecuritySettingsPanel.tsx
@@ -114,7 +114,7 @@ export function SecuritySettingsPanel({ value, onChange }: SecuritySettingsPanel
 					Score 0–100 aggregated from auth, URL, classifier, and reputation signals.
 					Values below take effect when the pipeline is enabled.
 				</p>
-				<div className="grid grid-cols-3 gap-3">
+				<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
 					<Input
 						label="Tag"
 						type="number"

--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -5,14 +5,16 @@ import {
 	GaugeIcon,
 	GearSixIcon,
 	GraphIcon,
+	ListIcon,
 	MagnifyingGlassIcon,
 	MoonIcon,
 	SparkleIcon,
 	SunIcon,
 	TrayIcon,
+	XIcon,
 } from "@phosphor-icons/react";
 import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
-import { NavLink, useNavigate, useParams } from "react-router";
+import { NavLink, useLocation, useNavigate, useParams } from "react-router";
 import { useUIStore } from "~/hooks/useUIStore";
 import { useDashboardSummary } from "~/queries/dashboard";
 import { useMailbox, useMailboxes } from "~/queries/mailboxes";
@@ -96,23 +98,164 @@ function NavItem({ to, icon, label, count, end }: NavItemProps) {
 
 function SectionLabel({ children }: { children: ReactNode }) {
 	return (
-		<div className="px-3 pt-4 pb-1.5 text-[10.5px] uppercase tracking-[0.08em] text-ink-4">
+		<div className="px-3 pt-4 pb-1.5 text-[10.5px] uppercase tracking-[0.08em] text-ink-3">
 			{children}
 		</div>
+	);
+}
+
+interface NavContentsProps {
+	mailboxId: string | undefined;
+	mailbox: { name?: string | null; email?: string | null } | undefined;
+	mailboxCount: number;
+	pipelineState: PipelineState;
+	theme: "light" | "dark";
+	onToggleTheme: () => void;
+	onSwitchOrg: () => void;
+	onPipelineClick: () => void;
+}
+
+// Shared sidebar contents — rendered inline on `md+` and inside the mobile
+// drawer on `<md`. Keeping a single source of truth here means the next
+// nav-item addition only has to touch one place.
+function NavContents({
+	mailboxId,
+	mailbox,
+	mailboxCount,
+	pipelineState,
+	theme,
+	onToggleTheme,
+	onSwitchOrg,
+	onPipelineClick,
+}: NavContentsProps) {
+	const orgDomain = mailbox?.email?.split("@")[1] ?? "—";
+	const orgInitial = (mailbox?.name || mailbox?.email || "?")[0]?.toUpperCase();
+	const base = mailboxId ? `/mailbox/${encodeURIComponent(mailboxId)}` : "";
+
+	return (
+		<>
+			<div className="px-4 pt-4 pb-3">
+				<Logo />
+			</div>
+
+			{/* Org switcher card — clicking it would open a tenant switcher;
+			    in POC it just routes to the home picker. */}
+			<button
+				type="button"
+				onClick={onSwitchOrg}
+				className="mx-3 flex items-center gap-2.5 rounded-md border border-line bg-paper px-2.5 py-2 text-left hover:border-line-strong transition-colors"
+			>
+				<span className="flex h-7 w-7 items-center justify-center rounded-md bg-accent-tint text-accent-ink pp-serif text-[15px]">
+					{orgInitial}
+				</span>
+				<span className="flex-1 min-w-0">
+					<span className="block truncate text-[12.5px] font-medium text-ink">
+						{mailbox?.name || "Select mailbox"}
+					</span>
+					<span className="block truncate text-[10.5px] text-ink-3">
+						{orgDomain} · {mailboxCount} mailbox{mailboxCount === 1 ? "" : "es"}
+					</span>
+				</span>
+				<CaretRightIcon size={12} className="text-ink-3 shrink-0" />
+			</button>
+
+			<nav className="mt-3 px-3 flex-1 overflow-y-auto">
+				{mailboxId ? (
+					<>
+						<NavItem
+							to={`${base}/dashboard`}
+							icon={<GaugeIcon size={16} />}
+							label="Dashboard"
+						/>
+						<NavItem
+							to={`${base}/cases`}
+							icon={<BriefcaseIcon size={16} />}
+							label="Cases"
+						/>
+						<NavItem
+							to={`${base}/emails/inbox`}
+							icon={<TrayIcon size={16} />}
+							label="Mail review"
+						/>
+						<NavItem
+							to={`${base}/hub`}
+							icon={<GraphIcon size={16} />}
+							label="Threat-intel hub"
+						/>
+						<SectionLabel>System</SectionLabel>
+						<NavItem
+							to={`${base}/settings`}
+							icon={<GearSixIcon size={16} />}
+							label="Settings"
+						/>
+					</>
+				) : (
+					<div className="px-3 py-2 text-[12px] text-ink-3">
+						Pick a mailbox to begin.
+					</div>
+				)}
+			</nav>
+
+			{/* Pipeline status pill. State derives from the dashboard summary's
+			    `pipelineSuccess` (#86). Real p50/p95 latency is tracked in #71
+			    and isn't surfaced here yet — the previous static "p50 —"
+			    placeholder was misleading and has been removed. */}
+			{mailboxId && (
+				<button
+					type="button"
+					role="status"
+					aria-live="polite"
+					aria-label={`Pipeline status: ${pipelineState.label}`}
+					onClick={onPipelineClick}
+					className="mx-3 mb-3 flex items-center gap-2 rounded-md border border-line bg-paper px-2.5 py-1.5 text-left hover:border-line-strong transition-colors"
+				>
+					<span className="relative flex h-2 w-2">
+						{pipelineState.pulse && (
+							<span
+								aria-hidden
+								className={`absolute inline-flex h-full w-full animate-ping rounded-full opacity-60 ${PIPELINE_DOT_BG[pipelineState.tone]}`}
+							/>
+						)}
+						<span
+							aria-hidden
+							className={`relative inline-flex h-2 w-2 rounded-full ${PIPELINE_DOT_BG[pipelineState.tone]}`}
+						/>
+					</span>
+					<span className="text-[11px] text-ink-2">
+						{pipelineState.label}
+					</span>
+				</button>
+			)}
+
+			<div className="border-t border-line px-3 py-2.5 flex items-center gap-2">
+				<div className="flex h-7 w-7 items-center justify-center rounded-full bg-accent-tint text-accent-ink text-[11px] font-medium">
+					SA
+				</div>
+				<div className="flex-1 min-w-0">
+					<div className="text-[12px] text-ink truncate">SOC analyst</div>
+					<div className="text-[10.5px] text-ink-3 truncate">Preview</div>
+				</div>
+				<button
+					type="button"
+					onClick={onToggleTheme}
+					className="flex h-7 w-7 items-center justify-center rounded-md text-ink-3 hover:bg-paper-3 hover:text-ink transition-colors"
+					aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+				>
+					{theme === "dark" ? <SunIcon size={14} /> : <MoonIcon size={14} />}
+				</button>
+			</div>
+		</>
 	);
 }
 
 export default function Shell({ children }: { children: ReactNode }) {
 	const { mailboxId } = useParams<{ mailboxId: string }>();
 	const navigate = useNavigate();
-	const { theme, toggleTheme } = useUIStore();
+	const location = useLocation();
+	const { theme, toggleTheme, isSidebarOpen, openSidebar, closeSidebar } = useUIStore();
 	const { data: mailbox } = useMailbox(mailboxId);
 	const { data: mailboxes } = useMailboxes();
 	const mailboxCount = mailboxes?.length ?? 0;
-	const orgDomain = mailbox?.email?.split("@")[1] ?? "—";
-	const orgInitial = (mailbox?.name || mailbox?.email || "?")[0]?.toUpperCase();
-
-	const base = mailboxId ? `/mailbox/${encodeURIComponent(mailboxId)}` : "";
 
 	const { data: dashboardSummary } = useDashboardSummary(mailboxId);
 	const pipelineState = computePipelineState(dashboardSummary?.pipelineSuccess);
@@ -121,17 +264,31 @@ export default function Shell({ children }: { children: ReactNode }) {
 	const [searchQuery, setSearchQuery] = useState("");
 
 	useEffect(() => {
-		// Cmd/Ctrl+K from anywhere focuses the search input.
+		// Cmd/Ctrl+K from anywhere focuses the search input. Escape closes the
+		// mobile drawer if it's open.
 		const onKey = (e: KeyboardEvent) => {
 			if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
 				e.preventDefault();
 				searchInputRef.current?.focus();
 				searchInputRef.current?.select();
+				return;
+			}
+			if (e.key === "Escape" && useUIStore.getState().isSidebarOpen) {
+				e.preventDefault();
+				useUIStore.getState().closeSidebar();
 			}
 		};
 		window.addEventListener("keydown", onKey);
 		return () => window.removeEventListener("keydown", onKey);
 	}, []);
+
+	// Close the mobile drawer whenever the route changes. The mailbox-switch
+	// effect in routes/mailbox.tsx covers cross-mailbox navigation; this covers
+	// in-mailbox nav (Dashboard ↔ Cases etc.), so individual NavItem onClicks
+	// don't have to remember to dismiss.
+	useEffect(() => {
+		closeSidebar();
+	}, [location.pathname, closeSidebar]);
 
 	const handleSearchSubmit = (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
@@ -142,125 +299,75 @@ export default function Shell({ children }: { children: ReactNode }) {
 		);
 	};
 
+	const navContents = (
+		<NavContents
+			mailboxId={mailboxId}
+			mailbox={mailbox}
+			mailboxCount={mailboxCount}
+			pipelineState={pipelineState}
+			theme={theme}
+			onToggleTheme={toggleTheme}
+			onSwitchOrg={() => {
+				closeSidebar();
+				navigate("/");
+			}}
+			onPipelineClick={() => {
+				if (!mailboxId) return;
+				closeSidebar();
+				navigate(`/mailbox/${encodeURIComponent(mailboxId)}/dashboard`);
+			}}
+		/>
+	);
+
 	return (
 		<div className="flex h-screen overflow-hidden bg-paper text-ink">
-			{/* Sidebar — 232px on desktop, hidden on mobile (mobile collapse not in scope for POC). */}
+			{/* Sidebar — 232px on desktop. On `<md` the same contents are surfaced
+			    via the hamburger drawer below. */}
 			<aside className="hidden md:flex w-[232px] shrink-0 flex-col bg-paper-2 border-r border-line">
-				<div className="px-4 pt-4 pb-3">
-					<Logo />
-				</div>
-
-				{/* Org switcher card — clicking it would open a tenant switcher;
-				    in POC it just routes to the home picker. */}
-				<button
-					type="button"
-					onClick={() => navigate("/")}
-					className="mx-3 flex items-center gap-2.5 rounded-md border border-line bg-paper px-2.5 py-2 text-left hover:border-line-strong transition-colors"
-				>
-					<span className="flex h-7 w-7 items-center justify-center rounded-md bg-accent-tint text-accent-ink pp-serif text-[15px]">
-						{orgInitial}
-					</span>
-					<span className="flex-1 min-w-0">
-						<span className="block truncate text-[12.5px] font-medium text-ink">
-							{mailbox?.name || "Select mailbox"}
-						</span>
-						<span className="block truncate text-[10.5px] text-ink-3">
-							{orgDomain} · {mailboxCount} mailbox{mailboxCount === 1 ? "" : "es"}
-						</span>
-					</span>
-					<CaretRightIcon size={12} className="text-ink-3 shrink-0" />
-				</button>
-
-				<nav className="mt-3 px-3 flex-1 overflow-y-auto">
-					{mailboxId ? (
-						<>
-							<NavItem
-								to={`${base}/dashboard`}
-								icon={<GaugeIcon size={16} />}
-								label="Dashboard"
-							/>
-							<NavItem
-								to={`${base}/cases`}
-								icon={<BriefcaseIcon size={16} />}
-								label="Cases"
-							/>
-							<NavItem
-								to={`${base}/emails/inbox`}
-								icon={<TrayIcon size={16} />}
-								label="Mail review"
-							/>
-							<NavItem
-								to={`${base}/hub`}
-								icon={<GraphIcon size={16} />}
-								label="Threat-intel hub"
-							/>
-							<SectionLabel>System</SectionLabel>
-							<NavItem
-								to={`${base}/settings`}
-								icon={<GearSixIcon size={16} />}
-								label="Settings"
-							/>
-						</>
-					) : (
-						<div className="px-3 py-2 text-[12px] text-ink-3">
-							Pick a mailbox to begin.
-						</div>
-					)}
-				</nav>
-
-				{/* Pipeline status pill. State derives from the dashboard summary's
-				    `pipelineSuccess` (#86). Real p50/p95 latency is tracked in #71
-				    and isn't surfaced here yet — the previous static "p50 —"
-				    placeholder was misleading and has been removed. */}
-				{mailboxId && (
-					<button
-						type="button"
-						role="status"
-						aria-live="polite"
-						aria-label={`Pipeline status: ${pipelineState.label}`}
-						onClick={() => navigate(`${base}/dashboard`)}
-						className="mx-3 mb-3 flex items-center gap-2 rounded-md border border-line bg-paper px-2.5 py-1.5 text-left hover:border-line-strong transition-colors"
-					>
-						<span className="relative flex h-2 w-2">
-							{pipelineState.pulse && (
-								<span
-									aria-hidden
-									className={`absolute inline-flex h-full w-full animate-ping rounded-full opacity-60 ${PIPELINE_DOT_BG[pipelineState.tone]}`}
-								/>
-							)}
-							<span
-								aria-hidden
-								className={`relative inline-flex h-2 w-2 rounded-full ${PIPELINE_DOT_BG[pipelineState.tone]}`}
-							/>
-						</span>
-						<span className="text-[11px] text-ink-2">
-							{pipelineState.label}
-						</span>
-					</button>
-				)}
-
-				<div className="border-t border-line px-3 py-2.5 flex items-center gap-2">
-					<div className="flex h-7 w-7 items-center justify-center rounded-full bg-accent-tint text-accent-ink text-[11px] font-medium">
-						SA
-					</div>
-					<div className="flex-1 min-w-0">
-						<div className="text-[12px] text-ink truncate">SOC analyst</div>
-						<div className="text-[10.5px] text-ink-3 truncate">Preview</div>
-					</div>
-					<button
-						type="button"
-						onClick={toggleTheme}
-						className="flex h-7 w-7 items-center justify-center rounded-md text-ink-3 hover:bg-paper-3 hover:text-ink transition-colors"
-						aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-					>
-						{theme === "dark" ? <SunIcon size={14} /> : <MoonIcon size={14} />}
-					</button>
-				</div>
+				{navContents}
 			</aside>
+
+			{/* Mobile drawer — backdrop + slide-over. Kept out of the DOM when
+			    closed so Esc/click-outside listeners aren't always attached and
+			    the desktop test surface stays unchanged. */}
+			{isSidebarOpen && (
+				<>
+					<div
+						data-testid="mobile-drawer-backdrop"
+						aria-hidden
+						className="md:hidden fixed inset-0 z-40 bg-black/50"
+						onClick={closeSidebar}
+					/>
+					<aside
+						role="dialog"
+						aria-label="Primary navigation"
+						className="md:hidden fixed left-0 top-0 bottom-0 z-50 w-[260px] max-w-[85vw] flex flex-col bg-paper-2 border-r border-line shadow-xl"
+					>
+						<button
+							type="button"
+							onClick={closeSidebar}
+							aria-label="Close menu"
+							className="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-md text-ink-3 hover:bg-paper-3 hover:text-ink transition-colors"
+						>
+							<XIcon size={16} />
+						</button>
+						{navContents}
+					</aside>
+				</>
+			)}
 
 			{/* Main column. Topbar pinned, content scrolls. */}
 			<div className="flex-1 flex flex-col min-w-0">
 				<header className="flex items-center gap-3 h-[52px] px-4 md:px-6 border-b border-line bg-paper">
+					<button
+						type="button"
+						onClick={openSidebar}
+						aria-label="Open menu"
+						aria-expanded={isSidebarOpen}
+						className="md:hidden flex h-8 w-8 items-center justify-center rounded-md text-ink-3 hover:bg-paper-2 hover:text-ink transition-colors shrink-0"
+					>
+						<ListIcon size={18} />
+					</button>
 					<form
 						role="search"
 						onSubmit={handleSearchSubmit}

--- a/app/components/phishsoc/Sparkline.tsx
+++ b/app/components/phishsoc/Sparkline.tsx
@@ -1,25 +1,30 @@
 interface SparklineProps {
 	values: number[];
-	width?: number;
 	height?: number;
 	color?: string;
 }
+
+// Fixed virtual width — the SVG stretches to fill its container via
+// `preserveAspectRatio="none"`, so callers don't pass a pixel width. This is
+// what lets the chart reflow cleanly between a 320px phone and a 1280px
+// dashboard pane without overflow or hard-coded magic numbers.
+const VIRTUAL_WIDTH = 100;
 
 // Inline SVG line chart. Tiny by design — no axes, no labels, just shape.
 // Color defaults to the accent CSS var so it reflows with hue presets.
 export default function Sparkline({
 	values,
-	width = 96,
 	height = 24,
 	color = "var(--accent)",
 }: SparklineProps) {
 	if (values.length === 0) {
-		return <div style={{ width, height }} />;
+		return <div style={{ width: "100%", height }} />;
 	}
 	const min = Math.min(...values);
 	const max = Math.max(...values);
 	const range = max - min || 1;
-	const step = values.length > 1 ? width / (values.length - 1) : width;
+	const step =
+		values.length > 1 ? VIRTUAL_WIDTH / (values.length - 1) : VIRTUAL_WIDTH;
 	const points = values
 		.map((v, i) => {
 			const x = i * step;
@@ -29,9 +34,10 @@ export default function Sparkline({
 		.join(" ");
 	return (
 		<svg
-			width={width}
+			width="100%"
 			height={height}
-			viewBox={`0 0 ${width} ${height}`}
+			viewBox={`0 0 ${VIRTUAL_WIDTH} ${height}`}
+			preserveAspectRatio="none"
 			className="overflow-visible"
 			aria-hidden
 		>
@@ -42,6 +48,7 @@ export default function Sparkline({
 				strokeWidth={1.5}
 				strokeLinecap="round"
 				strokeLinejoin="round"
+				vectorEffect="non-scaling-stroke"
 			/>
 		</svg>
 	);

--- a/app/routes/cases.tsx
+++ b/app/routes/cases.tsx
@@ -137,40 +137,72 @@ export default function CasesRoute() {
 					No cases yet. Report a phish from any email in your inbox to open one.
 				</div>
 			) : (
-				<div className="pp-card overflow-hidden">
-					{/* Header row */}
-					<div className="grid grid-cols-[140px_1fr_120px_110px_60px] items-center gap-4 px-4 py-2.5 border-b border-line bg-paper-2 text-[10.5px] uppercase tracking-[0.06em] text-ink-3">
-						<span>Case</span>
-						<span>Subject</span>
-						<span>Status</span>
-						<span>Age</span>
-						<span />
+				<>
+					{/* Desktop: 5-column grid table. */}
+					<div className="hidden md:block pp-card overflow-hidden">
+						{/* Header row */}
+						<div className="grid grid-cols-[140px_1fr_120px_110px_60px] items-center gap-4 px-4 py-2.5 border-b border-line bg-paper-2 text-[10.5px] uppercase tracking-[0.06em] text-ink-3">
+							<span>Case</span>
+							<span>Subject</span>
+							<span>Status</span>
+							<span>Age</span>
+							<span />
+						</div>
+						<ul>
+							{cases.map((c) => (
+								<li key={c.id}>
+									<Link
+										to={`/mailbox/${encodeURIComponent(mailboxId ?? "")}/cases/${encodeURIComponent(c.id)}`}
+										className="grid grid-cols-[140px_1fr_120px_110px_60px] items-center gap-4 px-4 py-3 border-b border-line last:border-b-0 hover:bg-paper-2 transition-colors"
+									>
+										<span className="pp-mono text-[12px] text-ink-2 truncate">
+											{c.id.slice(0, 12)}
+										</span>
+										<span className="text-[13px] text-ink truncate">
+											{c.title}
+										</span>
+										<VerdictPill tone={statusTone(c.status)}>
+											{statusLabel(c.status)}
+										</VerdictPill>
+										<span className="pp-mono text-[12px] text-ink-3">
+											{relativeAge(c.created_at)}
+										</span>
+										<CaretRightIcon size={14} className="text-ink-3 justify-self-end" />
+									</Link>
+								</li>
+							))}
+						</ul>
 					</div>
-					<ul>
+
+					{/* Mobile: stacked cards. The 5-column grid clips at 375px, so each
+					    row becomes a card with title on top, status + age + id below. */}
+					<ul className="md:hidden space-y-2">
 						{cases.map((c) => (
 							<li key={c.id}>
 								<Link
 									to={`/mailbox/${encodeURIComponent(mailboxId ?? "")}/cases/${encodeURIComponent(c.id)}`}
-									className="grid grid-cols-[140px_1fr_120px_110px_60px] items-center gap-4 px-4 py-3 border-b border-line last:border-b-0 hover:bg-paper-2 transition-colors"
+									className="pp-card flex items-start gap-3 p-3 hover:bg-paper-2 transition-colors"
 								>
-									<span className="pp-mono text-[12px] text-ink-2 truncate">
-										{c.id.slice(0, 12)}
-									</span>
-									<span className="text-[13px] text-ink truncate">
-										{c.title}
-									</span>
-									<VerdictPill tone={statusTone(c.status)}>
-										{statusLabel(c.status)}
-									</VerdictPill>
-									<span className="pp-mono text-[12px] text-ink-3">
-										{relativeAge(c.created_at)}
-									</span>
-									<CaretRightIcon size={14} className="text-ink-3 justify-self-end" />
+									<div className="flex-1 min-w-0">
+										<div className="text-[14px] text-ink truncate mb-1">
+											{c.title}
+										</div>
+										<div className="flex flex-wrap items-center gap-2 text-[11.5px] text-ink-3">
+											<VerdictPill tone={statusTone(c.status)}>
+												{statusLabel(c.status)}
+											</VerdictPill>
+											<span className="pp-mono">{relativeAge(c.created_at)}</span>
+											<span className="pp-mono truncate">
+												{c.id.slice(0, 12)}
+											</span>
+										</div>
+									</div>
+									<CaretRightIcon size={14} className="text-ink-3 mt-1 shrink-0" />
 								</Link>
 							</li>
 						))}
 					</ul>
-				</div>
+				</>
 			)}
 		</div>
 	);

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -110,7 +110,7 @@ function KpiGrid({ data }: { data: DashboardSummary }) {
 	];
 
 	return (
-		<div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
+		<div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
 			{kpis.map((k) => (
 				<div key={k.label} className="pp-card p-4">
 					<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-2">
@@ -137,7 +137,7 @@ function ThreatPressureCard({ values }: { values: number[] }) {
 					{total} actioned
 				</div>
 			</div>
-			<Sparkline values={values} width={480} height={56} />
+			<Sparkline values={values} height={56} />
 			<p className="text-[11.5px] text-ink-3">
 				Per-2-hour count of emails the pipeline tagged, quarantined, or blocked.
 			</p>

--- a/tests/frontend/shell-mobile-drawer.test.tsx
+++ b/tests/frontend/shell-mobile-drawer.test.tsx
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Route, Routes, useLocation } from "react-router";
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({
+		data: { id: "m1", email: "alice@acme.com", name: "Alice" },
+	}),
+	useMailboxes: () => ({
+		data: [{ id: "m1", email: "alice@acme.com", name: "Alice" }],
+	}),
+}));
+
+vi.mock("~/queries/dashboard", () => ({
+	useDashboardSummary: () => ({
+		data: undefined,
+		isLoading: false,
+		isError: false,
+	}),
+}));
+
+import Shell from "~/components/phishsoc/Shell";
+import { renderWithProviders } from "./test-utils";
+
+function LocationReporter() {
+	const loc = useLocation();
+	return <div data-testid="location">{loc.pathname}</div>;
+}
+
+function renderShell(initialEntries: string[] = ["/mailbox/m1/dashboard"]) {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/mailbox/:mailboxId/*"
+				element={
+					<Shell>
+						<LocationReporter />
+					</Shell>
+				}
+			/>
+		</Routes>,
+		{ initialEntries },
+	);
+}
+
+describe("Shell mobile drawer", () => {
+	it("hamburger button is rendered with aria-expanded=false initially", () => {
+		renderShell();
+		const button = screen.getByRole("button", { name: /open menu/i });
+		expect(button).toBeInTheDocument();
+		expect(button).toHaveAttribute("aria-expanded", "false");
+		// No drawer in the DOM until opened.
+		expect(screen.queryByRole("dialog", { name: /primary navigation/i })).toBeNull();
+	});
+
+	it("clicking the hamburger opens a drawer with nav links", async () => {
+		const user = userEvent.setup();
+		renderShell();
+		const button = screen.getByRole("button", { name: /open menu/i });
+		await user.click(button);
+
+		const drawer = await screen.findByRole("dialog", { name: /primary navigation/i });
+		expect(drawer).toBeInTheDocument();
+		expect(button).toHaveAttribute("aria-expanded", "true");
+
+		// Drawer contains the same nav items as the desktop sidebar.
+		const drawerLinks = within(drawer).getAllByRole("link");
+		const labels = drawerLinks.map((l) => l.textContent?.trim().toLowerCase() ?? "");
+		expect(labels.some((l) => l.includes("dashboard"))).toBe(true);
+		expect(labels.some((l) => l.includes("cases"))).toBe(true);
+		expect(labels.some((l) => l.includes("mail"))).toBe(true);
+		expect(labels.some((l) => l.includes("hub"))).toBe(true);
+		expect(labels.some((l) => l.includes("settings"))).toBe(true);
+	});
+
+	it("tapping a nav item inside the drawer closes the drawer and navigates", async () => {
+		const user = userEvent.setup();
+		renderShell(["/mailbox/m1/dashboard"]);
+		await user.click(screen.getByRole("button", { name: /open menu/i }));
+		const drawer = await screen.findByRole("dialog", { name: /primary navigation/i });
+
+		const casesLink = within(drawer).getByRole("link", { name: /cases/i });
+		await user.click(casesLink);
+
+		// Route changed.
+		expect(screen.getByTestId("location")).toHaveTextContent("/mailbox/m1/cases");
+		// Drawer is gone.
+		expect(screen.queryByRole("dialog", { name: /primary navigation/i })).toBeNull();
+		expect(screen.getByRole("button", { name: /open menu/i })).toHaveAttribute(
+			"aria-expanded",
+			"false",
+		);
+	});
+
+	it("Escape closes the drawer", async () => {
+		const user = userEvent.setup();
+		renderShell();
+		await user.click(screen.getByRole("button", { name: /open menu/i }));
+		await screen.findByRole("dialog", { name: /primary navigation/i });
+
+		await user.keyboard("{Escape}");
+		expect(screen.queryByRole("dialog", { name: /primary navigation/i })).toBeNull();
+	});
+
+	it("clicking the backdrop closes the drawer", async () => {
+		const user = userEvent.setup();
+		renderShell();
+		await user.click(screen.getByRole("button", { name: /open menu/i }));
+		await screen.findByRole("dialog", { name: /primary navigation/i });
+
+		const backdrop = screen.getByTestId("mobile-drawer-backdrop");
+		await user.click(backdrop);
+		expect(screen.queryByRole("dialog", { name: /primary navigation/i })).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

The PhishSOC rebrand had no mobile fallbacks: the left nav was hidden with no replacement, the email list disappeared once an email was selected, the cases grid clipped at 375px, and the dashboard sparkline overflowed. This PR adds a hamburger drawer and walks every offending grid/chart down to a phone-friendly layout. Closes #81.

## What changed

- **`app/components/phishsoc/Shell.tsx`** — extracted `<NavContents>` so the desktop aside and the new mobile drawer share a single source of truth. Topbar now has a `md:hidden` hamburger (`aria-expanded`, `aria-label="Open menu"`); when open, a `role="dialog"` slide-over with backdrop renders the same nav. Drawer dismisses on Esc, backdrop tap, route change, and explicit close button. `aria-modal` is intentionally omitted — there is no focus trap yet (tracked separately).
- **`app/components/MailboxSplitView.tsx`** — on `<md` the list now goes full-width when empty and the detail full-width when an email is open, with a sticky `md:hidden` "Back to list" affordance at the top of the detail pane (the existing `EmailPanelToolbar` back is desktop-only).
- **`app/routes/cases.tsx`** — desktop keeps the 5-column grid table (`hidden md:block`); `<md` now renders a stacked card list (`md:hidden`) so the 430px-wide grid no longer clips at 375px. Both layouts link to the same case route.
- **`app/routes/dashboard.tsx`** — KPI grid progresses `grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4` instead of the cramped `2 → 4` jump. Dropped the hard-coded `width={480}` from the Sparkline call so the chart inherits its container width.
- **`app/components/SecuritySettingsPanel.tsx`** — Score-threshold inputs progress `grid-cols-1 sm:grid-cols-2 md:grid-cols-3` so labels stop truncating.
- **`app/components/phishsoc/Sparkline.tsx`** — switched to a fixed virtual `viewBox` with `preserveAspectRatio="none"`, `width="100%"`, and `vector-effect: non-scaling-stroke` so the chart reflows cleanly between 320px and 1280px without a hard-coded width prop.
- **`tests/frontend/shell-mobile-drawer.test.tsx`** — new suite covering hamburger `aria-expanded` state, drawer open via hamburger, drawer dismissal via nav-link click / Escape / backdrop tap, and presence of all five primary nav links inside the drawer.

## Test plan

- [x] `npm test` — 214 passing, 0 failing (5 new drawer tests + 209 prior).
- [x] `npm run typecheck` — clean.
- [ ] Dev-server smoke at 1280 / 1024 / 768 / 375 — **not run.** `npm run dev` requires Cloudflare Access service-token credentials (#89). Verified instead via tests + visual review of class progressions; recommend a follow-up smoke pass once #89 unblocks local dev.
- [x] Verified no regressions in `shell-search` or `shell-pipeline-pill` tests (both share `Shell.tsx`).

## Out of scope

- Agent + MCP sidebar overlay (#82) — `lg+` only, doesn't conflict with the `<md` drawer.
- Onboarding flow (#68).
- Per-touch-target audit (`h-6` buttons, etc.) — track separately.
- Focus trap + restore inside the mobile drawer — `aria-modal` was deliberately not promised. Worth a follow-up if/when keyboard-only navigation on phones becomes a goal.
- `ComposePanel.tsx:42,63` `p-4` → `p-6` jump — listed in #81's body but not in the task's authoritative file list. Spawned as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)