### PR TITLE
feat(ui): expose hub/MISP config in settings UI

### DIFF
--- a/app/components/HubSettingsPanel.tsx
+++ b/app/components/HubSettingsPanel.tsx
@@ -1,0 +1,280 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { Badge, Input, Switch } from "@cloudflare/kumo";
+import { GraphIcon } from "@phosphor-icons/react";
+import type { HubConfigSettings } from "~/types";
+
+/**
+ * Per-mailbox threat-intel hub configuration UI (#97). Mirrors the backend
+ * `HubConfig` shape in `workers/lib/hub-config.ts` so the same JSON
+ * round-trips through R2 unchanged.
+ *
+ * Important: the API key itself is NEVER entered here. Operators store the
+ * key with `wrangler secret put MY_HUB_KEY ...` and put the *name*
+ * (`MY_HUB_KEY`) into `Worker secret name`. The worker resolves the live
+ * value from `c.env` at call time, so rotating a key never requires
+ * touching mailbox JSON.
+ *
+ * Validation rules mirror `loadHubConfig`'s requirements: a hub config is
+ * "configured" only when url + org_uuid + api_key_secret_name are all
+ * non-empty. If the operator leaves all three empty we treat the section
+ * as unset and `intel.hub` is omitted from the saved settings entirely —
+ * never persisted as `{}` (which would force `loadHubConfig` to return
+ * null anyway, but pollutes the at-rest blob and makes audit harder).
+ *
+ * Inline validation (`errors`) is computed from the props so the parent's
+ * Save handler can call `validateHubConfig(value)` to refuse a bad save.
+ */
+
+export interface HubSettingsPanelProps {
+	value: HubConfigSettings | undefined;
+	onChange: (next: HubConfigSettings | undefined) => void;
+	errors?: HubFieldErrors;
+}
+
+export interface HubFieldErrors {
+	url?: string;
+	org_uuid?: string;
+	api_key_secret_name?: string;
+	default_sharing_group_uuid?: string;
+}
+
+/**
+ * Returns inline-validation errors (or `null` for a valid / fully-empty
+ * config). Exported so `routes/settings.tsx` can short-circuit Save before
+ * calling the mutation. Pure — no React state.
+ */
+export function validateHubConfig(
+	value: HubConfigSettings | undefined,
+): HubFieldErrors | null {
+	const cfg = value ?? {};
+	const url = (cfg.url ?? "").trim();
+	const org = (cfg.org_uuid ?? "").trim();
+	const secret = (cfg.api_key_secret_name ?? "").trim();
+	const sharing = (cfg.default_sharing_group_uuid ?? "").trim();
+
+	const anyCoreSet = !!(url || org || secret);
+	const anyOptionalSet =
+		!!sharing || cfg.auto_report === true;
+
+	const errors: HubFieldErrors = {};
+
+	// Empty config is valid (we'll persist nothing).
+	if (!anyCoreSet && !anyOptionalSet) return null;
+
+	// Once any hub field is touched, the three core fields are mutually
+	// required — that's the contract `loadHubConfig` enforces server-side.
+	if (!url) errors.url = "Required when configuring the hub.";
+	else if (!isValidHttpUrl(url)) errors.url = "Must be a valid http(s) URL.";
+
+	if (!org) errors.org_uuid = "Required when configuring the hub.";
+	else if (!isValidUuid(org))
+		errors.org_uuid = "Must be a UUID (e.g. 11111111-2222-3333-4444-555555555555).";
+
+	if (!secret)
+		errors.api_key_secret_name =
+			"Required. The name of a worker secret, not the value.";
+
+	if (sharing && !isValidUuid(sharing))
+		errors.default_sharing_group_uuid = "Must be a UUID, or leave blank.";
+
+	return Object.keys(errors).length === 0 ? null : errors;
+}
+
+/**
+ * Normalize the panel's working state for persistence. Returns `undefined`
+ * when nothing should be written under `intel.hub` (every field empty / off),
+ * preventing the "junk `{}` blob" failure mode the backend would treat as
+ * unconfigured but pollutes the audit trail.
+ */
+export function normalizeHubConfig(
+	value: HubConfigSettings | undefined,
+): HubConfigSettings | undefined {
+	const cfg = value ?? {};
+	const url = (cfg.url ?? "").trim();
+	const org = (cfg.org_uuid ?? "").trim();
+	const secret = (cfg.api_key_secret_name ?? "").trim();
+	const sharing = (cfg.default_sharing_group_uuid ?? "").trim();
+	const auto = cfg.auto_report === true;
+
+	if (!url && !org && !secret && !sharing && !auto) return undefined;
+
+	const out: HubConfigSettings = {
+		url,
+		org_uuid: org,
+		api_key_secret_name: secret,
+	};
+	if (sharing) out.default_sharing_group_uuid = sharing;
+	if (auto) out.auto_report = true;
+	return out;
+}
+
+export function HubSettingsPanel({
+	value,
+	onChange,
+	errors,
+}: HubSettingsPanelProps) {
+	const cfg = value ?? {};
+	const patch = (partial: Partial<HubConfigSettings>) =>
+		onChange({ ...cfg, ...partial });
+
+	const configured =
+		!!(cfg.url ?? "").trim() &&
+		!!(cfg.org_uuid ?? "").trim() &&
+		!!(cfg.api_key_secret_name ?? "").trim();
+
+	return (
+		<section id="hub" className="pp-card p-5 space-y-5">
+			<div className="flex items-center gap-2">
+				<GraphIcon size={16} weight="duotone" className="text-ink-3" />
+				<span className="text-sm font-medium text-ink">
+					Threat-intel hub
+				</span>
+				{configured ? (
+					<Badge variant="primary">Configured</Badge>
+				) : (
+					<Badge variant="secondary">Not configured</Badge>
+				)}
+			</div>
+
+			<p className="text-xs text-ink-3 -mt-2">
+				Connect this mailbox to a MISP-compatible hub to pull corroborated
+				indicators and push your own confirmed phishing reports back. Leave
+				every field blank to disable the hub for this mailbox.
+			</p>
+
+			<div className="space-y-4">
+				<div>
+					<Input
+						label="Hub URL"
+						placeholder="https://misp.example.org"
+						value={cfg.url ?? ""}
+						onChange={(e) => patch({ url: e.target.value })}
+						aria-invalid={errors?.url ? true : undefined}
+						aria-describedby={errors?.url ? "hub-url-error" : "hub-url-help"}
+					/>
+					<p id="hub-url-help" className="text-xs text-ink-3 mt-1">
+						Base URL of your MISP-compatible instance.
+					</p>
+					{errors?.url ? (
+						<p id="hub-url-error" className="text-xs text-red-500 mt-1">
+							{errors.url}
+						</p>
+					) : null}
+				</div>
+
+				<div>
+					<Input
+						label="Organization UUID"
+						placeholder="11111111-2222-3333-4444-555555555555"
+						value={cfg.org_uuid ?? ""}
+						onChange={(e) => patch({ org_uuid: e.target.value })}
+						aria-invalid={errors?.org_uuid ? true : undefined}
+						aria-describedby={
+							errors?.org_uuid ? "hub-org-error" : "hub-org-help"
+						}
+					/>
+					<p id="hub-org-help" className="text-xs text-ink-3 mt-1">
+						Your MISP organization UUID. Required so peers can attribute
+						contributions back to your org.
+					</p>
+					{errors?.org_uuid ? (
+						<p id="hub-org-error" className="text-xs text-red-500 mt-1">
+							{errors.org_uuid}
+						</p>
+					) : null}
+				</div>
+
+				<div>
+					<Input
+						label="Worker secret name"
+						placeholder="HUB_API_KEY"
+						value={cfg.api_key_secret_name ?? ""}
+						onChange={(e) => patch({ api_key_secret_name: e.target.value })}
+						aria-invalid={errors?.api_key_secret_name ? true : undefined}
+						aria-describedby={
+							errors?.api_key_secret_name
+								? "hub-secret-error"
+								: "hub-secret-help"
+						}
+					/>
+					<p id="hub-secret-help" className="text-xs text-ink-3 mt-1">
+						<strong>Name only — never the raw API key.</strong> Store the
+						actual key with{" "}
+						<code className="pp-mono">wrangler secret put</code> and enter
+						the binding name here. The worker reads the live value at call
+						time, so rotating the key never requires editing mailbox JSON.
+					</p>
+					{errors?.api_key_secret_name ? (
+						<p id="hub-secret-error" className="text-xs text-red-500 mt-1">
+							{errors.api_key_secret_name}
+						</p>
+					) : null}
+				</div>
+
+				<div>
+					<Input
+						label="Default sharing group UUID (optional)"
+						placeholder="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+						value={cfg.default_sharing_group_uuid ?? ""}
+						onChange={(e) =>
+							patch({ default_sharing_group_uuid: e.target.value })
+						}
+						aria-invalid={
+							errors?.default_sharing_group_uuid ? true : undefined
+						}
+						aria-describedby={
+							errors?.default_sharing_group_uuid
+								? "hub-sharing-error"
+								: "hub-sharing-help"
+						}
+					/>
+					<p id="hub-sharing-help" className="text-xs text-ink-3 mt-1">
+						If set, auto-reports are scoped to this sharing group instead of
+						being your-org-only.
+					</p>
+					{errors?.default_sharing_group_uuid ? (
+						<p
+							id="hub-sharing-error"
+							className="text-xs text-red-500 mt-1"
+						>
+							{errors.default_sharing_group_uuid}
+						</p>
+					) : null}
+				</div>
+
+				<div>
+					<Switch
+						label="Auto-report confirmed phishing"
+						checked={!!cfg.auto_report}
+						onCheckedChange={(v) => patch({ auto_report: v })}
+					/>
+					<p className="text-xs text-ink-3 mt-1">
+						When a case is confirmed as phishing, push the indicators to the
+						hub automatically. Off by default — turn on once you trust your
+						triage.
+					</p>
+				</div>
+			</div>
+		</section>
+	);
+}
+
+function isValidHttpUrl(raw: string): boolean {
+	try {
+		const u = new URL(raw);
+		return u.protocol === "http:" || u.protocol === "https:";
+	} catch {
+		return false;
+	}
+}
+
+// RFC 4122 — accepts any version (1–5) and the nil UUID. Permissive on case
+// because MISP's REST API normalises before comparison; we only block
+// obviously-wrong shapes (e.g. missing dashes).
+const UUID_RE =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isValidUuid(raw: string): boolean {
+	return UUID_RE.test(raw);
+}

--- a/app/routes/hub.tsx
+++ b/app/routes/hub.tsx
@@ -82,10 +82,10 @@ function NotConfiguredHint({ mailboxId }: { mailboxId: string | undefined }) {
 			</p>
 			{mailboxId ? (
 				<Link
-					to={`/mailbox/${mailboxId}/settings`}
+					to={`/mailbox/${mailboxId}/settings#hub`}
 					className="inline-flex items-center gap-1.5 text-[12px] text-accent hover:opacity-80 underline"
 				>
-					<GearSixIcon size={14} /> Open settings
+					<GearSixIcon size={14} /> Configure hub credentials
 				</Link>
 			) : null}
 		</div>

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -10,7 +10,13 @@ import { useFeedback } from "~/lib/feedback";
 import { useMailbox, useUpdateMailbox } from "~/queries/mailboxes";
 import { useTextModels } from "~/queries/text-models";
 import { SecuritySettingsPanel } from "~/components/SecuritySettingsPanel";
-import type { SecuritySettings } from "~/types";
+import {
+	HubSettingsPanel,
+	normalizeHubConfig,
+	validateHubConfig,
+	type HubFieldErrors,
+} from "~/components/HubSettingsPanel";
+import type { HubConfigSettings, SecuritySettings } from "~/types";
 import {
 	DEFAULT_CLASSIFIER_MODEL,
 	DEFAULT_DRAFT_VERIFIER_MODEL,
@@ -32,6 +38,8 @@ export default function SettingsRoute() {
 	const [displayName, setDisplayName] = useState("");
 	const [agentPrompt, setAgentPrompt] = useState("");
 	const [security, setSecurity] = useState<SecuritySettings | undefined>(undefined);
+	const [hub, setHub] = useState<HubConfigSettings | undefined>(undefined);
+	const [hubErrors, setHubErrors] = useState<HubFieldErrors | undefined>(undefined);
 	const [autoDraftEnabled, setAutoDraftEnabled] = useState(true);
 	const [modelChoice, setModelChoice] = useState<string>(TEXT_MODELS[0]);
 	const [customModel, setCustomModel] = useState("");
@@ -45,6 +53,8 @@ export default function SettingsRoute() {
 			setDisplayName(mailbox.settings?.fromName || mailbox.name || "");
 			setAgentPrompt(mailbox.settings?.agentSystemPrompt || "");
 			setSecurity(mailbox.settings?.security);
+			setHub(mailbox.settings?.intel?.hub);
+			setHubErrors(undefined);
 
 			const behavior = mailbox.settings as
 				| {
@@ -108,12 +118,35 @@ export default function SettingsRoute() {
 			}
 		}
 
+		// Validate the hub panel before kicking off a save. `validateHubConfig`
+		// returns `null` when the form is fully empty (treat as "unset"); any
+		// errors here surface inline next to the offending field instead of
+		// silently writing a half-config that the backend would treat as
+		// unconfigured.
+		const hubValidation = validateHubConfig(hub);
+		setHubErrors(hubValidation ?? undefined);
+		if (hubValidation) {
+			feedback.error("Fix the threat-intel hub fields before saving.");
+			return;
+		}
+
+		// Preserve unrelated `intel.*` keys (e.g. #29 peer subscriptions land
+		// here in future) by merging on top of whatever's in mailbox.settings.
+		const normalizedHub = normalizeHubConfig(hub);
+		const existingIntel = mailbox.settings?.intel ?? {};
+		const nextIntel: typeof existingIntel = { ...existingIntel };
+		if (normalizedHub) nextIntel.hub = normalizedHub;
+		else delete nextIntel.hub;
+		const intelToPersist =
+			Object.keys(nextIntel).length === 0 ? undefined : nextIntel;
+
 		setIsSaving(true);
 		const settings = {
 			...mailbox.settings,
 			fromName: displayName,
 			agentSystemPrompt: agentPrompt.trim() || undefined,
 			security,
+			intel: intelToPersist,
 			autoDraft: { enabled: autoDraftEnabled },
 			agentModel: resolvedModel || availableModels[0] || TEXT_MODELS[0],
 			injectionScannerModel: injectionScannerModel.trim() || undefined,
@@ -326,6 +359,18 @@ export default function SettingsRoute() {
 
 				{/* Security */}
 				<SecuritySettingsPanel value={security} onChange={setSecurity} />
+
+				{/* Threat-intel hub (#97) */}
+				<HubSettingsPanel
+					value={hub}
+					onChange={(next) => {
+						setHub(next);
+						// Re-validate eagerly once the user starts editing so
+						// stale errors disappear as the form is fixed.
+						if (hubErrors) setHubErrors(validateHubConfig(next) ?? undefined);
+					}}
+					errors={hubErrors}
+				/>
 
 				{/* Save */}
 				<div className="flex justify-end">

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -36,6 +36,24 @@ export interface FolderPolicySettings {
 	treat_as_verified?: boolean;
 }
 
+/**
+ * Per-mailbox threat-intel hub config (#97). Mirrors the backend `HubConfig`
+ * shape in `workers/lib/hub-config.ts`. `api_key_secret_name` holds the NAME
+ * of a worker secret, not the secret value — the raw key never leaves
+ * `wrangler secret put`.
+ */
+export interface HubConfigSettings {
+	url?: string;
+	org_uuid?: string;
+	api_key_secret_name?: string;
+	default_sharing_group_uuid?: string;
+	auto_report?: boolean;
+}
+
+export interface IntelSettings {
+	hub?: HubConfigSettings;
+}
+
 export interface SecuritySettings {
 	enabled?: boolean;
 	learning_mode?: boolean;
@@ -58,6 +76,7 @@ export interface MailboxSettings {
 	autoReply?: { enabled: boolean; subject: string; message: string };
 	agentSystemPrompt?: string;
 	security?: SecuritySettings;
+	intel?: IntelSettings;
 }
 
 export interface Mailbox {

--- a/shared/mailbox-settings.ts
+++ b/shared/mailbox-settings.ts
@@ -45,6 +45,36 @@ const SecuritySettings = z
   })
   .passthrough();
 
+/**
+ * Per-mailbox MISP-compatible threat-intel hub config (#97).
+ *
+ * Mirrors the backend `HubConfig` interface in `workers/lib/hub-config.ts`.
+ * The API key itself is NEVER persisted in R2 — only the *name* of a worker
+ * secret (`api_key_secret_name`) is stored, and the worker resolves the live
+ * value from `c.env` at call time. That way an org can rotate the key with
+ * `wrangler secret put` without rewriting the mailbox JSON.
+ *
+ * `loadHubConfig` requires `url`, `org_uuid`, and `api_key_secret_name` to be
+ * non-empty strings, so the schema marks them required when `hub` is present.
+ * The whole `intel` block is optional + passthrough so unrelated future intel
+ * fields (#29 peer subscriptions) round-trip without a coordinated deploy.
+ */
+const HubConfig = z
+  .object({
+    url: z.string().min(1),
+    org_uuid: z.string().min(1),
+    api_key_secret_name: z.string().min(1),
+    default_sharing_group_uuid: z.string().optional(),
+    auto_report: z.boolean().optional(),
+  })
+  .passthrough();
+
+const IntelSettings = z
+  .object({
+    hub: HubConfig.optional(),
+  })
+  .passthrough();
+
 export const MailboxSettings = z.object({
   agentSystemPrompt: z.string().optional(),
   autoDraft: z
@@ -71,6 +101,7 @@ export const MailboxSettings = z.object({
    */
   classifierModel: z.string().optional(),
   security: SecuritySettings.optional(),
+  intel: IntelSettings.optional(),
 }).passthrough();
 
 export type MailboxSettings = z.infer<typeof MailboxSettings>;

--- a/tests/frontend/hub-settings.test.tsx
+++ b/tests/frontend/hub-settings.test.tsx
@@ -1,0 +1,220 @@
+// Coverage for the new HubSettingsPanel (#97). Drives the form through
+// the full settings save flow so we verify the merged settings payload
+// that hits the PUT route, not just local component state.
+//
+// Mirrors `security-settings.test.tsx` — same mocking pattern for
+// useMailbox / useUpdateMailbox so the assertions are about what gets
+// persisted, not internal React state.
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+import type { HubConfigSettings, Mailbox, MailboxSettings } from "~/types";
+import {
+	normalizeHubConfig,
+	validateHubConfig,
+} from "~/components/HubSettingsPanel";
+
+const mutateAsync = vi.fn();
+const updateMailboxMock = {
+	mutateAsync,
+	isPending: false,
+} as unknown as ReturnType<typeof import("~/queries/mailboxes").useUpdateMailbox>;
+
+let mailboxFixture: Mailbox;
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({ data: mailboxFixture }),
+	useUpdateMailbox: () => updateMailboxMock,
+}));
+
+import SettingsRoute from "~/routes/settings";
+import { renderWithProviders } from "./test-utils";
+
+function renderSettings() {
+	return renderWithProviders(
+		<Routes>
+			<Route path="/mailbox/:mailboxId/settings" element={<SettingsRoute />} />
+		</Routes>,
+		{ initialEntries: ["/mailbox/m1/settings"] },
+	);
+}
+
+function makeMailbox(hub?: HubConfigSettings): Mailbox {
+	return {
+		id: "m1",
+		email: "ops@example.com",
+		name: "Ops",
+		settings: {
+			autoDraft: { enabled: true },
+			agentModel: "@cf/moonshotai/kimi-k2.5",
+			intel: hub ? { hub } : undefined,
+		} as MailboxSettings,
+	} as unknown as Mailbox;
+}
+
+async function lastSavedSettings(): Promise<MailboxSettings> {
+	await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+	const payload = mutateAsync.mock.calls[0][0] as {
+		mailboxId: string;
+		settings: MailboxSettings;
+	};
+	return payload.settings;
+}
+
+const VALID_ORG_UUID = "11111111-2222-3333-4444-555555555555";
+const VALID_SHARING_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+describe("HubSettingsPanel · pure helpers", () => {
+	it("validateHubConfig accepts a fully empty config (returns null)", () => {
+		expect(validateHubConfig(undefined)).toBeNull();
+		expect(validateHubConfig({})).toBeNull();
+		expect(
+			validateHubConfig({ url: "", org_uuid: "", api_key_secret_name: "" }),
+		).toBeNull();
+	});
+
+	it("validateHubConfig requires all three core fields when any is set", () => {
+		const errs = validateHubConfig({ url: "https://misp.example.org" });
+		expect(errs).not.toBeNull();
+		expect(errs?.org_uuid).toBeTruthy();
+		expect(errs?.api_key_secret_name).toBeTruthy();
+	});
+
+	it("validateHubConfig rejects an invalid URL", () => {
+		const errs = validateHubConfig({
+			url: "not a url",
+			org_uuid: VALID_ORG_UUID,
+			api_key_secret_name: "HUB_KEY",
+		});
+		expect(errs?.url).toMatch(/valid http/i);
+	});
+
+	it("validateHubConfig rejects a non-UUID org_uuid", () => {
+		const errs = validateHubConfig({
+			url: "https://misp.example.org",
+			org_uuid: "not-a-uuid",
+			api_key_secret_name: "HUB_KEY",
+		});
+		expect(errs?.org_uuid).toMatch(/UUID/);
+	});
+
+	it("validateHubConfig accepts a fully valid config", () => {
+		expect(
+			validateHubConfig({
+				url: "https://misp.example.org",
+				org_uuid: VALID_ORG_UUID,
+				api_key_secret_name: "HUB_KEY",
+			}),
+		).toBeNull();
+	});
+
+	it("normalizeHubConfig returns undefined for an empty config", () => {
+		expect(normalizeHubConfig(undefined)).toBeUndefined();
+		expect(normalizeHubConfig({})).toBeUndefined();
+		expect(
+			normalizeHubConfig({ url: "", org_uuid: "", api_key_secret_name: "" }),
+		).toBeUndefined();
+	});
+
+	it("normalizeHubConfig trims whitespace and drops empty optionals", () => {
+		const out = normalizeHubConfig({
+			url: "  https://misp.example.org  ",
+			org_uuid: ` ${VALID_ORG_UUID} `,
+			api_key_secret_name: " HUB_KEY ",
+			default_sharing_group_uuid: "  ",
+			auto_report: false,
+		});
+		expect(out).toEqual({
+			url: "https://misp.example.org",
+			org_uuid: VALID_ORG_UUID,
+			api_key_secret_name: "HUB_KEY",
+		});
+	});
+});
+
+describe("HubSettingsPanel · save flow", () => {
+	beforeEach(() => {
+		mutateAsync.mockReset();
+		mutateAsync.mockResolvedValue(undefined);
+	});
+
+	it("does not persist intel.hub when the form is left empty", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox(); // no hub
+		renderSettings();
+
+		// No hub fields touched. Save should succeed and the saved payload
+		// must NOT contain `intel.hub` — that's the regression guard for
+		// "we wrote `{}` to R2".
+		await user.click(await screen.findByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		expect(saved.intel).toBeUndefined();
+	});
+
+	it("round-trips a valid hub config through the save mutation", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox(); // start empty
+		renderSettings();
+
+		await user.type(await screen.findByLabelText(/hub url/i), "https://misp.example.org");
+		await user.type(screen.getByLabelText(/organization uuid/i), VALID_ORG_UUID);
+		await user.type(screen.getByLabelText(/worker secret name/i), "HUB_KEY");
+		await user.type(
+			screen.getByLabelText(/default sharing group uuid/i),
+			VALID_SHARING_UUID,
+		);
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		expect(saved.intel?.hub).toEqual({
+			url: "https://misp.example.org",
+			org_uuid: VALID_ORG_UUID,
+			api_key_secret_name: "HUB_KEY",
+			default_sharing_group_uuid: VALID_SHARING_UUID,
+		});
+	});
+
+	it("toggling auto_report persists when paired with the required core fields", async () => {
+		const user = userEvent.setup();
+		// Pre-seed the core fields so toggling auto_report alone is a valid
+		// save (the backend requires url/org/secret to be set).
+		mailboxFixture = makeMailbox({
+			url: "https://misp.example.org",
+			org_uuid: VALID_ORG_UUID,
+			api_key_secret_name: "HUB_KEY",
+		});
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /auto-report confirmed phishing/i,
+		});
+		await user.click(toggle);
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		expect(saved.intel?.hub?.auto_report).toBe(true);
+		expect(saved.intel?.hub?.url).toBe("https://misp.example.org");
+	});
+
+	it("surfaces inline validation for an invalid URL and refuses to save", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox();
+		renderSettings();
+
+		await user.type(await screen.findByLabelText(/hub url/i), "not a url");
+		await user.type(screen.getByLabelText(/organization uuid/i), VALID_ORG_UUID);
+		await user.type(screen.getByLabelText(/worker secret name/i), "HUB_KEY");
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		// Inline error is surfaced near the URL field…
+		expect(await screen.findByText(/must be a valid http/i)).toBeInTheDocument();
+		// …and the save mutation never fired.
+		expect(mutateAsync).not.toHaveBeenCalled();
+	});
+});

--- a/tests/frontend/hub.test.tsx
+++ b/tests/frontend/hub.test.tsx
@@ -68,9 +68,11 @@ describe("HubRoute", () => {
 		sharingGroupsState = unconfigured();
 		renderHub();
 		expect(screen.getByText(/hub not configured/i)).toBeInTheDocument();
+		// Deep-links to the hub panel anchor so a fresh operator lands on the
+		// right form (#97).
 		expect(
-			screen.getByRole("link", { name: /open settings/i }),
-		).toHaveAttribute("href", "/mailbox/m1/settings");
+			screen.getByRole("link", { name: /configure hub credentials/i }),
+		).toHaveAttribute("href", "/mailbox/m1/settings#hub");
 		expect(screen.queryByText(/my contributions/i)).not.toBeInTheDocument();
 	});
 


### PR DESCRIPTION
## Summary

Operators couldn't configure the threat-intel hub (`intel.hub` in `mailboxes/<id>.json`) without hand-editing R2 — the backend was fully wired (`workers/lib/hub-config.ts`, `workers/routes/hub-ui.ts`) but no UI surface existed. This PR adds a `HubSettingsPanel` to `/mailbox/:id/settings`, mirroring the PR #93 pattern (schema extension → type → panel → route wiring → component tests).

Closes #97 and unblocks the "clean install configurable without writing code" criterion in #23.

## What changed

- **Schema** (`shared/mailbox-settings.ts`): adds `intel.hub` (passthrough) with `url` / `org_uuid` / `api_key_secret_name` required when present. Whole `intel` block is optional + passthrough so #29 peer-subscription work can extend without a coordinated deploy.
- **Frontend type** (`app/types/index.ts`): adds `HubConfigSettings` + `IntelSettings`; extends `MailboxSettings` with optional `intel`.
- **UI** (`app/components/HubSettingsPanel.tsx`): five fields — Hub URL, Organization UUID, Worker secret name, Default sharing group UUID, Auto-report toggle. Help text on the secret-name field is explicit: "Name only — never the raw API key. Store the actual key with `wrangler secret put` and enter the binding name here." Inline validation enforces URL shape + UUID shape + the "all three core fields required together" rule.
- **Settings route wiring** (`app/routes/settings.tsx`): hydrates from `mailbox.settings?.intel?.hub`, runs `validateHubConfig` before save, calls `normalizeHubConfig` to drop empty optionals and **omit `intel.hub` entirely when the form is empty** (so we never write `{}` blobs the backend would treat as unconfigured anyway). Preserves unrelated `intel.*` keys via spread.
- **Hub route deep-link** (`app/routes/hub.tsx`): "Open settings" hint now deep-links to `…/settings#hub` and reads "Configure hub credentials" — a fresh operator who lands on `/hub` before configuring credentials gets routed straight to the right form.

## Out of scope (intentional)

- Backend hub publisher untouched.
- No new API endpoint — saves go through the existing `useUpdateMailbox` → PUT `/api/v1/mailboxes/:id` path.
- No raw API keys accepted in the form by design.
- No new fields on `HubConfig` (e.g. peer-subscription stuff from #29) — separate issue.

## Test plan

- [x] `npm test` — **305 passing, 0 failing** (11 new in `tests/frontend/hub-settings.test.tsx`: 6 pure-helper + 5 save-flow / inline-validation; baseline was 294)
- [x] `npm run typecheck` — clean
- [x] Empty-form regression guard: `saved.intel === undefined` when no hub fields are touched (covers the "we wrote `{}` to R2" failure mode)
- [x] Round-trip: a valid hub config (url + org_uuid + api_key_secret_name + default_sharing_group_uuid) flows through the save mutation unchanged
- [x] `auto_report` toggle persists when paired with required core fields
- [x] Invalid URL surfaces inline validation and refuses to save (mutation never fires)
- [x] Existing `tests/frontend/hub.test.tsx` updated to match the new deep-link target/copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)