### PR TITLE
feat: 7d verdict mix on org overview (#103)

### DIFF
--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -7,6 +7,7 @@ import {
 	ShieldCheckIcon,
 	WarningIcon,
 } from "@phosphor-icons/react";
+import { useState } from "react";
 import { Link as RouterLink } from "react-router";
 import Shell from "~/components/phishsoc/Shell";
 import { useAutoProvisionMailboxes } from "~/hooks/useAutoProvisionMailboxes";
@@ -102,7 +103,10 @@ function OrgBody({
 		<>
 			<KpiGrid data={data} />
 			<div className="grid gap-4 lg:grid-cols-3">
-				<VerdictMixCard mix={data.verdictMix} />
+				<VerdictMixCard
+					mix24h={data.verdictMix}
+					mix7d={data.verdictMix7d}
+				/>
 				<TopThreatsCard threats={data.topThreats} />
 			</div>
 		</>
@@ -192,7 +196,17 @@ const VERDICT_LABEL: Record<keyof OrgVerdictMix, string> = {
 	bec: "BEC",
 };
 
-function VerdictMixCard({ mix }: { mix: OrgVerdictMix }) {
+type VerdictWindow = "24h" | "7d";
+
+function VerdictMixCard({
+	mix24h,
+	mix7d,
+}: {
+	mix24h: OrgVerdictMix;
+	mix7d: OrgVerdictMix;
+}) {
+	const [window, setWindow] = useState<VerdictWindow>("24h");
+	const mix = window === "24h" ? mix24h : mix7d;
 	const entries = (Object.keys(VERDICT_LABEL) as Array<keyof OrgVerdictMix>).map(
 		(k) => ({ key: k, label: VERDICT_LABEL[k], count: mix[k] }),
 	);
@@ -202,7 +216,29 @@ function VerdictMixCard({ mix }: { mix: OrgVerdictMix }) {
 			<div className="flex items-baseline justify-between gap-3">
 				<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 flex items-center gap-1.5">
 					<ShieldCheckIcon size={12} />
-					Verdict mix · 24h
+					Verdict mix
+				</div>
+				<div
+					role="tablist"
+					aria-label="Verdict-mix window"
+					className="flex items-center gap-1 rounded-md bg-paper-2 p-0.5"
+				>
+					{(["24h", "7d"] as const).map((w) => (
+						<button
+							key={w}
+							type="button"
+							role="tab"
+							aria-selected={window === w}
+							onClick={() => setWindow(w)}
+							className={`px-2 py-0.5 rounded text-[11px] tabular-nums transition-colors ${
+								window === w
+									? "bg-paper text-ink shadow-sm"
+									: "text-ink-3 hover:text-ink"
+							}`}
+						>
+							{w}
+						</button>
+					))}
 				</div>
 				<div className="text-[12px] text-ink-3">{total} classified</div>
 			</div>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -190,6 +190,8 @@ export interface OrgOverview {
 	mailboxesCount: number;
 	domainsCount: number;
 	verdictMix: OrgVerdictMix;
+	/** 7-day verdict mix (#103). Always present, sums per-mailbox tallies. */
+	verdictMix7d: OrgVerdictMix;
 	topThreats: OrgTopThreat[];
 	pipelineHealth: OrgPipelineHealth;
 	hubContributions24h: number;

--- a/tests/frontend/home.test.tsx
+++ b/tests/frontend/home.test.tsx
@@ -62,6 +62,7 @@ const populated: OrgOverview = {
 	domainsCount: 2,
 	hubContributions24h: 4,
 	verdictMix: { safe: 50, suspicious: 6, phishing: 3, spam: 8, bec: 1 },
+	verdictMix7d: { safe: 360, suspicious: 40, phishing: 21, spam: 56, bec: 7 },
 	topThreats: [
 		{ category: "phishing", count: 9 },
 		{ category: "spam", count: 4 },
@@ -78,6 +79,7 @@ const empty: OrgOverview = {
 	domainsCount: 0,
 	hubContributions24h: 0,
 	verdictMix: { safe: 0, suspicious: 0, phishing: 0, spam: 0, bec: 0 },
+	verdictMix7d: { safe: 0, suspicious: 0, phishing: 0, spam: 0, bec: 0 },
 	topThreats: [],
 	pipelineHealth: { successRate24h: null, p95Ms: null, runs24h: 0 },
 };
@@ -134,6 +136,22 @@ describe("HomeRoute (org overview)", () => {
 		renderHome();
 		// Both Pipeline success and Pipeline p95 fall back to "—".
 		expect(screen.getAllByText("—")).toHaveLength(2);
+	});
+
+	it("toggles the verdict-mix card between 24h and 7d windows", async () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderHome();
+
+		// Default view is 24h: total classified count is 50+6+3+8+1 = 68.
+		expect(screen.getByText(/68 classified/)).toBeInTheDocument();
+
+		// Switch to the 7d tab — total becomes 360+40+21+56+7 = 484.
+		await userEvent.click(screen.getByRole("tab", { name: "7d" }));
+		expect(screen.getByText(/484 classified/)).toBeInTheDocument();
+
+		// Switch back to 24h.
+		await userEvent.click(screen.getByRole("tab", { name: "24h" }));
+		expect(screen.getByText(/68 classified/)).toBeInTheDocument();
 	});
 
 	it("formats p95 latency on the org overview KPI grid", () => {

--- a/tests/lib/dashboard-aggregation.test.ts
+++ b/tests/lib/dashboard-aggregation.test.ts
@@ -5,6 +5,7 @@ import {
 	aggregateOrgOverview,
 	bucketThreatPressure,
 	computeP95,
+	computeVerdictMix,
 	pipelineSuccessRate,
 	type OrgMailboxSummary,
 } from "../../workers/lib/dashboard-aggregation";
@@ -129,6 +130,50 @@ function summary(partial: Partial<OrgMailboxSummary> = {}): OrgMailboxSummary {
 	};
 }
 
+describe("computeVerdictMix", () => {
+	it("tallies recognized labels and drops unparseable rows", () => {
+		const mix = computeVerdictMix([
+			verdictRow("allow", "safe"),
+			verdictRow("allow", "safe"),
+			verdictRow("tag", "suspicious"),
+			verdictRow("quarantine", "phishing"),
+			verdictRow("block", "phishing"),
+			verdictRow("tag", "spam"),
+			verdictRow("quarantine", "bec"),
+			{ date: NOW.toISOString(), security_verdict: "not-json" },
+			{ date: NOW.toISOString(), security_verdict: null },
+		]);
+		expect(mix).toEqual({
+			safe: 2,
+			suspicious: 1,
+			phishing: 2,
+			spam: 1,
+			bec: 1,
+		});
+	});
+
+	it("returns all-zeros for an empty input", () => {
+		expect(computeVerdictMix([])).toEqual({
+			safe: 0,
+			suspicious: 0,
+			phishing: 0,
+			spam: 0,
+			bec: 0,
+		});
+	});
+
+	it("ignores labels outside the recognized set", () => {
+		const mix = computeVerdictMix([verdictRow("tag", "marketing")]);
+		expect(mix).toEqual({
+			safe: 0,
+			suspicious: 0,
+			phishing: 0,
+			spam: 0,
+			bec: 0,
+		});
+	});
+});
+
 describe("aggregateOrgOverview", () => {
 	it("returns zeroed counters and empty verdict mix for an empty org", () => {
 		const result = aggregateOrgOverview({
@@ -145,6 +190,7 @@ describe("aggregateOrgOverview", () => {
 			domainsCount: 0,
 			topThreats: [],
 			verdictMix: { safe: 0, suspicious: 0, phishing: 0, spam: 0, bec: 0 },
+			verdictMix7d: { safe: 0, suspicious: 0, phishing: 0, spam: 0, bec: 0 },
 			pipelineHealth: { successRate24h: null, p95Ms: null, runs24h: 0 },
 		});
 	});
@@ -209,6 +255,34 @@ describe("aggregateOrgOverview", () => {
 			suspicious: 1,
 			phishing: 2,
 			spam: 1,
+			bec: 1,
+		});
+	});
+
+	it("sums pre-aggregated 7d verdict mixes across mailboxes (#103)", () => {
+		const result = aggregateOrgOverview({
+			mailboxes: [
+				{ id: "a@x.com", email: "a@x.com" },
+				{ id: "b@x.com", email: "b@x.com" },
+				{ id: "c@x.com", email: "c@x.com" },
+			],
+			summaries: [
+				summary({
+					verdictMix7d: { safe: 100, suspicious: 5, phishing: 2, spam: 3, bec: 0 },
+				}),
+				summary({
+					verdictMix7d: { safe: 50, suspicious: 1, phishing: 4, spam: 1, bec: 1 },
+				}),
+				// Older DO replica without verdictMix7d — must be tolerated as zero.
+				summary({}),
+			],
+			now: NOW.toISOString(),
+		});
+		expect(result.verdictMix7d).toEqual({
+			safe: 150,
+			suspicious: 6,
+			phishing: 6,
+			spam: 4,
 			bec: 1,
 		});
 	});

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -11,6 +11,7 @@ import { Folders } from "../../shared/folders";
 import type { Env } from "../types";
 import { applyMigrations, mailboxMigrations } from "./migrations";
 import { attachmentObjectKey } from "../lib/attachments";
+import { computeVerdictMix } from "../lib/dashboard-aggregation";
 
 /**
  * SQL expression to normalize email subjects by stripping common
@@ -1512,6 +1513,19 @@ export class MailboxDO extends DurableObject<Env> {
 			.where(sql`${schema.emails.date} >= ${dayAgoIso}`)
 			.all();
 
+		// 7-day verdict mix (#103). Aggregated server-side here so the
+		// org-overview wire payload doesn't have to ship the raw 7d rows
+		// — only the five-key counts cross the boundary.
+		const verdictRows7d = this.db
+			.select({
+				date: schema.emails.date,
+				security_verdict: schema.emails.security_verdict,
+			})
+			.from(schema.emails)
+			.where(sql`${schema.emails.date} >= ${weekAgoIso}`)
+			.all();
+		const verdictMix7d = computeVerdictMix(verdictRows7d);
+
 		const recentCases = this.db
 			.select({
 				id: schema.cases.id,
@@ -1535,6 +1549,7 @@ export class MailboxDO extends DurableObject<Env> {
 			pipelineScan: { completed, failed },
 			pipelineDurationsMs,
 			verdictRows,
+			verdictMix7d,
 			recentCases,
 		};
 	}

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -149,6 +149,8 @@ app.get("/api/v1/org/overview", async (c) => {
 		}
 		const v = r.value as OrgMailboxSummary;
 		// `threatsBlocked7d` was added by this PR; tolerate older clients.
+		// `verdictMix7d` (#103) is also optional — older DO replicas omit it
+		// and the aggregator treats them as zeros.
 		return { ...v, threatsBlocked7d: v.threatsBlocked7d ?? 0 };
 	});
 

--- a/workers/lib/dashboard-aggregation.ts
+++ b/workers/lib/dashboard-aggregation.ts
@@ -128,6 +128,13 @@ export interface OrgMailboxSummary {
 	pipelineScan: PipelineSuccessInput;
 	verdictRows: VerdictBucketRow[];
 	/**
+	 * Pre-aggregated 7d verdict mix from the DO (#103). Pre-aggregating
+	 * server-side keeps the org-overview wire payload from doubling — only
+	 * the five-key counts cross the boundary, not the raw 7d rows. Optional
+	 * so older DO replicas mid-deploy degrade gracefully (counted as zero).
+	 */
+	verdictMix7d?: VerdictMix;
+	/**
 	 * Per-pipeline-run durations from `pipeline_runs` (#71). Unioned across
 	 * mailboxes to compute an org-wide p95. Optional so older DO replicas
 	 * mid-deploy degrade gracefully (treated as no samples).
@@ -168,6 +175,12 @@ export interface OrgOverview {
 	mailboxesCount: number;
 	domainsCount: number;
 	verdictMix: VerdictMix;
+	/**
+	 * 7-day verdict mix (#103). Sums each mailbox's pre-aggregated 7d mix.
+	 * Mailboxes with no `verdictMix7d` (older DO replicas mid-deploy)
+	 * contribute zero, so the field is always present.
+	 */
+	verdictMix7d: VerdictMix;
 	topThreats: OrgTopThreat[];
 	pipelineHealth: OrgPipelineHealth;
 	hubContributions24h: number;
@@ -184,6 +197,29 @@ const VERDICT_MIX_KEYS: ReadonlyArray<keyof VerdictMix> = [
 
 function emptyVerdictMix(): VerdictMix {
 	return { safe: 0, suspicious: 0, phishing: 0, spam: 0, bec: 0 };
+}
+
+/**
+ * Pure helper: tally verdict-mix labels from a list of `(date,
+ * security_verdict)` rows. Used by the DO to pre-aggregate the 7-day
+ * window server-side so the org-overview payload doesn't have to ship
+ * raw 7d rows over the wire.
+ */
+export function computeVerdictMix(rows: VerdictBucketRow[]): VerdictMix {
+	const mix = emptyVerdictMix();
+	for (const row of rows) {
+		if (!row.security_verdict) continue;
+		const parsed = parseVerdict(row.security_verdict);
+		if (!parsed) continue;
+		const label = parsed.classification?.label;
+		if (
+			typeof label === "string" &&
+			(VERDICT_MIX_KEYS as readonly string[]).includes(label)
+		) {
+			mix[label as keyof VerdictMix] += 1;
+		}
+	}
+	return mix;
 }
 
 interface AggregateOrgOverviewInput {
@@ -221,6 +257,7 @@ export function aggregateOrgOverview(
 	const allDurationsMs: number[] = [];
 
 	const verdictMix = emptyVerdictMix();
+	const verdictMix7d = emptyVerdictMix();
 	const threatCounts = new Map<string, number>();
 
 	for (const summary of summaries) {
@@ -233,6 +270,14 @@ export function aggregateOrgOverview(
 		pipelineFailed += summary.pipelineScan.failed;
 		if (summary.pipelineDurationsMs?.length) {
 			allDurationsMs.push(...summary.pipelineDurationsMs);
+		}
+
+		// Pre-aggregated 7d mix per mailbox — sum into the org-wide tally.
+		// Optional on the wire so older DO replicas degrade as zeros.
+		if (summary.verdictMix7d) {
+			for (const k of VERDICT_MIX_KEYS) {
+				verdictMix7d[k] += summary.verdictMix7d[k];
+			}
 		}
 
 		for (const row of summary.verdictRows) {
@@ -286,6 +331,7 @@ export function aggregateOrgOverview(
 		mailboxesCount: mailboxes.length,
 		domainsCount: domains.size,
 		verdictMix,
+		verdictMix7d,
 		topThreats,
 		pipelineHealth,
 		hubContributions24h,


### PR DESCRIPTION
## Summary
- Add a 7-day verdict-mix surface to the org overview (`/`) alongside the existing 24h view, switchable via a tab toggle inside the existing `VerdictMixCard`.
- DO `getDashboardSummary` now also pulls the 7d verdict rows and pre-aggregates them server-side via a new pure helper `computeVerdictMix`. Only the five-key counts cross the boundary, not the raw 7d rows — keeps the org-overview wire payload from doubling.
- Aggregator (`aggregateOrgOverview`) sums per-mailbox `verdictMix7d` into an org-wide tally. Older DO replicas mid-deploy that omit the field contribute zero — same tolerant-degradation pattern used for `threatsBlocked7d`.

## Acceptance criteria
- [x] DO `getDashboardSummary` exposes a 7d verdict-row source without bloating the 24h payload (pre-aggregated server-side; only five integers cross the wire per mailbox).
- [x] Org overview surfaces both windows via a tab toggle.
- [x] `OrgVerdictMix` shape unchanged; `OrgOverview` grows a parallel `verdictMix7d`.
- [x] Aggregator tests cover the 7d window (and the older-replica fallback).

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 261 passing, 0 failing (29 test files; +5 vs main: 3 `computeVerdictMix` cases + 1 aggregator `verdictMix7d` case + 1 home tab-toggle case)

Closes #103
