### PR TITLE
feat(ui): hub invite flow modal

### DIFF
--- a/app/components/HubInviteModal.tsx
+++ b/app/components/HubInviteModal.tsx
@@ -1,0 +1,269 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Two-state modal for issuing a one-time hub invite token (#74).
+ *
+ *   form    → user enters optional note and TTL (default 72h), clicks Issue.
+ *   success → modal swaps to a read-only token field with a Copy button,
+ *             a one-time warning, and the absolute expiry timestamp.
+ *
+ * The token never persists outside the lifetime of this open modal. Closing
+ * the dialog (X button, ESC, backdrop click, or Cancel/Done) drops it from
+ * React state via the `onOpenChange={false}` reset path; remounting the
+ * modal from the same parent button does not surface a stale token because
+ * we also clear the mutation result so a fresh open shows the form again.
+ */
+
+import { Button, Dialog, Input, Text } from "@cloudflare/kumo";
+import { CopyIcon, WarningIcon } from "@phosphor-icons/react";
+import {
+	type FormEvent,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+import { useCreateHubInvite } from "~/queries/hub";
+
+export interface HubInviteModalProps {
+	open: boolean;
+	mailboxId: string | undefined;
+	sharingGroup: { uuid: string; name: string } | null;
+	onOpenChange: (open: boolean) => void;
+}
+
+export default function HubInviteModal({
+	open,
+	mailboxId,
+	sharingGroup,
+	onOpenChange,
+}: HubInviteModalProps) {
+	const mutation = useCreateHubInvite();
+	const [note, setNote] = useState("");
+	const [ttlHours, setTtlHours] = useState<number>(72);
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	// Token lives in local state during the open modal. We deliberately do
+	// NOT pull it from `mutation.data` for rendering — clearing local state
+	// on close is the source of truth that the token is gone from the DOM.
+	const [token, setToken] = useState<string | null>(null);
+	const [expiresAt, setExpiresAt] = useState<string | null>(null);
+	const [copyState, setCopyState] = useState<"idle" | "copied" | "fallback">(
+		"idle",
+	);
+	const tokenInputRef = useRef<HTMLInputElement | null>(null);
+
+	const reset = useCallback(() => {
+		setNote("");
+		setTtlHours(72);
+		setErrorMessage(null);
+		setToken(null);
+		setExpiresAt(null);
+		setCopyState("idle");
+		mutation.reset();
+	}, [mutation]);
+
+	const handleOpenChange = useCallback(
+		(next: boolean) => {
+			if (!next) {
+				// Drop the token from React state immediately on any close
+				// reason (X, ESC, backdrop click, Cancel, Done).
+				reset();
+			}
+			onOpenChange(next);
+		},
+		[onOpenChange, reset],
+	);
+
+	// If the parent flips `open` to false externally, still clear state.
+	useEffect(() => {
+		if (!open) reset();
+		// `reset` identity changes when mutation changes; we only want this
+		// to fire on `open` transitions, so deliberately omit `reset`.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [open]);
+
+	// When the success state lands, focus + select the token field so the
+	// clipboard fallback (Cmd/Ctrl-C) just works without an extra click.
+	useEffect(() => {
+		if (token && tokenInputRef.current) {
+			tokenInputRef.current.focus();
+			tokenInputRef.current.select();
+		}
+	}, [token]);
+
+	const handleSubmit = async (e: FormEvent) => {
+		e.preventDefault();
+		if (!mailboxId) return;
+		setErrorMessage(null);
+		try {
+			const res = await mutation.mutateAsync({
+				mailboxId,
+				body: {
+					sharing_group_uuid: sharingGroup?.uuid,
+					note: note.trim() || undefined,
+					ttl_hours: ttlHours,
+				},
+			});
+			setToken(res.token);
+			setExpiresAt(res.expires_at);
+		} catch (err: unknown) {
+			const msg =
+				err instanceof Error && err.message
+					? err.message
+					: "Failed to create invite";
+			setErrorMessage(msg);
+		}
+	};
+
+	const handleCopy = async () => {
+		if (!token) return;
+		const clipboard =
+			typeof navigator !== "undefined" ? navigator.clipboard : undefined;
+		if (clipboard?.writeText) {
+			try {
+				await clipboard.writeText(token);
+				setCopyState("copied");
+				return;
+			} catch {
+				// fall through to manual fallback
+			}
+		}
+		// Clipboard unavailable or denied — keep input focused and selected
+		// so the user can Cmd-C/Ctrl-C from the keyboard.
+		setCopyState("fallback");
+		if (tokenInputRef.current) {
+			tokenInputRef.current.focus();
+			tokenInputRef.current.select();
+		}
+	};
+
+	return (
+		<Dialog.Root open={open} onOpenChange={handleOpenChange}>
+			<Dialog size="sm" className="p-6">
+				<Dialog.Title className="text-base font-semibold mb-1">
+					Invite peer
+				</Dialog.Title>
+				{sharingGroup ? (
+					<Dialog.Description className="text-ink-3 text-sm mb-5">
+						Issue a one-time invite to{" "}
+						<strong className="text-ink">{sharingGroup.name}</strong>.
+					</Dialog.Description>
+				) : null}
+
+				{!token ? (
+					<form onSubmit={handleSubmit} className="space-y-4">
+						{errorMessage ? (
+							<Text variant="error" size="sm">
+								{errorMessage}
+							</Text>
+						) : null}
+						<Input
+							label="Note (optional)"
+							placeholder="What's this invite for?"
+							size="sm"
+							value={note}
+							onChange={(e) => setNote(e.target.value)}
+							maxLength={500}
+						/>
+						<Input
+							label="TTL (hours)"
+							type="number"
+							size="sm"
+							min={1}
+							max={24 * 30}
+							value={String(ttlHours)}
+							onChange={(e) => {
+								const n = Number(e.target.value);
+								if (Number.isFinite(n)) setTtlHours(n);
+							}}
+						/>
+						<div className="flex justify-end gap-2 pt-2">
+							<Dialog.Close
+								render={(props) => (
+									<Button {...props} variant="secondary" size="sm" type="button">
+										Cancel
+									</Button>
+								)}
+							/>
+							<Button
+								type="submit"
+								variant="primary"
+								size="sm"
+								loading={mutation.isPending}
+							>
+								Issue invite
+							</Button>
+						</div>
+					</form>
+				) : (
+					<div className="space-y-4">
+						<div className="flex items-start gap-2 rounded-md bg-paper-2 border border-line p-3 text-[12.5px] text-ink">
+							<WarningIcon size={16} className="mt-[1px] shrink-0" />
+							<div>
+								<div className="font-medium">
+									Copy this token now — it won't be shown again.
+								</div>
+								<div className="text-ink-3 mt-0.5">
+									Share it with the peer through a trusted channel. They
+									redeem it via <span className="pp-mono">/orgs/accept</span>.
+								</div>
+							</div>
+						</div>
+						<div>
+							<span className="text-sm font-medium text-ink mb-1.5 block">
+								Invite token
+							</span>
+							<div className="flex items-center gap-2">
+								<div className="flex-1">
+									<Input
+										ref={tokenInputRef}
+										aria-label="Invite token"
+										readOnly
+										size="sm"
+										value={token}
+										className="pp-mono"
+										onFocus={(e) => e.currentTarget.select()}
+									/>
+								</div>
+								<Button
+									type="button"
+									variant="secondary"
+									size="sm"
+									icon={<CopyIcon size={14} />}
+									onClick={handleCopy}
+								>
+									{copyState === "copied"
+										? "Copied"
+										: copyState === "fallback"
+											? "Press Cmd-C"
+											: "Copy"}
+								</Button>
+							</div>
+							{copyState === "fallback" ? (
+								<p className="text-[11.5px] text-ink-3 mt-1">
+									Clipboard access denied. The token is selected — press
+									Cmd-C (macOS) or Ctrl-C (Windows/Linux) to copy.
+								</p>
+							) : null}
+						</div>
+						{expiresAt ? (
+							<div className="text-[12px] text-ink-3">
+								Expires {new Date(expiresAt).toLocaleString()}
+							</div>
+						) : null}
+						<div className="flex justify-end pt-2">
+							<Button
+								type="button"
+								variant="primary"
+								size="sm"
+								onClick={() => handleOpenChange(false)}
+							>
+								Done
+							</Button>
+						</div>
+					</div>
+				)}
+			</Dialog>
+		</Dialog.Root>
+	);
+}

--- a/app/queries/hub.ts
+++ b/app/queries/hub.ts
@@ -1,10 +1,12 @@
 // Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import api from "~/services/api";
 import type {
 	HubContributionsResponse,
 	HubDestroylistResponse,
+	HubInviteRequest,
+	HubInviteResponse,
 	HubSharingGroupsResponse,
 } from "~/types";
 import { queryKeys } from "./keys";
@@ -46,5 +48,23 @@ export function useHubSharingGroups(mailboxId: string | undefined) {
 			api.getHubSharingGroups(mailboxId!, { signal }) as Promise<HubSharingGroupsResponse>,
 		enabled: !!mailboxId,
 		staleTime: STALE_MS,
+	});
+}
+
+/**
+ * Mutation: create a one-time invite via the worker's hub-proxy. Resolves to
+ * `{ token, expires_at }` on success — the caller must show the token in the
+ * UI ONCE and clear it on close. Errors (notably 403 from the hub when the
+ * inviter isn't a member of the requested sharing group) bubble up as
+ * `ApiError`; the worker forwards the hub's response verbatim.
+ */
+export function useCreateHubInvite() {
+	return useMutation<
+		HubInviteResponse,
+		Error,
+		{ mailboxId: string; body: HubInviteRequest }
+	>({
+		mutationFn: ({ mailboxId, body }) =>
+			api.createHubInvite(mailboxId, body) as Promise<HubInviteResponse>,
 	});
 }

--- a/app/routes/hub.tsx
+++ b/app/routes/hub.tsx
@@ -2,10 +2,11 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { GearSixIcon, GraphIcon, WarningIcon } from "@phosphor-icons/react";
-import { Loader } from "@cloudflare/kumo";
-import type { ReactNode } from "react";
+import { GearSixIcon, GraphIcon, UserPlusIcon, WarningIcon } from "@phosphor-icons/react";
+import { Button, Loader } from "@cloudflare/kumo";
+import { useState, type ReactNode } from "react";
 import { Link, useParams } from "react-router";
+import HubInviteModal from "~/components/HubInviteModal";
 import {
 	useHubContributions,
 	useHubDestroylist,
@@ -43,7 +44,7 @@ export default function HubRoute() {
 				<div className="grid gap-4 lg:grid-cols-2">
 					<ContributionsPanel query={contributions} />
 					<DestroylistPanel query={destroylist} />
-					<SharingGroupsPanel query={sharingGroups} />
+					<SharingGroupsPanel query={sharingGroups} mailboxId={mailboxId} />
 				</div>
 			)}
 		</div>
@@ -208,7 +209,18 @@ function DestroylistPanel({
 
 function SharingGroupsPanel({
 	query,
-}: { query: ReturnType<typeof useHubSharingGroups> }) {
+	mailboxId,
+}: {
+	query: ReturnType<typeof useHubSharingGroups>;
+	mailboxId: string | undefined;
+}) {
+	// Hub-side gating: a non-member of the requested sharing group gets a
+	// 403 from POST /orgs/invite, which the worker forwards verbatim. The
+	// UI just exposes the button on every row and surfaces the error from
+	// the mutation if it lands.
+	const [invitingGroup, setInvitingGroup] = useState<HubSharingGroup | null>(
+		null,
+	);
 	return (
 		<PanelShell title="Sharing groups">
 			{renderListPanel<HubSharingGroupsResponse, HubSharingGroup>({
@@ -220,23 +232,46 @@ function SharingGroupsPanel({
 				render: (groups) => (
 					<ul className="space-y-2">
 						{groups.map((g) => (
-							<li key={g.uuid} className="flex flex-col">
-								<div className="text-[13px] text-ink">{g.name}</div>
-								{g.description ? (
-									<div className="text-[11px] text-ink-3 truncate">
-										{g.description}
-									</div>
-								) : null}
-								{g.role ? (
-									<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mt-0.5">
-										{g.role}
-									</div>
-								) : null}
+							<li key={g.uuid} className="flex items-start justify-between gap-2">
+								<div className="flex flex-col min-w-0">
+									<div className="text-[13px] text-ink truncate">{g.name}</div>
+									{g.description ? (
+										<div className="text-[11px] text-ink-3 truncate">
+											{g.description}
+										</div>
+									) : null}
+									{g.role ? (
+										<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mt-0.5">
+											{g.role}
+										</div>
+									) : null}
+								</div>
+								<Button
+									type="button"
+									variant="secondary"
+									size="sm"
+									icon={<UserPlusIcon size={12} />}
+									onClick={() => setInvitingGroup(g)}
+								>
+									Invite peer
+								</Button>
 							</li>
 						))}
 					</ul>
 				),
 			})}
+			<HubInviteModal
+				open={invitingGroup !== null}
+				mailboxId={mailboxId}
+				sharingGroup={
+					invitingGroup
+						? { uuid: invitingGroup.uuid, name: invitingGroup.name }
+						: null
+				}
+				onOpenChange={(open) => {
+					if (!open) setInvitingGroup(null);
+				}}
+			/>
 		</PanelShell>
 	);
 }

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -8,6 +8,8 @@ import type {
 	Folder,
 	HubContributionsResponse,
 	HubDestroylistResponse,
+	HubInviteRequest,
+	HubInviteResponse,
 	HubSharingGroupsResponse,
 	Mailbox,
 	OrgOverview,
@@ -191,6 +193,8 @@ const api = {
 		get<HubSharingGroupsResponse>(`/api/v1/mailboxes/${mailboxId}/hub/sharing-groups`, {
 			signal: opts?.signal,
 		}),
+	createHubInvite: (mailboxId: string, body: HubInviteRequest) =>
+		post<HubInviteResponse>(`/api/v1/mailboxes/${mailboxId}/hub/invites`, body),
 
 	// AI — Workers AI text-generation model list (#64). Worker
 	// read-through caches against KV with a static fallback, so this

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -235,3 +235,21 @@ export type HubEnvelope<T> = { configured: true; data: T } | { configured: false
 export type HubContributionsResponse = HubEnvelope<HubContribution[]>;
 export type HubDestroylistResponse = HubEnvelope<{ values: string[]; count: number }>;
 export type HubSharingGroupsResponse = HubEnvelope<{ groups: HubSharingGroup[] }>;
+
+/**
+ * Hub invite request — mirrors the hub `POST /orgs/invite` zod schema. All
+ * fields optional; `sharing_group_uuid` binds the invite to a specific
+ * sharing group (the hub returns 403 if the inviter isn't a member).
+ */
+export interface HubInviteRequest {
+	sharing_group_uuid?: string;
+	note?: string;
+	ttl_hours?: number;
+}
+
+/** Hub invite response — token is returned ONCE; the modal must show it
+ * immediately and clear it on close. `expires_at` is an ISO timestamp. */
+export interface HubInviteResponse {
+	token: string;
+	expires_at: string;
+}

--- a/tests/frontend/hub-invite-modal.test.tsx
+++ b/tests/frontend/hub-invite-modal.test.tsx
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import api from "~/services/api";
+import HubInviteModal from "~/components/HubInviteModal";
+import { renderWithProviders } from "./test-utils";
+
+// Mock the api client — we want the mutation hook (real react-query) to call
+// our stub, not the worker. Spying on the imported module's method is enough
+// because `api` is a const object exported as default.
+vi.mock("~/services/api", async () => {
+	const actual = await vi.importActual<typeof import("~/services/api")>(
+		"~/services/api",
+	);
+	return {
+		...actual,
+		default: {
+			...actual.default,
+			createHubInvite: vi.fn(),
+		},
+	};
+});
+
+const createHubInvite = api.createHubInvite as unknown as ReturnType<
+	typeof vi.fn
+>;
+
+describe("HubInviteModal", () => {
+	const onOpenChange = vi.fn();
+
+	beforeEach(() => {
+		createHubInvite.mockReset();
+		onOpenChange.mockReset();
+		// Default clipboard mock — individual tests override.
+		Object.defineProperty(globalThis, "navigator", {
+			value: {
+				...globalThis.navigator,
+				clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+			},
+			configurable: true,
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	function render(open = true) {
+		return renderWithProviders(
+			<HubInviteModal
+				open={open}
+				mailboxId="m1"
+				sharingGroup={{ uuid: "sg-1", name: "Trusted retailers" }}
+				onOpenChange={onOpenChange}
+			/>,
+		);
+	}
+
+	it("submits the form, shows the token, and writes it to the clipboard on Copy", async () => {
+		createHubInvite.mockResolvedValue({
+			token: "tok-abcdef-123456",
+			expires_at: "2026-05-04T12:00:00.000Z",
+		});
+
+		render();
+
+		// Form is visible first.
+		expect(screen.getByRole("button", { name: /issue invite/i })).toBeInTheDocument();
+		expect(screen.queryByLabelText(/invite token/i)).not.toBeInTheDocument();
+
+		const noteInput = screen.getByLabelText(/note/i);
+		await userEvent.type(noteInput, "for alice@example.com");
+
+		await userEvent.click(screen.getByRole("button", { name: /issue invite/i }));
+
+		// Token shows up in a read-only field.
+		const tokenInput = await screen.findByLabelText(/invite token/i);
+		expect(tokenInput).toHaveValue("tok-abcdef-123456");
+		expect(tokenInput).toHaveAttribute("readonly");
+		expect(screen.getByText(/won't be shown again/i)).toBeInTheDocument();
+		// Expiry timestamp rendered.
+		expect(screen.getByText(/expires/i)).toBeInTheDocument();
+
+		// Worker proxy was called with the right body.
+		expect(createHubInvite).toHaveBeenCalledWith("m1", {
+			sharing_group_uuid: "sg-1",
+			note: "for alice@example.com",
+			ttl_hours: 72,
+		});
+
+		// Copy button writes the token to the clipboard.
+		await userEvent.click(screen.getByRole("button", { name: /^copy$/i }));
+		const writeText = (navigator.clipboard as unknown as {
+			writeText: ReturnType<typeof vi.fn>;
+		}).writeText;
+		expect(writeText).toHaveBeenCalledWith("tok-abcdef-123456");
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: /copied/i })).toBeInTheDocument(),
+		);
+	});
+
+	it("clears the token from the DOM when the modal closes", async () => {
+		createHubInvite.mockResolvedValue({
+			token: "tok-secret-xyz",
+			expires_at: "2026-05-04T12:00:00.000Z",
+		});
+
+		const { rerender } = render(true);
+		await userEvent.click(screen.getByRole("button", { name: /issue invite/i }));
+		const tokenInput = await screen.findByLabelText(/invite token/i);
+		expect(tokenInput).toHaveValue("tok-secret-xyz");
+
+		// Close via the Done button — handler flips parent open=false. Then
+		// rerender with open=false to simulate the parent's response. The
+		// token field, the warning, and the token value must all be gone.
+		await userEvent.click(screen.getByRole("button", { name: /done/i }));
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+
+		rerender(
+			<HubInviteModal
+				open={false}
+				mailboxId="m1"
+				sharingGroup={{ uuid: "sg-1", name: "Trusted retailers" }}
+				onOpenChange={onOpenChange}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(screen.queryByLabelText(/invite token/i)).not.toBeInTheDocument();
+		});
+		expect(screen.queryByText("tok-secret-xyz")).not.toBeInTheDocument();
+		expect(screen.queryByText(/won't be shown again/i)).not.toBeInTheDocument();
+		// The token value must not appear ANYWHERE in the document tree.
+		expect(document.body.innerHTML).not.toContain("tok-secret-xyz");
+	});
+
+	it("falls back to a focused, selected input when clipboard.writeText is unavailable", async () => {
+		createHubInvite.mockResolvedValue({
+			token: "tok-fallback-123",
+			expires_at: "2026-05-04T12:00:00.000Z",
+		});
+		// Clipboard absent.
+		Object.defineProperty(globalThis, "navigator", {
+			value: { ...globalThis.navigator, clipboard: undefined },
+			configurable: true,
+		});
+
+		render();
+		await userEvent.click(screen.getByRole("button", { name: /issue invite/i }));
+		const tokenInput = (await screen.findByLabelText(/invite token/i)) as HTMLInputElement;
+
+		await userEvent.click(screen.getByRole("button", { name: /^copy$/i }));
+
+		// Fallback hint surfaces and the input is focused.
+		expect(await screen.findByText(/clipboard access denied/i)).toBeInTheDocument();
+		expect(document.activeElement).toBe(tokenInput);
+	});
+});

--- a/tests/frontend/hub.test.tsx
+++ b/tests/frontend/hub.test.tsx
@@ -27,6 +27,18 @@ vi.mock("~/queries/hub", () => ({
 	useHubContributions: () => contributionsState,
 	useHubDestroylist: () => destroylistState,
 	useHubSharingGroups: () => sharingGroupsState,
+	// The Sharing groups panel renders a HubInviteModal that calls
+	// `useCreateHubInvite`. The route-level test doesn't drive the modal,
+	// so a no-op stub matching the mutation shape is enough.
+	useCreateHubInvite: () => ({
+		mutate: () => undefined,
+		mutateAsync: async () => ({ token: "", expires_at: "" }),
+		reset: () => undefined,
+		isPending: false,
+		isError: false,
+		isSuccess: false,
+		data: undefined,
+	}),
 }));
 
 import HubRoute from "~/routes/hub";

--- a/workers/routes/hub-ui.ts
+++ b/workers/routes/hub-ui.ts
@@ -91,3 +91,55 @@ hubUiRoutes.get("/sharing-groups", async (c) => {
 	});
 	return c.json(result);
 });
+
+/**
+ * Issue a one-time invite token via the hub `POST /orgs/invite` endpoint
+ * (#74). The hub owns role gating: a non-member of the requested sharing
+ * group gets a 403 from the hub, which we forward verbatim — we do NOT
+ * substitute fallback behavior on hub error so the UI can show the real
+ * reason. Body shape mirrors the hub: `{ sharing_group_uuid?, note?,
+ * ttl_hours? }`. On success the hub returns `{ token, expires_at }` and
+ * the token is shown ONCE in the modal.
+ */
+hubUiRoutes.post("/invites", async (c) => {
+	const mailboxId = c.req.param("mailboxId");
+	if (!mailboxId) return c.json({ error: "missing mailboxId" }, 400);
+	const creds = await loadHubCredentials(
+		c.env as unknown as Record<string, unknown>,
+		c.env.BUCKET,
+		mailboxId,
+	);
+	if (!creds) return c.json({ error: "hub not configured" }, 412);
+
+	const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+	// Only forward the keys the hub expects — drops accidental extras
+	// without rejecting the request locally (the hub validates with zod).
+	const forwardBody: Record<string, unknown> = {};
+	if (body.sharing_group_uuid !== undefined) forwardBody.sharing_group_uuid = body.sharing_group_uuid;
+	if (body.note !== undefined) forwardBody.note = body.note;
+	if (body.ttl_hours !== undefined) forwardBody.ttl_hours = body.ttl_hours;
+
+	const url = `${creds.cfg.url.replace(/\/$/, "")}/orgs/invite`;
+	const upstream = await fetch(url, {
+		method: "POST",
+		headers: {
+			"Authorization": creds.apiKey,
+			"Accept": "application/json",
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(forwardBody),
+		signal: AbortSignal.timeout(10000),
+	}).catch(() => null);
+
+	if (!upstream) return c.json({ error: "hub unreachable" }, 502);
+
+	// Forward the hub's response honestly — both 200/201 and 4xx (notably
+	// 403 "not a member of that sharing group"). Returning JSON shape on
+	// success means the UI never sees a stripped/mangled token.
+	const text = await upstream.text();
+	const contentType = upstream.headers.get("content-type") ?? "application/json";
+	return new Response(text, {
+		status: upstream.status,
+		headers: { "content-type": contentType },
+	});
+});


### PR DESCRIPTION
## Summary

- Adds the cut-from-#57 invite flow: a worker proxy at `POST /api/v1/mailboxes/:mailboxId/hub/invites` that forwards verbatim (status, body, content-type) to hub `POST /orgs/invite`, plus a `useCreateHubInvite` mutation hook.
- A new two-state `HubInviteModal` mounts on each row of the Sharing groups panel. Form state collects optional `note` and `ttl_hours` (default 72); the success state swaps to a read-only token field, a Copy button, a one-time warning, the absolute expiry, and a Done button.
- Token never persists outside the open modal: any close reason (X, ESC, backdrop click, Cancel, Done, or parent flipping `open=false`) clears local state and resets the mutation, so the next open shows the form again. Verified by a DOM-absence assertion in the test.
- Copy button tries `navigator.clipboard.writeText`; on failure or absence it falls back to a focused + selected input with an inline `Cmd-C/Ctrl-C` hint.
- Role gating stays hub-side: a non-member of the requested sharing group gets a 403 from `POST /orgs/invite`, which the worker forwards honestly. No fallback behavior on hub error.

## Test plan

- [x] `npm test` — **297 passing, 0 failing** (3 new tests in `tests/frontend/hub-invite-modal.test.tsx`: form → token visible + clipboard write; close → token gone from DOM; clipboard-unavailable fallback)
- [x] `npm run typecheck` — passes
- [x] Worker proxy returns the hub's status code and response body verbatim (no swallowed 403/4xx, no synthesized success)
- [x] Existing `tests/frontend/hub.test.tsx` extended with a `useCreateHubInvite` stub for the SharingGroupsPanel's modal mount

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)