### PR TITLE
security: pin path-to-regexp to ^8.4.0 via npm overrides (#52)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,6 @@
 			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
 			"integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"json-schema": "^0.4.0"
 			},
@@ -230,7 +229,6 @@
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -754,15 +752,13 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
 			"integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@cloudflare/ai-chat": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/@cloudflare/ai-chat/-/ai-chat-0.1.8.tgz",
 			"integrity": "sha512-ukEKQGCnoqhE9OYiOW1MCWhYxomPQG6BCdFJ/JusyvbNZP4cYDNgfpo4vXd0dXtTnp24E1thDuCGaaWhRFM4xg==",
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@ai-sdk/react": "^3.0.0",
 				"agents": "^0.7.3",
@@ -935,8 +931,7 @@
 			"version": "4.20260426.1",
 			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260426.1.tgz",
 			"integrity": "sha512-cBYeQaWwv/jFV8ualmwp6wIxmAf0rDe2DPPQwPbslKmPHqgv861YpAvm45r05K40QboZgxNQVIPgNkmtHqZeJQ==",
-			"license": "MIT OR Apache-2.0",
-			"peer": true
+			"license": "MIT OR Apache-2.0"
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -1050,7 +1045,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			},
@@ -1099,7 +1093,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			}
@@ -1603,7 +1596,6 @@
 			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
 			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@floating-ui/core": "^1.7.5",
 				"@floating-ui/utils": "^0.2.11"
@@ -2238,7 +2230,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -2248,7 +2239,6 @@
 			"resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
 			"integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -3332,7 +3322,6 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.2.tgz",
 			"integrity": "sha512-zKW4LqZt+aNdvz9o4R0/j+D+gfhwzuFItwh7wbqz8g8bWi0jaV95VybeVFVKeg/KGTc3sAa4mm+hGgvgrY+Gvg==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -3594,7 +3583,6 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.20.2.tgz",
 			"integrity": "sha512-x9h1fDeaLah60WJTb6517nRbAKcbdBsTpmglqxQ9c827PUOUyiVEAu2o2cFEuOMw6Htvty4obOKBUgYi8EAgDA==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -3700,7 +3688,6 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.20.2.tgz",
 			"integrity": "sha512-jvVRtFdEJNjKgIL8wtMg3W4BJMlKyH9aF2jYNU2rf3jA9GJM0rtqtth3jjFnApZoyINtx6jr4o4Ot6+/5d0XYA==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -3727,7 +3714,6 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.20.2.tgz",
 			"integrity": "sha512-gzntns6z/kTgwrX89ydc3rNqDsv8D8sAkyl8HE9X+2D9wtdCgNljevIR6MBNcxG7bVm2+XnId1P9YciCZLuefg==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -3742,7 +3728,6 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.2.tgz",
 			"integrity": "sha512-tEMZlLy/6ms41PQtyjmniZ3tTd8elavd8htjYzHLPSHtz11zaYV9YjnmnwHK8gynhcSES1orO9z1U4nT4ZLpqg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"prosemirror-changeset": "^2.3.0",
 				"prosemirror-collab": "^1.3.1",
@@ -3836,7 +3821,8 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/chai": {
 			"version": "5.2.3",
@@ -3954,7 +3940,6 @@
 			"integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -3964,7 +3949,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
 			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -3974,7 +3958,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
@@ -4183,7 +4166,6 @@
 			"resolved": "https://registry.npmjs.org/agents/-/agents-0.7.6.tgz",
 			"integrity": "sha512-wR5L+3t+kIN1aog7AqAs5RBKfW4GhYtdSEE2thNvWefaZXrEZXDzN8NVaO2CMVEwNWAG+edqEfxzMOViMOlUJQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@cfworker/json-schema": "^4.1.1",
 				"@modelcontextprotocol/sdk": "1.26.0",
@@ -4263,7 +4245,6 @@
 			"resolved": "https://registry.npmjs.org/ai/-/ai-6.0.116.tgz",
 			"integrity": "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@ai-sdk/gateway": "3.0.66",
 				"@ai-sdk/provider": "3.0.8",
@@ -4464,7 +4445,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -4927,7 +4907,8 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/dompurify": {
 			"version": "3.4.0",
@@ -5775,7 +5756,6 @@
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
 			"integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -6484,6 +6464,7 @@
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -7900,6 +7881,7 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -7915,6 +7897,7 @@
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -7925,6 +7908,7 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -8054,7 +8038,6 @@
 			"resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
 			"integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"orderedmap": "^2.0.0"
 			}
@@ -8084,7 +8067,6 @@
 			"resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
 			"integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"prosemirror-model": "^1.0.0",
 				"prosemirror-transform": "^1.0.0",
@@ -8133,7 +8115,6 @@
 			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.6.tgz",
 			"integrity": "sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"prosemirror-model": "^1.20.0",
 				"prosemirror-state": "^1.0.0",
@@ -8216,7 +8197,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
 			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8248,7 +8228,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
 			"integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -8261,7 +8240,8 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/react-markdown": {
 			"version": "10.1.0",
@@ -8305,7 +8285,6 @@
 			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
 			"integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cookie": "^1.0.1",
 				"set-cookie-parser": "^2.6.0"
@@ -8524,9 +8503,9 @@
 			}
 		},
 		"node_modules/router/node_modules/path-to-regexp": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-			"integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -8955,6 +8934,7 @@
 			"resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
 			"integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"dequal": "^2.0.3",
 				"use-sync-external-store": "^1.6.0"
@@ -9012,6 +8992,7 @@
 			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
 			"integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -9162,7 +9143,8 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
 			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-			"license": "0BSD"
+			"license": "0BSD",
+			"peer": true
 		},
 		"node_modules/type-is": {
 			"version": "2.0.1",
@@ -9209,7 +9191,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -9247,7 +9228,6 @@
 			"integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"pathe": "^2.0.3"
 			}
@@ -9453,7 +9433,6 @@
 			"integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",
@@ -9770,7 +9749,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"workerd": "bin/workerd"
 			},
@@ -10448,7 +10426,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
 			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -10467,6 +10444,7 @@
 			"resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
 			"integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"tslib": "2.3.0"
 			}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"@cloudflare/kumo": {
 			"zod": "$zod"
 		},
+		"path-to-regexp@>=8.0.0 <8.4.0": "^8.4.0",
 		"@tiptap/core": "3.20.2",
 		"@tiptap/pm": "3.20.2",
 		"@tiptap/extensions": "3.20.2",


### PR DESCRIPTION
## Summary
- Add npm override `"path-to-regexp@>=8.0.0 <8.4.0": "^8.4.0"` to root `package.json` to close two open Dependabot advisories (GHSA-j3q9-mxjg-w52f High, GHSA-27v5-c462-wpq7 Medium).
- After reinstall, the transitive `path-to-regexp@8.3.0` (pulled in by `agents → @modelcontextprotocol/sdk → express → router`) bumps to `8.4.2`.
- The override is range-scoped, so `wrangler`'s unrelated `path-to-regexp@6.3.0` is untouched.

## Verification
- `npm ls path-to-regexp` before: `path-to-regexp@8.3.0` (vulnerable). After: `path-to-regexp@8.4.2` (patched).
- `npm audit` before: 1 high severity vulnerability. After: `found 0 vulnerabilities`.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 256 passing, 0 failing (29 test files)
- [x] `npm ls path-to-regexp` — confirms only patched 8.4.2 + unaffected 6.3.0 present
- [x] `npm audit` — no vulnerabilities

Closes #52
