### PR TITLE
fix(ui): remove fabricated case-detail placeholders

### DIFF
--- a/app/routes/case-detail.tsx
+++ b/app/routes/case-detail.tsx
@@ -5,13 +5,10 @@
 import {
 	ArrowLeftIcon,
 	BriefcaseIcon,
-	CompassIcon,
-	ShieldCheckIcon,
 	ShieldWarningIcon,
 } from "@phosphor-icons/react";
 import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router";
-import ScoreRing from "~/components/phishsoc/ScoreRing";
 import VerdictPill from "~/components/phishsoc/VerdictPill";
 import { statusLabel, statusTone } from "~/components/phishsoc/verdict";
 import { useFeedback } from "~/lib/feedback";
@@ -113,10 +110,6 @@ export default function CaseDetailRoute() {
 	}
 
 	const tone = statusTone(data.status);
-	// Numeric score isn't computed yet — render a clear placeholder rather
-	// than fabricate a value. Real score lands when the security pipeline
-	// is plumbed into the case record.
-	const placeholderScore = data.status === "closed-fp" ? 30 : 80;
 
 	return (
 		<div className="px-6 md:px-10 py-8 max-w-[1280px] space-y-5">
@@ -128,9 +121,11 @@ export default function CaseDetailRoute() {
 				<ArrowLeftIcon size={12} /> Cases
 			</Link>
 
-			{/* Title bar */}
+			{/* Title bar — score badge intentionally omitted. The cases table
+			    doesn't yet persist a verdict score (see issue #87); rendering a
+			    fabricated value misled operators making release decisions, so
+			    we show status only until per-case scoring lands. */}
 			<div className="pp-card p-5 flex items-start gap-5">
-				<ScoreRing score={placeholderScore} />
 				<div className="flex-1 min-w-0">
 					<div className="flex items-center gap-2 mb-1.5">
 						<VerdictPill tone={tone}>{statusLabel(data.status)}</VerdictPill>
@@ -209,31 +204,10 @@ export default function CaseDetailRoute() {
 						</div>
 					)}
 
-					{/* Co-pilot summary — placeholder card matching the design.
-					    Lights up when the AI summarizer is wired to cases. */}
-					<div
-						className="rounded-[14px] p-5 border"
-						style={{
-							background: "var(--accent-tint)",
-							borderColor: "color-mix(in oklch, var(--accent) 25%, transparent)",
-						}}
-					>
-						<div className="flex items-center gap-2 mb-2">
-							<span className="flex h-7 w-7 items-center justify-center rounded-full bg-accent text-paper">
-								<CompassIcon size={14} weight="fill" />
-							</span>
-							<div className="flex-1">
-								<div className="text-[12px] font-medium text-accent-ink">
-									Co-pilot summary
-								</div>
-								<div className="text-[11px] text-ink-3">Coming soon</div>
-							</div>
-						</div>
-						<p className="text-[12.5px] text-accent-ink leading-relaxed opacity-90">
-							When AI summarization lands, you'll see plain-language reasoning
-							here for why the pipeline reached this verdict.
-						</p>
-					</div>
+					{/* Co-pilot summary card intentionally omitted until AI
+					    summarization is wired to cases. A "Coming soon"
+					    placeholder read as a real product surface to operators
+					    — empty space is more honest. */}
 				</div>
 
 				{/* Right column: observables / IOCs + status controls */}
@@ -298,22 +272,11 @@ export default function CaseDetailRoute() {
 						</button>
 					</div>
 
-					{/* Pipeline trace placeholder — full trace lands when the
-					    security pipeline writes per-stage records to the case. */}
-					<div className="pp-card p-5">
-						<div className="text-[11px] uppercase tracking-[0.06em] text-ink-3 mb-2">
-							Pipeline trace
-						</div>
-						<div className="flex items-start gap-2 text-[12.5px] text-ink-3">
-							<ShieldCheckIcon size={14} className="text-ink-4 mt-0.5" />
-							<span>
-								Stage-level scoring isn't surfaced for cases yet. The
-								security pipeline runs per email — once we link the trace,
-								you'll see auth, URL, reputation, intel, triage, LLM, and
-								verdict stages here.
-							</span>
-						</div>
-					</div>
+					{/* Pipeline trace card intentionally omitted until per-stage
+					    scoring is persisted on the case record. Today the
+					    pipeline runs per-email and stages aren't stored on the
+					    case, so any rendered timeline would be either empty or
+					    fabricated. */}
 				</div>
 			</div>
 		</div>

--- a/tests/frontend/case-detail.test.tsx
+++ b/tests/frontend/case-detail.test.tsx
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+
+import CaseDetailRoute from "~/routes/case-detail";
+import { renderWithProviders } from "./test-utils";
+
+// The case API today returns only the columns persisted on the `cases` table
+// (id, status, title, notes, …) plus the linked-emails and observables joins.
+// It does NOT return `score`, `summary`, or `stage_trace` — issue #87 is about
+// removing the placeholder UI that pretended otherwise. The mock mirrors that
+// real shape so the assertions below verify behavior under current data, not
+// a hypothetical future schema.
+const baseCase = {
+	id: "case_abc123",
+	created_at: "2026-04-29T11:00:00Z",
+	updated_at: "2026-04-29T11:30:00Z",
+	status: "open",
+	title: "Suspicious wire-transfer request",
+	notes: null,
+	shared_to_hub: 0,
+	hub_event_uuid: null,
+	emails: [],
+	observables: [],
+};
+
+function mockFetchOnce(payload: unknown) {
+	const fetchMock = vi.fn().mockResolvedValue({
+		ok: true,
+		json: async () => payload,
+	} as Response);
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+function renderCaseDetail() {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/mailbox/:mailboxId/cases/:caseId"
+				element={<CaseDetailRoute />}
+			/>
+		</Routes>,
+		{ initialEntries: ["/mailbox/m1/cases/case_abc123"] },
+	);
+}
+
+describe("CaseDetailRoute (interim mitigation, issue #87)", () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("renders no fabricated score, no co-pilot placeholder, no pipeline-trace placeholder when the case API omits score/summary/stage_trace", async () => {
+		mockFetchOnce({ case: baseCase });
+		renderCaseDetail();
+
+		// Wait for the fetch-driven render to commit.
+		expect(
+			await screen.findByText(/Suspicious wire-transfer request/i),
+		).toBeInTheDocument();
+
+		// 1. No fabricated score badge. <ScoreRing> renders the literal
+		//    "/ 100" subtitle under the numeric score; if it's gone, the
+		//    title-bar fabrication is gone. We also confirm the
+		//    "open" → 80 / "closed-fp" → 30 numeric placeholders are absent.
+		expect(screen.queryByText(/\/\s*100/)).toBeNull();
+		expect(screen.queryByText(/^80$/)).toBeNull();
+		expect(screen.queryByText(/^30$/)).toBeNull();
+
+		// 2. No "Coming soon" co-pilot card.
+		expect(screen.queryByText(/coming soon/i)).toBeNull();
+		expect(screen.queryByText(/co-pilot summary/i)).toBeNull();
+
+		// 3. No pipeline-trace placeholder copy.
+		expect(
+			screen.queryByText(/stage-level scoring isn't surfaced/i),
+		).toBeNull();
+		expect(screen.queryByText(/pipeline trace/i)).toBeNull();
+	});
+
+	it("still renders core case content (title, status, linked-emails empty state) so the page isn't blanked out", async () => {
+		mockFetchOnce({ case: { ...baseCase, status: "closed-fp" } });
+		renderCaseDetail();
+
+		expect(
+			await screen.findByText(/Suspicious wire-transfer request/i),
+		).toBeInTheDocument();
+		// "closed-fp" maps to a "Released" / "Closed" verdict label via
+		// statusLabel(); we only need to confirm a status pill is present
+		// and the dangerous fabricated score isn't.
+		await waitFor(() => {
+			expect(screen.queryByText(/\/\s*100/)).toBeNull();
+		});
+		expect(screen.getByText(/case_abc123/i)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary

Interim mitigation for #87 — remove three POC placeholders on the case-detail page that misled operators making release / confirm-threat decisions:

- **Fabricated score badge.** `<ScoreRing>` was rendering `placeholderScore = data.status === "closed-fp" ? 30 : 80` in the title bar. A 0–100 score reads like a real verdict score; it was a status-derived stub. Removed entirely — title bar is now status-only until per-case scoring is persisted.
- **"Co-pilot summary" card** with "Coming soon" copy. Card removed entirely.
- **"Pipeline trace" card** whose body was explanatory copy ("Stage-level scoring isn't surfaced for cases yet…"). Card removed entirely.

The full backend work (real per-case score persistence, AI summary plumbing, per-stage pipeline records) is **out of scope** here and tracked in three follow-up issues filed against this PR.

## What's NOT in this PR

- No changes to the cases-table schema.
- No changes to the case API response shape (`/api/v1/mailboxes/:id/cases/:caseId`).
- No new endpoints or backend work.

Empty space until the data exists; better than fabricating values an operator might trust.

## Test plan

- Added `tests/frontend/case-detail.test.tsx` (2 tests) asserting that with the current case-API shape (no `score` / `summary` / `stage_trace` fields), the rendered page contains no `/100` score subtitle, no `80`/`30` placeholder values, no "Coming soon" copy, no "Co-pilot summary" header, no "Pipeline trace" header, and no "Stage-level scoring isn't surfaced" copy. Confirms the title still renders so the page isn't blanked out.
- Full suite: **296 passing, 0 failing** (33 files) via `npm test`.
- Typecheck: clean via `npm run typecheck`.

## Follow-up issues (filed alongside this PR)

- Persist per-case verdict score on the cases table (real-score path).
- AI co-pilot summary on case detail (summary card).
- Per-stage pipeline trace persisted on cases (timeline).

Closes #87