### PR TITLE
refactor: memoize useFeedback's returned object (#66)

### DIFF
--- a/app/lib/feedback.ts
+++ b/app/lib/feedback.ts
@@ -1,17 +1,25 @@
 // Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
 
+import { useMemo } from "react";
 import { useKumoToastManager } from "@cloudflare/kumo";
 
 /**
  * Thin wrapper over kumo's toast manager so call sites don't need to
  * remember the {variant: "error"} shape. The hook is the only API — use
  * the returned object's methods inside event handlers / effects.
+ *
+ * The returned object is memoized so it can safely appear in
+ * `useEffect` / `useCallback` dependency arrays without re-firing on
+ * every render.
  */
 export function useFeedback() {
   const toasts = useKumoToastManager();
-  return {
-    error: (title: string) => toasts.add({ title, variant: "error" }),
-    success: (title: string) => toasts.add({ title }),
-    info: (title: string) => toasts.add({ title }),
-  };
+  return useMemo(
+    () => ({
+      error: (title: string) => toasts.add({ title, variant: "error" }),
+      success: (title: string) => toasts.add({ title }),
+      info: (title: string) => toasts.add({ title }),
+    }),
+    [toasts.add],
+  );
 }

--- a/app/routes/search-results.tsx
+++ b/app/routes/search-results.tsx
@@ -68,10 +68,7 @@ export default function SearchResultsRoute() {
 	const feedback = useFeedback();
 	useEffect(() => {
 		if (isError) feedback.error("Search failed. Try again.");
-		// feedback identity changes every render (returns a fresh object), so we
-		// gate the effect on isError alone to avoid spamming toasts.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isError]);
+	}, [isError, feedback]);
 
 	const handleRowClick = (email: Email) => {
 		selectEmail(email.id);

--- a/tests/frontend/feedback.test.tsx
+++ b/tests/frontend/feedback.test.tsx
@@ -30,4 +30,16 @@ describe("useFeedback", () => {
 		expect(add).toHaveBeenNthCalledWith(1, { title: "yay" });
 		expect(add).toHaveBeenNthCalledWith(2, { title: "fyi" });
 	});
+
+	// Identity stability — the returned object must not change across
+	// renders, so consumers can safely include `feedback` in
+	// `useEffect` / `useCallback` dependency arrays without re-firing
+	// on every render. See issue #66.
+	it("returns a reference-stable object across renders", () => {
+		const { result, rerender } = renderHook(() => useFeedback());
+		const first = result.current;
+		rerender();
+		rerender();
+		expect(result.current).toBe(first);
+	});
 });


### PR DESCRIPTION
## Summary
- Wrap `useFeedback`'s returned object in `useMemo` keyed on `toasts.add` so the object is reference-stable across renders. Consumers can now safely include `feedback` in `useEffect` / `useCallback` dependency arrays without re-firing on every render.
- Remove the documented `eslint-disable-next-line react-hooks/exhaustive-deps` in `app/routes/search-results.tsx` and re-add `feedback` to the `useEffect` dep array — the exception is no longer needed.
- Add an identity-stability test that pins the contract (two re-renders return reference-equal objects).

## Why `[toasts.add]` and not `[toasts]`?
`toasts.add` is the stable identity in both shapes the kumo manager could plausibly take (singleton manager OR per-render wrapper around a stable `add`). Keying on `add` directly survives both, and matches the proposal in the issue.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 257 passing, 0 failing (29 test files; +1 vs main is the new stability test)
- [x] Acceptance: `grep eslint-disable-next-line react-hooks/exhaustive-deps app/` returns 0 hits in the search-results error effect (and 0 hits anywhere in `app/`).

Closes #66
