### PR TITLE
fix(ui): theme accent text + dark-mode email body

### DIFF
--- a/app/components/AgentPanel.tsx
+++ b/app/components/AgentPanel.tsx
@@ -151,7 +151,7 @@ function MessageBubble({
 			<div
 				className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full ${
 					isUser
-						? "bg-accent text-accent-ink"
+						? "bg-accent text-paper"
 						: "bg-paper-3 text-ink"
 				}`}
 			>
@@ -174,7 +174,7 @@ function MessageBubble({
 								key={key}
 								className={`rounded-lg px-3 py-2 text-[13px] leading-relaxed break-words overflow-wrap-anywhere ${
 									isUser
-										? "bg-accent text-accent-ink rounded-br-sm"
+										? "bg-accent text-paper rounded-br-sm"
 										: "bg-paper-3 text-ink border border-line rounded-bl-sm overflow-hidden"
 								}`}
 							>

--- a/app/components/EmailIframe.tsx
+++ b/app/components/EmailIframe.tsx
@@ -4,12 +4,36 @@
 
 import DOMPurify from "dompurify";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useUIStore } from "~/hooks/useUIStore";
 
 interface EmailIframeProps {
 	body: string;
 	/** When true, iframe auto-sizes to content height instead of filling parent */
 	autoSize?: boolean;
 }
+
+// Email-body design system, intentionally distinct from the app tokens because
+// the PhishSOC oklch tokens are not reachable past the CSP boundary inside the
+// sandboxed iframe. Hex values approximate the corresponding `--paper` /
+// `--ink` tokens for each theme so unstyled email bodies blend with the chrome.
+const EMAIL_PALETTES = {
+	light: {
+		bg: "#ffffff",
+		text: "#1a1a1a",
+		link: "#2563eb",
+		quoteBorder: "#d1d5db",
+		quoteText: "#6b7280",
+		preBg: "#f3f4f6",
+	},
+	dark: {
+		bg: "#1a1816",
+		text: "#ebe9e3",
+		link: "#60a5fa",
+		quoteBorder: "#3a352d",
+		quoteText: "#968f80",
+		preBg: "#29241e",
+	},
+} as const;
 
 /**
  * Renders email HTML inside a sandboxed iframe.
@@ -30,6 +54,7 @@ interface EmailIframeProps {
 export default function EmailIframe({ body, autoSize }: EmailIframeProps) {
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const [height, setHeight] = useState(autoSize ? 100 : 0);
+	const theme = useUIStore((s) => s.theme);
 
 	// Listen for height reports from the sandboxed iframe
 	const handleMessage = useCallback(
@@ -86,11 +111,7 @@ export default function EmailIframe({ body, autoSize }: EmailIframeProps) {
 
 		// Use srcdoc so the iframe is truly sandboxed (no same-origin access).
 		// We can't use doc.write() because that requires allow-same-origin.
-		//
-		// The hex colors below render the email body, which is a separate
-		// document from the SOC chrome — the PhishSOC oklch tokens are not
-		// reachable past the CSP boundary. Treat these as the email-body
-		// design system, intentionally distinct from the app tokens.
+		const palette = EMAIL_PALETTES[theme === "dark" ? "dark" : "light"];
 		iframe.srcdoc = `<!DOCTYPE html>
 <html>
 <head>
@@ -100,15 +121,15 @@ export default function EmailIframe({ body, autoSize }: EmailIframeProps) {
 <style>
 * { box-sizing: border-box; }
 html {
-	background: #ffffff;
-	color-scheme: light;
+	background: ${palette.bg};
+	color-scheme: ${theme === "dark" ? "dark" : "light"};
 }
 body {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 	font-size: 14px;
 	line-height: 1.6;
-	color: #1a1a1a;
-	background: #ffffff;
+	color: ${palette.text};
+	background: ${palette.bg};
 	padding: ${padding};
 	margin: 0;
 	word-wrap: break-word;
@@ -118,16 +139,16 @@ body {
 [style*="position: fixed"], [style*="position:fixed"], [style*="position: absolute"], [style*="position:absolute"] {
 	position: relative !important;
 }
-a { color: #2563eb; }
+a { color: ${palette.link}; }
 img { max-width: 100%; height: auto; }
 blockquote {
-	border-left: 3px solid #d1d5db;
+	border-left: 3px solid ${palette.quoteBorder};
 	padding-left: 1em;
 	margin-left: 0;
-	color: #6b7280;
+	color: ${palette.quoteText};
 }
 pre {
-	background: #f3f4f6;
+	background: ${palette.preBg};
 	padding: 12px;
 	border-radius: 6px;
 	overflow-x: auto;
@@ -142,7 +163,7 @@ ul, ol { padding-left: 20px; margin: 4px 0; }
 </head>
 <body>${cleanBody}${heightScript}</body>
 </html>`;
-	}, [body, autoSize]);
+	}, [body, autoSize, theme]);
 
 	return (
 		<iframe

--- a/app/components/email-panel/ThreadMessage.tsx
+++ b/app/components/email-panel/ThreadMessage.tsx
@@ -44,7 +44,7 @@ function Avatar({ isDraft, isSelf, sender }: { isDraft?: boolean; isSelf: boolea
 				isDraft
 					? "bg-paper-3 text-ink-3"
 					: isSelf
-						? "bg-accent text-accent-ink"
+						? "bg-accent text-paper"
 						: "bg-paper-3 text-ink"
 			}`}
 		>

--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -418,14 +418,14 @@ export default function Shell({ children, rightPanel }: ShellProps) {
 							aria-controls="agent-panel"
 							className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[12px] font-medium transition-colors ${
 								isAgentPanelOpen
-									? "bg-accent text-accent-ink border-accent hover:bg-[color-mix(in_oklch,var(--accent)_85%,black)]"
-									: "bg-accent-tint text-accent-ink border-[color-mix(in_oklch,var(--accent)_25%,transparent)] hover:bg-[color-mix(in_oklch,var(--accent-tint)_70%,var(--paper))]"
+									? "bg-accent text-paper border-accent hover:bg-[color-mix(in_oklch,var(--accent)_85%,black)]"
+									: "bg-accent-tint text-accent border-[color-mix(in_oklch,var(--accent)_25%,transparent)] hover:bg-[color-mix(in_oklch,var(--accent-tint)_70%,var(--paper))]"
 							}`}
 						>
 							<SparkleIcon
 								size={13}
 								weight="fill"
-								className={isAgentPanelOpen ? "text-accent-ink" : "text-accent"}
+								className={isAgentPanelOpen ? "text-paper" : "text-accent"}
 							/>
 							Ask co-pilot
 						</button>


### PR DESCRIPTION
## Summary

- Switch `bg-accent text-accent-ink` to `bg-accent text-paper` in user chat bubbles, thread-message avatars, and the active "Ask co-pilot" button — matching the established pattern in `case-detail.tsx`.
- Inactive "Ask co-pilot" button: `text-accent-ink` → `text-accent` on `bg-accent-tint` for similar readability reasons.
- `EmailIframe` now picks a `dark` palette alongside the existing `light` one based on `useUIStore` theme, so the email body no longer renders pure white inside dark-mode chrome.

## Why

Two theming inconsistencies surfaced in dark mode:

1. **Sidebar contrast** — `--accent-ink` is tuned for `bg-accent-tint` (dark muted bg + light text). When reused on solid `bg-accent`, the text-bg lightness gap shrinks to ~14%, so user message bubbles and the active topbar pill rendered cream-on-coral. `text-paper` always inverts vs the page background and gives ~55% lightness diff against `bg-accent` in both themes, which is the convention `case-detail.tsx:222` already uses.
2. **White email body in dark mode** — `EmailIframe` hardcoded `#ffffff` / `#1a1a1a` because CSP blocks the parent's oklch tokens from reaching the sandbox. Kept that "separate design system" model but introduced a paired dark palette (paper-equivalent `#1a1816`, ink-equivalent `#ebe9e3`, lighter `#60a5fa` link, theme-matched quote/pre tones). Marketing emails with explicit inline `bg="#fff"` will still render white — that's the right behavior for preserving sender intent.

## Test plan

- [x] `npm run typecheck` passes locally
- [x] `npm test` passes locally — 236/236
- [ ] Manually exercised: open the agent sidebar in dark mode and verify user bubbles + "Ask co-pilot" active state read clearly; open an email in dark mode and verify the body adopts dark chrome; toggle theme while an email is open and verify the iframe re-renders.

## Notes for reviewer

- The iframe re-renders srcdoc when `theme` changes, which reloads it. Acceptable for a rare user action.
- The remaining `bg-accent-tint text-accent-ink` usages (two avatars in `Shell.tsx`) were left alone — they pair tint-with-ink as designed and have ~58% lightness contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)