### PR TITLE
fix(ui): preserve raw text in SecuritySettingsPanel list inputs

### DIFF
--- a/app/components/SecuritySettingsPanel.tsx
+++ b/app/components/SecuritySettingsPanel.tsx
@@ -4,6 +4,7 @@
 
 import { Badge, Input, Switch } from "@cloudflare/kumo";
 import { ShieldIcon } from "@phosphor-icons/react";
+import { useEffect, useRef, useState } from "react";
 import type { SecuritySettings, BusinessHoursSettings, VerdictThresholdSettings } from "~/types";
 
 /**
@@ -121,9 +122,9 @@ export function SecuritySettingsPanel({ value, onChange }: SecuritySettingsPanel
 					this prevents an attacker-controlled upstream relay from forging a pass verdict.
 					Leave empty to trust any authserv (less secure).
 				</p>
-				<Input
-					value={(s.trusted_authserv_ids ?? []).join(", ")}
-					onChange={(e) => patch({ trusted_authserv_ids: parseList(e.target.value) })}
+				<ListInput
+					value={s.trusted_authserv_ids ?? []}
+					onChange={(next) => patch({ trusted_authserv_ids: next })}
 					placeholder="mx.cloudflare.net, mx.google.com"
 					disabled={!s.enabled}
 				/>
@@ -137,17 +138,17 @@ export function SecuritySettingsPanel({ value, onChange }: SecuritySettingsPanel
 					Without the DMARC requirement, the allowlist alone would let any attacker spoof a trusted From: address.
 				</p>
 				<div className="space-y-3">
-					<Input
+					<ListInput
 						label="Allowed senders (comma-separated)"
-						value={(s.allowlist_senders ?? []).join(", ")}
-						onChange={(e) => patch({ allowlist_senders: parseList(e.target.value) })}
+						value={s.allowlist_senders ?? []}
+						onChange={(next) => patch({ allowlist_senders: next })}
 						placeholder="ceo@company.com, payroll@vendor.com"
 						disabled={!s.enabled}
 					/>
-					<Input
+					<ListInput
 						label="Allowed domains (comma-separated; subdomains are included)"
-						value={(s.allowlist_domains ?? []).join(", ")}
-						onChange={(e) => patch({ allowlist_domains: parseList(e.target.value) })}
+						value={s.allowlist_domains ?? []}
+						onChange={(next) => patch({ allowlist_domains: next })}
 						placeholder="company.com, trustedvendor.com"
 						disabled={!s.enabled}
 					/>
@@ -245,6 +246,75 @@ export function SecuritySettingsPanel({ value, onChange }: SecuritySettingsPanel
 			</div>
 		</div>
 	);
+}
+
+interface ListInputProps {
+	value: string[];
+	onChange: (next: string[]) => void;
+	parse?: (raw: string) => string[];
+	label?: string;
+	placeholder?: string;
+	disabled?: boolean;
+}
+
+/**
+ * Input bound to a `string[]` via comma-separated text.
+ *
+ * The naive pattern (`value={array.join(", ")}` + parse-on-change) collapses
+ * partial entries: typing the comma re-emits the parsed array, the controlled
+ * value drops the trailing separator, and the next character lands appended
+ * to the previous entry. Repro: typing `dmg, rtf, ace` into such an input
+ * yields a single `["dmgrtface"]` instead of three entries.
+ *
+ * Fix: hold the raw string locally so the user's separators survive between
+ * keystrokes; emit the parsed array on every change for the parent's
+ * Save-on-click flow; only resync the displayed text when the parent's value
+ * diverges from what we last emitted (external load, reset).
+ */
+function ListInput({
+	value,
+	onChange,
+	parse = parseList,
+	label,
+	placeholder,
+	disabled,
+}: ListInputProps) {
+	const [draft, setDraft] = useState(() => value.join(", "));
+	const lastEmitted = useRef<string[]>(value);
+
+	useEffect(() => {
+		if (!arraysEqual(value, lastEmitted.current)) {
+			lastEmitted.current = value;
+			setDraft(value.join(", "));
+		}
+	}, [value]);
+
+	return (
+		<Input
+			label={label}
+			placeholder={placeholder}
+			disabled={disabled}
+			value={draft}
+			onChange={(e) => {
+				const raw = e.target.value;
+				setDraft(raw);
+				const parsed = parse(raw);
+				if (!arraysEqual(parsed, lastEmitted.current)) {
+					lastEmitted.current = parsed;
+					onChange(parsed);
+				}
+			}}
+		/>
+	);
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+	if (a === b) return true;
+	if (a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i++) {
+		if (a[i] !== b[i]) return false;
+	}
+	return true;
 }
 
 function parseList(raw: string): string[] {

--- a/tests/frontend/security-settings-list-input.test.tsx
+++ b/tests/frontend/security-settings-list-input.test.tsx
@@ -80,7 +80,7 @@ describe("SecuritySettingsPanel · comma-separated list inputs", () => {
 		const onLatest = vi.fn();
 		renderWithProviders(<ControlledHost onLatest={onLatest} />);
 
-		const input = screen.getByPlaceholderText(/mx\.cloudflare\.net/i);
+		const input = screen.getByPlaceholderText("mx.cloudflare.net, mx.google.com");
 		await user.type(input, "mx.cloudflare.net, mx.google.com, mx.proton.me");
 
 		const last = onLatest.mock.calls.at(-1)?.[0] as SecuritySettings;

--- a/tests/frontend/security-settings-list-input.test.tsx
+++ b/tests/frontend/security-settings-list-input.test.tsx
@@ -1,0 +1,115 @@
+// Regression for the comma-separated list inputs in SecuritySettingsPanel
+// (allowlist senders/domains, trusted authserv-ids).
+//
+// The previous controlled-input pattern re-emitted `parsed.join(", ")` as the
+// input value, which collapsed partial entries before the user reached the
+// next comma — typing `dmg, rtf, ace` ended up as a single `["dmgrtface"]`
+// instead of three entries. The fix holds the raw draft string locally and
+// only resyncs the displayed text when the parent's value diverges from what
+// the input last emitted.
+//
+// These tests TYPE the list one character at a time (userEvent.type) — pasting
+// would mask the bug because the parser sees the full string in one go.
+
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { SecuritySettingsPanel } from "~/components/SecuritySettingsPanel";
+import type { SecuritySettings } from "~/types";
+import { renderWithProviders } from "./test-utils";
+
+function ControlledHost({
+	initial,
+	onLatest,
+}: {
+	initial?: SecuritySettings;
+	onLatest: (next: SecuritySettings) => void;
+}) {
+	const [security, setSecurity] = useState<SecuritySettings>(
+		initial ?? { enabled: true },
+	);
+	return (
+		<SecuritySettingsPanel
+			value={security}
+			onChange={(next) => {
+				setSecurity(next);
+				onLatest(next);
+			}}
+		/>
+	);
+}
+
+describe("SecuritySettingsPanel · comma-separated list inputs", () => {
+	it("captures three entries when the user types a senders list one char at a time", async () => {
+		const user = userEvent.setup();
+		const onLatest = vi.fn();
+		renderWithProviders(<ControlledHost onLatest={onLatest} />);
+
+		const input = screen.getByLabelText(/allowed senders/i);
+		await user.type(input, "ceo@a.com, cfo@b.com, ops@c.com");
+
+		expect(input).toHaveValue("ceo@a.com, cfo@b.com, ops@c.com");
+		const last = onLatest.mock.calls.at(-1)?.[0] as SecuritySettings;
+		expect(last.allowlist_senders).toEqual([
+			"ceo@a.com",
+			"cfo@b.com",
+			"ops@c.com",
+		]);
+	});
+
+	it("captures three entries when the user types a domains list one char at a time", async () => {
+		const user = userEvent.setup();
+		const onLatest = vi.fn();
+		renderWithProviders(<ControlledHost onLatest={onLatest} />);
+
+		const input = screen.getByLabelText(/allowed domains/i);
+		await user.type(input, "company.com, vendor.com, partner.com");
+
+		expect(input).toHaveValue("company.com, vendor.com, partner.com");
+		const last = onLatest.mock.calls.at(-1)?.[0] as SecuritySettings;
+		expect(last.allowlist_domains).toEqual([
+			"company.com",
+			"vendor.com",
+			"partner.com",
+		]);
+	});
+
+	it("captures three entries in the trusted authserv-ids input (no label)", async () => {
+		const user = userEvent.setup();
+		const onLatest = vi.fn();
+		renderWithProviders(<ControlledHost onLatest={onLatest} />);
+
+		const input = screen.getByPlaceholderText(/mx\.cloudflare\.net/i);
+		await user.type(input, "mx.cloudflare.net, mx.google.com, mx.proton.me");
+
+		const last = onLatest.mock.calls.at(-1)?.[0] as SecuritySettings;
+		expect(last.trusted_authserv_ids).toEqual([
+			"mx.cloudflare.net",
+			"mx.google.com",
+			"mx.proton.me",
+		]);
+	});
+
+	it("resyncs the displayed text when the parent's value changes externally", async () => {
+		const onLatest = vi.fn();
+		const { rerender } = renderWithProviders(
+			<SecuritySettingsPanel
+				value={{ enabled: true, allowlist_senders: ["alice@example.com"] }}
+				onChange={onLatest}
+			/>,
+		);
+
+		const input = screen.getByLabelText(/allowed senders/i);
+		expect(input).toHaveValue("alice@example.com");
+
+		rerender(
+			<SecuritySettingsPanel
+				value={{ enabled: true, allowlist_senders: ["bob@example.com", "carol@example.com"] }}
+				onChange={onLatest}
+			/>,
+		);
+
+		expect(input).toHaveValue("bob@example.com, carol@example.com");
+	});
+});


### PR DESCRIPTION
## Summary

- The comma-separated list inputs in [`SecuritySettingsPanel`](app/components/SecuritySettingsPanel.tsx) (`trusted_authserv_ids`, `allowlist_senders`, `allowlist_domains`) collapsed partial entries while typing. Typing `dmg, rtf, ace` one character at a time yielded a single `["dmgrtface"]` instead of three entries, because each keystroke re-emitted `parsed.join(", ")` as the input value, dropping the trailing comma's empty entry and joining without a separator. The next character then appended to the previous entry.
- Fix: introduce a `ListInput` subcomponent that holds the raw draft string in local state and only resyncs from props when the parent's value diverges from what the input last emitted (e.g. external load, reset). Trailing commas/whitespace now survive between keystrokes.
- New `tests/frontend/security-settings-list-input.test.tsx` regression types each list one character at a time (not paste) and asserts the parsed array.

## Why not blur-only?

Settings.tsx triggers save via a button `onClick` that reads `security` from its closure. A blur-only commit would race: the focused input's `onBlur` queues a `setState`, but the click handler reads the pre-render value, losing the most recent edit. Emitting on every keystroke avoids that race entirely while still preserving the raw draft locally.

## Forward-compatibility

`ListInput` accepts a `parse` prop with `parseList` as the default. PR #83 (which adds a fourth list field, `custom_blocklist_extensions`, with its own `parseExtensionList` parser) can switch to `<ListInput parse={parseExtensionList} ...>` on rebase — same component, same fix.

## Test plan

- [x] `npx vitest run` — 213 tests pass (25 files), including the four new regressions
- [x] `npm run typecheck` — clean
- [ ] Manual smoke: open `/mailbox/.../settings`, enable security, type a multi-entry list one character at a time, confirm it doesn't collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)