### PR TITLE
fix(ui): smooth ComposePanel padding progression

### DIFF
--- a/app/components/ComposePanel.tsx
+++ b/app/components/ComposePanel.tsx
@@ -60,7 +60,7 @@ export default function ComposePanel() {
 				onSubmit={(e) => handleSend(e, closePanel)}
 				className="flex flex-col flex-1 min-h-0 overflow-y-auto"
 			>
-				<div className="p-4 md:p-6 space-y-4">
+				<div className="p-4 sm:p-5 md:p-6 space-y-4">
 					{error && <Banner variant="error" text={error} />}
 
 					<div className="space-y-3">


### PR DESCRIPTION
## Summary

ComposePanel's form body was jumping directly from `p-4` (16px) to `md:p-6` (24px) at the `md` breakpoint with no intermediate step. This adds an `sm:p-5` (20px) stop at 640px so padding scales smoothly 16 → 20 → 24 as viewport widens.

Deferred from [#81](https://github.com/schmug/PhishSOC/issues/81) (mobile responsive sweep) — left out of the original PR for that issue and tracked as a follow-up.

## What changed

```diff
- <div className="p-4 md:p-6 space-y-4">
+ <div className="p-4 sm:p-5 md:p-6 space-y-4">
```

Only the form body wrapper at `app/components/ComposePanel.tsx:63` was touched. The header (line 42) and footer (line 152) keep `px-4 ... md:px-6` because that two-step progression is the project-wide shell convention also used in `Shell.tsx`, `EmailPanelHeader`, `ThreadMessage`, `SingleMessageView`, etc. — adding `sm:` to those would diverge from shell density rather than match it.

## Behavior matrix

| Viewport | Before | After | Notes |
| --- | --- | --- | --- |
| `<640px` (mobile, incl. 375px) | `p-4` | `p-4` | Unchanged |
| `640–767px` (sm) | `p-4` | `p-5` | New intermediate step |
| `≥768px` (md+) | `p-6` | `p-6` | Unchanged |

So mobile usability at 375px is identical to current `main` — no horizontal scroll risk, no layout-structure change, only a Tailwind class string was edited.

## Test plan

- [x] `npm test` — 17/17 loadable test files pass (176/176 tests). 7 test files fail to load due to a pre-existing missing-jsdom resolution issue in this worktree's parent `node_modules`; same failure occurs on `main` without this change.
- [x] `npm run typecheck` — produces the same set of pre-existing errors (missing `@testing-library/*` types, an `@cf/meta/llama-3.1-8b-instruct-fast` model ID type) on this branch and on `main`. No new errors introduced. None of them touch `ComposePanel.tsx`.
- [ ] **Live browser verification skipped.** Triggering compose mode requires seeded mailbox + auth + UI navigation, which is disproportionate for a one-line additive Tailwind class change in a viewport range (640–767px) that doesn't include the 375px target. Mobile and desktop behavior are mathematically unchanged; reviewer welcome to spot-check at `sm` width if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)