### PR TITLE
feat(ui): expose attachment_policy + folder_policies in SecuritySettingsPanel (#83)

### DIFF
--- a/app/components/SecuritySettingsPanel.tsx
+++ b/app/components/SecuritySettingsPanel.tsx
@@ -5,7 +5,15 @@
 import { Badge, Input, Switch } from "@cloudflare/kumo";
 import { ShieldIcon } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
-import type { SecuritySettings, BusinessHoursSettings, VerdictThresholdSettings } from "~/types";
+import type {
+	SecuritySettings,
+	BusinessHoursSettings,
+	VerdictThresholdSettings,
+	AttachmentAction,
+	AttachmentPolicySettings,
+	FolderPolicySettings,
+} from "~/types";
+import { SYSTEM_FOLDER_IDS, FOLDER_DISPLAY_NAMES } from "shared/folders";
 
 /**
  * Per-mailbox security settings UI. Mirrors `MailboxSecuritySettings` in
@@ -28,6 +36,17 @@ const DEFAULT_BUSINESS_HOURS: BusinessHoursSettings = {
 	boost_on_off_hours: false,
 };
 
+// Mirrors `DEFAULT_ATTACHMENT_POLICY` in `workers/security/attachments.ts`.
+// Kept here so the form shows the same effective state operators get from
+// leaving the section untouched on the server. Update both together.
+const DEFAULT_ATTACHMENT_POLICY: Required<
+	Pick<AttachmentPolicySettings, "executable_action" | "container_action" | "macro_office_action">
+> = {
+	executable_action: "block",
+	container_action: "score",
+	macro_office_action: "score",
+};
+
 export interface SecuritySettingsPanelProps {
 	value: SecuritySettings | undefined;
 	onChange: (next: SecuritySettings) => void;
@@ -37,8 +56,21 @@ export function SecuritySettingsPanel({ value, onChange }: SecuritySettingsPanel
 	const s = value ?? {};
 	const thresholds = s.thresholds ?? DEFAULT_THRESHOLDS;
 	const bh = s.business_hours;
+	const attachment = s.attachment_policy ?? {};
+	const folders = s.folder_policies ?? {};
 
 	const patch = (partial: Partial<SecuritySettings>) => onChange({ ...s, ...partial });
+	const patchAttachment = (partial: Partial<AttachmentPolicySettings>) =>
+		patch({ attachment_policy: { ...attachment, ...partial } });
+	const patchFolder = (folderId: string, next: FolderPolicySettings | undefined) => {
+		const nextFolders = { ...folders };
+		if (!next || (next.mode === undefined && !next.treat_as_verified)) {
+			delete nextFolders[folderId];
+		} else {
+			nextFolders[folderId] = next;
+		}
+		patch({ folder_policies: nextFolders });
+	};
 
 	return (
 		<div className="pp-card p-5 space-y-5">
@@ -244,6 +276,201 @@ export function SecuritySettingsPanel({ value, onChange }: SecuritySettingsPanel
 					/>
 				</div>
 			</div>
+
+			{/* Attachment filtering */}
+			<details className="border-t border-line pt-5 group">
+				<summary className="cursor-pointer list-none flex items-center justify-between">
+					<span className="text-xs font-medium text-ink">Attachment filtering</span>
+					<span className="text-xs text-ink-3 group-open:hidden">Show</span>
+					<span className="text-xs text-ink-3 hidden group-open:inline">Hide</span>
+				</summary>
+				<p className="text-xs text-ink-3 mt-3 mb-4">
+					How the attachment-type gate handles risky filetypes. Runs before the LLM
+					classifier so a known-bad attachment never spends LLM budget. Custom blocklist
+					entries always hard-block, even on a trusted/allowlisted sender.
+				</p>
+
+				<div className="space-y-5">
+					<AttachmentActionGroup
+						label="Executable files"
+						helper="Includes .exe, .scr, .com, .msi, .jar, .js, .vbs, .ps1, .bat, .lnk, and similar."
+						value={attachment.executable_action ?? DEFAULT_ATTACHMENT_POLICY.executable_action}
+						onChange={(v) => patchAttachment({ executable_action: v })}
+						disabled={!s.enabled}
+					/>
+					<AttachmentActionGroup
+						label="Container files"
+						helper="Includes .iso, .img, .vhd, .vhdx — commonly used to smuggle executables past gateways that block .exe directly."
+						value={attachment.container_action ?? DEFAULT_ATTACHMENT_POLICY.container_action}
+						onChange={(v) => patchAttachment({ container_action: v })}
+						disabled={!s.enabled}
+					/>
+					<AttachmentActionGroup
+						label="Macro-enabled Office files"
+						helper="Includes .docm, .xlsm, .pptm, .xlam, .xltm, .potm, .ppsm — macros are the classic malware delivery path."
+						value={attachment.macro_office_action ?? DEFAULT_ATTACHMENT_POLICY.macro_office_action}
+						onChange={(v) => patchAttachment({ macro_office_action: v })}
+						disabled={!s.enabled}
+					/>
+
+					<div>
+						<ListInput
+							label="Custom blocklist (extensions)"
+							value={attachment.custom_blocklist_extensions ?? []}
+							onChange={(next) => patchAttachment({ custom_blocklist_extensions: next })}
+							parse={parseExtensionList}
+							placeholder="dmg, rtf"
+							disabled={!s.enabled}
+						/>
+						<p className="text-xs text-ink-3 mt-2">
+							Lowercase, no leading dot. e.g. <code className="text-ink">dmg, rtf</code>.
+							Anything listed here always hard-blocks, regardless of sender trust.
+						</p>
+					</div>
+				</div>
+			</details>
+
+			{/* Folder rules */}
+			<details className="border-t border-line pt-5 group">
+				<summary className="cursor-pointer list-none flex items-center justify-between">
+					<span className="text-xs font-medium text-ink">Folder rules</span>
+					<span className="text-xs text-ink-3 group-open:hidden">Show</span>
+					<span className="text-xs text-ink-3 hidden group-open:inline">Hide</span>
+				</summary>
+				<p className="text-xs text-ink-3 mt-3 mb-4">
+					Per-folder bypasses and trust signals. <strong>Skip classifier</strong> keeps the
+					rest of the pipeline (auth, URLs, intel) running but skips the LLM.
+					<strong> Skip all</strong> bypasses the entire pipeline — use only on folders an
+					attacker cannot deliver into. <strong>Treat moves here as verified</strong> bumps a
+					sender's reputation when you move their mail into the folder.
+				</p>
+
+				<div className="space-y-4">
+					{SYSTEM_FOLDER_IDS.map((folderId) => {
+						const policy = folders[folderId] ?? {};
+						return (
+							<FolderPolicyRow
+								key={folderId}
+								folderId={folderId}
+								label={FOLDER_DISPLAY_NAMES[folderId] ?? folderId}
+								policy={policy}
+								disabled={!s.enabled}
+								onChange={(next) => patchFolder(folderId, next)}
+							/>
+						);
+					})}
+				</div>
+			</details>
+		</div>
+	);
+}
+
+interface AttachmentActionGroupProps {
+	label: string;
+	helper: string;
+	value: AttachmentAction;
+	onChange: (next: AttachmentAction) => void;
+	disabled?: boolean;
+}
+
+function AttachmentActionGroup({ label, helper, value, onChange, disabled }: AttachmentActionGroupProps) {
+	const id = label.replace(/\s+/g, "-").toLowerCase();
+	return (
+		<fieldset disabled={disabled} className="space-y-2">
+			<legend className="text-sm text-ink">{label}</legend>
+			<p className="text-xs text-ink-3">{helper}</p>
+			<div role="radiogroup" aria-label={label} className="flex gap-4">
+				{(["block", "score", "ignore"] as const).map((action) => (
+					<label key={action} className="flex items-center gap-2 text-xs text-ink-2">
+						<input
+							type="radio"
+							name={`attachment-${id}`}
+							value={action}
+							checked={value === action}
+							onChange={() => onChange(action)}
+							disabled={disabled}
+							className="h-3.5 w-3.5 accent-accent"
+						/>
+						<span className="capitalize">{action}</span>
+					</label>
+				))}
+			</div>
+		</fieldset>
+	);
+}
+
+interface FolderPolicyRowProps {
+	folderId: string;
+	label: string;
+	policy: FolderPolicySettings;
+	disabled?: boolean;
+	onChange: (next: FolderPolicySettings | undefined) => void;
+}
+
+function FolderPolicyRow({ folderId, label, policy, disabled, onChange }: FolderPolicyRowProps) {
+	const skipAll = policy.mode === "skip_all";
+	const skipClassifier = policy.mode === "skip_classifier";
+	const treatAsVerified = !!policy.treat_as_verified;
+
+	const update = (next: Partial<FolderPolicySettings>) => onChange({ ...policy, ...next });
+
+	const onSkipClassifier = (checked: boolean) => {
+		// Mode is mutex on the server side: setting one clears the other.
+		// `skip_all` is the strict superset, so it stays winning when both
+		// would be on.
+		if (checked) {
+			update({ mode: skipAll ? "skip_all" : "skip_classifier" });
+		} else {
+			update({ mode: skipAll ? "skip_all" : undefined });
+		}
+	};
+	const onSkipAll = (checked: boolean) => {
+		if (checked) update({ mode: "skip_all" });
+		else update({ mode: skipClassifier ? "skip_classifier" : undefined });
+	};
+	const onTreatVerified = (checked: boolean) => update({ treat_as_verified: checked || undefined });
+
+	return (
+		<div className="rounded-md border border-line p-3">
+			<div className="text-sm text-ink mb-2">{label}</div>
+			<div className="space-y-2">
+				<label className="flex items-center gap-2 text-xs text-ink-2">
+					<input
+						type="checkbox"
+						checked={skipClassifier && !skipAll}
+						onChange={(e) => onSkipClassifier(e.target.checked)}
+						disabled={disabled || skipAll}
+						aria-label={`Skip classifier on ${label}`}
+						data-testid={`skip-classifier-${folderId}`}
+						className="h-3.5 w-3.5 accent-accent"
+					/>
+					<span>Skip classifier</span>
+				</label>
+				<label className="flex items-center gap-2 text-xs text-ink-2">
+					<input
+						type="checkbox"
+						checked={treatAsVerified}
+						onChange={(e) => onTreatVerified(e.target.checked)}
+						disabled={disabled}
+						aria-label={`Treat moves to ${label} as verified`}
+						data-testid={`treat-verified-${folderId}`}
+						className="h-3.5 w-3.5 accent-accent"
+					/>
+					<span>Treat moves here as verified</span>
+				</label>
+				<label className="flex items-center gap-2 text-xs text-red-500">
+					<input
+						type="checkbox"
+						checked={skipAll}
+						onChange={(e) => onSkipAll(e.target.checked)}
+						disabled={disabled}
+						aria-label={`Skip all on ${label}`}
+						data-testid={`skip-all-${folderId}`}
+						className="h-3.5 w-3.5 accent-red-500"
+					/>
+					<span>Skip all (bypass entire pipeline — only safe on folders an attacker cannot deliver into)</span>
+				</label>
+			</div>
 		</div>
 	);
 }
@@ -321,6 +548,15 @@ function parseList(raw: string): string[] {
 	return raw
 		.split(",")
 		.map((s) => s.trim().toLowerCase())
+		.filter(Boolean);
+}
+
+/** Like parseList but also strips a leading dot, so users can paste either
+ *  `dmg, rtf` or `.dmg, .rtf` without breaking the consumer's match logic. */
+function parseExtensionList(raw: string): string[] {
+	return raw
+		.split(",")
+		.map((s) => s.trim().toLowerCase().replace(/^\./, ""))
 		.filter(Boolean);
 }
 

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -22,6 +22,20 @@ export interface VerdictThresholdSettings {
 	block: number;
 }
 
+export type AttachmentAction = "block" | "score" | "ignore";
+
+export interface AttachmentPolicySettings {
+	executable_action?: AttachmentAction;
+	container_action?: AttachmentAction;
+	macro_office_action?: AttachmentAction;
+	custom_blocklist_extensions?: string[];
+}
+
+export interface FolderPolicySettings {
+	mode?: "skip_all" | "skip_classifier";
+	treat_as_verified?: boolean;
+}
+
 export interface SecuritySettings {
 	enabled?: boolean;
 	learning_mode?: boolean;
@@ -33,6 +47,8 @@ export interface SecuritySettings {
 	trusted_auto_allow_min_messages?: number;
 	intel_auto_block?: boolean;
 	business_hours?: BusinessHoursSettings;
+	attachment_policy?: AttachmentPolicySettings;
+	folder_policies?: Record<string, FolderPolicySettings>;
 }
 
 export interface MailboxSettings {

--- a/shared/mailbox-settings.ts
+++ b/shared/mailbox-settings.ts
@@ -10,7 +10,41 @@ import { z } from "zod";
  * future fields can land without coordinated frontend/backend deploys.
  * Strict on the read side: every consumer that reads a typed field uses
  * `MailboxSettings.parse(...)` which fills in defaults.
+ *
+ * `security` is a typed sub-shape: only `attachment_policy` and
+ * `folder_policies` are validated here — the rest of the object is
+ * passthrough so unrelated security fields (allowlist_senders, thresholds,
+ * business_hours, etc.) round-trip untouched. Defaults intentionally NOT
+ * set in the schema; the runtime consumer in `workers/security/settings.ts`
+ * (`getSecuritySettings`) is the single source of default values, and
+ * duplicating them here would invite drift.
  */
+
+const AttachmentAction = z.enum(["block", "score", "ignore"]);
+
+const AttachmentPolicy = z
+  .object({
+    executable_action: AttachmentAction.optional(),
+    container_action: AttachmentAction.optional(),
+    macro_office_action: AttachmentAction.optional(),
+    custom_blocklist_extensions: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+const FolderPolicy = z
+  .object({
+    mode: z.enum(["skip_all", "skip_classifier"]).optional(),
+    treat_as_verified: z.boolean().optional(),
+  })
+  .passthrough();
+
+const SecuritySettings = z
+  .object({
+    attachment_policy: AttachmentPolicy.optional(),
+    folder_policies: z.record(z.string(), FolderPolicy).optional(),
+  })
+  .passthrough();
+
 export const MailboxSettings = z.object({
   agentSystemPrompt: z.string().optional(),
   autoDraft: z
@@ -19,6 +53,7 @@ export const MailboxSettings = z.object({
     })
     .default({ enabled: true }),
   agentModel: z.string().default("@cf/moonshotai/kimi-k2.5"),
+  security: SecuritySettings.optional(),
 }).passthrough();
 
 export type MailboxSettings = z.infer<typeof MailboxSettings>;

--- a/tests/agent/settings.test.ts
+++ b/tests/agent/settings.test.ts
@@ -23,4 +23,96 @@ describe("MailboxSettings", () => {
     const parsed = MailboxSettings.parse({ agentSystemPrompt: "Hi" });
     expect(parsed.agentSystemPrompt).toBe("Hi");
   });
+
+  // The security sub-shape is opt-in: an undefined `security` block must
+  // round-trip to undefined (no surprise object materialised). The runtime
+  // consumer in `workers/security/settings.ts` is the single source of
+  // default values — we don't want the schema to invent a default that the
+  // consumer would then overwrite.
+  it("leaves security undefined when missing", () => {
+    const parsed = MailboxSettings.parse({});
+    expect((parsed as { security?: unknown }).security).toBeUndefined();
+  });
+
+  it("accepts a valid attachment_policy", () => {
+    const parsed = MailboxSettings.parse({
+      security: {
+        attachment_policy: {
+          executable_action: "block",
+          container_action: "score",
+          macro_office_action: "ignore",
+          custom_blocklist_extensions: ["dmg", "rtf"],
+        },
+      },
+    });
+    expect(parsed.security?.attachment_policy?.executable_action).toBe("block");
+    expect(parsed.security?.attachment_policy?.custom_blocklist_extensions).toEqual(["dmg", "rtf"]);
+  });
+
+  it("rejects an invalid attachment action enum", () => {
+    const result = MailboxSettings.safeParse({
+      security: {
+        attachment_policy: { executable_action: "lol" },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // Issue should point at the bad enum value, not surface a generic 500.
+      const path = result.error.issues[0].path.join(".");
+      expect(path).toContain("executable_action");
+    }
+  });
+
+  it("preserves co-existing security fields (allowlist alongside attachment_policy)", () => {
+    // Regression guard for the passthrough hazard: adding a typed `security`
+    // sub-shape must NOT strip unrelated security fields like
+    // `allowlist_senders` or `thresholds` — they live in passthrough.
+    const parsed = MailboxSettings.parse({
+      security: {
+        allowlist_senders: ["ceo@company.com"],
+        thresholds: { tag: 30, quarantine: 60, block: 80 },
+        attachment_policy: { executable_action: "score" },
+      },
+    });
+    const sec = parsed.security as Record<string, unknown>;
+    expect(sec.allowlist_senders).toEqual(["ceo@company.com"]);
+    expect(sec.thresholds).toEqual({ tag: 30, quarantine: 60, block: 80 });
+  });
+
+  it("accepts folder_policies with mode + treat_as_verified", () => {
+    const parsed = MailboxSettings.parse({
+      security: {
+        folder_policies: {
+          inbox: { treat_as_verified: true },
+          archive: { mode: "skip_classifier" },
+          quarantine: { mode: "skip_all" },
+        },
+      },
+    });
+    expect(parsed.security?.folder_policies?.inbox?.treat_as_verified).toBe(true);
+    expect(parsed.security?.folder_policies?.archive?.mode).toBe("skip_classifier");
+    expect(parsed.security?.folder_policies?.quarantine?.mode).toBe("skip_all");
+  });
+
+  it("allows unknown folder names in folder_policies (forward-compatible)", () => {
+    // User-defined custom folders must survive the round-trip — folder ids
+    // are runtime data, not a closed enum.
+    const result = MailboxSettings.safeParse({
+      security: {
+        folder_policies: {
+          "Newsletters/2026": { mode: "skip_classifier" },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an invalid folder mode value", () => {
+    const result = MailboxSettings.safeParse({
+      security: {
+        folder_policies: { inbox: { mode: "burn_it_down" } },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/tests/frontend/security-settings.test.tsx
+++ b/tests/frontend/security-settings.test.tsx
@@ -1,0 +1,143 @@
+// Coverage for the new attachment-policy + folder-policy controls in
+// `app/components/SecuritySettingsPanel.tsx`. Drives them through the full
+// settings save flow so we verify the merged settings payload that hits the
+// PUT route, not just the local component state.
+
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+import type { Mailbox, MailboxSettings, SecuritySettings } from "~/types";
+
+const mutateAsync = vi.fn();
+const updateMailboxMock = {
+	mutateAsync,
+	isPending: false,
+} as unknown as ReturnType<typeof import("~/queries/mailboxes").useUpdateMailbox>;
+
+let mailboxFixture: Mailbox;
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({ data: mailboxFixture }),
+	useUpdateMailbox: () => updateMailboxMock,
+}));
+
+import SettingsRoute from "~/routes/settings";
+import { renderWithProviders } from "./test-utils";
+
+function renderSettings() {
+	return renderWithProviders(
+		<Routes>
+			<Route path="/mailbox/:mailboxId/settings" element={<SettingsRoute />} />
+		</Routes>,
+		{ initialEntries: ["/mailbox/m1/settings"] },
+	);
+}
+
+function makeMailbox(security: SecuritySettings = { enabled: true }): Mailbox {
+	return {
+		id: "m1",
+		email: "ops@example.com",
+		name: "Ops",
+		settings: {
+			autoDraft: { enabled: true },
+			agentModel: "@cf/moonshotai/kimi-k2.5",
+			security,
+		} as MailboxSettings,
+	} as unknown as Mailbox;
+}
+
+async function lastSavedSettings(): Promise<MailboxSettings> {
+	await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+	const payload = mutateAsync.mock.calls[0][0] as {
+		mailboxId: string;
+		settings: MailboxSettings;
+	};
+	return payload.settings;
+}
+
+describe("SecuritySettingsPanel · attachment + folder controls", () => {
+	beforeEach(() => {
+		mutateAsync.mockReset();
+		mutateAsync.mockResolvedValue(undefined);
+	});
+
+	it("persists a changed executable_action through the save mutation", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox({ enabled: true });
+		renderSettings();
+
+		// Open the collapsible attachment-filtering section.
+		await user.click(await screen.findByText(/attachment filtering/i));
+
+		const group = await screen.findByRole("radiogroup", { name: /executable files/i });
+		await user.click(within(group).getByRole("radio", { name: /score/i }));
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		expect(saved.security?.attachment_policy?.executable_action).toBe("score");
+	});
+
+	it("persists a custom blocklist extension list", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox({ enabled: true });
+		renderSettings();
+
+		await user.click(await screen.findByText(/attachment filtering/i));
+
+		const input = await screen.findByLabelText(/custom blocklist/i);
+		await user.clear(input);
+		// Type one character at a time. The previous controlled-input pattern
+		// would collapse partial entries before the next comma was reached
+		// (typing `dmg, rtf, ace` produced a single `dmgrtface` entry); the
+		// `<ListInput>` adopted from #95 holds the raw draft locally so each
+		// keystroke survives. Typing here is the regression guard — pasting
+		// would mask the bug because the parser sees the full string in one go.
+		await user.type(input, "dmg, .rtf, ACE");
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		// Lowercased + leading-dot stripped (matches the consumer's
+		// normalisation in workers/security/settings.ts so the round-trip is
+		// idempotent).
+		expect(saved.security?.attachment_policy?.custom_blocklist_extensions).toEqual([
+			"dmg",
+			"rtf",
+			"ace",
+		]);
+	});
+
+	it("persists a folder skip_classifier toggle", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox({ enabled: true });
+		renderSettings();
+
+		await user.click(await screen.findByText(/folder rules/i));
+
+		const archiveSkipClassifier = await screen.findByTestId("skip-classifier-archive");
+		await user.click(archiveSkipClassifier);
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		expect(saved.security?.folder_policies?.archive?.mode).toBe("skip_classifier");
+	});
+
+	it("persists a treat_as_verified toggle for a folder", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox({ enabled: true });
+		renderSettings();
+
+		await user.click(await screen.findByText(/folder rules/i));
+
+		const inboxVerified = await screen.findByTestId("treat-verified-inbox");
+		await user.click(inboxVerified);
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		expect(saved.security?.folder_policies?.inbox?.treat_as_verified).toBe(true);
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -21,6 +21,7 @@ import { Folders } from "../shared/folders";
 import type { Env } from "./types";
 import { requireMailbox, type MailboxContext } from "./lib/mailbox";
 import { getMailboxSettings } from "./lib/mailbox-settings";
+import { MailboxSettings } from "../shared/mailbox-settings";
 import { runSecurityPipeline } from "./security";
 import { runDeepScan } from "./intel/deep-scan";
 import { getSecuritySettings } from "./security/settings";
@@ -168,7 +169,16 @@ app.get("/api/v1/mailboxes/:mailboxId/events", async (c) => {
 
 app.put("/api/v1/mailboxes/:mailboxId", async (c) => {
 	const mailboxId = c.req.param("mailboxId")!;
-	const { settings } = (await c.req.json()) as { settings: Record<string, unknown> };
+	const body = (await c.req.json()) as { settings?: unknown };
+	// Validate the typed sub-shapes (autoDraft, agentModel, security.attachment_policy,
+	// security.folder_policies). The schema is passthrough, so unknown fields
+	// round-trip untouched — bad enum values (e.g. executable_action: "lol")
+	// surface here as 400, not 500 from a downstream consumer.
+	const parsed = MailboxSettings.safeParse(body?.settings ?? {});
+	if (!parsed.success) {
+		return c.json({ error: "Invalid settings", issues: parsed.error.issues }, 400);
+	}
+	const settings = parsed.data;
 	const key = `mailboxes/${mailboxId}.json`;
 	if (!(await c.env.BUCKET.head(key))) return c.json({ error: "Not found" }, 404);
 	await c.env.BUCKET.put(key, JSON.stringify(settings));


### PR DESCRIPTION
## Summary

Two security settings existed in the worker but had no UI — operators couldn't change `attachment_policy` (executable / container / macro-Office filetype actions + a custom blocklist) or `folder_policies` (per-folder `skip_classifier` / `skip_all` / `treat_as_verified` bypasses) without editing R2 directly. This PR adds two collapsible sections to the existing `SecuritySettingsPanel`. Closes #83.

## What changed

- **Schema** (`shared/mailbox-settings.ts`): typed `security` sub-shape adds `attachment_policy` (passthrough) and `folder_policies` (`z.record` of passthrough). Every level uses `.passthrough()` so unrelated security fields (allowlist_senders, thresholds, business_hours, …) round-trip untouched. No defaults set in the schema — the runtime consumer in `workers/security/settings.ts` is the single source of defaults; duplicating them here would invite drift.
- **PUT validation** (`workers/index.ts`): `MailboxSettings.safeParse` → `400 { error, issues }` on bad input. Schema-level test (`rejects an invalid attachment action enum`) covers the same validation path the route calls.
- **Frontend type** (`app/types/index.ts`): added `AttachmentAction`, `AttachmentPolicySettings`, `FolderPolicySettings`; extended `SecuritySettings` to include the two new fields.
- **UI** (`app/components/SecuritySettingsPanel.tsx`): two new `<details>` sections — radio groups for executable/container/macro actions plus a custom-blocklist comma input; per-folder rows (driven by `SYSTEM_FOLDER_IDS`) with checkboxes for `skip_classifier`, `treat_as_verified`, and a red-styled `skip_all` warning. `mode` is mutex on the server side, so `skip_all` and `skip_classifier` interlock client-side: turning on `skip_all` disables the `skip_classifier` checkbox.
- **No consumer wiring needed** — `workers/security/triage.ts:97` and `:137` already read `settings.folder_policies` and `settings.attachment_policy`; `workers/security/settings.ts:145-152` already merges attachment_policy defaults field-by-field.

## Note: PUT now normalizes settings on disk

The PUT route used to write `body.settings` verbatim; it now writes `MailboxSettings.parse(...)` output. So a partial PUT like `{settings: {agentSystemPrompt: "x"}}` now stores `{agentSystemPrompt: "x", autoDraft: {enabled: true}, agentModel: "@cf/moonshotai/kimi-k2.5"}`. The frontend already merges these on the client; this just normalizes the at-rest shape.

## Test plan

- [x] `npm test` — **220 passing, 0 failing** (11 new: 7 schema + 4 UI; baseline was 209)
- [x] `npm run typecheck` — clean
- [x] Schema test: PUT with `executable_action: "lol"` produces a zod issue with path `.executable_action` (the route's only added behavior is the 400 wrapper)
- [x] Schema regression guard: a security payload with both `allowlist_senders` and `attachment_policy` round-trips both fields (passthrough)
- [ ] Local dev-server smoke not run — `npm run dev` requires Cloudflare Access service-token credentials per #89; component-level UI tests assert the save round-trip for executable_action, custom blocklist, `skip_classifier` mode, and `treat_as_verified`

## Defaults preserve current behavior

Existing mailboxes with no `attachment_policy` / `folder_policies` blob continue to work — `getSecuritySettings` already merges `DEFAULT_ATTACHMENT_POLICY` field-by-field and `folder_policies?.[folderId]` returns `undefined` for unconfigured folders. No migration.

## Out of scope (separate follow-ups)

- Rate-limit override
- Threat-intel feed selection (#22, #77)
- LLM 5s cap fail-mode toggle (#28)
- Existing controlled-input wart in `parseList` (typed comma-lists collapse partial entries) — pre-existing, surfaced while writing tests; flagged as a separate task

🤖 Generated with [Claude Code](https://claude.com/claude-code)