### PR TITLE
feat: dynamic Workers AI text-generation model list (#64)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,3 +1,11 @@
 # Cloudflare Access (required in production). TEAM_DOMAIN may be the base Access URL or the full /cdn-cgi/access/certs URL.
 POLICY_AUD=your-access-policy-audience-tag
 TEAM_DOMAIN=https://your-team.cloudflareaccess.com
+
+# Optional — enable the dynamic Workers AI text-generation model list (#64).
+# When both are set, the worker fetches the live model catalog from the
+# Cloudflare API and caches it in BLOOM_KV for 1h; when missing, the
+# Settings dropdown falls back to the curated TEXT_MODELS constant. The
+# token only needs the AI:Read scope.
+#CLOUDFLARE_API_TOKEN=
+#CLOUDFLARE_ACCOUNT_ID=

--- a/app/queries/keys.ts
+++ b/app/queries/keys.ts
@@ -33,4 +33,5 @@ export const queryKeys = {
 		sharingGroups: (mailboxId: string) => ["hub", mailboxId, "sharing-groups"] as const,
 	},
 	config: ["config"] as const,
+	textModels: ["ai", "text-models"] as const,
 };

--- a/app/queries/text-models.ts
+++ b/app/queries/text-models.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { useQuery } from "@tanstack/react-query";
+import { TEXT_MODELS } from "shared/mailbox-settings";
+import api from "~/services/api";
+import { queryKeys } from "./keys";
+
+/**
+ * Workers AI text-generation models (#64).
+ *
+ * Calls the worker's `/api/v1/ai/text-models` endpoint, which itself
+ * does a read-through KV cache against the Cloudflare API and falls
+ * back to the curated `TEXT_MODELS` constant when the upstream call
+ * isn't possible. The hook surfaces a fallback `models` value so the
+ * Settings dropdown is never empty even on transient errors.
+ */
+export function useTextModels() {
+	const query = useQuery<{ models: string[] }>({
+		queryKey: queryKeys.textModels,
+		queryFn: ({ signal }) => api.getTextModels({ signal }),
+		// Worker caches at 1h; client refresh on this scale doesn't
+		// need to be tighter than 5 min.
+		staleTime: 5 * 60_000,
+	});
+	return {
+		...query,
+		models: query.data?.models ?? [...TEXT_MODELS],
+	};
+}

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router";
 import { useFeedback } from "~/lib/feedback";
 import { useMailbox, useUpdateMailbox } from "~/queries/mailboxes";
+import { useTextModels } from "~/queries/text-models";
 import { SecuritySettingsPanel } from "~/components/SecuritySettingsPanel";
 import type { SecuritySettings } from "~/types";
 import {
@@ -26,6 +27,7 @@ export default function SettingsRoute() {
 	const feedback = useFeedback();
 	const { data: mailbox } = useMailbox(mailboxId);
 	const updateMailboxMutation = useUpdateMailbox();
+	const { models: availableModels } = useTextModels();
 
 	const [displayName, setDisplayName] = useState("");
 	const [agentPrompt, setAgentPrompt] = useState("");
@@ -56,8 +58,8 @@ export default function SettingsRoute() {
 			const enabled = behavior?.autoDraft?.enabled;
 			setAutoDraftEnabled(enabled === undefined ? true : enabled);
 
-			const m = behavior?.agentModel ?? TEXT_MODELS[0];
-			if (TEXT_MODELS.includes(m as (typeof TEXT_MODELS)[number])) {
+			const m = behavior?.agentModel ?? availableModels[0] ?? TEXT_MODELS[0];
+			if (availableModels.includes(m)) {
 				setModelChoice(m);
 				setCustomModel("");
 			} else {
@@ -69,6 +71,13 @@ export default function SettingsRoute() {
 			setDraftVerifierModel(behavior?.draftVerifierModel ?? "");
 			setClassifierModel(behavior?.classifierModel ?? "");
 		}
+		// `availableModels` is intentionally not in the dep list — re-running
+		// this effect when the dynamic list resolves would reset every other
+		// piece of edited state (auto-draft toggle, custom prompt, …) back to
+		// the saved values, silently undoing the user's edits. The initial
+		// fallback list (`[...TEXT_MODELS]`) is stable enough to map saved
+		// models on first render.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [mailbox]);
 
 	const handleSave = async () => {
@@ -106,7 +115,7 @@ export default function SettingsRoute() {
 			agentSystemPrompt: agentPrompt.trim() || undefined,
 			security,
 			autoDraft: { enabled: autoDraftEnabled },
-			agentModel: resolvedModel || TEXT_MODELS[0],
+			agentModel: resolvedModel || availableModels[0] || TEXT_MODELS[0],
 			injectionScannerModel: injectionScannerModel.trim() || undefined,
 			draftVerifierModel: draftVerifierModel.trim() || undefined,
 			classifierModel: classifierModel.trim() || undefined,
@@ -228,7 +237,7 @@ export default function SettingsRoute() {
 							onChange={(e) => setModelChoice(e.target.value)}
 							className="w-full rounded-md border border-line bg-paper-2 px-3 py-2 text-sm text-ink focus:outline-none focus:ring-1 focus:ring-accent"
 						>
-							{TEXT_MODELS.map((m) => (
+							{availableModels.map((m) => (
 								<option key={m} value={m}>{m}</option>
 							))}
 							<option value="__custom__">Custom…</option>

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -191,6 +191,12 @@ const api = {
 		get<HubSharingGroupsResponse>(`/api/v1/mailboxes/${mailboxId}/hub/sharing-groups`, {
 			signal: opts?.signal,
 		}),
+
+	// AI — Workers AI text-generation model list (#64). Worker
+	// read-through caches against KV with a static fallback, so this
+	// endpoint always resolves to a usable list.
+	getTextModels: (opts?: { signal?: AbortSignal }) =>
+		get<{ models: string[] }>("/api/v1/ai/text-models", { signal: opts?.signal }),
 };
 
 export default api;

--- a/tests/lib/text-models.test.ts
+++ b/tests/lib/text-models.test.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listTextModels, type TextModelsEnv } from "../../workers/lib/text-models";
+import { TEXT_MODELS } from "../../shared/mailbox-settings";
+
+interface FakeKv {
+	store: Map<string, string>;
+	puts: Array<{ key: string; value: string; ttl?: number }>;
+	get: KVNamespace["get"];
+	put: KVNamespace["put"];
+}
+
+function fakeKv(initial: Record<string, unknown> = {}): FakeKv {
+	const store = new Map(
+		Object.entries(initial).map(([k, v]) => [k, JSON.stringify(v)]),
+	);
+	const puts: FakeKv["puts"] = [];
+	const get: KVNamespace["get"] = (async (key: string, type?: unknown) => {
+		const raw = store.get(key);
+		if (raw === undefined) return null;
+		if (type === "json" || (type && typeof type === "object" && (type as { type?: string }).type === "json")) {
+			try {
+				return JSON.parse(raw);
+			} catch {
+				return null;
+			}
+		}
+		return raw;
+	}) as KVNamespace["get"];
+	const put: KVNamespace["put"] = (async (
+		key: string,
+		value: string,
+		opts?: { expirationTtl?: number },
+	) => {
+		store.set(key, value);
+		puts.push({ key, value, ttl: opts?.expirationTtl });
+	}) as KVNamespace["put"];
+	return { store, puts, get, put };
+}
+
+function asKv(fk: FakeKv): KVNamespace {
+	return { get: fk.get, put: fk.put } as unknown as KVNamespace;
+}
+
+describe("listTextModels", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("falls back to the static list when no creds and no cache", async () => {
+		const fk = fakeKv();
+		const env: TextModelsEnv = { BLOOM_KV: asKv(fk) };
+		const result = await listTextModels(env);
+		expect(result.source).toBe("fallback");
+		expect(result.models).toEqual([...TEXT_MODELS]);
+	});
+
+	it("returns the cached list without hitting the network when KV has data", async () => {
+		const fetcher = vi.fn();
+		const fk = fakeKv({
+			"text-models:v1": {
+				models: ["@cf/cached/one", "@cf/cached/two"],
+				cachedAt: "2026-04-30T12:00:00Z",
+			},
+		});
+		const env: TextModelsEnv = {
+			BLOOM_KV: asKv(fk),
+			CLOUDFLARE_API_TOKEN: "tok",
+			CLOUDFLARE_ACCOUNT_ID: "acct",
+		};
+		const result = await listTextModels(env, { fetcher: fetcher as typeof fetch });
+		expect(result.source).toBe("kv");
+		expect(result.models).toEqual(["@cf/cached/one", "@cf/cached/two"]);
+		expect(fetcher).not.toHaveBeenCalled();
+	});
+
+	it("hits the upstream API when cache is empty and writes back to KV", async () => {
+		const upstream = {
+			success: true,
+			result: [
+				{ name: "@cf/meta/llama-3.3-70b-instruct-fp8-fast" },
+				{ name: "@cf/moonshotai/kimi-k2.5" },
+				// Non-`@cf/` entry should be filtered out (defensive against
+				// the API drifting to include partner-routed models).
+				{ name: "anthropic/claude-3" },
+			],
+		};
+		const fetcher = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify(upstream), { status: 200 }),
+		);
+		const fk = fakeKv();
+		const env: TextModelsEnv = {
+			BLOOM_KV: asKv(fk),
+			CLOUDFLARE_API_TOKEN: "tok",
+			CLOUDFLARE_ACCOUNT_ID: "acct123",
+		};
+		const result = await listTextModels(env, { fetcher: fetcher as typeof fetch });
+
+		expect(result.source).toBe("remote");
+		expect(result.models).toEqual([
+			"@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+			"@cf/moonshotai/kimi-k2.5",
+		]);
+
+		expect(fetcher).toHaveBeenCalledTimes(1);
+		const url = (fetcher.mock.calls[0]![0] as string).toString();
+		expect(url).toContain("/accounts/acct123/ai/models/search");
+		expect(url).toContain("task=Text+Generation");
+		const init = fetcher.mock.calls[0]![1] as RequestInit;
+		expect(init.headers).toMatchObject({ authorization: "Bearer tok" });
+
+		// KV write happened with the right TTL.
+		// Allow a tick for the fire-and-forget put to land.
+		await new Promise((r) => setTimeout(r, 0));
+		expect(fk.puts).toHaveLength(1);
+		expect(fk.puts[0].key).toBe("text-models:v1");
+		expect(fk.puts[0].ttl).toBe(60 * 60);
+	});
+
+	it("falls back to the static list when upstream returns non-OK", async () => {
+		const fetcher = vi
+			.fn()
+			.mockResolvedValue(new Response("nope", { status: 500 }));
+		const fk = fakeKv();
+		const env: TextModelsEnv = {
+			BLOOM_KV: asKv(fk),
+			CLOUDFLARE_API_TOKEN: "tok",
+			CLOUDFLARE_ACCOUNT_ID: "acct",
+		};
+		const result = await listTextModels(env, { fetcher: fetcher as typeof fetch });
+		expect(result.source).toBe("fallback");
+		expect(result.models).toEqual([...TEXT_MODELS]);
+		expect(fk.puts).toHaveLength(0); // nothing cached on a failure
+	});
+
+	it("falls back to the static list when upstream throws", async () => {
+		const fetcher = vi.fn().mockRejectedValue(new Error("network"));
+		const fk = fakeKv();
+		const env: TextModelsEnv = {
+			BLOOM_KV: asKv(fk),
+			CLOUDFLARE_API_TOKEN: "tok",
+			CLOUDFLARE_ACCOUNT_ID: "acct",
+		};
+		const result = await listTextModels(env, { fetcher: fetcher as typeof fetch });
+		expect(result.source).toBe("fallback");
+		expect(result.models).toEqual([...TEXT_MODELS]);
+	});
+
+	it("falls back when upstream returns zero @cf/ models", async () => {
+		const fetcher = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ result: [{ name: "openai/gpt-4" }] })),
+		);
+		const fk = fakeKv();
+		const env: TextModelsEnv = {
+			BLOOM_KV: asKv(fk),
+			CLOUDFLARE_API_TOKEN: "tok",
+			CLOUDFLARE_ACCOUNT_ID: "acct",
+		};
+		const result = await listTextModels(env, { fetcher: fetcher as typeof fetch });
+		expect(result.source).toBe("fallback");
+		expect(result.models).toEqual([...TEXT_MODELS]);
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -37,6 +37,7 @@ import {
 	type OrgMailboxSummary,
 	type OrgOverview,
 } from "./lib/dashboard-aggregation";
+import { listTextModels } from "./lib/text-models";
 
 type AppContext = Context<MailboxContext>;
 
@@ -111,6 +112,24 @@ app.get("/api/v1/config", (c) => {
 	const domains = domainsRaw.split(",").map((d) => d.trim()).filter(Boolean);
 	const emailAddresses = c.env.EMAIL_ADDRESSES ?? [];
 	return c.json({ domains, emailAddresses });
+});
+
+// Workers AI text-generation model list (#64). KV-cached read-through to
+// the Cloudflare API; falls back to the curated TEXT_MODELS constant when
+// CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID aren't configured or the
+// upstream call fails.
+app.get("/api/v1/ai/text-models", async (c) => {
+	const env = c.env as typeof c.env & {
+		CLOUDFLARE_API_TOKEN?: string;
+		CLOUDFLARE_ACCOUNT_ID?: string;
+	};
+	const result = await listTextModels({
+		BLOOM_KV: env.BLOOM_KV,
+		CLOUDFLARE_API_TOKEN: env.CLOUDFLARE_API_TOKEN,
+		CLOUDFLARE_ACCOUNT_ID: env.CLOUDFLARE_ACCOUNT_ID,
+	});
+	c.header("X-Text-Models-Source", result.source);
+	return c.json({ models: result.models });
 });
 
 // -- Mailboxes ------------------------------------------------------

--- a/workers/lib/text-models.ts
+++ b/workers/lib/text-models.ts
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Dynamic Workers AI text-generation model list (#64).
+ *
+ * Fetches `?task=Text Generation` from the Cloudflare Workers AI REST API,
+ * normalizes to a `string[]` of model ids (`@cf/...`), and caches the
+ * result in `BLOOM_KV` for 1 hour.
+ *
+ * Falls back to the curated `TEXT_MODELS` constant when:
+ *  - the runtime secrets aren't configured (`CLOUDFLARE_API_TOKEN` /
+ *    `CLOUDFLARE_ACCOUNT_ID` missing or empty),
+ *  - the upstream call fails or returns an unexpected shape, or
+ *  - KV is unavailable on the env (defensive — current deploys always
+ *    bind it).
+ *
+ * Pure function — accepts the env-shaped object so tests can stub
+ * `fetch`/KV without spinning up a full worker.
+ */
+
+import { TEXT_MODELS } from "../../shared/mailbox-settings";
+
+export interface TextModelsEnv {
+	BLOOM_KV?: KVNamespace;
+	CLOUDFLARE_API_TOKEN?: string;
+	CLOUDFLARE_ACCOUNT_ID?: string;
+}
+
+export interface TextModelsResult {
+	models: string[];
+	/** Where the response came from — used by tests and a debug header. */
+	source: "kv" | "remote" | "fallback";
+}
+
+const CACHE_KEY = "text-models:v1";
+const CACHE_TTL_S = 60 * 60; // 1 hour
+
+interface CachedShape {
+	models: string[];
+	cachedAt: string;
+}
+
+/** Fallback list — the hand-curated set we shipped before #64. */
+function fallback(): TextModelsResult {
+	return { models: [...TEXT_MODELS], source: "fallback" };
+}
+
+/**
+ * Read-through cache: KV → upstream API → static fallback. Always
+ * resolves to a usable list even on partial failure.
+ */
+export async function listTextModels(
+	env: TextModelsEnv,
+	options: {
+		fetcher?: typeof fetch;
+		now?: () => number;
+	} = {},
+): Promise<TextModelsResult> {
+	const fetcher = options.fetcher ?? globalThis.fetch;
+
+	if (env.BLOOM_KV) {
+		try {
+			const cached = await env.BLOOM_KV.get(CACHE_KEY, "json");
+			if (cached && isCachedShape(cached) && cached.models.length > 0) {
+				return { models: cached.models, source: "kv" };
+			}
+		} catch (e) {
+			console.error("text-models: KV read failed:", (e as Error).message);
+		}
+	}
+
+	const token = env.CLOUDFLARE_API_TOKEN?.trim();
+	const accountId = env.CLOUDFLARE_ACCOUNT_ID?.trim();
+	if (!token || !accountId) {
+		// No creds configured — fall back without bumping KV.
+		return fallback();
+	}
+
+	try {
+		const url = new URL(
+			`https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/ai/models/search`,
+		);
+		url.searchParams.set("task", "Text Generation");
+		const resp = await fetcher(url.toString(), {
+			headers: {
+				authorization: `Bearer ${token}`,
+				accept: "application/json",
+			},
+		});
+		if (!resp.ok) {
+			console.warn(`text-models: upstream returned ${resp.status}`);
+			return fallback();
+		}
+		const body = (await resp.json()) as unknown;
+		const models = parseModelsResponse(body);
+		if (models.length === 0) {
+			console.warn("text-models: upstream returned 0 models, using fallback");
+			return fallback();
+		}
+
+		if (env.BLOOM_KV) {
+			const payload: CachedShape = {
+				models,
+				cachedAt: new Date().toISOString(),
+			};
+			env.BLOOM_KV.put(CACHE_KEY, JSON.stringify(payload), {
+				expirationTtl: CACHE_TTL_S,
+			}).catch((e) => {
+				// Cache write is best-effort — never block the response.
+				console.error("text-models: KV write failed:", (e as Error).message);
+			});
+		}
+
+		return { models, source: "remote" };
+	} catch (e) {
+		console.error("text-models: upstream fetch failed:", (e as Error).message);
+		return fallback();
+	}
+}
+
+function isCachedShape(v: unknown): v is CachedShape {
+	if (!v || typeof v !== "object") return false;
+	const obj = v as { models?: unknown };
+	return Array.isArray(obj.models) && obj.models.every((m) => typeof m === "string");
+}
+
+/**
+ * Pull `name` strings from the upstream `result[]` array. The API
+ * response shape is `{ success, result: [{ name, task: { name } }] }`.
+ * We only keep entries whose name starts with `@cf/` — defensive
+ * against the API drifting to include partner-routed models that
+ * Workers AI bindings don't accept directly.
+ */
+function parseModelsResponse(body: unknown): string[] {
+	if (!body || typeof body !== "object") return [];
+	const result = (body as { result?: unknown }).result;
+	if (!Array.isArray(result)) return [];
+	const names = new Set<string>();
+	for (const entry of result) {
+		if (!entry || typeof entry !== "object") continue;
+		const name = (entry as { name?: unknown }).name;
+		if (typeof name !== "string") continue;
+		if (!name.startsWith("@cf/")) continue;
+		names.add(name);
+	}
+	return [...names].sort();
+}


### PR DESCRIPTION
## Summary
Replaces the hand-curated `TEXT_MODELS` array as the *only* source of truth in the Settings model dropdown with a runtime fetch against the Cloudflare Workers AI REST API. The static list stays as a guaranteed fallback so the dropdown is never empty.

### Worker side
- New `GET /api/v1/ai/text-models` endpoint backed by `listTextModels`, a read-through cache: **BLOOM_KV → upstream API → static fallback**.
- KV cache key `text-models:v1`, TTL 1 hour. Cache writes are fire-and-forget so a slow KV write never blocks the response.
- Upstream parser keeps only `@cf/`-prefixed names (defensive against the API drifting to include partner-routed models).
- Falls back to the curated `TEXT_MODELS` when:
  - `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` are missing or empty,
  - upstream returns non-OK or throws,
  - upstream returns zero `@cf/` models.
- Response carries an `X-Text-Models-Source` debug header (`kv` / `remote` / `fallback`).

### Frontend side
- New `useTextModels()` hook reads through `/api/v1/ai/text-models` and exposes `models: string[]` with the static list as the immediate fallback so the dropdown is populated on first paint.
- The settings useEffect deliberately does NOT depend on `availableModels`: re-running on resolution would silently reset every other piece of edited state (auto-draft toggle, prompt, …) back to the saved values mid-edit. Documented inline.

### Required infrastructure (optional secrets)
- `CLOUDFLARE_API_TOKEN` with `AI:Read` scope.
- `CLOUDFLARE_ACCOUNT_ID`.
Both are optional — the endpoint degrades cleanly to the static list when either is unset.

## Acceptance criteria
- [x] Worker route returns `{ models: string[] }` from a 1h-cached upstream fetch.
- [x] Frontend hook reads the worker route and feeds the Settings dropdown.
- [x] Fallback to a small hardcoded list (current `TEXT_MODELS`) on token-missing / API-down / upstream-empty.
- [x] Documentation: `.dev.vars.example` documents both new optional secrets.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 262 passing, 0 failing (30 test files; +6 vs main: KV hit, upstream-success + KV write, no-creds fallback, upstream-non-OK fallback, upstream-throw fallback, zero-`@cf/` upstream fallback)

Closes #64
