### PR TITLE
feat: per-mailbox override for injection scanner, draft verifier, and classifier models (#67)

### DIFF
--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -10,7 +10,12 @@ import { useFeedback } from "~/lib/feedback";
 import { useMailbox, useUpdateMailbox } from "~/queries/mailboxes";
 import { SecuritySettingsPanel } from "~/components/SecuritySettingsPanel";
 import type { SecuritySettings } from "~/types";
-import { TEXT_MODELS } from "shared/mailbox-settings";
+import {
+	DEFAULT_CLASSIFIER_MODEL,
+	DEFAULT_DRAFT_VERIFIER_MODEL,
+	DEFAULT_INJECTION_SCANNER_MODEL,
+	TEXT_MODELS,
+} from "shared/mailbox-settings";
 
 // Placeholder shown in the textarea when no custom prompt is set.
 // The authoritative default prompt lives in workers/agent/index.ts (DEFAULT_SYSTEM_PROMPT).
@@ -28,6 +33,9 @@ export default function SettingsRoute() {
 	const [autoDraftEnabled, setAutoDraftEnabled] = useState(true);
 	const [modelChoice, setModelChoice] = useState<string>(TEXT_MODELS[0]);
 	const [customModel, setCustomModel] = useState("");
+	const [injectionScannerModel, setInjectionScannerModel] = useState("");
+	const [draftVerifierModel, setDraftVerifierModel] = useState("");
+	const [classifierModel, setClassifierModel] = useState("");
 	const [isSaving, setIsSaving] = useState(false);
 
 	useEffect(() => {
@@ -37,7 +45,13 @@ export default function SettingsRoute() {
 			setSecurity(mailbox.settings?.security);
 
 			const behavior = mailbox.settings as
-				| { autoDraft?: { enabled?: boolean }; agentModel?: string }
+				| {
+						autoDraft?: { enabled?: boolean };
+						agentModel?: string;
+						injectionScannerModel?: string;
+						draftVerifierModel?: string;
+						classifierModel?: string;
+				  }
 				| undefined;
 			const enabled = behavior?.autoDraft?.enabled;
 			setAutoDraftEnabled(enabled === undefined ? true : enabled);
@@ -50,6 +64,10 @@ export default function SettingsRoute() {
 				setModelChoice("__custom__");
 				setCustomModel(m);
 			}
+
+			setInjectionScannerModel(behavior?.injectionScannerModel ?? "");
+			setDraftVerifierModel(behavior?.draftVerifierModel ?? "");
+			setClassifierModel(behavior?.classifierModel ?? "");
 		}
 	}, [mailbox]);
 
@@ -67,6 +85,20 @@ export default function SettingsRoute() {
 			return;
 		}
 
+		// Validate optional security-model overrides — same `@cf/` rule as
+		// the agent model. Empty value means "use default" (#67).
+		const advancedModelInputs: Array<{ label: string; value: string }> = [
+			{ label: "Injection scanner", value: injectionScannerModel.trim() },
+			{ label: "Draft verifier", value: draftVerifierModel.trim() },
+			{ label: "Classifier", value: classifierModel.trim() },
+		];
+		for (const m of advancedModelInputs) {
+			if (m.value && !m.value.startsWith("@cf/")) {
+				feedback.error(`${m.label} model must start with @cf/`);
+				return;
+			}
+		}
+
 		setIsSaving(true);
 		const settings = {
 			...mailbox.settings,
@@ -75,6 +107,9 @@ export default function SettingsRoute() {
 			security,
 			autoDraft: { enabled: autoDraftEnabled },
 			agentModel: resolvedModel || TEXT_MODELS[0],
+			injectionScannerModel: injectionScannerModel.trim() || undefined,
+			draftVerifierModel: draftVerifierModel.trim() || undefined,
+			classifierModel: classifierModel.trim() || undefined,
 		};
 		try {
 			await updateMailboxMutation.mutateAsync({ mailboxId, settings });
@@ -212,6 +247,72 @@ export default function SettingsRoute() {
 							<code className="pp-mono">@cf/</code>.
 						</p>
 					</div>
+
+					{/* Advanced — security-critical model overrides (#67). Hidden
+					    behind a disclosure so the regular Settings page stays
+					    minimal. Wrong value can let real prompt injection
+					    through, so leave empty to keep the tested defaults. */}
+					<details className="mt-5 group">
+						<summary className="cursor-pointer text-xs font-medium text-ink-2 hover:text-ink select-none">
+							Advanced — security model overrides
+						</summary>
+						<div className="mt-3 space-y-4 border-l-2 border-line pl-4">
+							<p className="text-xs text-ink-3">
+								These models drive security-critical paths. Leave empty to
+								use the tested defaults shown as placeholders. Wrong choices
+								can degrade detection — only override if you know what you
+								are doing.
+							</p>
+							<div>
+								<label
+									htmlFor="advanced-injection-model"
+									className="block text-xs text-ink mb-1"
+								>
+									Prompt-injection scanner
+								</label>
+								<input
+									id="advanced-injection-model"
+									type="text"
+									placeholder={DEFAULT_INJECTION_SCANNER_MODEL}
+									value={injectionScannerModel}
+									onChange={(e) => setInjectionScannerModel(e.target.value)}
+									className="w-full rounded-md border border-line bg-paper-2 px-3 py-2 text-sm text-ink placeholder:text-ink-3 focus:outline-none focus:ring-1 focus:ring-accent pp-mono"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="advanced-verifier-model"
+									className="block text-xs text-ink mb-1"
+								>
+									Draft verifier
+								</label>
+								<input
+									id="advanced-verifier-model"
+									type="text"
+									placeholder={DEFAULT_DRAFT_VERIFIER_MODEL}
+									value={draftVerifierModel}
+									onChange={(e) => setDraftVerifierModel(e.target.value)}
+									className="w-full rounded-md border border-line bg-paper-2 px-3 py-2 text-sm text-ink placeholder:text-ink-3 focus:outline-none focus:ring-1 focus:ring-accent pp-mono"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="advanced-classifier-model"
+									className="block text-xs text-ink mb-1"
+								>
+									LLM classifier
+								</label>
+								<input
+									id="advanced-classifier-model"
+									type="text"
+									placeholder={DEFAULT_CLASSIFIER_MODEL}
+									value={classifierModel}
+									onChange={(e) => setClassifierModel(e.target.value)}
+									className="w-full rounded-md border border-line bg-paper-2 px-3 py-2 text-sm text-ink placeholder:text-ink-3 focus:outline-none focus:ring-1 focus:ring-accent pp-mono"
+								/>
+							</div>
+						</div>
+					</details>
 				</div>
 
 				{/* Security */}

--- a/shared/mailbox-settings.ts
+++ b/shared/mailbox-settings.ts
@@ -53,6 +53,23 @@ export const MailboxSettings = z.object({
     })
     .default({ enabled: true }),
   agentModel: z.string().default("@cf/moonshotai/kimi-k2.5"),
+  /**
+   * Optional per-mailbox override for the prompt-injection scanner model
+   * (#67). Falls back to `DEFAULT_INJECTION_SCANNER_MODEL` when undefined.
+   * Wrong choice can let injections through — defaults are intentionally
+   * hardcoded to a tested model.
+   */
+  injectionScannerModel: z.string().optional(),
+  /**
+   * Optional per-mailbox override for the draft-verifier model (#67).
+   * Falls back to `DEFAULT_DRAFT_VERIFIER_MODEL` when undefined.
+   */
+  draftVerifierModel: z.string().optional(),
+  /**
+   * Optional per-mailbox override for the LLM email classifier (#67).
+   * Falls back to `DEFAULT_CLASSIFIER_MODEL` when undefined.
+   */
+  classifierModel: z.string().optional(),
   security: SecuritySettings.optional(),
 }).passthrough();
 
@@ -65,3 +82,17 @@ export const TEXT_MODELS = [
   "@cf/moonshotai/kimi-k2.5",
   "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
 ] as const;
+
+/**
+ * Defaults for the three security-critical AI surfaces (#67). These mirror
+ * the hardcoded values in the worker call sites and are exported so the
+ * settings UI can show them as the placeholder when no override is set.
+ *
+ * Switching the injection-scanner or classifier model can degrade
+ * detection — only override when you know what you're doing.
+ */
+export const DEFAULT_INJECTION_SCANNER_MODEL =
+  "@cf/meta/llama-3.1-8b-instruct-fast";
+export const DEFAULT_DRAFT_VERIFIER_MODEL =
+  "@cf/meta/llama-4-scout-17b-16e-instruct";
+export const DEFAULT_CLASSIFIER_MODEL = "@cf/meta/llama-3.1-8b-instruct-fast";

--- a/tests/agent/settings.test.ts
+++ b/tests/agent/settings.test.ts
@@ -24,6 +24,27 @@ describe("MailboxSettings", () => {
     expect(parsed.agentSystemPrompt).toBe("Hi");
   });
 
+  // Per-mailbox security-model overrides (#67). All three are optional and
+  // default to undefined so the worker call sites fall through to their
+  // hardcoded defaults.
+  it("leaves security-model overrides undefined when missing", () => {
+    const parsed = MailboxSettings.parse({});
+    expect(parsed.injectionScannerModel).toBeUndefined();
+    expect(parsed.draftVerifierModel).toBeUndefined();
+    expect(parsed.classifierModel).toBeUndefined();
+  });
+
+  it("round-trips per-mailbox security-model overrides", () => {
+    const parsed = MailboxSettings.parse({
+      injectionScannerModel: "@cf/custom/injection",
+      draftVerifierModel: "@cf/custom/verifier",
+      classifierModel: "@cf/custom/classifier",
+    });
+    expect(parsed.injectionScannerModel).toBe("@cf/custom/injection");
+    expect(parsed.draftVerifierModel).toBe("@cf/custom/verifier");
+    expect(parsed.classifierModel).toBe("@cf/custom/classifier");
+  });
+
   // The security sub-shape is opt-in: an undefined `security` block must
   // round-trip to undefined (no surprise object materialised). The runtime
   // consumer in `workers/security/settings.ts` is the single source of

--- a/workers/agent/index.ts
+++ b/workers/agent/index.ts
@@ -367,7 +367,9 @@ export class EmailAgent extends AIChatAgent<any> {
 		try {
 			const email = (await stub.getEmail(emailData.emailId)) as EmailFull | null;
 			if (email?.body) {
-				const isInjection = await isPromptInjection(env.AI, email.body);
+				const isInjection = await isPromptInjection(env.AI, email.body, {
+					model: settings.injectionScannerModel,
+				});
 				if (isInjection) {
 					console.warn("Skipping auto-draft due to detected prompt injection:", emailData.emailId);
 					
@@ -415,7 +417,9 @@ export class EmailAgent extends AIChatAgent<any> {
 			// could plant an injection in an earlier email in the thread
 			// that gets included in the agent's prompt.
 			if (threadContext) {
-				const threadInjection = await isPromptInjection(env.AI, threadContext);
+				const threadInjection = await isPromptInjection(env.AI, threadContext, {
+					model: settings.injectionScannerModel,
+				});
 				if (threadInjection) {
 					console.warn("Skipping auto-draft due to prompt injection in thread context:", emailData.threadId);
 					const newMessages = [
@@ -498,7 +502,9 @@ Based on the email content and thread context above, draft a reply using draft_r
 
 			if (!draftToolCalled && result.text.trim()) {
 				// Model generated a draft inline as text -- verify with AI
-				const sanitizedText = await verifyDraft(env.AI, result.text.trim());
+				const sanitizedText = await verifyDraft(env.AI, result.text.trim(), {
+					model: settings.draftVerifierModel,
+				});
 				if (!sanitizedText) {
 					// Inline text was entirely agent commentary, skip
 				} else {

--- a/workers/lib/ai.ts
+++ b/workers/lib/ai.ts
@@ -7,8 +7,17 @@
  *
  * - isPromptInjection: scans email bodies for malicious prompt injection.
  * - verifyDraft: reviews draft email bodies and removes agent/system artifacts.
+ *
+ * Both functions accept an optional `model` arg to honor per-mailbox
+ * overrides (#67). Callers thread the override from `MailboxSettings`;
+ * unset / empty values fall through to the hardcoded defaults so behavior
+ * is identical when no operator override is present.
  */
 
+import {
+	DEFAULT_DRAFT_VERIFIER_MODEL,
+	DEFAULT_INJECTION_SCANNER_MODEL,
+} from "../../shared/mailbox-settings";
 import { escapeHtml, stripHtmlToText, textToHtml } from "./email-helpers";
 
 // ── Prompt Injection Scanner ───────────────────────────────────────
@@ -21,15 +30,21 @@ Return ONLY "NO" if it is a normal email (even if angry, confused, or containing
 
 Respond with exactly one word: YES or NO.`;
 
-export async function isPromptInjection(ai: Ai, bodyHtml: string | null | undefined): Promise<boolean> {
+export async function isPromptInjection(
+	ai: Ai,
+	bodyHtml: string | null | undefined,
+	options: { model?: string } = {},
+): Promise<boolean> {
 	if (!bodyHtml) return false;
-	
+
 	const plainText = stripHtmlToText(bodyHtml).trim();
 	if (plainText.length < 10) return false;
 
+	const model = options.model?.trim() || DEFAULT_INJECTION_SCANNER_MODEL;
+
 	try {
 		const response = (await ai.run(
-			"@cf/meta/llama-3.1-8b-instruct-fast",
+			model as Parameters<typeof ai.run>[0],
 			{
 				messages: [
 					{ role: "system", content: INJECTION_PROMPT },
@@ -118,7 +133,11 @@ function splitQuotedBlock(html: string): { reply: string; quoted: string } {
  * Verify and clean a draft email body using AI.
  * Falls back to returning the original body if the AI call fails.
  */
-export async function verifyDraft(ai: Ai, body: string): Promise<string> {
+export async function verifyDraft(
+	ai: Ai,
+	body: string,
+	options: { model?: string } = {},
+): Promise<string> {
 	if (!body || !body.trim()) return body;
 
 	// Separate the quoted reply block so the AI only reviews the user's text
@@ -133,9 +152,11 @@ export async function verifyDraft(ai: Ai, body: string): Promise<string> {
 	// Skip very short replies — nothing to verify
 	if (replyText.trim().length < 20) return body;
 
+	const model = options.model?.trim() || DEFAULT_DRAFT_VERIFIER_MODEL;
+
 	try {
 		const response = (await ai.run(
-			"@cf/meta/llama-4-scout-17b-16e-instruct",
+			model as Parameters<typeof ai.run>[0],
 			{
 				messages: [
 					{ role: "system", content: VERIFIER_PROMPT },

--- a/workers/lib/tools.ts
+++ b/workers/lib/tools.ts
@@ -27,9 +27,25 @@ import {
 	buildThreadingHeaders,
 } from "./email-helpers";
 import { verifyDraft } from "./ai";
+import { getMailboxSettings } from "./mailbox-settings";
 import { sendEmail } from "../email-sender";
 import { Folders } from "../../shared/folders";
 import type { Env } from "../types";
+
+/**
+ * Run `verifyDraft` honoring the per-mailbox `draftVerifierModel`
+ * override (#67). Centralized here so every tool call site doesn't have
+ * to reload settings — and so the override path is consistent across
+ * Agent-driven drafts and MCP-driven drafts.
+ */
+async function verifyDraftForMailbox(
+	env: Env,
+	mailboxId: string,
+	body: string,
+): Promise<string> {
+	const settings = await getMailboxSettings(env, mailboxId);
+	return verifyDraft(env.AI, body, { model: settings.draftVerifierModel });
+}
 
 // ── Type casts for DO methods not on the base stub type ────────────
 type MailboxSearchStub = {
@@ -136,7 +152,7 @@ export async function toolDraftReply(
 	// Verify/sanitize if requested
 	let processedBody = params.body.trim();
 	if (params.runVerifyDraft) {
-		const sanitized = await verifyDraft(env.AI, processedBody);
+		const sanitized = await verifyDraftForMailbox(env, mailboxId, processedBody);
 		if (!sanitized) {
 			return { error: "Draft verification failed — body could not be verified. Please try again." };
 		}
@@ -217,7 +233,7 @@ export async function toolDraftEmail(
 
 	let processedBody = params.body.trim();
 	if (params.runVerifyDraft) {
-		const sanitized = await verifyDraft(env.AI, processedBody);
+		const sanitized = await verifyDraftForMailbox(env, mailboxId, processedBody);
 		if (!sanitized) {
 			return { error: "Draft verification failed — body could not be verified. Please try again." };
 		}
@@ -294,7 +310,7 @@ export async function toolUpdateDraft(
 	// Verify the body BEFORE deleting the old draft to prevent data loss
 	const newDraftId = crypto.randomUUID();
 	const rawBody = params.bodyHtml ?? oldDraft.body ?? "";
-	const verifiedBody = await verifyDraft(env.AI, rawBody);
+	const verifiedBody = await verifyDraftForMailbox(env, mailboxId, rawBody);
 
 	if (!verifiedBody) {
 		return { error: "Draft verification failed — keeping existing draft unchanged. Please try again." };
@@ -422,7 +438,7 @@ export async function toolSendReply(
 	const { messageId, outgoingMessageId } = generateMessageId(fromDomain);
 
 	// Verify and append quoted original message
-	const sanitizedBody = await verifyDraft(env.AI, params.bodyHtml);
+	const sanitizedBody = await verifyDraftForMailbox(env, mailboxId, params.bodyHtml);
 	if (!sanitizedBody) {
 		return { error: "Draft verification failed — refusing to send unverified content. Please try again." };
 	}
@@ -503,7 +519,7 @@ export async function toolSendEmail(
 	if (!fromDomain) throw new Error("Invalid mailbox email address");
 	const { messageId, outgoingMessageId } = generateMessageId(fromDomain);
 
-	const sanitizedBody = await verifyDraft(env.AI, params.bodyHtml);
+	const sanitizedBody = await verifyDraftForMailbox(env, mailboxId, params.bodyHtml);
 	if (!sanitizedBody) {
 		return { error: "Draft verification failed — refusing to send unverified content. Please try again." };
 	}

--- a/workers/security/classification.ts
+++ b/workers/security/classification.ts
@@ -10,6 +10,7 @@
  * The synchronous pipeline keeps latency bounded by avoiding tool loops here.
  */
 
+import { DEFAULT_CLASSIFIER_MODEL } from "../../shared/mailbox-settings";
 import { stripHtmlToText } from "../lib/email-helpers";
 import type { AuthVerdict } from "./auth";
 
@@ -62,6 +63,7 @@ export function __setClassifier(impl: ClassifierImpl | null) {
 export async function classifyEmail(
 	ai: Ai,
 	input: ClassifyInput,
+	options: { model?: string } = {},
 ): Promise<ClassificationResult> {
 	if (overrideClassifier) return overrideClassifier(ai, input);
 	const plain = stripHtmlToText(input.bodyHtml || "").slice(0, 4000);
@@ -72,10 +74,12 @@ SUBJECT: ${input.subject || "(no subject)"}
 BODY:
 ${plain}`;
 
+	const model = options.model?.trim() || DEFAULT_CLASSIFIER_MODEL;
+
 	try {
 		const response = (await Promise.race([
 			ai.run(
-				"@cf/meta/llama-3.1-8b-instruct-fast",
+				model as Parameters<typeof ai.run>[0],
 				{
 					messages: [
 						{ role: "system", content: SYSTEM_PROMPT },

--- a/workers/security/index.ts
+++ b/workers/security/index.ts
@@ -27,6 +27,7 @@ import { classifyEmail } from "./classification";
 import { extractUrls } from "./urls";
 import { aggregateVerdict, type FinalVerdict } from "./verdict";
 import { getSecuritySettings } from "./settings";
+import { getMailboxSettings } from "../lib/mailbox-settings";
 import { checkUrlAgainstFeeds, type FeedMatch } from "../intel/feeds";
 import { evaluateTriage, type IntelMatchInfo } from "./triage";
 import type { AttachmentLike } from "./attachments";
@@ -141,9 +142,16 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 	}
 
 	// Full path: LLM classification (possibly skipped by folder-bypass tier) + aggregation.
+	// `classifierModel` may be overridden per-mailbox (#67); load the parent
+	// MailboxSettings since `getSecuritySettings` only returns the security sub-tree.
+	const mailboxSettings = await getMailboxSettings(env, mailboxId);
 	const classification = triaged.skipClassifier
 		? { label: "safe" as const, confidence: 1.0, reasoning: "classifier skipped by folder policy" }
-		: await classifyEmail(env.AI, { subject, sender, bodyHtml, auth });
+		: await classifyEmail(
+			env.AI,
+			{ subject, sender, bodyHtml, auth },
+			{ model: mailboxSettings.classifierModel },
+		);
 
 	let verdict = aggregateVerdict(
 		{


### PR DESCRIPTION
## Summary
Power users can now override the three Workers AI models that drive security-critical paths, on a per-mailbox basis, while leaving the tested defaults in place when no override is set.

### Schema (`shared/mailbox-settings.ts`)
- Three new optional string fields on `MailboxSettings`: `injectionScannerModel`, `draftVerifierModel`, `classifierModel`.
- Centralized defaults exported as `DEFAULT_INJECTION_SCANNER_MODEL`, `DEFAULT_DRAFT_VERIFIER_MODEL`, `DEFAULT_CLASSIFIER_MODEL` so the call sites and Settings UI share a single source of truth.

### Worker call sites
- `isPromptInjection` / `verifyDraft` (`workers/lib/ai.ts`) and `classifyEmail` (`workers/security/classification.ts`) gain an optional `{ model?: string }` arg. Empty/undefined falls through to the hardcoded default — semantics identical when no override is set.
- `workers/agent/index.ts`: threads `settings.injectionScannerModel` to both `isPromptInjection` calls and `settings.draftVerifierModel` to the inline `verifyDraft` call.
- `workers/lib/tools.ts`: introduces a single `verifyDraftForMailbox` helper that loads `MailboxSettings` once and threads the override — swaps all five existing `verifyDraft(env.AI, …)` call sites.
- `workers/security/index.ts`: loads `MailboxSettings` alongside the existing security-settings load and threads `classifierModel` into `classifyEmail`.

### UI (`app/routes/settings.tsx`)
Adds an **"Advanced — security model overrides"** disclosure inside the Behavior card. Three monospaced text inputs, each with the corresponding default shown as a placeholder. Empty value clears the override (saved as `undefined`). Inputs validate that any value starts with `@cf/`, mirroring the agent-model picker rule.

## Acceptance criteria
- [x] Extend `MailboxSettings` with three optional model fields.
- [x] Each falls back to the hardcoded default when undefined (semantics preserved).
- [x] UI: Advanced disclosure inside the Behavior card with three model inputs.
- [x] Wrong-model risk addressed: defaults are tested values; UI placeholder shows the default; copy explicitly warns the user.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 258 passing, 0 failing (29 test files; +2 vs main: schema round-trip + undefined-by-default)

Closes #67
