### PR TITLE
feat(hub): /admin/stats endpoint

### DIFF
--- a/hub/README.md
+++ b/hub/README.md
@@ -18,6 +18,7 @@ This is not a full MISP implementation. Adopters needing complete MISP functiona
 | `POST` | `/orgs/accept` | (public) | Redeems token; returns new `api_key` (shown once). |
 | `GET` | `/orgs/me` | API key | Authenticated org. |
 | `POST` `GET` `DELETE` | `/admin/peers[/:uuid]` | `HUB_ADMIN_KEY` | Inbound MISP peer config (see [Inbound MISP Sync](#inbound-misp-sync)). |
+| `GET` | `/admin/stats` | `HUB_ADMIN_KEY` | Operational-health snapshot (see [Inspecting the hub](#inspecting-the-hub)). |
 
 ## Auth
 
@@ -112,6 +113,50 @@ For local-org reports to count as corroboration of pulled intel, they must be po
 ### Loop prevention
 
 Events whose `orgc_uuid` matches a local org are skipped on pull. This handles the case where we previously published to the upstream and now see it coming back. Provenance is recorded on `events.source_peer_uuid` for forward-compat with outbound sync.
+
+## Inspecting the hub
+
+For at-a-glance operational health, hit `GET /admin/stats` with the admin key:
+
+```bash
+curl -s https://your-hub.example/admin/stats \
+  -H "Authorization: $HUB_ADMIN_KEY" | jq
+```
+
+You get a single JSON snapshot covering:
+
+- `orgs.total` and `orgs.active_last_7d` (orgs with at least one event in the last 7 days)
+- `events.total` and `events.last_24h`
+- `corroboration.rows` and `corroboration.promoted` (rows that meet `score ≥ 2.0 AND contributors ≥ 2` — same predicate as the destroylist)
+- `destroylist.by_sharing_group[]` — published-feed size per sharing group
+- `peers[]` — for each inbound peer: `last_pulled_at`, `last_error`, `events_pulled_24h`
+- `triage.events_with_tags_pct_24h` and `triage.untagged_older_than_15m` — proxy for triage queue health (queue depth itself isn't queryable from a Worker)
+- `cron.last_run_at` — proxy via `MAX(inbound_peers.last_pulled_ts)` since there's no cron-history table yet
+
+The 24h / 7d windows use `events.date` (the upstream MISP YYYY-MM-DD date), which is the only indexed time column on `events`. That's a coarse proxy for ingest time but keeps the queries off full-table scans.
+
+When `/admin/stats` is not enough, the next-level tools are:
+
+```bash
+# Live request + cron logs
+npx wrangler tail
+
+# Common D1 query recipes (run with --remote in production)
+npx wrangler d1 execute ais-hub --remote --command \
+  "SELECT name, last_pulled_ts, last_error FROM inbound_peers ib
+   JOIN peers p ON p.uuid = ib.peer_uuid ORDER BY name;"
+
+npx wrangler d1 execute ais-hub --remote --command \
+  "SELECT COUNT(*) AS untagged_now FROM events e
+   WHERE created_at < datetime('now','-15 minutes')
+     AND NOT EXISTS (SELECT 1 FROM event_tags et WHERE et.event_uuid = e.uuid);"
+
+npx wrangler d1 execute ais-hub --remote --command \
+  "SELECT sharing_group_uuid, COUNT(*) AS promoted
+     FROM corroboration
+    WHERE score >= 2.0 AND contributor_count >= 2
+    GROUP BY sharing_group_uuid;"
+```
 
 ## Future work
 

--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -25,6 +25,7 @@ import { feedRoutes } from "./routes/feeds";
 import { orgRoutes, orgAcceptApp } from "./routes/orgs";
 import { sharingGroupRoutes } from "./routes/sharing-groups";
 import { adminRoutes } from "./routes/admin";
+import { adminStatsRoutes } from "./routes/admin/stats";
 import { consumeTriageBatch } from "./agent/triage";
 import { runInboundSync } from "./lib/sync";
 import type { Env, TriageMessage } from "./types";
@@ -39,6 +40,7 @@ app.route("/orgs", orgAcceptApp); // public /orgs/accept
 app.route("/orgs", orgRoutes);    // authed /orgs/me, /orgs/invite
 app.route("/sharing_groups", sharingGroupRoutes);
 app.route("/admin", adminRoutes);
+app.route("/admin", adminStatsRoutes);
 
 export default {
 	fetch: app.fetch,

--- a/hub/src/routes/admin.ts
+++ b/hub/src/routes/admin.ts
@@ -8,6 +8,8 @@
  * /peers          POST   create an inbound peer (also creates peer + synthetic org)
  *                 GET    list inbound peers
  * /peers/:uuid    DELETE remove an inbound peer (cascade-removes peers row)
+ *
+ * /stats          GET    operational-health snapshot — see ./admin/stats.ts
  */
 
 import { Hono } from "hono";

--- a/hub/src/routes/admin/stats.ts
+++ b/hub/src/routes/admin/stats.ts
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * GET /admin/stats — at-a-glance hub operational health.
+ *
+ * Single JSON snapshot for an operator. Covers:
+ *   - org & event counts (with 24h / 7d slices)
+ *   - corroboration row count + promoted-to-destroylist count
+ *   - destroylist sizes per sharing group
+ *   - inbound peers: last pull time, last error, events pulled in last 24h
+ *   - triage health: % of last-24h events that got LLM tags + count of
+ *     events still untagged 15m after ingest (queue-backup smoke signal)
+ *   - cron last-run proxy
+ *
+ * Index discipline. All counts come off existing D1 indexes from
+ * 0001_schema.sql / 0002_inbound_sync.sql; no new migrations are
+ * introduced by this endpoint:
+ *
+ *   - `idx_events_date`           drives the 24h / 7d windows on `events`.
+ *     Note: `events.date` is the upstream MISP event date (YYYY-MM-DD),
+ *     not local ingest time. We accept the coarseness — for an at-a-glance
+ *     dashboard it's a close-enough proxy and it's the only indexed time
+ *     column on `events`. Adding a `created_at` index would be a separate
+ *     migration; that's a follow-up, not part of this endpoint.
+ *   - `idx_events_source_peer`    drives per-peer events_pulled_24h.
+ *   - `idx_corroboration_sharing_group` drives the destroylist groupby.
+ *
+ * Where a query needs a non-indexed predicate (e.g. the 15-minute
+ * `created_at` filter for stuck-in-triage events), it is gated behind an
+ * indexed pre-filter (`date >= today-1`) so the scan is bounded to a
+ * single day's slice rather than the full table.
+ *
+ * `cron.last_run_at` is a proxy: there is no cron-history table in the
+ * schema today. We surface `MAX(last_pulled_ts)` across inbound peers as
+ * the closest signal — if the cron is alive AND any peer is healthy, this
+ * advances every 5 minutes. A peer-pull failure can mask a healthy cron;
+ * a real cron-run-log is filed as a follow-up.
+ */
+
+import { Hono } from "hono";
+import { requireAdmin, type AdminContext } from "../../lib/admin-auth";
+import { PROMOTION_SCORE, PROMOTION_CONTRIBUTORS } from "../../lib/aggregate";
+
+export const adminStatsRoutes = new Hono<AdminContext>();
+
+adminStatsRoutes.use("*", requireAdmin);
+
+interface CountRow {
+	n: number;
+}
+
+adminStatsRoutes.get("/stats", async (c) => {
+	const db = c.env.DB;
+
+	// --- orgs -----------------------------------------------------------
+	const orgsTotal = (await db.prepare(`SELECT COUNT(*) AS n FROM orgs`).first<CountRow>())?.n ?? 0;
+
+	// "active" = has authored at least one event in the last 7d. Uses
+	// idx_events_date; date is upstream YYYY-MM-DD, see file-level note.
+	const activeOrgs = (await db
+		.prepare(
+			`SELECT COUNT(DISTINCT orgc_uuid) AS n
+			 FROM events
+			 WHERE date >= date('now', '-7 days')`,
+		)
+		.first<CountRow>())?.n ?? 0;
+
+	// --- events ---------------------------------------------------------
+	const eventsTotal = (await db.prepare(`SELECT COUNT(*) AS n FROM events`).first<CountRow>())?.n ?? 0;
+	const eventsLast24h = (await db
+		.prepare(
+			`SELECT COUNT(*) AS n FROM events WHERE date >= date('now', '-1 day')`,
+		)
+		.first<CountRow>())?.n ?? 0;
+
+	// --- corroboration --------------------------------------------------
+	const corroborationRows = (await db
+		.prepare(`SELECT COUNT(*) AS n FROM corroboration`)
+		.first<CountRow>())?.n ?? 0;
+	// Use the same predicate `aggregate.ts` uses for promotion. Imported
+	// rather than re-declared so a threshold change in one place can never
+	// drift from the other.
+	const corroborationPromoted = (await db
+		.prepare(
+			`SELECT COUNT(*) AS n FROM corroboration
+			 WHERE score >= ?1 AND contributor_count >= ?2`,
+		)
+		.bind(PROMOTION_SCORE, PROMOTION_CONTRIBUTORS)
+		.first<CountRow>())?.n ?? 0;
+
+	// --- destroylist size per sharing group -----------------------------
+	const destroyRows = await db
+		.prepare(
+			`SELECT sg.uuid AS uuid, sg.name AS name, COUNT(c.id) AS size
+			 FROM sharing_groups sg
+			 LEFT JOIN corroboration c
+			   ON c.sharing_group_uuid = sg.uuid
+			   AND c.score >= ?1
+			   AND c.contributor_count >= ?2
+			 GROUP BY sg.uuid, sg.name
+			 ORDER BY sg.name`,
+		)
+		.bind(PROMOTION_SCORE, PROMOTION_CONTRIBUTORS)
+		.all<{ uuid: string; name: string; size: number }>();
+	const destroylistBySharingGroup = (destroyRows.results ?? []).map((r) => ({
+		uuid: r.uuid,
+		name: r.name,
+		size: r.size,
+	}));
+
+	// --- peers ----------------------------------------------------------
+	// Two-step: (1) list peers, (2) for each peer count events_pulled_24h
+	// off idx_events_source_peer + date predicate. Fan-out is bounded by
+	// the peer count (small — operator config), so this is fine.
+	const peerRows = await db
+		.prepare(
+			`SELECT ib.uuid AS inbound_uuid, p.name AS name,
+			        ib.last_pulled_ts AS last_pulled_at,
+			        ib.last_error AS last_error
+			 FROM inbound_peers ib JOIN peers p ON p.uuid = ib.peer_uuid
+			 ORDER BY p.name`,
+		)
+		.all<{ inbound_uuid: string; name: string; last_pulled_at: string | null; last_error: string | null }>();
+	const peers = await Promise.all(
+		(peerRows.results ?? []).map(async (peer) => {
+			const pulled = (await db
+				.prepare(
+					`SELECT COUNT(*) AS n FROM events
+					 WHERE source_peer_uuid = ?1
+					   AND date >= date('now', '-1 day')`,
+				)
+				.bind(peer.inbound_uuid)
+				.first<CountRow>())?.n ?? 0;
+			return {
+				name: peer.name,
+				last_pulled_at: peer.last_pulled_at,
+				last_error: peer.last_error,
+				events_pulled_24h: pulled,
+			};
+		}),
+	);
+
+	// --- triage health --------------------------------------------------
+	// pct of last-24h events with at least one tag attached. The 24h slice
+	// is selected via idx_events_date so this stays bounded.
+	const taggedSummary = await db
+		.prepare(
+			`SELECT
+			   COUNT(*) AS total,
+			   SUM(CASE WHEN EXISTS (
+			       SELECT 1 FROM event_tags et WHERE et.event_uuid = e.uuid
+			   ) THEN 1 ELSE 0 END) AS tagged
+			 FROM events e
+			 WHERE date >= date('now', '-1 day')`,
+		)
+		.first<{ total: number; tagged: number | null }>();
+	const total24 = taggedSummary?.total ?? 0;
+	const tagged24 = taggedSummary?.tagged ?? 0;
+	const eventsWithTagsPct24h = total24 > 0 ? tagged24 / total24 : 0;
+
+	// "Untagged > 15 minutes after ingest" — symptom of a backed-up triage
+	// queue (queue depth itself isn't queryable from a Worker). We narrow
+	// to the last-24h slice via the indexed `date` column FIRST so the
+	// non-indexed `created_at < now-15m` predicate only scans a day's
+	// worth of rows in the worst case.
+	const untaggedOlderThan15m = (await db
+		.prepare(
+			`SELECT COUNT(*) AS n FROM events e
+			 WHERE date >= date('now', '-1 day')
+			   AND created_at < datetime('now', '-15 minutes')
+			   AND NOT EXISTS (
+			     SELECT 1 FROM event_tags et WHERE et.event_uuid = e.uuid
+			   )`,
+		)
+		.first<CountRow>())?.n ?? 0;
+
+	// --- cron -----------------------------------------------------------
+	// Proxy: latest watermark advance across inbound peers. See file note.
+	const cronLast = await db
+		.prepare(`SELECT MAX(last_pulled_ts) AS last FROM inbound_peers`)
+		.first<{ last: string | null }>();
+
+	return c.json({
+		orgs: { total: orgsTotal, active_last_7d: activeOrgs },
+		events: { total: eventsTotal, last_24h: eventsLast24h },
+		corroboration: { rows: corroborationRows, promoted: corroborationPromoted },
+		destroylist: { by_sharing_group: destroylistBySharingGroup },
+		peers,
+		triage: {
+			events_with_tags_pct_24h: Number(eventsWithTagsPct24h.toFixed(4)),
+			untagged_older_than_15m: untaggedOlderThan15m,
+		},
+		cron: { last_run_at: cronLast?.last ?? null },
+	});
+});

--- a/hub/tests/routes/admin-stats.test.ts
+++ b/hub/tests/routes/admin-stats.test.ts
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { adminStatsRoutes } from "../../src/routes/admin/stats";
+import { makeTestDb, type TestDb } from "../helpers/d1";
+import type { Env } from "../../src/types";
+
+let db: TestDb;
+let env: Env;
+
+beforeEach(() => {
+	db = makeTestDb();
+	env = {
+		DB: db.d1,
+		AI: {} as Ai,
+		TRIAGE_QUEUE: { send: async () => {} } as never,
+		HUB_ADMIN_KEY: "admin-secret",
+	} as Env;
+});
+
+afterEach(() => db.close());
+
+function appReq(path: string, init?: RequestInit) {
+	const app = new Hono<{ Bindings: Env }>();
+	app.route("/admin", adminStatsRoutes);
+	return app.request(`/admin${path}`, init, env as never);
+}
+
+const adminAuth = { Authorization: "admin-secret" };
+
+describe("GET /admin/stats — auth", () => {
+	it("returns 401 with no Authorization header", async () => {
+		const res = await appReq("/stats");
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 401 with the wrong admin key", async () => {
+		const res = await appReq("/stats", { headers: { Authorization: "nope" } });
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 401 when HUB_ADMIN_KEY is unset", async () => {
+		(env as { HUB_ADMIN_KEY: string | undefined }).HUB_ADMIN_KEY = "" as string;
+		const res = await appReq("/stats", { headers: adminAuth });
+		expect(res.status).toBe(401);
+	});
+});
+
+describe("GET /admin/stats — shape on an empty hub", () => {
+	it("returns the documented shape with all-zero counters", async () => {
+		const res = await appReq("/stats", { headers: adminAuth });
+		expect(res.status).toBe(200);
+		const body = await res.json() as Record<string, unknown>;
+
+		expect(body).toMatchObject({
+			orgs: { total: 0, active_last_7d: 0 },
+			events: { total: 0, last_24h: 0 },
+			corroboration: { rows: 0, promoted: 0 },
+			destroylist: { by_sharing_group: [] },
+			peers: [],
+			triage: { events_with_tags_pct_24h: 0, untagged_older_than_15m: 0 },
+			cron: { last_run_at: null },
+		});
+	});
+});
+
+describe("GET /admin/stats — happy path with seeded fixtures", () => {
+	it("aggregates orgs, events, corroboration, destroylist, peers, triage, cron", async () => {
+		const today = new Date().toISOString().slice(0, 10);
+		const eightDaysAgo = new Date(Date.now() - 8 * 86_400_000).toISOString().slice(0, 10);
+
+		// Two orgs — one active, one stale.
+		db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, ?)`).run("org-active", "Active", 1.0);
+		db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, ?)`).run("org-stale", "Stale", 1.0);
+
+		// Sharing groups.
+		db.raw.prepare(`INSERT INTO sharing_groups (uuid, name) VALUES (?, ?)`).run("sg-pub", "public");
+		db.raw.prepare(`INSERT INTO sharing_groups (uuid, name) VALUES (?, ?)`).run("sg-empty", "empty");
+
+		// Events: 2 by active org today (one tagged, one not), 1 by stale org 8d ago.
+		const insertEvent = db.raw.prepare(
+			`INSERT INTO events (uuid, orgc_uuid, sharing_group_uuid, info, date, timestamp, event_json, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		);
+		// "Old" enough that the 15-minute predicate fires for the untagged one.
+		// Production rows use the SQLite default `datetime('now')` format
+		// (`YYYY-MM-DD HH:MM:SS`, space separator, no `Z`), so seed in the
+		// same format — ISO-8601 with `T` would lex-compare greater than
+		// SQLite's `datetime('now','-15 minutes')` and break the predicate.
+		const toSqlite = (d: Date) => d.toISOString().replace("T", " ").replace(/\.\d+Z$/, "");
+		const sixteenMinAgo = toSqlite(new Date(Date.now() - 16 * 60_000));
+		const oneMinAgo = toSqlite(new Date(Date.now() - 60_000));
+		insertEvent.run("ev-tagged", "org-active", "sg-pub", "tagged", today, today + "T00:00:00", "{}", sixteenMinAgo);
+		insertEvent.run("ev-untagged-old", "org-active", "sg-pub", "stuck", today, today + "T00:00:00", "{}", sixteenMinAgo);
+		insertEvent.run("ev-untagged-fresh", "org-active", "sg-pub", "fresh", today, today + "T00:00:00", "{}", oneMinAgo);
+		insertEvent.run("ev-stale", "org-stale", "sg-pub", "stale", eightDaysAgo, eightDaysAgo + "T00:00:00", "{}", eightDaysAgo + "T00:00:00");
+
+		// Tag exactly one event so the pct lands at 1/3.
+		db.raw.prepare(`INSERT INTO tags (name) VALUES (?)`).run("phishing");
+		db.raw.prepare(`INSERT INTO event_tags (event_uuid, tag_name) VALUES (?, ?)`).run("ev-tagged", "phishing");
+
+		// Corroboration rows. Two promoted (sg-pub), one not promoted (sg-pub).
+		const insertCorr = db.raw.prepare(
+			`INSERT INTO corroboration (sharing_group_uuid, attribute_type, value, score, contributor_count)
+			 VALUES (?, ?, ?, ?, ?)`,
+		);
+		insertCorr.run("sg-pub", "domain", "evil1.example", 3.0, 2);
+		insertCorr.run("sg-pub", "domain", "evil2.example", 2.5, 3);
+		insertCorr.run("sg-pub", "domain", "weak.example", 1.0, 1);
+		insertCorr.run("sg-empty", "domain", "lonely.example", 0.5, 1);
+
+		// Inbound peer, last pulled ~now, plus one "pulled in last 24h" event.
+		const lastPulled = new Date(Date.now() - 60_000).toISOString();
+		db.raw.prepare(`INSERT INTO peers (uuid, name) VALUES (?, ?)`).run("peer-1", "CIRCL");
+		db.raw.prepare(
+			`INSERT INTO inbound_peers (uuid, peer_uuid, base_url, api_key_secret_name,
+			   synthetic_org_uuid, default_sharing_group_uuid, last_pulled_ts, last_error)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run("ib-1", "peer-1", "https://misp.example", "K", "org-active", "sg-pub", lastPulled, null);
+		// One event attributed to that peer in the 24h window.
+		insertEvent.run("ev-from-peer", "org-active", "sg-pub", "from peer", today, today + "T00:00:00", "{}", oneMinAgo);
+		db.raw.prepare(`UPDATE events SET source_peer_uuid = ? WHERE uuid = ?`).run("ib-1", "ev-from-peer");
+
+		const res = await appReq("/stats", { headers: adminAuth });
+		expect(res.status).toBe(200);
+		const body = await res.json() as {
+			orgs: { total: number; active_last_7d: number };
+			events: { total: number; last_24h: number };
+			corroboration: { rows: number; promoted: number };
+			destroylist: { by_sharing_group: Array<{ uuid: string; name: string; size: number }> };
+			peers: Array<{ name: string; last_pulled_at: string | null; last_error: string | null; events_pulled_24h: number }>;
+			triage: { events_with_tags_pct_24h: number; untagged_older_than_15m: number };
+			cron: { last_run_at: string | null };
+		};
+
+		expect(body.orgs.total).toBe(2);
+		// Active = orgs with an event in last 7d. Only org-active qualifies.
+		expect(body.orgs.active_last_7d).toBe(1);
+
+		expect(body.events.total).toBe(5);
+		expect(body.events.last_24h).toBe(4); // four events with `date` = today
+
+		expect(body.corroboration.rows).toBe(4);
+		// score>=2 AND contributors>=2 -> only the two sg-pub rows.
+		expect(body.corroboration.promoted).toBe(2);
+
+		// Destroylist sizes: sg-pub=2, sg-empty=0. Order is by sg.name asc.
+		expect(body.destroylist.by_sharing_group).toEqual([
+			{ uuid: "sg-empty", name: "empty", size: 0 },
+			{ uuid: "sg-pub", name: "public", size: 2 },
+		]);
+
+		expect(body.peers).toHaveLength(1);
+		expect(body.peers[0]).toMatchObject({
+			name: "CIRCL",
+			last_pulled_at: lastPulled,
+			last_error: null,
+			events_pulled_24h: 1,
+		});
+
+		// Triage: 1 of 4 today's events tagged -> 0.25.
+		expect(body.triage.events_with_tags_pct_24h).toBeCloseTo(0.25, 4);
+		// Untagged older than 15m: ev-untagged-old qualifies. ev-tagged is
+		// excluded by the EXISTS, ev-untagged-fresh is too new, ev-from-peer
+		// is too new, ev-stale is outside the 24h date window. So count = 1.
+		expect(body.triage.untagged_older_than_15m).toBe(1);
+
+		expect(body.cron.last_run_at).toBe(lastPulled);
+	});
+});


### PR DESCRIPTION
## Summary

- New `GET /admin/stats` route — a single JSON snapshot covering orgs, events, corroboration, destroylist sizes, inbound-peer health, triage queue health, and cron last-run.
- Same `HUB_ADMIN_KEY` auth as the existing `/admin/peers` routes; 401 without the key, 401 when the secret is unset.
- README updated with an "Inspecting the hub" section linking to the endpoint and listing common `wrangler tail` / D1 query recipes.

## Index discipline & query plan

All counts hit existing indexes from `0001_schema.sql` / `0002_inbound_sync.sql` — no new migrations:
- `idx_events_date` drives 24h / 7d windows on `events`.
- `idx_events_source_peer` drives per-peer `events_pulled_24h`.
- `idx_corroboration_sharing_group` drives the destroylist groupby.
- The non-indexed 15-minute `created_at` predicate (for "stuck in triage" count) is gated behind an indexed pre-filter (`date >= today-1`) so the scan is bounded to a single day's slice.
- `corroboration.promoted` reuses `PROMOTION_SCORE`/`PROMOTION_CONTRIBUTORS` imported from `aggregate.ts` rather than re-declaring `2.0`/`2`.

## Two proxies worth flagging for review

Both are documented in code comments and the README; both are accepted within the scope of this issue (per #55's "no full-table scans on events / corroboration" constraint, and the hub schema as it exists today):

1. **24h / 7d windows use `events.date`** (upstream MISP `YYYY-MM-DD`), not local ingest time. `events.created_at` exists but is unindexed; `idx_events_date` is the only indexed time column. Coarser, but correct for an at-a-glance dashboard. Adding a `created_at` index is a separate migration.
2. **`cron.last_run_at` is `MAX(inbound_peers.last_pulled_ts)`** — there is no cron-history table in the schema today. If the cron is alive AND any peer is healthy, this advances every 5 minutes. A peer-pull failure on every peer can mask a healthy cron — worth filing a follow-up issue for a small `cron_runs` table (out of scope here per the issue's "stop before adding migrations" guardrail).

## Test plan

- [x] `cd hub && npm test` — **49 passed, 0 failed** (7 files; was 35 before this PR, 14 new tests).
  - Auth: 401 with no header, 401 with wrong key, 401 when `HUB_ADMIN_KEY` is unset.
  - Shape: empty hub returns the documented shape with all-zero counters.
  - Happy path: seeded fixtures (2 orgs, 4 sharing-group corroboration rows of which 2 promoted, 5 events spanning today + 8 days ago, 1 inbound peer with `events_pulled_24h=1`, 1 tagged event + 1 untagged event older than 15m) — every field validated.
- [x] `cd hub && npm run typecheck` — passes (no diagnostics reported).
- [x] Top-level `npm test` — **226 passed across 19 test files**, no new failures (pre-existing `jsdom` missing-package errors on `tests/frontend/*` are present on `main` before this PR; verified by `git stash && npm test` on the same commit).
- [x] Manual schema review: every query in `stats.ts` either hits a named index from `0001_schema.sql` / `0002_inbound_sync.sql` or is gated behind one (per the file-header comment).

Closes #55