### PR TITLE
feat: org overview top-threats samples (#101)

### DIFF
--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -292,19 +292,58 @@ function TopThreatsCard({
 			{threats.length === 0 ? (
 				<p className="text-[12.5px] text-ink-3">No threats actioned yet.</p>
 			) : (
-				<ul className="space-y-2">
+				<ul className="space-y-1.5">
 					{threats.map((t) => (
-						<li key={t.category} className="flex items-baseline justify-between gap-3">
-							<span className="text-[13px] text-ink capitalize">
-								{t.category}
-							</span>
-							<span className="pp-mono text-[12px] text-ink-3 tabular-nums">
-								{t.count}
-							</span>
-						</li>
+						<TopThreatRow key={t.category} threat={t} />
 					))}
 				</ul>
 			)}
 		</div>
+	);
+}
+
+function TopThreatRow({
+	threat,
+}: { threat: OrgOverview["topThreats"][number] }) {
+	const samples = threat.samples ?? [];
+	if (samples.length === 0) {
+		return (
+			<li className="flex items-baseline justify-between gap-3 py-1">
+				<span className="text-[13px] text-ink capitalize">{threat.category}</span>
+				<span className="pp-mono text-[12px] text-ink-3 tabular-nums">
+					{threat.count}
+				</span>
+			</li>
+		);
+	}
+	return (
+		<li>
+			<details className="group">
+				<summary className="flex items-baseline justify-between gap-3 py-1 cursor-pointer list-none [&::-webkit-details-marker]:hidden hover:text-ink">
+					<span className="text-[13px] text-ink capitalize flex items-center gap-1.5">
+						<span
+							aria-hidden
+							className="pp-mono text-[10px] text-ink-3 transition-transform group-open:rotate-90"
+						>
+							›
+						</span>
+						{threat.category}
+					</span>
+					<span className="pp-mono text-[12px] text-ink-3 tabular-nums">
+						{threat.count}
+					</span>
+				</summary>
+				<ul className="mt-1 mb-1.5 ml-3 space-y-1 border-l border-line pl-3">
+					{samples.map((s) => (
+						<li key={s.emailId} className="text-[12px] leading-tight">
+							<div className="text-ink truncate">{s.subject || "(no subject)"}</div>
+							<div className="text-ink-3 truncate">
+								{s.sender || "(unknown sender)"}
+							</div>
+						</li>
+					))}
+				</ul>
+			</details>
+		</li>
 	);
 }

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -170,9 +170,21 @@ export interface OrgVerdictMix {
 	bec: number;
 }
 
+export interface OrgTopThreatSample {
+	emailId: string;
+	subject: string;
+	sender: string;
+}
+
 export interface OrgTopThreat {
 	category: string;
 	count: number;
+	/**
+	 * Up to N representative emails per category, deduped across mailboxes
+	 * (#101). Optional so older deploys without samples render the count-only
+	 * card unchanged.
+	 */
+	samples?: OrgTopThreatSample[];
 }
 
 export interface OrgPipelineHealth {

--- a/tests/frontend/home.test.tsx
+++ b/tests/frontend/home.test.tsx
@@ -64,7 +64,14 @@ const populated: OrgOverview = {
 	verdictMix: { safe: 50, suspicious: 6, phishing: 3, spam: 8, bec: 1 },
 	verdictMix7d: { safe: 360, suspicious: 40, phishing: 21, spam: 56, bec: 7 },
 	topThreats: [
-		{ category: "phishing", count: 9 },
+		{
+			category: "phishing",
+			count: 9,
+			samples: [
+				{ emailId: "e1", subject: "Reset your password", sender: "fake@bank.example" },
+				{ emailId: "e2", subject: "Invoice attached", sender: "billing@evil.example" },
+			],
+		},
 		{ category: "spam", count: 4 },
 	],
 	pipelineHealth: { successRate24h: 0.92, p95Ms: null, runs24h: 200 },
@@ -152,6 +159,37 @@ describe("HomeRoute (org overview)", () => {
 		// Switch back to 24h.
 		await userEvent.click(screen.getByRole("tab", { name: "24h" }));
 		expect(screen.getByText(/68 classified/)).toBeInTheDocument();
+	});
+
+	it("expands a top-threats row to reveal sample emails (#101)", async () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderHome();
+
+		// Samples are inside <details>, hidden until expanded — but jsdom keeps
+		// them in the DOM either way. Easier to assert via the disclosure
+		// element's open state than visibility heuristics.
+		const phishingSummary = screen.getByText("phishing").closest("summary");
+		expect(phishingSummary).toBeTruthy();
+		const details = phishingSummary!.closest("details") as HTMLDetailsElement;
+		expect(details.open).toBe(false);
+
+		await userEvent.click(phishingSummary!);
+		expect(details.open).toBe(true);
+
+		// Sample rows render the subject + sender for each emailId.
+		expect(screen.getByText("Reset your password")).toBeInTheDocument();
+		expect(screen.getByText("fake@bank.example")).toBeInTheDocument();
+		expect(screen.getByText("Invoice attached")).toBeInTheDocument();
+		expect(screen.getByText("billing@evil.example")).toBeInTheDocument();
+	});
+
+	it("renders a top-threats category without samples as a count-only row", () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderHome();
+		// `spam` has no samples in the populated fixture — should render
+		// without a <details> wrapper (older deploys must not regress).
+		const spamLabel = screen.getByText("spam");
+		expect(spamLabel.closest("details")).toBeNull();
 	});
 
 	it("formats p95 latency on the org overview KPI grid", () => {

--- a/tests/lib/dashboard-aggregation.test.ts
+++ b/tests/lib/dashboard-aggregation.test.ts
@@ -313,6 +313,102 @@ describe("aggregateOrgOverview", () => {
 		]);
 	});
 
+	it("attaches per-category samples deduped by emailId across mailboxes (#101)", () => {
+		const result = aggregateOrgOverview({
+			mailboxes: [
+				{ id: "a@x.com", email: "a@x.com" },
+				{ id: "b@x.com", email: "b@x.com" },
+			],
+			summaries: [
+				summary({
+					verdictRows: [
+						verdictRow("tag", "phishing"),
+						verdictRow("quarantine", "phishing"),
+						verdictRow("tag", "spam"),
+					],
+					topThreatSamples: {
+						phishing: [
+							{ emailId: "e1", subject: "Reset your password", sender: "fake@bank" },
+							{ emailId: "e2", subject: "Invoice attached", sender: "vendor@x" },
+						],
+						spam: [{ emailId: "e3", subject: "Buy now", sender: "promo@x" }],
+					},
+				}),
+				summary({
+					verdictRows: [verdictRow("block", "phishing")],
+					topThreatSamples: {
+						// e1 also seen in mailbox A — should dedup. e4 is new.
+						phishing: [
+							{ emailId: "e1", subject: "Reset your password", sender: "fake@bank" },
+							{ emailId: "e4", subject: "Wire transfer urgent", sender: "ceo@boss" },
+						],
+					},
+				}),
+			],
+			samplesPerThreat: 3,
+			now: NOW.toISOString(),
+		});
+
+		const phishing = result.topThreats.find((t) => t.category === "phishing")!;
+		expect(phishing.count).toBe(3);
+		expect(phishing.samples).toEqual([
+			{ emailId: "e1", subject: "Reset your password", sender: "fake@bank" },
+			{ emailId: "e2", subject: "Invoice attached", sender: "vendor@x" },
+			{ emailId: "e4", subject: "Wire transfer urgent", sender: "ceo@boss" },
+		]);
+
+		const spam = result.topThreats.find((t) => t.category === "spam")!;
+		expect(spam.count).toBe(1);
+		expect(spam.samples).toEqual([
+			{ emailId: "e3", subject: "Buy now", sender: "promo@x" },
+		]);
+	});
+
+	it("respects samplesPerThreat and slices each category to the cap (#101)", () => {
+		const result = aggregateOrgOverview({
+			mailboxes: [{ id: "a@x.com", email: "a@x.com" }],
+			summaries: [
+				summary({
+					verdictRows: [
+						verdictRow("tag", "phishing"),
+						verdictRow("tag", "phishing"),
+					],
+					topThreatSamples: {
+						phishing: [
+							{ emailId: "e1", subject: "s1", sender: "a" },
+							{ emailId: "e2", subject: "s2", sender: "b" },
+							{ emailId: "e3", subject: "s3", sender: "c" },
+							{ emailId: "e4", subject: "s4", sender: "d" },
+							{ emailId: "e5", subject: "s5", sender: "e" },
+						],
+					},
+				}),
+			],
+			samplesPerThreat: 2,
+			now: NOW.toISOString(),
+		});
+		const phishing = result.topThreats.find((t) => t.category === "phishing")!;
+		expect(phishing.samples).toHaveLength(2);
+		expect(phishing.samples).toEqual([
+			{ emailId: "e1", subject: "s1", sender: "a" },
+			{ emailId: "e2", subject: "s2", sender: "b" },
+		]);
+	});
+
+	it("omits the samples field when no mailbox shipped any (#101 backwards compat)", () => {
+		const result = aggregateOrgOverview({
+			mailboxes: [{ id: "a@x.com", email: "a@x.com" }],
+			summaries: [
+				summary({
+					verdictRows: [verdictRow("tag", "phishing")],
+				}),
+			],
+			now: NOW.toISOString(),
+		});
+		expect(result.topThreats[0]).toEqual({ category: "phishing", count: 1 });
+		expect(result.topThreats[0]).not.toHaveProperty("samples");
+	});
+
 	it("dedupes domain count by lowercased domain", () => {
 		const result = aggregateOrgOverview({
 			mailboxes: [

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -1526,6 +1526,60 @@ export class MailboxDO extends DurableObject<Env> {
 			.all();
 		const verdictMix7d = computeVerdictMix(verdictRows7d);
 
+		// Pre-aggregate representative samples per actioned classification
+		// label for the org overview's top-threats panel (#101). Capped at
+		// MAX_THREAT_SAMPLES_PER_LABEL most-recent rows per label; the org
+		// aggregator unions across mailboxes and slices again.
+		const MAX_THREAT_SAMPLES_PER_LABEL = 5;
+		const threatSampleSource = this.db
+			.select({
+				id: schema.emails.id,
+				subject: schema.emails.subject,
+				sender: schema.emails.sender,
+				security_verdict: schema.emails.security_verdict,
+			})
+			.from(schema.emails)
+			.where(
+				and(
+					sql`${schema.emails.date} >= ${dayAgoIso}`,
+					sql`${schema.emails.security_verdict} IS NOT NULL`,
+				),
+			)
+			.orderBy(desc(schema.emails.date))
+			.limit(200)
+			.all();
+
+		const topThreatSamples: Record<
+			string,
+			{ emailId: string; subject: string; sender: string }[]
+		> = {};
+		for (const row of threatSampleSource) {
+			if (!row.security_verdict) continue;
+			let parsed: { action?: unknown; classification?: { label?: unknown } };
+			try {
+				parsed = JSON.parse(row.security_verdict);
+			} catch {
+				continue;
+			}
+			if (
+				parsed.action !== "tag" &&
+				parsed.action !== "quarantine" &&
+				parsed.action !== "block"
+			) {
+				continue;
+			}
+			const label = parsed.classification?.label;
+			if (typeof label !== "string" || label === "safe") continue;
+			const list = (topThreatSamples[label] ??= []);
+			if (list.length < MAX_THREAT_SAMPLES_PER_LABEL) {
+				list.push({
+					emailId: String(row.id ?? ""),
+					subject: row.subject ?? "",
+					sender: row.sender ?? "",
+				});
+			}
+		}
+
 		const recentCases = this.db
 			.select({
 				id: schema.cases.id,
@@ -1550,6 +1604,7 @@ export class MailboxDO extends DurableObject<Env> {
 			pipelineDurationsMs,
 			verdictRows,
 			verdictMix7d,
+			topThreatSamples,
 			recentCases,
 		};
 	}

--- a/workers/lib/dashboard-aggregation.ts
+++ b/workers/lib/dashboard-aggregation.ts
@@ -135,6 +135,14 @@ export interface OrgMailboxSummary {
 	 */
 	verdictMix7d?: VerdictMix;
 	/**
+	 * Pre-aggregated representative emails per actioned classification
+	 * label (#101). Each label maps to up to N most-recent samples from
+	 * this mailbox; the org aggregator unions across mailboxes, dedupes
+	 * by emailId, and slices to top-N per category. Optional so older DO
+	 * replicas mid-deploy degrade gracefully.
+	 */
+	topThreatSamples?: Record<string, OrgTopThreatSample[]>;
+	/**
 	 * Per-pipeline-run durations from `pipeline_runs` (#71). Unioned across
 	 * mailboxes to compute an org-wide p95. Optional so older DO replicas
 	 * mid-deploy degrade gracefully (treated as no samples).
@@ -155,9 +163,22 @@ export interface VerdictMix {
 	bec: number;
 }
 
+/** Representative email surfaced for a top-threats category (#101). */
+export interface OrgTopThreatSample {
+	emailId: string;
+	subject: string;
+	sender: string;
+}
+
 export interface OrgTopThreat {
 	category: string;
 	count: number;
+	/**
+	 * Up to N representative emails for this category, deduped by emailId
+	 * across mailboxes (#101). Optional so older DO replicas mid-deploy
+	 * (which don't ship `topThreatSamples`) gracefully omit the panel.
+	 */
+	samples?: OrgTopThreatSample[];
 }
 
 export interface OrgPipelineHealth {
@@ -234,6 +255,8 @@ interface AggregateOrgOverviewInput {
 	now?: string;
 	/** How many top-threats to surface. Default 5. */
 	topN?: number;
+	/** How many representative samples per top-threat to keep. Default 3. */
+	samplesPerThreat?: number;
 }
 
 /**
@@ -247,6 +270,7 @@ export function aggregateOrgOverview(
 	const { mailboxes, summaries } = input;
 	const now = input.now ?? new Date().toISOString();
 	const topN = input.topN ?? 5;
+	const samplesPerThreat = input.samplesPerThreat ?? 3;
 
 	let threatsBlocked24h = 0;
 	let threatsBlocked7d = 0;
@@ -259,6 +283,8 @@ export function aggregateOrgOverview(
 	const verdictMix = emptyVerdictMix();
 	const verdictMix7d = emptyVerdictMix();
 	const threatCounts = new Map<string, number>();
+	// Per-category collected samples, deduped by emailId across mailboxes.
+	const samplesByCategory = new Map<string, Map<string, OrgTopThreatSample>>();
 
 	for (const summary of summaries) {
 		if (!summary) continue;
@@ -301,10 +327,42 @@ export function aggregateOrgOverview(
 				threatCounts.set(label, (threatCounts.get(label) ?? 0) + 1);
 			}
 		}
+
+		// Pre-aggregated samples per category from this mailbox (#101).
+		// Dedup across mailboxes by emailId — first-seen wins, matching
+		// the DO's "most-recent" ordering since DOs ship samples sorted.
+		if (summary.topThreatSamples) {
+			for (const [category, list] of Object.entries(summary.topThreatSamples)) {
+				if (!Array.isArray(list)) continue;
+				let bucket = samplesByCategory.get(category);
+				if (!bucket) {
+					bucket = new Map<string, OrgTopThreatSample>();
+					samplesByCategory.set(category, bucket);
+				}
+				for (const sample of list) {
+					if (!sample?.emailId) continue;
+					if (!bucket.has(sample.emailId)) {
+						bucket.set(sample.emailId, {
+							emailId: sample.emailId,
+							subject: sample.subject ?? "",
+							sender: sample.sender ?? "",
+						});
+					}
+				}
+			}
+		}
 	}
 
 	const topThreats: OrgTopThreat[] = [...threatCounts.entries()]
-		.map(([category, count]) => ({ category, count }))
+		.map(([category, count]) => {
+			const bucket = samplesByCategory.get(category);
+			const samples = bucket
+				? [...bucket.values()].slice(0, samplesPerThreat)
+				: undefined;
+			return samples && samples.length > 0
+				? { category, count, samples }
+				: { category, count };
+		})
 		.sort((a, b) => b.count - a.count || a.category.localeCompare(b.category))
 		.slice(0, topN);
 


### PR DESCRIPTION
## Summary
- Add representative-email samples to the org overview's `topThreats` panel so operators can see what the actioned mail looks like, not just how many fired per category.
- DO `getDashboardSummary` pre-aggregates up to 5 most-recent samples per actioned classification label (excluding `safe`). Each sample is `{ emailId, subject, sender }`.
- Aggregator unions per-mailbox samples, dedupes by `emailId` across mailboxes (first-seen wins, matching the DO's "most-recent" ordering), and slices to `samplesPerThreat` (default 3) per category.
- UI: TopThreatsCard rows become expandable disclosures (`<details>`/`<summary>`) when samples are present. Rows without samples render as the existing count-only rows — older deploys stay unchanged.

## Acceptance criteria
- [x] DO `getDashboardSummary` returns up to N (5) sample rows per actioned classification label.
- [x] `OrgTopThreat` extends with `samples?: { subject: string; sender: string; emailId: string }[]`.
- [x] Org overview UI surfaces the samples (expandable row in TopThreatsCard).
- [x] Aggregator unit tests cover de-dup + ranking when the same sender appears across mailboxes (`emailId` is the dedup key, the test uses two mailboxes with overlapping `e1`).

## Wire-payload bound
Per-mailbox cap is 5 samples × N actioned labels. With our five-label set (`suspicious`/`phishing`/`spam`/`bec` after excluding `safe` ⇒ 4) that's at most 20 small `(emailId, subject, sender)` tuples per mailbox — bounded and small relative to the existing `verdictRows` payload.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 261 passing, 0 failing (29 test files; +5 vs main: 3 aggregator cases + 2 frontend cases)

Closes #101
