### PR TITLE
chore(hub): migrate off @cloudflare/workers-types to wrangler-generated runtime types (#53)

### DIFF
--- a/hub/package-lock.json
+++ b/hub/package-lock.json
@@ -12,7 +12,6 @@
 				"zod": "^3.23.0"
 			},
 			"devDependencies": {
-				"@cloudflare/workers-types": "^4.20250101.0",
 				"@types/better-sqlite3": "^7.6.13",
 				"better-sqlite3": "^12.9.0",
 				"typescript": "^5.5.0",
@@ -130,13 +129,6 @@
 			"engines": {
 				"node": ">=16"
 			}
-		},
-		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20260426.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260426.1.tgz",
-			"integrity": "sha512-cBYeQaWwv/jFV8ualmwp6wIxmAf0rDe2DPPQwPbslKmPHqgv861YpAvm45r05K40QboZgxNQVIPgNkmtHqZeJQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0"
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",

--- a/hub/package.json
+++ b/hub/package.json
@@ -17,7 +17,6 @@
 		"zod": "^3.23.0"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20250101.0",
 		"@types/better-sqlite3": "^7.6.13",
 		"better-sqlite3": "^12.9.0",
 		"typescript": "^5.5.0",

--- a/hub/src/lib/aggregate.ts
+++ b/hub/src/lib/aggregate.ts
@@ -14,8 +14,6 @@
  *   - contributor_count ≥ PROMOTION_CONTRIBUTORS
  */
 
-import type { D1Database } from "@cloudflare/workers-types";
-
 export const PROMOTION_SCORE = 2.0;
 export const PROMOTION_CONTRIBUTORS = 2;
 

--- a/hub/tests/helpers/d1.ts
+++ b/hub/tests/helpers/d1.ts
@@ -14,7 +14,6 @@
 import Database from "better-sqlite3";
 import { readFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
-import type { D1Database } from "@cloudflare/workers-types";
 
 interface PreparedLike {
 	bind(...args: unknown[]): PreparedLike;

--- a/hub/tsconfig.json
+++ b/hub/tsconfig.json
@@ -4,7 +4,6 @@
 		"module": "esnext",
 		"moduleResolution": "bundler",
 		"lib": ["es2022"],
-		"types": ["@cloudflare/workers-types"],
 		"strict": true,
 		"noEmit": true,
 		"skipLibCheck": true,
@@ -13,5 +12,5 @@
 		"resolveJsonModule": true,
 		"jsx": "react-jsx"
 	},
-	"include": ["src/**/*.ts"]
+	"include": ["src/**/*.ts", "worker-configuration.d.ts"]
 }


### PR DESCRIPTION
## Summary
- Drop `@cloudflare/workers-types` from `hub/package.json` devDependencies (and refresh the hub lockfile).
- Drop `"types": ["@cloudflare/workers-types"]` from `hub/tsconfig.json`.
- Add `worker-configuration.d.ts` to `hub/tsconfig.json`'s `include` list so wrangler's generated ambient declarations are picked up the same way the root package consumes them.

## Result
- `wrangler types` continues to regenerate `hub/worker-configuration.d.ts` on every typecheck, but the **"Action required: Migrate from `@cloudflare/workers-types`"** banner that used to print on every CI run is gone.
- Aligns hub with root, which already follows the new pattern.

## Test plan
- [x] `cd hub && npm install` — clean
- [x] `cd hub && npm run typecheck` — passes, deprecation banner is no longer printed
- [x] `cd hub && npm test` — 44 passing, 0 failing (6 test files)

Closes #53
