### PR TITLE
feat(ui): breadcrumb above main content for org → mailbox context (#102)

### DIFF
--- a/app/components/phishsoc/Breadcrumb.tsx
+++ b/app/components/phishsoc/Breadcrumb.tsx
@@ -1,0 +1,131 @@
+import { Link, useLocation, useParams } from "react-router";
+import { useMailbox } from "~/queries/mailboxes";
+
+interface Segment {
+	label: string;
+	to?: string;
+}
+
+const FOLDER_LABELS: Record<string, string> = {
+	inbox: "Inbox",
+	sent: "Sent",
+	draft: "Drafts",
+	archive: "Archive",
+	trash: "Trash",
+	quarantine: "Quarantine",
+};
+
+// Map a route path + params to a list of breadcrumb segments. Returns
+// null when the breadcrumb should be hidden (org overview / not-found).
+function segmentsFor(
+	pathname: string,
+	mailboxId: string | undefined,
+	mailboxLabel: string,
+): Segment[] | null {
+	if (pathname === "/" || pathname === "") return null;
+
+	const orgRoot: Segment = { label: "Org", to: "/" };
+
+	if (pathname.startsWith("/mailboxes")) {
+		return [orgRoot, { label: "Mailboxes" }];
+	}
+
+	if (!mailboxId) return null;
+
+	const base = `/mailbox/${encodeURIComponent(mailboxId)}`;
+	const mailboxSegment: Segment = { label: mailboxLabel, to: base };
+
+	const tail = pathname.slice(base.length);
+
+	if (tail === "" || tail === "/") {
+		return [orgRoot, { label: mailboxLabel }];
+	}
+
+	if (tail.startsWith("/dashboard")) {
+		return [orgRoot, mailboxSegment, { label: "Dashboard" }];
+	}
+	if (tail.startsWith("/settings")) {
+		return [orgRoot, mailboxSegment, { label: "Settings" }];
+	}
+	if (tail.startsWith("/search")) {
+		return [orgRoot, mailboxSegment, { label: "Search" }];
+	}
+	if (tail.startsWith("/dmarc")) {
+		return [orgRoot, mailboxSegment, { label: "DMARC" }];
+	}
+	if (tail.startsWith("/hub")) {
+		return [orgRoot, mailboxSegment, { label: "Threat-intel hub" }];
+	}
+	if (tail.startsWith("/cases")) {
+		const casesSegment: Segment = { label: "Cases", to: `${base}/cases` };
+		// /cases/:caseId — derive the trailing case id from the path so
+		// this works regardless of which route matched (e.g. when a
+		// parent route uses a wildcard match).
+		const caseId = tail.split("/")[2];
+		if (caseId) {
+			return [orgRoot, mailboxSegment, casesSegment, { label: caseId }];
+		}
+		return [orgRoot, mailboxSegment, { label: "Cases" }];
+	}
+	if (tail.startsWith("/emails/")) {
+		const folder = tail.split("/")[2] ?? "";
+		const folderLabel = FOLDER_LABELS[folder.toLowerCase()] ?? folder;
+		return [orgRoot, mailboxSegment, { label: folderLabel }];
+	}
+
+	return [orgRoot, mailboxSegment];
+}
+
+export default function Breadcrumb() {
+	const location = useLocation();
+	const { mailboxId } = useParams<{ mailboxId?: string }>();
+	const { data: mailbox } = useMailbox(mailboxId);
+
+	const mailboxLabel = mailbox?.email ?? mailbox?.name ?? mailboxId ?? "Mailbox";
+	const segments = segmentsFor(location.pathname, mailboxId, mailboxLabel);
+
+	if (!segments || segments.length === 0) return null;
+
+	return (
+		<nav
+			aria-label="Breadcrumb"
+			className="flex items-center gap-1.5 px-4 md:px-6 py-2 text-[12px] text-ink-3 border-b border-line bg-paper"
+		>
+			<ol className="flex items-center gap-1.5 min-w-0">
+				{segments.map((segment, idx) => {
+					const isLast = idx === segments.length - 1;
+					return (
+						<li
+							key={`${segment.label}-${idx}`}
+							className="flex items-center gap-1.5 min-w-0"
+						>
+							{idx > 0 && (
+								<span
+									aria-hidden
+									className="pp-mono text-ink-4 select-none"
+								>
+									›
+								</span>
+							)}
+							{segment.to && !isLast ? (
+								<Link
+									to={segment.to}
+									className="truncate hover:text-ink transition-colors"
+								>
+									{segment.label}
+								</Link>
+							) : (
+								<span
+									className={`truncate ${isLast ? "text-ink" : ""}`}
+									aria-current={isLast ? "page" : undefined}
+								>
+									{segment.label}
+								</span>
+							)}
+						</li>
+					);
+				})}
+			</ol>
+		</nav>
+	);
+}

--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -21,6 +21,7 @@ import { useUIStore } from "~/hooks/useUIStore";
 import { useDashboardSummary } from "~/queries/dashboard";
 import { useMailbox, useMailboxes } from "~/queries/mailboxes";
 import AgentPanelSlot from "./AgentPanelSlot";
+import Breadcrumb from "./Breadcrumb";
 import Logo from "./Logo";
 
 type PipelineTone = "safe" | "suspect" | "danger" | "muted";
@@ -452,7 +453,12 @@ export default function Shell({ children, rightPanel }: ShellProps) {
 				    Below xl the slot renders a slide-over that owns its own
 				    positioning and doesn't push the main column. */}
 				<div className="flex-1 flex min-h-0 overflow-hidden">
-					<main className="flex-1 min-w-0 overflow-y-auto">{children}</main>
+					<main className="flex-1 min-w-0 overflow-y-auto flex flex-col">
+						{/* Breadcrumb shows org → mailbox → section context.
+						    Hidden at "/" since the org root is implied. */}
+						<Breadcrumb />
+						<div className="flex-1 min-h-0">{children}</div>
+					</main>
 					{rightPanel && <AgentPanelSlot rightPanel={rightPanel} />}
 				</div>
 			</div>

--- a/tests/frontend/breadcrumb.test.tsx
+++ b/tests/frontend/breadcrumb.test.tsx
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({
+		data: { id: "m1", email: "alice@acme.com", name: "Alice" },
+	}),
+}));
+
+import Breadcrumb from "~/components/phishsoc/Breadcrumb";
+import { renderWithProviders } from "./test-utils";
+
+function renderBreadcrumb(initialEntry: string) {
+	return renderWithProviders(
+		<Routes>
+			<Route path="/" element={<Breadcrumb />} />
+			<Route path="/mailboxes" element={<Breadcrumb />} />
+			<Route path="/mailbox/:mailboxId/*" element={<Breadcrumb />} />
+		</Routes>,
+		{ initialEntries: [initialEntry] },
+	);
+}
+
+describe("Breadcrumb", () => {
+	it("is hidden on the org overview (/)", () => {
+		renderBreadcrumb("/");
+		// No nav landmark for breadcrumb.
+		expect(screen.queryByRole("navigation", { name: /breadcrumb/i })).toBeNull();
+	});
+
+	it("renders Org › Mailboxes on /mailboxes (Org is a link, last item is not)", () => {
+		renderBreadcrumb("/mailboxes");
+		const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
+		const items = within(nav).getAllByRole("listitem");
+		expect(items).toHaveLength(2);
+
+		// First segment is a link to "/".
+		const orgLink = within(nav).getByRole("link", { name: "Org" });
+		expect(orgLink).toHaveAttribute("href", "/");
+
+		// Last segment is plain text with aria-current="page".
+		expect(within(nav).queryByRole("link", { name: "Mailboxes" })).toBeNull();
+		expect(within(nav).getByText("Mailboxes")).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+	});
+
+	it("renders Org › alice@acme.com › Cases › CASE-1 on /mailbox/m1/cases/CASE-1", () => {
+		renderBreadcrumb("/mailbox/m1/cases/CASE-1");
+		const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
+		const items = within(nav).getAllByRole("listitem");
+		expect(items).toHaveLength(4);
+
+		// Org → / link.
+		expect(within(nav).getByRole("link", { name: "Org" })).toHaveAttribute(
+			"href",
+			"/",
+		);
+		// Mailbox link uses email.
+		expect(
+			within(nav).getByRole("link", { name: "alice@acme.com" }),
+		).toHaveAttribute("href", "/mailbox/m1");
+		// Cases link to mailbox-scoped cases route.
+		expect(within(nav).getByRole("link", { name: "Cases" })).toHaveAttribute(
+			"href",
+			"/mailbox/m1/cases",
+		);
+		// Case ID is the trailing, non-link segment.
+		expect(within(nav).queryByRole("link", { name: "CASE-1" })).toBeNull();
+		expect(within(nav).getByText("CASE-1")).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+	});
+
+	it("uses a monospaced separator between segments", () => {
+		const { container } = renderBreadcrumb("/mailbox/m1/dashboard");
+		// Three segments → two separators.
+		const separators = container.querySelectorAll(".pp-mono");
+		expect(separators.length).toBeGreaterThanOrEqual(2);
+		separators.forEach((sep) => {
+			expect(sep.textContent?.trim()).toBe("›");
+		});
+	});
+
+	it("maps known folder slugs to friendly labels", () => {
+		renderBreadcrumb("/mailbox/m1/emails/inbox");
+		expect(screen.getByText("Inbox")).toHaveAttribute("aria-current", "page");
+	});
+});


### PR DESCRIPTION
## Summary
- New `app/components/phishsoc/Breadcrumb.tsx` renders the active **org → mailbox → section** path above the main content (e.g. *"Org › alice@acme.com › Cases › INC-0123"*).
- Mounted in the Shell's main column, above the route children, with a thin bottom border to separate it from page content.
- Hidden on the org overview (`/`) since the root context is implied (per the issue's acceptance checklist).
- Reuses PhishSOC tokens: `text-ink-3` for inactive segments, monospaced `›` separator (`pp-mono`), paper background.

## Acceptance criteria
- [x] Render a breadcrumb at the top of the Shell main column.
- [x] Breadcrumb segments are links where applicable (Org → `/`; mailbox → `/mailbox/:id`; Cases → `/mailbox/:id/cases`).
- [x] Hidden on the org overview itself.
- [x] Reuses PhishSOC tokens (`text-ink-3`, monospaced separator).

## Implementation notes
- Mailbox label prefers `mailbox.email`, then `name`, then `mailboxId` — covers the loading case so the breadcrumb never renders an empty string mid-fetch.
- Folder slugs (`/emails/inbox`) get friendly labels (`Inbox`, `Quarantine`, …).
- Case IDs and folder slugs are parsed from the pathname rather than `useParams()` so the component renders correctly regardless of which route pattern matched (the parent `/mailbox/:mailboxId/*` doesn't bind `caseId`).
- Future extension for #85 (per-domain drilldown) will only need to add one branch to `segmentsFor()`.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 261 passing, 0 failing (30 test files; +5 vs main covers hide-at-root, /mailboxes shape, mailbox/cases/:id deep path, monospaced separator, folder-slug mapping)

Closes #102
