### PR TITLE
feat: hub corroboration card

### DIFF
--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -111,10 +111,17 @@ function KpiGrid({ data }: { data: DashboardSummary }) {
 			label: "Hub contributions · 24h",
 			value: String(data.hubContributions),
 		},
+		{
+			// Issue #72: own attributes that received ≥1 additional contributor
+			// on the hub in the last 24h. `null` = hub unreachable / no config;
+			// render an em-dash so the card stays visible without misleading 0.
+			label: "Hub corroboration · 24h",
+			value: data.corroboration === null ? "—" : String(data.corroboration),
+		},
 	];
 
 	return (
-		<div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
+		<div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6">
 			{kpis.map((k) => (
 				<div key={k.label} className="pp-card p-4">
 					<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-2">

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -174,6 +174,13 @@ export interface DashboardSummary {
 	threatsBlocked: number;
 	openCases: number;
 	hubContributions: number;
+	/**
+	 * Count of own attributes corroborated by ≥1 other contributor on the hub
+	 * within the last 24h (#72). Null when the hub is unreachable or the
+	 * mailbox has no hub config — the UI renders "unavailable" rather than
+	 * failing the whole dashboard.
+	 */
+	corroboration: number | null;
 	pipelineSuccess: number | null;
 	/** 95th-percentile pipeline duration over the last 24h, in ms. Null when no completed runs. */
 	p95Ms: number | null;

--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -26,6 +26,7 @@ import { orgRoutes, orgAcceptApp } from "./routes/orgs";
 import { sharingGroupRoutes } from "./routes/sharing-groups";
 import { adminRoutes } from "./routes/admin";
 import { adminStatsRoutes } from "./routes/admin/stats";
+import { corroborationRoutes } from "./routes/corroboration";
 import { consumeTriageBatch } from "./agent/triage";
 import { runInboundSync } from "./lib/sync";
 import type { Env, TriageMessage } from "./types";
@@ -41,6 +42,7 @@ app.route("/orgs", orgRoutes);    // authed /orgs/me, /orgs/invite
 app.route("/sharing_groups", sharingGroupRoutes);
 app.route("/admin", adminRoutes);
 app.route("/admin", adminStatsRoutes);
+app.route("/api/v1/corroboration", corroborationRoutes);
 
 export default {
 	fetch: app.fetch,

--- a/hub/src/routes/corroboration.ts
+++ b/hub/src/routes/corroboration.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Hub corroboration count for an org's "own" attributes (#72).
+ *
+ * Returns the number of attributes contributed by `orgUuid` that have
+ * received at least one additional contributor on the hub within the
+ * window `[since, now]`.
+ *
+ * Schema caveat (worth knowing as a reviewer):
+ *   `corroboration_contributors` carries no per-row timestamp, so we cannot
+ *   tell precisely *when* a second contributor arrived. The closest we can
+ *   express is "rows where this org is a contributor AND ≥2 distinct
+ *   contributors AND `last_seen >= since`". `last_seen` updates on any
+ *   contribution to the row, so this is a reasonable proxy for "the row
+ *   saw activity in the window" — including the case where the second
+ *   contributor showed up earlier and our org re-submitted in-window. For
+ *   a 24h dashboard widget that's fine; if drilldown lands later (out of
+ *   scope here) we'd want a contributor timestamp column.
+ */
+
+import { Hono } from "hono";
+import { requireOrg, type HubContext } from "../lib/auth";
+
+export const corroborationRoutes = new Hono<HubContext>();
+
+corroborationRoutes.use("*", requireOrg);
+
+/**
+ * `GET /api/v1/corroboration?orgUuid=<self>&since=<iso>`
+ *
+ * Auth model: the caller must be authenticated and `orgUuid` must equal the
+ * authenticated org. Cross-tenant reads are rejected with 403 — otherwise
+ * any authed org could enumerate another org's corroboration count.
+ */
+corroborationRoutes.get("/", async (c) => {
+	const orgUuid = c.req.query("orgUuid");
+	const since = c.req.query("since");
+
+	if (!orgUuid) return c.json({ error: "orgUuid required" }, 400);
+	if (!since) return c.json({ error: "since required" }, 400);
+
+	// Reject malformed `since` — must be parseable ISO-8601. `last_seen` is
+	// written by `applyCorroboration` as `new Date().toISOString()` (ISO with
+	// T and Z), so we compare against the same canonical form. SQLite text
+	// comparison is lexicographic, which sorts ISO-8601 timestamps correctly.
+	const sinceMs = Date.parse(since);
+	if (Number.isNaN(sinceMs)) {
+		return c.json({ error: "since must be a parseable ISO-8601 timestamp" }, 400);
+	}
+	const sinceSql = new Date(sinceMs).toISOString();
+
+	if (orgUuid !== c.var.org.uuid) {
+		return c.json({ error: "orgUuid must match authenticated org" }, 403);
+	}
+
+	// Count distinct corroboration rows where:
+	//  - this org is in `corroboration_contributors` (the row is "ours")
+	//  - the row has ≥2 distinct contributors total (someone else corroborated)
+	//  - the row was touched within the window
+	//
+	// The `last_seen >= ?` filter narrows the scan first; for a 24h window
+	// this is a small slice in practice. EXISTS short-circuits per row.
+	const row = await c.env.DB
+		.prepare(
+			`SELECT COUNT(*) AS n
+			 FROM corroboration c
+			 WHERE c.last_seen >= ?1
+			   AND c.contributor_count >= 2
+			   AND EXISTS (
+			     SELECT 1 FROM corroboration_contributors cc
+			     WHERE cc.corroboration_id = c.id AND cc.orgc_uuid = ?2
+			   )`,
+		)
+		.bind(sinceSql, orgUuid)
+		.first<{ n: number }>();
+
+	return c.json({ corroboratedCount: row?.n ?? 0 });
+});

--- a/hub/tests/routes/corroboration.test.ts
+++ b/hub/tests/routes/corroboration.test.ts
@@ -1,0 +1,219 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { corroborationRoutes } from "../../src/routes/corroboration";
+import { sha256 } from "../../src/lib/hash";
+import { makeTestDb, type TestDb } from "../helpers/d1";
+import type { Env } from "../../src/types";
+
+let db: TestDb;
+let env: Env;
+
+const SELF_ORG = "11111111-1111-1111-1111-111111111111";
+const OTHER_ORG = "22222222-2222-2222-2222-222222222222";
+const THIRD_ORG = "33333333-3333-3333-3333-333333333333";
+const SELF_KEY = "self-api-key";
+
+beforeEach(async () => {
+	db = makeTestDb();
+	env = {
+		DB: db.d1,
+		AI: {} as Ai,
+		TRIAGE_QUEUE: { send: async () => {} } as never,
+		HUB_ADMIN_KEY: "admin-secret",
+	} as Env;
+
+	// Seed orgs and an api_key for SELF_ORG so requireOrg auth succeeds.
+	db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, 1.0)`)
+		.run(SELF_ORG, "self");
+	db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, 1.0)`)
+		.run(OTHER_ORG, "other");
+	db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, 1.0)`)
+		.run(THIRD_ORG, "third");
+
+	const keyHash = await sha256(SELF_KEY);
+	db.raw
+		.prepare(`INSERT INTO api_keys (key_hash, org_uuid, label) VALUES (?, ?, 'test')`)
+		.run(keyHash, SELF_ORG);
+});
+
+afterEach(() => db.close());
+
+function appReq(path: string, init?: RequestInit) {
+	const app = new Hono<{ Bindings: Env }>();
+	app.route("/api/v1/corroboration", corroborationRoutes);
+	return app.request(path, init, env as never);
+}
+
+/**
+ * Inserts a corroboration row + N contributors. `lastSeen` is an ISO-8601
+ * timestamp (matches what `applyCorroboration` writes in production).
+ */
+function seedCorroboration(opts: {
+	id: number;
+	type: string;
+	value: string;
+	lastSeen: string;
+	contributors: string[];
+}) {
+	db.raw
+		.prepare(
+			`INSERT INTO corroboration
+			   (id, sharing_group_uuid, attribute_type, value, first_seen, last_seen, contributor_count, score)
+			 VALUES (?, NULL, ?, ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			opts.id,
+			opts.type,
+			opts.value,
+			opts.lastSeen,
+			opts.lastSeen,
+			opts.contributors.length,
+			opts.contributors.length * 1.0,
+		);
+	for (const orgc of opts.contributors) {
+		db.raw
+			.prepare(
+				`INSERT INTO corroboration_contributors (corroboration_id, orgc_uuid) VALUES (?, ?)`,
+			)
+			.run(opts.id, orgc);
+	}
+}
+
+describe("GET /api/v1/corroboration", () => {
+	it("rejects unauthenticated requests with 401", async () => {
+		const since = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+		const res = await appReq(
+			`/api/v1/corroboration?orgUuid=${SELF_ORG}&since=${encodeURIComponent(since)}`,
+		);
+		expect(res.status).toBe(401);
+	});
+
+	it("rejects missing query params with 400", async () => {
+		const res = await appReq(`/api/v1/corroboration`, {
+			headers: { Authorization: SELF_KEY },
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("rejects malformed `since` with 400", async () => {
+		const res = await appReq(
+			`/api/v1/corroboration?orgUuid=${SELF_ORG}&since=not-a-date`,
+			{ headers: { Authorization: SELF_KEY } },
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("rejects orgUuid that doesn't match the authenticated org with 403", async () => {
+		const since = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+		const res = await appReq(
+			`/api/v1/corroboration?orgUuid=${OTHER_ORG}&since=${encodeURIComponent(since)}`,
+			{ headers: { Authorization: SELF_KEY } },
+		);
+		expect(res.status).toBe(403);
+	});
+
+	it("counts an attribute corroborated by self + another org in window", async () => {
+		const inWindow = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+		const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+		seedCorroboration({
+			id: 1,
+			type: "domain",
+			value: "evil.example",
+			lastSeen: inWindow,
+			contributors: [SELF_ORG, OTHER_ORG],
+		});
+
+		const res = await appReq(
+			`/api/v1/corroboration?orgUuid=${SELF_ORG}&since=${encodeURIComponent(since)}`,
+			{ headers: { Authorization: SELF_KEY } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { corroboratedCount: number };
+		expect(body.corroboratedCount).toBe(1);
+	});
+
+	it("does not count when only self is the contributor (no second contributor)", async () => {
+		const inWindow = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+		const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+		// Same contributor twice would be deduped by the contributors PK in
+		// production — model the post-dedup state: a single contributor.
+		seedCorroboration({
+			id: 1,
+			type: "domain",
+			value: "lonely.example",
+			lastSeen: inWindow,
+			contributors: [SELF_ORG],
+		});
+
+		const res = await appReq(
+			`/api/v1/corroboration?orgUuid=${SELF_ORG}&since=${encodeURIComponent(since)}`,
+			{ headers: { Authorization: SELF_KEY } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { corroboratedCount: number };
+		expect(body.corroboratedCount).toBe(0);
+	});
+
+	it("does not count attributes whose `last_seen` falls outside the window", async () => {
+		const outOfWindow = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+		const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+		seedCorroboration({
+			id: 1,
+			type: "domain",
+			value: "stale.example",
+			lastSeen: outOfWindow,
+			contributors: [SELF_ORG, OTHER_ORG],
+		});
+
+		const res = await appReq(
+			`/api/v1/corroboration?orgUuid=${SELF_ORG}&since=${encodeURIComponent(since)}`,
+			{ headers: { Authorization: SELF_KEY } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { corroboratedCount: number };
+		expect(body.corroboratedCount).toBe(0);
+	});
+
+	it("counts each corroborated attribute once even with three contributors", async () => {
+		const inWindow = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+		const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+		seedCorroboration({
+			id: 1,
+			type: "url",
+			value: "https://a.example",
+			lastSeen: inWindow,
+			contributors: [SELF_ORG, OTHER_ORG, THIRD_ORG],
+		});
+		seedCorroboration({
+			id: 2,
+			type: "url",
+			value: "https://b.example",
+			lastSeen: inWindow,
+			contributors: [SELF_ORG, OTHER_ORG],
+		});
+		// Row not contributed by self — must not count.
+		seedCorroboration({
+			id: 3,
+			type: "url",
+			value: "https://c.example",
+			lastSeen: inWindow,
+			contributors: [OTHER_ORG, THIRD_ORG],
+		});
+
+		const res = await appReq(
+			`/api/v1/corroboration?orgUuid=${SELF_ORG}&since=${encodeURIComponent(since)}`,
+			{ headers: { Authorization: SELF_KEY } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { corroboratedCount: number };
+		expect(body.corroboratedCount).toBe(2);
+	});
+});

--- a/tests/frontend/dashboard.test.tsx
+++ b/tests/frontend/dashboard.test.tsx
@@ -34,6 +34,7 @@ const populated: DashboardSummary = {
 	threatsBlocked: 3,
 	openCases: 7,
 	hubContributions: 2,
+	corroboration: 4,
 	pipelineSuccess: 0.92,
 	p95Ms: 1500,
 	threatPressure: [0, 1, 0, 2, 1, 0, 3, 0, 0, 1, 0, 0],
@@ -78,17 +79,21 @@ describe("DashboardRoute", () => {
 		// down on the underlying 1.4499999… binary representation.
 		expect(screen.getByText("1.5s")).toBeInTheDocument();
 		expect(screen.getByText("2")).toBeInTheDocument();
+		// Hub corroboration card (#72) renders alongside Hub contributions.
+		expect(screen.getByText(/hub corroboration · 24h/i)).toBeInTheDocument();
+		expect(screen.getByText("4")).toBeInTheDocument();
 		expect(screen.getByText(/suspicious wire request/i)).toBeInTheDocument();
 		expect(screen.getByText(/credential phish/i)).toBeInTheDocument();
 	});
 
-	it("renders '—' for pipelineSuccess and p95 when no scans have run, and 'No cases yet.' when empty", () => {
+	it("renders '—' for pipelineSuccess, p95, and corroboration when null, and 'No cases yet.' when empty", () => {
 		queryState = {
 			data: {
 				now: populated.now,
 				threatsBlocked: 0,
 				openCases: 0,
 				hubContributions: 0,
+				corroboration: null,
 				pipelineSuccess: null,
 				p95Ms: null,
 				threatPressure: new Array(12).fill(0),
@@ -98,10 +103,27 @@ describe("DashboardRoute", () => {
 			isError: false,
 		};
 		renderDashboard();
-		// Both the pipeline-success and pipeline-p95 cards render the "—"
-		// placeholder when their respective values are null.
-		expect(screen.getAllByText("—")).toHaveLength(2);
+		// Three KPI cards (pipeline-success, pipeline-p95, hub-corroboration)
+		// render the "—" placeholder when their respective values are null.
+		expect(screen.getAllByText("—")).toHaveLength(3);
 		expect(screen.getByText(/no cases yet/i)).toBeInTheDocument();
+	});
+
+	it("renders sibling KPI cards unaffected when corroboration is null", () => {
+		// Hub outage shouldn't blank the rest of the dashboard — the hub
+		// contributions card and the threats-blocked count stay populated.
+		queryState = {
+			data: { ...populated, corroboration: null },
+			isLoading: false,
+			isError: false,
+		};
+		renderDashboard();
+		expect(screen.getByText(/hub contributions · 24h/i)).toBeInTheDocument();
+		expect(screen.getByText("2")).toBeInTheDocument(); // hubContributions
+		expect(screen.getByText("3")).toBeInTheDocument(); // threatsBlocked
+		expect(screen.getByText(/hub corroboration · 24h/i)).toBeInTheDocument();
+		// Exactly one "—" — the corroboration card.
+		expect(screen.getAllByText("—")).toHaveLength(1);
 	});
 
 	it("links each recent case to /mailbox/:id/cases/:caseId", () => {

--- a/tests/frontend/shell-pipeline-pill.test.tsx
+++ b/tests/frontend/shell-pipeline-pill.test.tsx
@@ -34,6 +34,7 @@ function makeSummary(pipelineSuccess: number | null): DashboardSummary {
 		threatsBlocked: 0,
 		openCases: 0,
 		hubContributions: 0,
+		corroboration: null,
 		pipelineSuccess,
 		p95Ms: null,
 		threatPressure: [],

--- a/tests/intel/hub-corroboration.test.ts
+++ b/tests/intel/hub-corroboration.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchHubCorroborationCount } from "../../workers/intel/hub-corroboration";
+
+const baseOpts = {
+	baseUrl: "https://hub.example",
+	apiKey: "k",
+	orgUuid: "11111111-1111-1111-1111-111111111111",
+	since: "2026-04-29T00:00:00.000Z",
+};
+
+describe("fetchHubCorroborationCount", () => {
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+	beforeEach(() => {
+		fetchSpy = vi.spyOn(globalThis, "fetch");
+	});
+	afterEach(() => {
+		fetchSpy.mockRestore();
+	});
+
+	it("returns the count on a happy 200 response", async () => {
+		fetchSpy.mockResolvedValueOnce(
+			new Response(JSON.stringify({ corroboratedCount: 7 }), { status: 200 }),
+		);
+		const n = await fetchHubCorroborationCount(baseOpts);
+		expect(n).toBe(7);
+
+		// Verify the URL + auth header shape match the hub contract.
+		const call = fetchSpy.mock.calls[0]!;
+		const url = call[0] as string;
+		expect(url).toContain("/api/v1/corroboration");
+		expect(url).toContain("orgUuid=11111111-1111-1111-1111-111111111111");
+		expect(url).toContain(`since=${encodeURIComponent(baseOpts.since)}`);
+		const init = call[1] as RequestInit;
+		expect((init.headers as Record<string, string>).Authorization).toBe("k");
+	});
+
+	it("returns null on non-2xx (hub down with 500)", async () => {
+		fetchSpy.mockResolvedValueOnce(new Response("oops", { status: 500 }));
+		const n = await fetchHubCorroborationCount(baseOpts);
+		expect(n).toBeNull();
+	});
+
+	it("returns null when the response body is malformed JSON", async () => {
+		fetchSpy.mockResolvedValueOnce(new Response("not json", { status: 200 }));
+		const n = await fetchHubCorroborationCount(baseOpts);
+		expect(n).toBeNull();
+	});
+
+	it("returns null when corroboratedCount is missing from the body", async () => {
+		fetchSpy.mockResolvedValueOnce(
+			new Response(JSON.stringify({ other: 1 }), { status: 200 }),
+		);
+		const n = await fetchHubCorroborationCount(baseOpts);
+		expect(n).toBeNull();
+	});
+
+	it("returns null when fetch throws (network error / timeout)", async () => {
+		fetchSpy.mockRejectedValueOnce(new Error("timeout"));
+		const n = await fetchHubCorroborationCount(baseOpts);
+		expect(n).toBeNull();
+	});
+
+	it("times out via the default 2s AbortSignal when the hub hangs", async () => {
+		// Drive the AbortSignal.timeout(2000) path: the Promise never resolves
+		// but the signal aborts; `fetch` should reject with an AbortError.
+		fetchSpy.mockImplementationOnce((_url: unknown, init: unknown) => {
+			return new Promise((_resolve, reject) => {
+				const signal = (init as RequestInit).signal as AbortSignal | undefined;
+				signal?.addEventListener("abort", () => {
+					reject(new DOMException("aborted", "AbortError"));
+				});
+			});
+		});
+		// Use a short signal to avoid actually waiting 2s in the test.
+		const ac = new AbortController();
+		queueMicrotask(() => ac.abort());
+		const n = await fetchHubCorroborationCount({ ...baseOpts, signal: ac.signal });
+		expect(n).toBeNull();
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -38,6 +38,8 @@ import {
 	type OrgOverview,
 } from "./lib/dashboard-aggregation";
 import { listTextModels } from "./lib/text-models";
+import { fetchHubCorroborationCount } from "./intel/hub-corroboration";
+import { loadHubCredentials } from "./lib/hub-config";
 
 type AppContext = Context<MailboxContext>;
 
@@ -215,11 +217,40 @@ app.get("/api/v1/mailboxes/:mailboxId/dashboard", async (c: AppContext) => {
 	const threatPressure = bucketThreatPressure(raw.verdictRows);
 	const pipelineSuccess = pipelineSuccessRate(raw.pipelineScan);
 	const p95Ms = computeP95(raw.pipelineDurationsMs);
+
+	// Hub corroboration count (#72). Best-effort: the hub may be down, the
+	// mailbox may have no hub config, or the call may time out. Any of those
+	// → `corroboration: null` and the rest of the dashboard ships unaffected.
+	let corroboration: number | null = null;
+	const mailboxId = c.req.param("mailboxId");
+	if (mailboxId) {
+		try {
+			const creds = await loadHubCredentials(
+				c.env as unknown as Record<string, unknown>,
+				c.env.BUCKET,
+				mailboxId,
+			);
+			if (creds) {
+				const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+				corroboration = await fetchHubCorroborationCount({
+					baseUrl: creds.cfg.url,
+					apiKey: creds.apiKey,
+					orgUuid: creds.cfg.org_uuid,
+					since,
+				});
+			}
+		} catch (e) {
+			console.error("dashboard corroboration fetch failed:", (e as Error)?.message);
+			corroboration = null;
+		}
+	}
+
 	return c.json({
 		now: raw.now,
 		threatsBlocked: raw.threatsBlocked,
 		openCases: raw.openCases,
 		hubContributions: raw.hubContributions,
+		corroboration,
 		pipelineSuccess,
 		p95Ms: p95Ms === null ? null : Math.round(p95Ms),
 		threatPressure,

--- a/workers/intel/hub-corroboration.ts
+++ b/workers/intel/hub-corroboration.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Hub corroboration count fetch (#72).
+ *
+ * Standalone fetch helper rather than a `MispClient` method because the
+ * corroboration endpoint isn't part of the MISP REST surface — it's a
+ * PhishSOC-hub-only addition that sums "own attributes that got a second
+ * contributor in the window."
+ *
+ * On any failure (non-2xx, malformed body, network error, timeout) the
+ * helper returns `null`. The dashboard endpoint forwards that `null` to the
+ * UI, which renders an "unavailable" placeholder instead of failing the
+ * whole dashboard when the hub is unreachable.
+ */
+
+export interface FetchCorroborationOpts {
+	baseUrl: string;
+	apiKey: string;
+	orgUuid: string;
+	since: string;
+	/** AbortSignal override — defaults to a 2s timeout. */
+	signal?: AbortSignal;
+}
+
+export async function fetchHubCorroborationCount(
+	opts: FetchCorroborationOpts,
+): Promise<number | null> {
+	const url = new URL(
+		`${opts.baseUrl.replace(/\/$/, "")}/api/v1/corroboration`,
+	);
+	url.searchParams.set("orgUuid", opts.orgUuid);
+	url.searchParams.set("since", opts.since);
+
+	try {
+		const res = await fetch(url.toString(), {
+			headers: {
+				Authorization: opts.apiKey,
+				Accept: "application/json",
+			},
+			signal: opts.signal ?? AbortSignal.timeout(2000),
+		});
+		if (!res.ok) return null;
+		const json = (await res.json().catch(() => null)) as
+			| { corroboratedCount?: unknown }
+			| null;
+		const n = json?.corroboratedCount;
+		if (typeof n !== "number" || !Number.isFinite(n)) return null;
+		return n;
+	} catch {
+		// Timeout / network error / DNS — collapse to null so the caller can
+		// degrade gracefully without trying to distinguish failure modes.
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **Hub corroboration · 24h** KPI card on the operations dashboard. The card shows the count of "own" attributes (i.e. contributed by this org) that have received at least one additional contributor on the hub within the last 24 hours. It sits alongside the existing **Hub contributions · 24h** card; the existing card is unchanged.

- **Hub:** new `GET /api/v1/corroboration?orgUuid=<self>&since=<iso>` route. Auth-gated via `requireOrg`; rejects cross-tenant reads (`orgUuid != authed.uuid`) with 403; rejects malformed `since` with 400.
- **Workers:** `/api/v1/mailboxes/:mailboxId/dashboard` enriches the response with a top-level `corroboration: number | null`. Hub fetch uses a 2s `AbortSignal` and collapses any non-2xx, network error, timeout, or malformed body into `null` so a hub outage can't fail the dashboard.
- **Frontend:** new card on the existing dashboard grid (now 6-up at lg+). Renders the count when present; renders an em-dash when `null`.

### Schema caveat

`corroboration_contributors` has no per-row timestamp, so the spec's literal "got a second contributor in the last 24h" can't be answered exactly. The query approximates with `last_seen >= since` (touched-in-window) AND `contributor_count >= 2` AND an `EXISTS` clause for our org. For a 24h widget this is reasonable; drilldown (out of scope) would want a real contributor timestamp.

### Corroboration count SQL

```sql
SELECT COUNT(*) AS n
FROM corroboration c
WHERE c.last_seen >= ?1
  AND c.contributor_count >= 2
  AND EXISTS (
    SELECT 1 FROM corroboration_contributors cc
    WHERE cc.corroboration_id = c.id AND cc.orgc_uuid = ?2
  )
```

`last_seen` filter narrows the scan first; `EXISTS` short-circuits per row. No new migrations, no new indexes.

## Test plan

- [x] `npm test` (root): **301 passing, 0 failing** (33 files)
- [x] `cd hub && npm test`: **52 passing, 0 failing** (7 files)
- [x] Both typecheck clean (`npm run typecheck` in root and hub)
- [x] Hub route tests cover: 401 unauth, 400 missing/malformed `since`, 403 cross-tenant, happy-path (own + other in window → 1), self-only → 0, out-of-window → 0, 3-row mixed scenario → 2.
- [x] Worker helper tests cover: 200 happy path, 500 → null, malformed JSON → null, missing field → null, network error → null, AbortSignal → null.
- [x] Frontend tests cover: card renders count, renders "—" when `null`, sibling cards unaffected by `null` corroboration.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)