### PR TITLE
security: replace regex HTML stripping with a real tokenizer

### DIFF
--- a/app/components/EmailPanel.tsx
+++ b/app/components/EmailPanel.tsx
@@ -11,7 +11,7 @@ import EmailPanelToolbar from "~/components/email-panel/EmailPanelToolbar";
 import SingleMessageView from "~/components/email-panel/SingleMessageView";
 import ThreadMessage from "~/components/email-panel/ThreadMessage";
 import { useFeedback } from "~/lib/feedback";
-import { splitEmailList, toEmailListValue } from "~/lib/utils";
+import { htmlToPlainText, splitEmailList, toEmailListValue } from "~/lib/utils";
 import api from "~/services/api";
 import { useDeleteEmail, useEmail, useMoveEmail, useReplyToEmail, useSendEmail, useThreadReplies, useUpdateEmail } from "~/queries/emails";
 import { useFolders } from "~/queries/folders";
@@ -125,7 +125,7 @@ export default function EmailPanel({ emailId }: { emailId: string }) {
 				from,
 				subject: target.subject || "(no subject)",
 				html: target.body || "",
-				text: target.body ? target.body.replace(/<[^>]*>/g, "").trim() : "",
+				text: target.body ? htmlToPlainText(target.body) : "",
 			};
 			if (originalEmail) await replyMut.mutateAsync({ mailboxId, emailId: originalEmail.id, email: emailData }); else await sendEmailMut.mutateAsync({ mailboxId, email: emailData });
 			await deleteEmailMut.mutateAsync({ mailboxId, id: target.id });

--- a/app/components/MCPPanel.tsx
+++ b/app/components/MCPPanel.tsx
@@ -10,7 +10,6 @@ import {
 	WrenchIcon,
 } from "@phosphor-icons/react";
 import { useState } from "react";
-import { useParams } from "react-router";
 
 function CopyButton({ text }: { text: string }) {
 	const [copied, setCopied] = useState(false);
@@ -59,7 +58,6 @@ const TOOLS = [
 ];
 
 export default function MCPPanel() {
-	const { mailboxId } = useParams<{ mailboxId: string }>();
 	const baseUrl =
 		typeof window !== "undefined" ? window.location.origin : "https://your-app.workers.dev";
 	const mcpUrl = `${baseUrl}/mcp`;

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -10,6 +10,7 @@
  */
 import DOMPurify from "dompurify";
 import { formatQuotedDate } from "shared/dates";
+import { htmlToPlainText as htmlToText } from "shared/html-text";
 import type { Attachment } from "~/types";
 
 export {
@@ -52,47 +53,18 @@ export function toEmailListValue(addresses: string[]): string | string[] | undef
 }
 
 /**
- * Convert HTML content to plain text.
- * Uses DOM APIs so must only be called client-side.
+ * Convert HTML content to plain text. Preserves paragraph breaks where the
+ * source had block-level structure.
  */
 export function htmlToPlainText(html: string): string {
-	// Sanitize with DOMPurify before DOM parsing to prevent XSS during innerHTML assignment.
-	// DOMPurify strips all dangerous content (scripts, event handlers, etc.)
-	// while preserving structural HTML for text extraction.
-	const sanitized = DOMPurify.sanitize(html);
-	const div = document.createElement("div");
-	div.innerHTML = sanitized
-		.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
-		.replace(/<br\s*\/?>/gi, "\n")
-		.replace(/<\/p>/gi, "\n\n")
-		.replace(/<p[^>]*>/gi, "")
-		.replace(/<div[^>]*>/gi, "")
-		.replace(/<\/div>/gi, "\n");
-	return (div.textContent || div.innerText || "").trim();
+	return htmlToText(html, { preserveLineBreaks: true });
 }
 
 /**
- * Strip all HTML tags from a string.
+ * Strip all HTML tags and collapse whitespace to a single line of plain text.
  */
 export function stripHtml(html: string): string {
-	return html.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
-}
-
-function decodeHtmlEntities(text: string): string {
-	return text
-		.replace(/&#(\d+);/g, (_match: string, code: string) =>
-			String.fromCharCode(Number(code)),
-		)
-		.replace(/&#x([0-9a-f]+);/gi, (_match: string, hex: string) =>
-			String.fromCharCode(Number.parseInt(hex, 16)),
-		)
-		.replace(/&amp;/g, "&")
-		.replace(/&lt;/g, "<")
-		.replace(/&gt;/g, ">")
-		.replace(/&quot;/g, '"')
-		.replace(/&#39;/g, "'")
-		.replace(/&apos;/g, "'")
-		.replace(/&nbsp;/g, " ");
+	return htmlToText(html);
 }
 
 export function getSnippetText(
@@ -100,17 +72,7 @@ export function getSnippetText(
 	maxLength = 100,
 ): string {
 	if (!snippet) return "";
-
-	const clean = decodeHtmlEntities(
-		snippet
-			.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
-			.replace(/<style[^>]*>[\s\S]*/gi, "")
-			.replace(/<[^>]*>/g, " ")
-			.replace(/<[^>]*$/g, ""),
-	)
-		.replace(/\s+/g, " ")
-		.trim();
-
+	const clean = htmlToText(snippet);
 	if (!clean) return "";
 	return clean.length > maxLength ? `${clean.slice(0, maxLength)}...` : clean;
 }

--- a/hub/tests/lib/aggregate.test.ts
+++ b/hub/tests/lib/aggregate.test.ts
@@ -139,9 +139,6 @@ describe("applyCorroboration", () => {
 		await seedSharingGroup("sg-2");
 
 		// Both orgs submit the same value to sg-1; only org-A submits to sg-2.
-		for (const sg of ["sg-1", "sg-1", "sg-2"]) {
-			const org = sg === "sg-2" ? "org-A" : sg === "sg-1" ? "org-A" : "org-B";
-		}
 		await applyCorroboration(db.d1, {
 			event_uuid: "e1", orgc_uuid: "org-A", sharing_group_uuid: "sg-1",
 			attributes: [{ type: "url", value: "https://x.example" }],

--- a/shared/html-text.ts
+++ b/shared/html-text.ts
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Runtime-agnostic HTML → plain text conversion.
+ *
+ * Used in two places where regex-based stripping was previously flagged by
+ * CodeQL (js/incomplete-multi-character-sanitization, js/bad-tag-filter,
+ * js/double-escaping):
+ *   - browser code in app/lib/utils.ts (snippets, quoted-reply blocks)
+ *   - worker code in workers/lib/email-helpers.ts (outbound MIME plain-text
+ *     alternative, classifier inputs)
+ *
+ * The implementation is a small character-walking tokenizer rather than a set
+ * of regex replacements. This avoids the well-known regex pitfalls — e.g.
+ * `/<script[^>]*>[\s\S]*?<\/script>/gi` misses `</script foo="">` — and
+ * handles attribute values that contain `>` correctly.
+ *
+ * It is *not* a full HTML parser. It does not validate structure, build a
+ * tree, or care about malformed input. Its only job is to extract the
+ * user-visible text while dropping script/style content.
+ */
+
+const NAMED_ENTITIES: Record<string, string> = {
+	amp: "&",
+	lt: "<",
+	gt: ">",
+	quot: '"',
+	apos: "'",
+	nbsp: " ",
+};
+
+/**
+ * Decode HTML entities in already-extracted text. Numeric (`&#39;`, `&#x27;`)
+ * and the small set of named entities above are recognized. Unknown entities
+ * are left as-is — no double-decoding.
+ */
+function decodeEntities(text: string): string {
+	if (!text || text.indexOf("&") === -1) return text;
+	return text.replace(/&(#x[0-9a-f]+|#[0-9]+|[a-z]+);/gi, (match, body: string) => {
+		if (body.startsWith("#x") || body.startsWith("#X")) {
+			const code = Number.parseInt(body.slice(2), 16);
+			return Number.isFinite(code) ? String.fromCodePoint(code) : match;
+		}
+		if (body.startsWith("#")) {
+			const code = Number.parseInt(body.slice(1), 10);
+			return Number.isFinite(code) ? String.fromCodePoint(code) : match;
+		}
+		const named = NAMED_ENTITIES[body.toLowerCase()];
+		return named ?? match;
+	});
+}
+
+/** Skip past the closing `>` of a tag, respecting quoted attribute values. */
+function skipTag(html: string, start: number): number {
+	let i = start;
+	let quote = "";
+	while (i < html.length) {
+		const ch = html[i];
+		if (quote) {
+			if (ch === quote) quote = "";
+		} else if (ch === '"' || ch === "'") {
+			quote = ch;
+		} else if (ch === ">") {
+			return i + 1;
+		}
+		i++;
+	}
+	return html.length;
+}
+
+/**
+ * Skip past `</tagName ...>` for the given tag name (case-insensitive). The
+ * HTML spec terminates rawtext on `</tag` followed by whitespace, `/`, or
+ * `>` — anything else is treated as text.
+ */
+function skipRawText(html: string, start: number, tagName: string): number {
+	const lower = html.toLowerCase();
+	const needle = `</${tagName}`;
+	let i = start;
+	while (i < html.length) {
+		const found = lower.indexOf(needle, i);
+		if (found === -1) return html.length;
+		const after = found + needle.length;
+		const next = html[after];
+		if (next === undefined || next === ">" || next === "/" || /\s/.test(next)) {
+			return skipTag(html, after);
+		}
+		i = found + needle.length;
+	}
+	return html.length;
+}
+
+export interface HtmlToTextOptions {
+	/** Convert <br> and block-level closes to newlines instead of spaces. */
+	preserveLineBreaks?: boolean;
+}
+
+const BLOCK_CLOSE_TAGS = new Set([
+	"p",
+	"div",
+	"br",
+	"li",
+	"tr",
+	"h1",
+	"h2",
+	"h3",
+	"h4",
+	"h5",
+	"h6",
+]);
+
+/**
+ * Extract user-visible text from an HTML fragment. Drops `<script>` and
+ * `<style>` content entirely; replaces all other tags with whitespace
+ * (or a newline, if `preserveLineBreaks` is set and the tag is block-level).
+ * Decodes HTML entities and collapses whitespace.
+ */
+export function htmlToPlainText(html: string, opts: HtmlToTextOptions = {}): string {
+	if (!html) return "";
+
+	const { preserveLineBreaks = false } = opts;
+	const out: string[] = [];
+	let i = 0;
+	const len = html.length;
+
+	while (i < len) {
+		const lt = html.indexOf("<", i);
+		if (lt === -1) {
+			out.push(html.slice(i));
+			break;
+		}
+		if (lt > i) out.push(html.slice(i, lt));
+
+		// Comment: `<!-- ... -->`. Treat as a word break so `a<!--x-->b`
+		// doesn't merge into `ab`.
+		if (html.startsWith("<!--", lt)) {
+			const end = html.indexOf("-->", lt + 4);
+			out.push(" ");
+			i = end === -1 ? len : end + 3;
+			continue;
+		}
+		// Doctype / processing instruction / CDATA — skip to next `>`.
+		if (html.startsWith("<!", lt) || html.startsWith("<?", lt)) {
+			i = skipTag(html, lt + 2);
+			continue;
+		}
+
+		// Read tag name. `<` not followed by a tag-name char is literal text.
+		const nameStart = html[lt + 1] === "/" ? lt + 2 : lt + 1;
+		const firstCh = html[nameStart];
+		if (!firstCh || !/[a-zA-Z]/.test(firstCh)) {
+			out.push("<");
+			i = lt + 1;
+			continue;
+		}
+
+		let nameEnd = nameStart;
+		while (nameEnd < len && /[a-zA-Z0-9]/.test(html[nameEnd])) nameEnd++;
+		const tagName = html.slice(nameStart, nameEnd).toLowerCase();
+		const afterTag = skipTag(html, nameEnd);
+
+		if (tagName === "script" || tagName === "style") {
+			// Rawtext element: drop content until the matching close tag.
+			// Emit a space so adjacent words don't merge.
+			out.push(" ");
+			i = skipRawText(html, afterTag, tagName);
+			continue;
+		}
+
+		const separator =
+			preserveLineBreaks && BLOCK_CLOSE_TAGS.has(tagName) ? "\n" : " ";
+		out.push(separator);
+		i = afterTag;
+	}
+
+	const text = decodeEntities(out.join(""));
+
+	if (preserveLineBreaks) {
+		// Collapse runs of spaces/tabs without eating newlines, then trim.
+		return text
+			.replace(/[^\S\n]+/g, " ")
+			.replace(/\n{3,}/g, "\n\n")
+			.replace(/[ \t]+\n/g, "\n")
+			.trim();
+	}
+	return text.replace(/\s+/g, " ").trim();
+}

--- a/tests/lib/html-text.test.ts
+++ b/tests/lib/html-text.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { htmlToPlainText } from "shared/html-text";
+
+describe("htmlToPlainText", () => {
+	it("returns empty string for empty input", () => {
+		expect(htmlToPlainText("")).toBe("");
+		expect(htmlToPlainText(undefined as unknown as string)).toBe("");
+	});
+
+	it("strips simple tags and collapses whitespace", () => {
+		expect(htmlToPlainText("<p>Hello <b>world</b></p>")).toBe("Hello world");
+	});
+
+	it("drops <script> content even with attributes containing >", () => {
+		const input = '<script type=">"]>alert(1)</script>after';
+		expect(htmlToPlainText(input)).toBe("after");
+	});
+
+	it("drops <script> content terminated by `</script foo>` (CodeQL js/bad-tag-filter)", () => {
+		const input = "before<script>alert(1)</script foo>after";
+		expect(htmlToPlainText(input)).toBe("before after");
+	});
+
+	it("drops <style> content with attributes containing >", () => {
+		const input = '<style media=">">body{color:red}</style>visible';
+		expect(htmlToPlainText(input)).toBe("visible");
+	});
+
+	it("preserves attribute text without leaking tag contents", () => {
+		// Naïve /<[^>]*>/g would emit `="x">` as text. Tokenizer must not.
+		expect(htmlToPlainText('<a href="x">link</a>')).toBe("link");
+	});
+
+	it("ignores `<` not followed by a tag name (literal text)", () => {
+		expect(htmlToPlainText("a < b and c > d")).toBe("a < b and c > d");
+	});
+
+	it("decodes named entities exactly once (no double-unescape)", () => {
+		// `&amp;lt;` should decode to `&lt;` (literal), not `<`. The previous
+		// regex pipeline did the double-decode that CodeQL flagged.
+		expect(htmlToPlainText("&amp;lt;tag&amp;gt;")).toBe("&lt;tag&gt;");
+	});
+
+	it("decodes numeric and hex entities", () => {
+		expect(htmlToPlainText("&#39;hi&#39; &#x2014; ok")).toBe("'hi' — ok");
+	});
+
+	it("strips HTML comments", () => {
+		expect(htmlToPlainText("a<!-- evil -->b")).toBe("a b");
+	});
+
+	it("preserves block-level breaks when requested", () => {
+		const out = htmlToPlainText("<p>one</p><p>two</p>", {
+			preserveLineBreaks: true,
+		});
+		expect(out).toBe("one\n\ntwo");
+	});
+
+	it("turns <br> into a newline when preserveLineBreaks is set", () => {
+		const out = htmlToPlainText("line1<br>line2", { preserveLineBreaks: true });
+		expect(out).toBe("line1\nline2");
+	});
+
+	it("does not execute or leak event-handler attributes", () => {
+		const input = '<img src=x onerror="alert(1)">';
+		expect(htmlToPlainText(input)).toBe("");
+	});
+
+	it("handles unclosed tags without infinite-looping", () => {
+		expect(htmlToPlainText("hello <b world")).toBe("hello");
+	});
+});

--- a/workers/dmarc/parser.ts
+++ b/workers/dmarc/parser.ts
@@ -66,7 +66,6 @@ export function parseDmarcXml(xml: string): DmarcReport {
 	for (const rec of allTags(xml, "record")) {
 		const row = tag(rec, "row") ?? "";
 		const identifiers = tag(rec, "identifiers") ?? "";
-		const authResults = tag(rec, "auth_results") ?? "";
 		const policyEval = tag(row, "policy_evaluated") ?? "";
 		const source_ip = tag(row, "source_ip")?.trim();
 		if (!source_ip) continue;

--- a/workers/intel/deep-scan.ts
+++ b/workers/intel/deep-scan.ts
@@ -31,7 +31,7 @@ import type { FinalVerdict, VerdictThresholds } from "../security/verdict";
 import { getMailboxStub } from "../lib/email-helpers";
 import { Folders } from "../../shared/folders";
 import { checkUrlAgainstFeeds } from "./feeds";
-import { lookupDomainAge, FRESH_DOMAIN_THRESHOLD_DAYS } from "./rdap";
+import { lookupDomainAge } from "./rdap";
 import { resolveUrl } from "./url-resolver";
 import {
 	aggregateAttachmentSignals,

--- a/workers/lib/ai.ts
+++ b/workers/lib/ai.ts
@@ -18,7 +18,7 @@ import {
 	DEFAULT_DRAFT_VERIFIER_MODEL,
 	DEFAULT_INJECTION_SCANNER_MODEL,
 } from "../../shared/mailbox-settings";
-import { escapeHtml, stripHtmlToText, textToHtml } from "./email-helpers";
+import { stripHtmlToText, textToHtml } from "./email-helpers";
 
 // ── Prompt Injection Scanner ───────────────────────────────────────
 

--- a/workers/lib/email-helpers.ts
+++ b/workers/lib/email-helpers.ts
@@ -13,6 +13,7 @@ import type { EmailFull } from "./schemas";
 import { Folders } from "../../shared/folders";
 import type { Env } from "../types";
 import { formatQuotedDate } from "../../shared/dates";
+import { htmlToPlainText } from "../../shared/html-text";
 
 // ── DO Stub ────────────────────────────────────────────────────────
 
@@ -176,17 +177,11 @@ export function textToHtml(text: string): string {
 
 /**
  * Strip HTML tags and normalize whitespace to produce plain text.
- * Removes <style> and <script> blocks first to avoid injecting their
- * content into the output.
+ * Drops `<script>` and `<style>` content via a real tokenizer so that
+ * variants like `</script foo="">` are handled correctly.
  */
 export function stripHtmlToText(html: string): string {
-	if (!html) return "";
-	return html
-		.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
-		.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
-		.replace(/<[^>]+>/g, " ")
-		.replace(/\s+/g, " ")
-		.trim();
+	return htmlToPlainText(html);
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the 8 high-severity CodeQL alerts (`js/incomplete-multi-character-sanitization`, `js/bad-tag-filter`, `js/double-escaping`) and the 5 `js/unused-local-variable` notes. Replaces fragile `/<script[^>]*>[\s\S]*?<\/script>/gi`-style strippers with a small shared tokenizer that handles attribute-`>` quoting, the `</script foo>` end-tag form, and HTML-entity decoding without double-unescape.

- New: [shared/html-text.ts](https://github.com/schmug/PhishSOC/blob/claude/ecstatic-heyrovsky-cb497d/shared/html-text.ts) — runtime-agnostic `htmlToPlainText(html, opts?)`. Used in both browser and Workers.
- Rewires call sites in [app/lib/utils.ts](https://github.com/schmug/PhishSOC/blob/claude/ecstatic-heyrovsky-cb497d/app/lib/utils.ts), [app/components/EmailPanel.tsx](https://github.com/schmug/PhishSOC/blob/claude/ecstatic-heyrovsky-cb497d/app/components/EmailPanel.tsx), and [workers/lib/email-helpers.ts](https://github.com/schmug/PhishSOC/blob/claude/ecstatic-heyrovsky-cb497d/workers/lib/email-helpers.ts).
- Cleans up 5 unused-var alerts.

Net **+212 / -64**, almost entirely the new tokenizer + 14-test suite.

## Why a custom tokenizer instead of `DOMParser` / `DOMPurify`?

Workers (`workerd`) doesn't ship `DOMParser`, and `DOMPurify` without a DOM is iffy on `workerd` — confirming or replacing it on the worker side is its own task ([#116](https://github.com/schmug/PhishSOC/issues/116)). A small char-walking tokenizer is portable across both runtimes, sidesteps every CodeQL pattern that flagged the old code, and is easier to test exhaustively. `DOMPurify` is still used for the rich cases (HTML signatures, iframe rendering) where preserving structural HTML matters — only the HTML-to-plain-text path was rewritten.

## Follow-ups filed

- [#116](https://github.com/schmug/PhishSOC/issues/116) — verify DOMPurify under workerd, swap if needed
- [#117](https://github.com/schmug/PhishSOC/issues/117) — gate PRs on CodeQL high-sev alerts via branch protection

## Test plan

- [x] `npx vitest run tests/lib/html-text.test.ts` — 14/14 (covers each CodeQL edge case: `</script foo>`, attribute `>`, double-decode, `<` literal, unclosed tag, event-handler attrs)
- [x] `npx vitest run` (node + pipeline pools) — 226 + 150 passing, no regressions in DMARC parser tests after `authResults` removal
- [x] `npm run typecheck` — no new errors (pre-existing `tests/frontend/**` `@testing-library/react` errors are env-only and unchanged from `main`)
- [ ] After merge: confirm code-scanning dashboard shows 0 open alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)