### PR TITLE
docs: clarify upstream setup walkthrough link in README (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Read the blog post to learn more about Cloudflare Email Service and how to use i
 
 ## How to setup
 
-**Important**: Clicking the 'Deploy to Cloudflare' button is only one part of the setup. You must follow the **After deploying** steps as well. For a full step-by-step guide with screenshots, refer to this comment: 
+**Important**: Clicking the 'Deploy to Cloudflare' button is only one part of the setup. You must follow the **After deploying** steps as well. For a full step-by-step guide with screenshots, refer to the upstream setup walkthrough — its deploy/Email-Routing/Access steps still apply to PhishSOC: 
 https://github.com/cloudflare/agentic-inbox/issues/4#issuecomment-4269118513
 
 ### To set up


### PR DESCRIPTION
## Summary
- Reword the README line-18 link description to flag the linked comment thread as the **upstream** setup walkthrough, while making clear its deploy / Email-Routing / Access steps still apply to PhishSOC.
- The URL itself is unchanged — the upstream comment is still the most detailed walkthrough we have.
- Line-64 (`wrangler r2 bucket create agentic-inbox`) is intentionally **not** touched in this PR; it's gated on the worker + R2 bucket rename in #62 and changing it in isolation would misalign with the actual deployed state.

## Test plan
- [x] No code change — README only. `npm run typecheck` / `npm test` not affected.
- [x] Visual review of the rendered README diff.

Closes #63
