### PR TITLE
fix(dev): make remote bindings opt-in so npm run dev works without Access creds (#89)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 !.env.example
 .dev.vars
 !.dev.vars.example
+.envrc
 .vite/
 dist/
 snapshot-*.txt

--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ npm install
 npm run dev
 ```
 
+By default the dev server runs with all bindings local-only — no Cloudflare Access service token is required. The Worker's `send_email` binding becomes a local no-op, which is fine for UI work and most backend iteration.
+
+### Optional: enable remote bindings locally
+
+If you have Cloudflare Access service-token credentials for the deployed Worker and want `send_email` (or future remote bindings) to route to it, install [direnv](https://direnv.net/) and create a gitignored `.envrc` at the repo root:
+
+```bash
+# .envrc — DO NOT COMMIT (already in .gitignore)
+export CLOUDFLARE_ACCESS_CLIENT_ID=<your token>.access
+export CLOUDFLARE_ACCESS_CLIENT_SECRET=<your secret>
+```
+
+Then `direnv allow .`. Vite will detect the creds at startup and enable the remote-binding proxy. Without these vars set, `vite.config.ts` passes `remoteBindings: false` so the dev server boots cleanly.
+
 ### Configuration
 
 1. Set your domain(s) in `wrangler.jsonc` — `DOMAINS` is comma-separated, e.g. `"a.example,b.example"`

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,9 +9,22 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import path from "node:path";
 
+// `wrangler.jsonc` marks the `send_email` binding as `remote: true`, which
+// makes the Cloudflare vite plugin authenticate against the deployed Worker
+// at startup. That Worker sits behind Cloudflare Access, so without service-
+// token creds the dev server fails to boot. Only enable remote bindings when
+// the contributor has opted in via direnv / their shell (see README).
+const hasAccessCreds = Boolean(
+  process.env.CLOUDFLARE_ACCESS_CLIENT_ID &&
+    process.env.CLOUDFLARE_ACCESS_CLIENT_SECRET,
+);
+
 export default defineConfig({
   plugins: [
-    cloudflare({ viteEnvironment: { name: "ssr" } }),
+    cloudflare({
+      viteEnvironment: { name: "ssr" },
+      remoteBindings: hasAccessCreds,
+    }),
     tailwindcss(),
     reactRouter(),
     tsconfigPaths(),


### PR DESCRIPTION
## Summary

- `wrangler.jsonc` marks `send_email` as `remote: true`, which made `@cloudflare/vite-plugin` authenticate against the Access-protected deployed Worker at startup. Without service-token creds the dev server fails closed — blocking fork contributors before a single page renders.
- `vite.config.ts` now derives `remoteBindings` from `CLOUDFLARE_ACCESS_CLIENT_ID` + `CLOUDFLARE_ACCESS_CLIENT_SECRET`. Unset → local-only bindings, dev server boots. Set → unchanged remote-binding behavior.
- README documents the recommended direnv + `.envrc` pattern for contributors who do have creds; `.envrc` is now gitignored so it can't be staged accidentally.
- Production deploys are unaffected: `wrangler.jsonc` still has `remote: true` (correct for `wrangler deploy`); only the vite dev server applies the env-gated override.

## Test plan

- [x] `env -u CLOUDFLARE_ACCESS_CLIENT_ID -u CLOUDFLARE_ACCESS_CLIENT_SECRET npm run dev` → dev server reaches `Local: http://localhost:5173/` (verified locally on this branch — previously failed with `UserError: ... no Access Service Token credentials were found`)
- [x] `npm run typecheck` introduces no new errors (the existing failures in `tests/frontend/*` and `workers/lib/ai.ts` are pre-existing on `main` and unrelated to this change)
- [ ] Smoke-test on a fresh checkout to confirm a brand-new contributor can `npm install && npm run dev` without any env setup

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)