### PR TITLE
feat(intel): CrowdSec CTI enrichment in deep-scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Fires after the sync verdict is stored and only ever *tightens* the decision (sy
 
 - **Redirect-chain resolution** — follows `bit.ly`-style wrappers up to 5 hops so downstream checks see the real destination.
 - **RDAP domain age** — queries `rdap.org` for registration date. Domains <7d get +20, <30d get +10. Fails silently on flaky RDAP servers.
+- **CrowdSec CTI enrichment** — *optional, async-only*. When `CROWDSEC_CTI_API_KEY` is set, redirect-target hostnames are resolved via DoH (`cloudflare-dns.com`) and each unique IP is looked up against [CrowdSec CTI](https://docs.crowdsec.net/u/cti_api/intro). Signals: `behaviors` matching `phishing`/`exploit` (+25), `reputation=malicious` (+15), `reputation=suspicious` or `classifications` containing `tor`/`vpn:public`/`data_center` (+10). Capped at +25 per inbound. Responses cached in `BLOOM_KV` for 12h (1h for 404s); 429 rate-limits return `null` without poisoning the cache. Free-tier CTI is rate-limited, so this stage **never runs on the synchronous receive path**. Set the secret with `wrangler secret put CROWDSEC_CTI_API_KEY`; deploys without it just no-op the stage.
 - **Attachment heuristics** — dangerous extensions, macro-enabled Office, `.pdf.exe`-style double extensions, MIME/extension mismatches, archives that advertise a payload in the filename.
 
 ### Threat-intel hub

--- a/test/fixtures/intel/crowdsec-cti-malicious.json
+++ b/test/fixtures/intel/crowdsec-cti-malicious.json
@@ -1,0 +1,46 @@
+{
+  "ip": "203.0.113.42",
+  "ip_range_score": 5,
+  "as_name": "EXAMPLE-ASN",
+  "as_num": 64500,
+  "location": { "country": "US", "city": null },
+  "reverse_dns": null,
+  "behaviors": [
+    {
+      "name": "http:phishing",
+      "label": "http:phishing",
+      "description": "Credential phishing pages observed"
+    },
+    {
+      "name": "http:scan",
+      "label": "http:scan",
+      "description": "Web application scanner"
+    }
+  ],
+  "history": {
+    "first_seen": "2026-04-01T00:00:00Z",
+    "last_seen": "2026-05-01T12:00:00Z",
+    "full_age": 30,
+    "days_age": 30
+  },
+  "classifications": {
+    "false_positives": [],
+    "classifications": [
+      { "name": "tor", "label": "Tor exit node", "description": "Known Tor exit node" }
+    ]
+  },
+  "attack_details": [],
+  "target_countries": { "US": 60, "GB": 40 },
+  "background_noise_score": 0,
+  "scores": {
+    "overall": { "aggressiveness": 4, "threat": 5, "trust": 5, "anomaly": 1, "total": 5 },
+    "last_day": { "aggressiveness": 4, "threat": 5, "trust": 5, "anomaly": 1, "total": 5 },
+    "last_week": { "aggressiveness": 4, "threat": 5, "trust": 5, "anomaly": 1, "total": 5 },
+    "last_month": { "aggressiveness": 4, "threat": 5, "trust": 5, "anomaly": 1, "total": 5 }
+  },
+  "reputation": "malicious",
+  "confidence": "high",
+  "mitre_techniques": [
+    { "name": "T1566", "label": "Phishing", "description": "..." }
+  ]
+}

--- a/test/security/crowdsec-cti.test.ts
+++ b/test/security/crowdsec-cti.test.ts
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * CrowdSec CTI client tests.
+ *
+ * Covers the four user-visible behaviours that operators rely on:
+ *   - missing API key → null (so unconfigured deploys no-op)
+ *   - 200 → normalised summary, cached
+ *   - 404 → null, miss sentinel cached briefly
+ *   - 429 → null, NOT cached, warning logged
+ *
+ * Cache hit must avoid a second fetch; that's the load-bearing rate-limit
+ * defence and we assert on it explicitly.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import { lookupIp, normalize } from "../../workers/intel/crowdsec-cti";
+import type { Env } from "../../workers/types";
+
+const FIXTURE_DIR = join(__dirname, "..", "fixtures", "intel");
+
+interface FakeKV {
+	store: Map<string, { value: string; expiresAt: number | null }>;
+	get: (key: string, type?: "text" | "arrayBuffer") => Promise<string | null>;
+	put: (key: string, value: string, opts?: { expirationTtl?: number }) => Promise<void>;
+}
+
+function makeKv(): FakeKV {
+	const store = new Map<string, { value: string; expiresAt: number | null }>();
+	return {
+		store,
+		async get(key: string) {
+			const row = store.get(key);
+			if (!row) return null;
+			if (row.expiresAt !== null && row.expiresAt < Date.now()) {
+				store.delete(key);
+				return null;
+			}
+			return row.value;
+		},
+		async put(key, value, opts) {
+			const expiresAt = opts?.expirationTtl
+				? Date.now() + opts.expirationTtl * 1000
+				: null;
+			store.set(key, { value, expiresAt });
+		},
+	};
+}
+
+function makeEnv(opts: { apiKey?: string; kv?: FakeKV } = {}): Env {
+	return {
+		CROWDSEC_CTI_API_KEY: opts.apiKey,
+		BLOOM_KV: opts.kv as unknown as KVNamespace | undefined,
+	} as unknown as Env;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+describe("crowdsec-cti normalize()", () => {
+	it("projects a representative payload to the documented shape", async () => {
+		const raw = JSON.parse(
+			await readFile(join(FIXTURE_DIR, "crowdsec-cti-malicious.json"), "utf8"),
+		);
+		const summary = normalize(raw);
+		expect(summary).not.toBeNull();
+		expect(summary?.reputation).toBe("malicious");
+		expect(summary?.classifications).toContain("tor");
+		expect(summary?.behaviors).toContain("http:phishing");
+		expect(summary?.scores.threat).toBe(5);
+	});
+
+	it("returns 'unknown' reputation when the field is missing or unrecognised", () => {
+		expect(normalize({})?.reputation).toBe("unknown");
+		expect(normalize({ reputation: "weird-value" })?.reputation).toBe("unknown");
+	});
+
+	it("treats non-object input as null", () => {
+		expect(normalize(null)).toBeNull();
+		expect(normalize("string")).toBeNull();
+	});
+});
+
+describe("crowdsec-cti lookupIp()", () => {
+	it("returns null when CROWDSEC_CTI_API_KEY is not configured", async () => {
+		const env = makeEnv({ kv: makeKv() });
+		const fetcher = vi.fn();
+		const out = await lookupIp(env, "203.0.113.42", fetcher as never);
+		expect(out).toBeNull();
+		expect(fetcher).not.toHaveBeenCalled();
+	});
+
+	it("on 200 returns the normalised summary AND caches it", async () => {
+		const raw = JSON.parse(
+			await readFile(join(FIXTURE_DIR, "crowdsec-cti-malicious.json"), "utf8"),
+		);
+		const kv = makeKv();
+		const env = makeEnv({ apiKey: "test-key", kv });
+		const fetcher = vi.fn(async () => jsonResponse(raw, 200));
+
+		const first = await lookupIp(env, "203.0.113.42", fetcher);
+		expect(first?.reputation).toBe("malicious");
+		expect(fetcher).toHaveBeenCalledTimes(1);
+		// Cache populated.
+		expect(kv.store.get("cti:crowdsec:203.0.113.42")?.value).toBeDefined();
+	});
+
+	it("on 200 + cached entry, second call hits the cache (no second fetch)", async () => {
+		const raw = JSON.parse(
+			await readFile(join(FIXTURE_DIR, "crowdsec-cti-malicious.json"), "utf8"),
+		);
+		const kv = makeKv();
+		const env = makeEnv({ apiKey: "test-key", kv });
+		const fetcher = vi.fn(async () => jsonResponse(raw, 200));
+
+		await lookupIp(env, "203.0.113.42", fetcher);
+		const second = await lookupIp(env, "203.0.113.42", fetcher);
+
+		expect(second?.reputation).toBe("malicious");
+		expect(fetcher).toHaveBeenCalledTimes(1);
+	});
+
+	it("on 404 returns null and caches a miss sentinel briefly", async () => {
+		const kv = makeKv();
+		const env = makeEnv({ apiKey: "test-key", kv });
+		const fetcher = vi.fn(async () => new Response("", { status: 404 }));
+
+		const out = await lookupIp(env, "198.51.100.7", fetcher);
+		expect(out).toBeNull();
+		expect(fetcher).toHaveBeenCalledTimes(1);
+
+		const cached = kv.store.get("cti:crowdsec:198.51.100.7");
+		expect(cached).toBeDefined();
+		expect(cached?.value).toMatch(/cti_miss/);
+
+		// Second call must not re-fetch — sentinel short-circuits.
+		const second = await lookupIp(env, "198.51.100.7", fetcher);
+		expect(second).toBeNull();
+		expect(fetcher).toHaveBeenCalledTimes(1);
+	});
+
+	it("on 429 returns null, logs a warning, and does NOT cache (no poisoning)", async () => {
+		const kv = makeKv();
+		const env = makeEnv({ apiKey: "test-key", kv });
+		const fetcher = vi.fn(async () => new Response("rate limited", { status: 429 }));
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		try {
+			const out = await lookupIp(env, "192.0.2.5", fetcher);
+			expect(out).toBeNull();
+			expect(warn).toHaveBeenCalled();
+			// CRITICAL: no cache write on rate-limit, otherwise we'd poison the
+			// cache with `null` and starve out future enrichment.
+			expect(kv.store.has("cti:crowdsec:192.0.2.5")).toBe(false);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it("on network error returns null without caching", async () => {
+		const kv = makeKv();
+		const env = makeEnv({ apiKey: "test-key", kv });
+		const fetcher = vi.fn(async () => {
+			throw new Error("ECONNRESET");
+		});
+
+		const out = await lookupIp(env, "192.0.2.6", fetcher);
+		expect(out).toBeNull();
+		expect(kv.store.has("cti:crowdsec:192.0.2.6")).toBe(false);
+	});
+
+	it("sends the API key in the x-api-key header (CrowdSec convention)", async () => {
+		const kv = makeKv();
+		const env = makeEnv({ apiKey: "secret-token", kv });
+		const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+			const headers = new Headers(init?.headers);
+			expect(headers.get("x-api-key")).toBe("secret-token");
+			return new Response("", { status: 404 });
+		});
+		await lookupIp(env, "203.0.113.99", fetcher);
+		expect(fetcher).toHaveBeenCalledTimes(1);
+	});
+});

--- a/test/security/deep-scan-cti.test.ts
+++ b/test/security/deep-scan-cti.test.ts
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Deep-scan + CrowdSec CTI integration tests.
+ *
+ * The deep-scan stage reaches out to the network for several things (URL
+ * resolution, RDAP, DoH, CTI). Here we monkey-patch `globalThis.fetch` to
+ * route every outbound call to a deterministic in-test responder so the
+ * suite stays hermetic.
+ *
+ * Two scenarios get end-to-end coverage:
+ *   1. CTI-malicious redirect target → reasons + score bump
+ *   2. No API key configured → no CTI calls, deep-scan still works
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runDeepScan } from "../../workers/intel/deep-scan";
+import type { Env } from "../../workers/types";
+
+interface FakeUrlRow {
+	id: string;
+	url: string;
+	resolved_url?: string | null;
+	page_title?: string | null;
+	fetch_status?: string;
+	verdict?: string | null;
+}
+
+interface FakeKv {
+	store: Map<string, string>;
+	get: (key: string, type?: "text" | "arrayBuffer") => Promise<string | null>;
+	put: (key: string, value: string, opts?: { expirationTtl?: number }) => Promise<void>;
+}
+
+function makeKv(): FakeKv {
+	const store = new Map<string, string>();
+	return {
+		store,
+		async get(key) {
+			return store.get(key) ?? null;
+		},
+		async put(key, value) {
+			store.set(key, value);
+		},
+	};
+}
+
+function makeStub(urls: FakeUrlRow[]) {
+	const updates: Record<string, FakeUrlRow> = {};
+	const verdictStore = new Map<string, { verdict_json: string; score: number; explanation: string }>();
+	const moves: Array<{ id: string; folderId: string }> = [];
+	let deepScanStatus: string | null = null;
+	const stub = {
+		async getStoredVerdict(emailId: string) {
+			// A pre-existing sync verdict that the deep-scan can layer onto.
+			return {
+				verdict: JSON.stringify({
+					action: "tag",
+					score: 35,
+					triage: "score",
+					signals: ["base"],
+					explanation: "base",
+				}),
+				score: 35,
+			};
+		},
+		async getUrlsForEmail(_emailId: string) {
+			return urls;
+		},
+		async updateUrlScan(id: string, data: Partial<FakeUrlRow>) {
+			updates[id] = { ...(updates[id] ?? { id, url: "" }), ...data, id };
+		},
+		async getAttachmentsForEmail(_emailId: string) {
+			return [];
+		},
+		async updateAttachmentScan() {},
+		async persistSecurityVerdict(emailId: string, data: { verdict_json: string; score: number; explanation: string }) {
+			verdictStore.set(emailId, data);
+		},
+		async moveEmail(id: string, folderId: string) {
+			moves.push({ id, folderId });
+		},
+		async updateDeepScanStatus(_emailId: string, status: string) {
+			deepScanStatus = status;
+		},
+	};
+	return { stub, updates, verdictStore, moves, getStatus: () => deepScanStatus };
+}
+
+function makeEnv(opts: { apiKey?: string; kv?: FakeKv; stub: unknown }): Env {
+	const mailboxNs = {
+		idFromName(_n: string) {
+			return { toString: () => _n } as unknown as DurableObjectId;
+		},
+		get(_id: DurableObjectId) {
+			return opts.stub as unknown as DurableObjectStub;
+		},
+	} as unknown as DurableObjectNamespace;
+	return {
+		CROWDSEC_CTI_API_KEY: opts.apiKey,
+		BLOOM_KV: opts.kv as unknown as KVNamespace | undefined,
+		MAILBOX: mailboxNs,
+	} as unknown as Env;
+}
+
+/**
+ * Build a fetch mock that dispatches by URL host. Anything unmatched is
+ * served as 404 so a missing route surfaces as a test failure rather than
+ * a network call.
+ */
+function makeFetchMock(handlers: Array<(url: string) => Response | Promise<Response> | null>) {
+	return vi.fn(async (input: string | URL | Request) => {
+		const url = typeof input === "string" ? input : input.toString();
+		for (const h of handlers) {
+			const out = await h(url);
+			if (out) return out;
+		}
+		return new Response("not mocked: " + url, { status: 404 });
+	});
+}
+
+const CTI_FIXTURE_MALICIOUS = {
+	reputation: "malicious",
+	classifications: { classifications: [{ name: "tor" }] },
+	behaviors: [{ name: "http:phishing", label: "http:phishing" }],
+	scores: { overall: { threat: 5, aggressiveness: 4, trust: 5 } },
+};
+
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+	originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("runDeepScan + CrowdSec CTI", () => {
+	it("CTI-malicious redirect target adds CTI reasons and bumps score", async () => {
+		const fetchMock = makeFetchMock([
+			// URL resolver hits the redirect target.
+			(url) => {
+				if (url.startsWith("https://phish.example.com")) {
+					return new Response("<html><title>Login</title></html>", {
+						status: 200,
+						headers: { "content-type": "text/html" },
+					});
+				}
+				return null;
+			},
+			// RDAP — no registration data, treated as no-signal.
+			(url) => (url.startsWith("https://rdap.org/") ? new Response("{}", { status: 200 }) : null),
+			// DoH for the resolved hostname.
+			(url) => {
+				if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+					return new Response(
+						JSON.stringify({
+							Answer: [{ name: "phish.example.com.", type: 1, TTL: 60, data: "203.0.113.42" }],
+						}),
+						{ status: 200, headers: { "content-type": "application/dns-json" } },
+					);
+				}
+				return null;
+			},
+			// CrowdSec CTI for the resolved IP.
+			(url) => {
+				if (url.startsWith("https://cti.api.crowdsec.net/v2/smoke/")) {
+					return new Response(JSON.stringify(CTI_FIXTURE_MALICIOUS), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					});
+				}
+				return null;
+			},
+		]);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const harness = makeStub([{ id: "u1", url: "https://phish.example.com/login" }]);
+		const env = makeEnv({ apiKey: "test-key", kv: makeKv(), stub: harness.stub });
+
+		const result = await runDeepScan({ env, mailboxId: "m@x", emailId: "e1" });
+
+		// CTI signals must surface in deep-scan reasons.
+		const reasonsBlob = result.reasons.join(" | ");
+		expect(reasonsBlob).toMatch(/redirect target IP 203\.0\.113\.42/);
+		expect(reasonsBlob).toMatch(/behavior=crowdsec:http:phishing/);
+		// Phishing behavior alone is +25; with reputation:malicious that would
+		// be 25+15 but the per-inbound CTI cap of 25 bounds the contribution.
+		expect(result.added_score).toBeGreaterThanOrEqual(25);
+		// CTI calls actually happened.
+		const ctiCalls = fetchMock.mock.calls.filter((c) =>
+			String(c[0]).startsWith("https://cti.api.crowdsec.net"),
+		);
+		expect(ctiCalls.length).toBe(1);
+	});
+
+	it("with no CROWDSEC_CTI_API_KEY: no CTI calls, deep-scan still completes", async () => {
+		const fetchMock = makeFetchMock([
+			(url) => {
+				if (url.startsWith("https://phish.example.com")) {
+					return new Response("<html><title>Login</title></html>", {
+						status: 200,
+						headers: { "content-type": "text/html" },
+					});
+				}
+				return null;
+			},
+			(url) => (url.startsWith("https://rdap.org/") ? new Response("{}", { status: 200 }) : null),
+		]);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const harness = makeStub([{ id: "u1", url: "https://phish.example.com/login" }]);
+		// No apiKey — CTI stage must short-circuit.
+		const env = makeEnv({ kv: makeKv(), stub: harness.stub });
+
+		const result = await runDeepScan({ env, mailboxId: "m@x", emailId: "e2" });
+
+		expect(result).toBeDefined();
+		// No CTI HTTP calls were made.
+		const ctiCalls = fetchMock.mock.calls.filter((c) =>
+			String(c[0]).startsWith("https://cti.api.crowdsec.net"),
+		);
+		expect(ctiCalls.length).toBe(0);
+		// And no DoH calls — the CTI stage gates DoH on the API key.
+		const dohCalls = fetchMock.mock.calls.filter((c) =>
+			String(c[0]).startsWith("https://cloudflare-dns.com"),
+		);
+		expect(dohCalls.length).toBe(0);
+		// No CTI reasons.
+		expect(result.reasons.join(" ")).not.toMatch(/redirect target IP/);
+	});
+});

--- a/test/security/deep-scan-cti.test.ts
+++ b/test/security/deep-scan-cti.test.ts
@@ -144,7 +144,7 @@ describe("runDeepScan + CrowdSec CTI", () => {
 		const fetchMock = makeFetchMock([
 			// URL resolver hits the redirect target.
 			(url) => {
-				if (url.startsWith("https://phish.example.com")) {
+				if (new URL(url).hostname === "phish.example.com") {
 					return new Response("<html><title>Login</title></html>", {
 						status: 200,
 						headers: { "content-type": "text/html" },
@@ -153,10 +153,11 @@ describe("runDeepScan + CrowdSec CTI", () => {
 				return null;
 			},
 			// RDAP — no registration data, treated as no-signal.
-			(url) => (url.startsWith("https://rdap.org/") ? new Response("{}", { status: 200 }) : null),
+			(url) => (new URL(url).hostname === "rdap.org" ? new Response("{}", { status: 200 }) : null),
 			// DoH for the resolved hostname.
 			(url) => {
-				if (url.startsWith("https://cloudflare-dns.com/dns-query")) {
+				const parsed = new URL(url);
+				if (parsed.hostname === "cloudflare-dns.com" && parsed.pathname.startsWith("/dns-query")) {
 					return new Response(
 						JSON.stringify({
 							Answer: [{ name: "phish.example.com.", type: 1, TTL: 60, data: "203.0.113.42" }],
@@ -168,7 +169,8 @@ describe("runDeepScan + CrowdSec CTI", () => {
 			},
 			// CrowdSec CTI for the resolved IP.
 			(url) => {
-				if (url.startsWith("https://cti.api.crowdsec.net/v2/smoke/")) {
+				const parsed = new URL(url);
+				if (parsed.hostname === "cti.api.crowdsec.net" && parsed.pathname.startsWith("/v2/smoke/")) {
 					return new Response(JSON.stringify(CTI_FIXTURE_MALICIOUS), {
 						status: 200,
 						headers: { "content-type": "application/json" },
@@ -193,7 +195,7 @@ describe("runDeepScan + CrowdSec CTI", () => {
 		expect(result.added_score).toBeGreaterThanOrEqual(25);
 		// CTI calls actually happened.
 		const ctiCalls = fetchMock.mock.calls.filter((c) =>
-			String(c[0]).startsWith("https://cti.api.crowdsec.net"),
+			new URL(String(c[0])).hostname === "cti.api.crowdsec.net",
 		);
 		expect(ctiCalls.length).toBe(1);
 	});
@@ -201,7 +203,7 @@ describe("runDeepScan + CrowdSec CTI", () => {
 	it("with no CROWDSEC_CTI_API_KEY: no CTI calls, deep-scan still completes", async () => {
 		const fetchMock = makeFetchMock([
 			(url) => {
-				if (url.startsWith("https://phish.example.com")) {
+				if (new URL(url).hostname === "phish.example.com") {
 					return new Response("<html><title>Login</title></html>", {
 						status: 200,
 						headers: { "content-type": "text/html" },
@@ -209,7 +211,7 @@ describe("runDeepScan + CrowdSec CTI", () => {
 				}
 				return null;
 			},
-			(url) => (url.startsWith("https://rdap.org/") ? new Response("{}", { status: 200 }) : null),
+			(url) => (new URL(url).hostname === "rdap.org" ? new Response("{}", { status: 200 }) : null),
 		]);
 		globalThis.fetch = fetchMock as unknown as typeof fetch;
 
@@ -222,12 +224,12 @@ describe("runDeepScan + CrowdSec CTI", () => {
 		expect(result).toBeDefined();
 		// No CTI HTTP calls were made.
 		const ctiCalls = fetchMock.mock.calls.filter((c) =>
-			String(c[0]).startsWith("https://cti.api.crowdsec.net"),
+			new URL(String(c[0])).hostname === "cti.api.crowdsec.net",
 		);
 		expect(ctiCalls.length).toBe(0);
 		// And no DoH calls — the CTI stage gates DoH on the API key.
 		const dohCalls = fetchMock.mock.calls.filter((c) =>
-			String(c[0]).startsWith("https://cloudflare-dns.com"),
+			new URL(String(c[0])).hostname === "cloudflare-dns.com",
 		);
 		expect(dohCalls.length).toBe(0);
 		// No CTI reasons.

--- a/workers/intel/crowdsec-cti.ts
+++ b/workers/intel/crowdsec-cti.ts
@@ -1,0 +1,237 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * CrowdSec CTI (Cyber Threat Intelligence) client.
+ *
+ * Hits the `smoke` endpoint at `cti.api.crowdsec.net/v2/smoke/{ip}` and
+ * normalises the response into a small `CtiSummary` shape that downstream
+ * scoring can map onto verdict-score deltas without re-parsing the upstream
+ * payload.
+ *
+ * Free-tier CTI is rate-limited, so callers MUST stay on the async deep-scan
+ * path — never on the synchronous mail-receive path. Responses are cached in
+ * BLOOM_KV under `cti:crowdsec:{ip}` for ~12h to keep us under the per-day
+ * ceiling. 404s (clean residential IPs not in CrowdSec's dataset) are cached
+ * briefly with a sentinel so we don't re-query the same dead IP on every
+ * email; 429s and network errors are NEVER cached — they're transient.
+ *
+ * The client is also designed for reuse from the (future) sync first-time-
+ * sender prior path (issue #79); that path will need more aggressive caching
+ * and stricter timeouts but the lookup surface stays the same.
+ */
+
+import type { Env } from "../types";
+
+export interface CtiSummary {
+	classifications: string[];
+	behaviors: string[];
+	scores: { threat: number; aggressiveness: number; trust: number };
+	reputation: "malicious" | "suspicious" | "known" | "benign" | "safe" | "unknown";
+}
+
+/**
+ * Cache TTL for positive (200) lookups. 12h chosen within the 12–24h range
+ * called for in the issue: long enough to keep us comfortably under the free-
+ * tier ceiling for repeat IPs, short enough that a freshly-blocked IP shows
+ * up in our enrichment within half a day.
+ */
+const CACHE_TTL_POSITIVE_S = 12 * 3600;
+
+/**
+ * Cache TTL for 404s (IP not in CrowdSec's dataset). Much shorter — clean
+ * residential IPs may pick up a reputation as campaigns rotate, and the
+ * sentinel is cheap to refresh. 1h is the recommended floor.
+ */
+const CACHE_TTL_MISS_S = 3600;
+
+/**
+ * Per-request CTI fetch timeout. Comfortably under workerd's overall fetch
+ * budget so a single slow CTI response can't dominate the deep-scan stage.
+ */
+const CTI_REQUEST_TIMEOUT_MS = 4000;
+
+const CACHE_PREFIX = "cti:crowdsec:";
+/** Sentinel JSON for "we asked, IP not in dataset" — distinguishes from KV miss. */
+const MISS_SENTINEL = "__cti_miss__";
+
+export type CtiTransport = (url: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Look up an IP in CrowdSec CTI. Returns `null` for any of:
+ *
+ *   - `CROWDSEC_CTI_API_KEY` not configured (no-op for unconfigured deploys)
+ *   - 404 (IP not in dataset; common for clean residential IPs)
+ *   - 429 rate-limit (logged warning; no retry; cache NOT poisoned)
+ *   - Network error / timeout / unparseable body
+ *
+ * Never throws; deep-scan treats `null` as "no CTI signal", not "fail closed".
+ */
+export async function lookupIp(
+	env: Env,
+	ip: string,
+	fetchImpl: CtiTransport = fetch,
+): Promise<CtiSummary | null> {
+	const apiKey = env.CROWDSEC_CTI_API_KEY;
+	if (!apiKey) return null;
+	if (!ip) return null;
+
+	const cacheKey = CACHE_PREFIX + ip;
+	if (env.BLOOM_KV) {
+		const cached = await env.BLOOM_KV.get(cacheKey, "text").catch(() => null);
+		if (cached === MISS_SENTINEL) return null;
+		if (cached) {
+			try {
+				return JSON.parse(cached) as CtiSummary;
+			} catch {
+				// Corrupt cache entry — fall through and re-fetch.
+			}
+		}
+	}
+
+	let res: Response;
+	try {
+		res = await fetchImpl(`https://cti.api.crowdsec.net/v2/smoke/${encodeURIComponent(ip)}`, {
+			headers: {
+				"x-api-key": apiKey,
+				"accept": "application/json",
+			},
+			signal: AbortSignal.timeout(CTI_REQUEST_TIMEOUT_MS),
+		});
+	} catch {
+		// Network or timeout — don't poison cache; transient errors should
+		// recover on the next email.
+		return null;
+	}
+
+	if (res.status === 404) {
+		// IP not in CrowdSec's dataset. Cache the miss briefly so we don't
+		// re-query for every email mentioning the same clean IP.
+		if (env.BLOOM_KV) {
+			await env.BLOOM_KV
+				.put(cacheKey, MISS_SENTINEL, { expirationTtl: CACHE_TTL_MISS_S })
+				.catch(() => {});
+		}
+		return null;
+	}
+	if (res.status === 429) {
+		// Rate-limited. Don't cache, don't retry — surface a warning so
+		// operators can monitor free-tier headroom.
+		console.warn(`crowdsec CTI rate-limited (429) on ${ip}`);
+		return null;
+	}
+	if (!res.ok) {
+		// Other 4xx/5xx — treat as transient, don't cache.
+		console.warn(`crowdsec CTI ${res.status} on ${ip}`);
+		return null;
+	}
+
+	let body: unknown;
+	try {
+		body = await res.json();
+	} catch {
+		return null;
+	}
+	const summary = normalize(body);
+	if (!summary) return null;
+
+	if (env.BLOOM_KV) {
+		await env.BLOOM_KV
+			.put(cacheKey, JSON.stringify(summary), { expirationTtl: CACHE_TTL_POSITIVE_S })
+			.catch(() => {});
+	}
+	return summary;
+}
+
+/**
+ * Project the full CrowdSec CTI smoke payload down to the small slice we
+ * actually use for scoring. Resilient to missing fields — CTI's response
+ * shape varies depending on what they know about an IP.
+ *
+ * Exported for tests; production callers should prefer `lookupIp`.
+ */
+export function normalize(body: unknown): CtiSummary | null {
+	if (!body || typeof body !== "object") return null;
+	const b = body as Record<string, unknown>;
+
+	const classifications = collectClassifications(b.classifications);
+	const behaviors = collectLabeledList(b.behaviors, "label");
+	const scores = collectScores(b.scores);
+	const reputation = collectReputation(b.reputation);
+
+	return { classifications, behaviors, scores, reputation };
+}
+
+function collectClassifications(raw: unknown): string[] {
+	// CrowdSec returns `classifications` as `{ classifications: [{name, label, ...}], false_positives: [...] }`
+	// or sometimes as a bare array. Be liberal in what we accept.
+	if (!raw) return [];
+	const list = Array.isArray(raw)
+		? raw
+		: Array.isArray((raw as { classifications?: unknown }).classifications)
+			? ((raw as { classifications: unknown[] }).classifications)
+			: [];
+	const out: string[] = [];
+	for (const item of list) {
+		if (typeof item === "string") {
+			out.push(item);
+			continue;
+		}
+		if (item && typeof item === "object") {
+			const name = (item as { name?: unknown }).name;
+			if (typeof name === "string" && name) out.push(name);
+		}
+	}
+	return out;
+}
+
+function collectLabeledList(raw: unknown, primaryKey: "label" | "name"): string[] {
+	if (!Array.isArray(raw)) return [];
+	const out: string[] = [];
+	for (const item of raw) {
+		if (typeof item === "string") {
+			out.push(item);
+			continue;
+		}
+		if (item && typeof item === "object") {
+			const obj = item as Record<string, unknown>;
+			const v = obj[primaryKey] ?? obj.name ?? obj.label;
+			if (typeof v === "string" && v) out.push(v);
+		}
+	}
+	return out;
+}
+
+function collectScores(raw: unknown): { threat: number; aggressiveness: number; trust: number } {
+	const empty = { threat: 0, aggressiveness: 0, trust: 0 };
+	if (!raw || typeof raw !== "object") return empty;
+	const overall = (raw as { overall?: unknown }).overall;
+	if (!overall || typeof overall !== "object") return empty;
+	const o = overall as Record<string, unknown>;
+	return {
+		threat: numericOr(o.threat, 0),
+		aggressiveness: numericOr(o.aggressiveness, 0),
+		trust: numericOr(o.trust, 0),
+	};
+}
+
+function collectReputation(raw: unknown): CtiSummary["reputation"] {
+	if (typeof raw !== "string") return "unknown";
+	const lower = raw.toLowerCase();
+	switch (lower) {
+		case "malicious":
+		case "suspicious":
+		case "known":
+		case "benign":
+		case "safe":
+			return lower;
+		default:
+			return "unknown";
+	}
+}
+
+function numericOr(v: unknown, fallback: number): number {
+	if (typeof v === "number" && Number.isFinite(v)) return v;
+	return fallback;
+}

--- a/workers/intel/deep-scan.ts
+++ b/workers/intel/deep-scan.ts
@@ -33,6 +33,7 @@ import { Folders } from "../../shared/folders";
 import { checkUrlAgainstFeeds } from "./feeds";
 import { lookupDomainAge } from "./rdap";
 import { resolveUrl } from "./url-resolver";
+import { lookupIp, type CtiSummary } from "./crowdsec-cti";
 import {
 	aggregateAttachmentSignals,
 	detectEncryptedArchive,
@@ -77,10 +78,12 @@ export async function runDeepScan(input: DeepScanInput): Promise<DeepScanResult>
 	const reasons: string[] = [];
 	let added = 0;
 
+	let resolvedHosts: string[] = [];
 	try {
 		const urlDelta = await scanUrls(env, mailboxId, emailId);
 		added += urlDelta.score;
 		reasons.push(...urlDelta.reasons);
+		resolvedHosts = urlDelta.resolvedHosts;
 	} catch (e) {
 		console.error("deep-scan URL stage failed:", (e as Error).message);
 	}
@@ -91,6 +94,17 @@ export async function runDeepScan(input: DeepScanInput): Promise<DeepScanResult>
 		reasons.push(...attDelta.reasons);
 	} catch (e) {
 		console.error("deep-scan attachment stage failed:", (e as Error).message);
+	}
+
+	// CTI runs as a peer stage (not nested inside scanUrls) so its own
+	// per-inbound cap composes with the URL cap rather than getting
+	// squashed by it. Gated on the API key — unconfigured deploys no-op.
+	try {
+		const ctiDelta = await scanCti(env, resolvedHosts);
+		added += ctiDelta.score;
+		reasons.push(...ctiDelta.reasons);
+	} catch (e) {
+		console.error("deep-scan CTI stage failed:", (e as Error).message);
 	}
 
 	added = Math.min(DEEP_SCAN_MAX_ADD, added);
@@ -131,10 +145,10 @@ async function scanUrls(
 	env: Env,
 	mailboxId: string,
 	emailId: string,
-): Promise<{ score: number; reasons: string[] }> {
+): Promise<{ score: number; reasons: string[]; resolvedHosts: string[] }> {
 	const stub = getMailboxStub(env, mailboxId);
 	const urls = await stub.getUrlsForEmail(emailId);
-	if (!urls.length) return { score: 0, reasons: [] };
+	if (!urls.length) return { score: 0, reasons: [], resolvedHosts: [] };
 
 	const reasons: string[] = [];
 	let score = 0;
@@ -189,7 +203,11 @@ async function scanUrls(
 
 	// Cap URL contribution so a particularly nasty-looking link can't
 	// single-handedly burn the whole deep-scan budget.
-	return { score: Math.min(30, score), reasons };
+	return {
+		score: Math.min(30, score),
+		reasons,
+		resolvedHosts: [...seenHosts],
+	};
 }
 
 async function scanAttachments(
@@ -223,6 +241,169 @@ async function scanAttachments(
 	}
 
 	return { score: agg.score, reasons: agg.reasons };
+}
+
+// ── CTI enrichment stage ─────────────────────────────────────────
+
+/**
+ * Cap on score that the CTI stage can add per inbound. Sized so a deeply
+ * enriched redirect chain can't single-handedly exceed `DEEP_SCAN_MAX_ADD`
+ * — we want to leave room for blocklist + URL + attachment signals to
+ * compose. Document this alongside the other deep-scan caps.
+ */
+const CTI_MAX_ADD = 25;
+
+/**
+ * Hard cap on number of unique hostnames the CTI stage will resolve via
+ * DoH. The deep-scan budget is tens-of-seconds end-to-end, and DNS+CTI
+ * fan-out for every host in a long redirect chain would dominate. 8 hosts
+ * is enough for realistic phishing chains (median <3) without burning the
+ * whole budget.
+ */
+const CTI_MAX_HOSTS = 8;
+
+/**
+ * Wall-clock budget shared across all DoH lookups in this stage. Per-host
+ * timeouts inside `resolveHostA` keep the slowest single resolve from
+ * pinning the whole stage — this constant just documents the design intent.
+ */
+const CTI_DOH_TIMEOUT_MS = 2000;
+
+/**
+ * Cap A-records inspected per hostname. Phishing infra typically resolves
+ * to one or two IPs, and CTI lookups are the rate-limited resource — we'd
+ * rather spread a budget across more hostnames than exhaustively enumerate
+ * all the IPs behind one CDN-fronted host.
+ */
+const A_RECORDS_PER_HOST = 2;
+
+interface CtiHit {
+	ip: string;
+	summary: CtiSummary;
+}
+
+/**
+ * Resolve A records for each unique hostname in the redirect-target set,
+ * look each unique IP up in CrowdSec CTI, and aggregate the signals into
+ * deep-scan reasons + a capped score delta. Best-effort; returns zero
+ * contribution when the API key is missing, no hostnames were resolved,
+ * or every lookup produced nothing.
+ */
+async function scanCti(
+	env: Env,
+	hosts: string[],
+): Promise<{ score: number; reasons: string[] }> {
+	if (!env.CROWDSEC_CTI_API_KEY) return { score: 0, reasons: [] };
+	if (!hosts.length) return { score: 0, reasons: [] };
+
+	const uniqueHosts = [...new Set(hosts)].slice(0, CTI_MAX_HOSTS);
+
+	// Resolve all hosts in parallel, each bounded by its own per-request
+	// timeout. The per-request timeout is set well below the overall stage
+	// budget so even N concurrent slow resolvers can't exceed it.
+	const resolved = await Promise.all(uniqueHosts.map((h) => resolveHostA(h)));
+	const ips = new Set<string>();
+	for (const arr of resolved) {
+		for (const ip of arr.slice(0, A_RECORDS_PER_HOST)) {
+			ips.add(ip);
+		}
+	}
+	if (!ips.size) return { score: 0, reasons: [] };
+
+	const lookups = await Promise.all(
+		[...ips].map(async (ip): Promise<CtiHit | null> => {
+			const summary = await lookupIp(env, ip).catch(() => null);
+			return summary ? { ip, summary } : null;
+		}),
+	);
+
+	const reasons: string[] = [];
+	let score = 0;
+	for (const hit of lookups) {
+		if (!hit) continue;
+		const { ip, summary } = hit;
+		// Score deltas per IP — take the largest single match per category to
+		// avoid double-counting (a single phishing IP shouldn't get +25 for
+		// "behaviors:phishing" AND +25 for "behaviors:exploit").
+		let perIp = 0;
+		const hitReasons: string[] = [];
+
+		const dangerousBehavior = summary.behaviors.find((b) => /phish|exploit/i.test(b));
+		if (dangerousBehavior) {
+			perIp = Math.max(perIp, 25);
+			hitReasons.push(`redirect target IP ${ip} behavior=crowdsec:${dangerousBehavior}`);
+		}
+
+		if (summary.reputation === "malicious") {
+			perIp = Math.max(perIp, 15);
+			hitReasons.push(`redirect target IP ${ip} reputation=malicious`);
+		} else if (summary.reputation === "suspicious") {
+			perIp = Math.max(perIp, 10);
+			hitReasons.push(`redirect target IP ${ip} reputation=suspicious`);
+		}
+
+		const flaggedClassification = summary.classifications.find(
+			(c) => c === "tor" || c === "vpn:public" || c === "data_center",
+		);
+		if (flaggedClassification) {
+			perIp = Math.max(perIp, 10);
+			hitReasons.push(
+				`redirect target IP ${ip} classified as crowdsec:${flaggedClassification}`,
+			);
+		}
+
+		if (perIp > 0) {
+			score += perIp;
+			reasons.push(...hitReasons);
+		}
+	}
+
+	return { score: Math.min(CTI_MAX_ADD, score), reasons };
+}
+
+/**
+ * Resolve a hostname to its A records via Cloudflare DNS-over-HTTPS.
+ * workerd has no native `dns.resolve()` — DoH is the standard pattern.
+ *
+ * Returns the IPv4 strings (no AAAA — CrowdSec CTI is keyed primarily on
+ * IPv4 and the reduction in fan-out is meaningful for the budget). Any
+ * failure (timeout, non-200, non-Answer payload) returns an empty array;
+ * the CTI stage treats unresolved hosts as "no signal".
+ */
+async function resolveHostA(host: string): Promise<string[]> {
+	if (!host) return [];
+	let res: Response;
+	try {
+		res = await fetch(
+			`https://cloudflare-dns.com/dns-query?name=${encodeURIComponent(host)}&type=A`,
+			{
+				headers: { accept: "application/dns-json" },
+				signal: AbortSignal.timeout(CTI_DOH_TIMEOUT_MS),
+			},
+		);
+	} catch {
+		return [];
+	}
+	if (!res.ok) return [];
+	let body: unknown;
+	try {
+		body = await res.json();
+	} catch {
+		return [];
+	}
+	const answer = (body as { Answer?: Array<{ type?: number; data?: unknown }> }).Answer;
+	if (!Array.isArray(answer)) return [];
+	const ips: string[] = [];
+	for (const a of answer) {
+		// DNS A records are type=1 in DoH JSON.
+		if (a.type !== 1) continue;
+		if (typeof a.data !== "string") continue;
+		// Be paranoid: the CTI URL path inserts this directly. Reject anything
+		// that isn't a plain dotted-quad.
+		if (!/^\d{1,3}(?:\.\d{1,3}){3}$/.test(a.data)) continue;
+		ips.push(a.data);
+	}
+	return ips;
 }
 
 /** Extensions for which we do a bounded R2 read to sniff encryption flags. */

--- a/workers/types.ts
+++ b/workers/types.ts
@@ -5,4 +5,10 @@
 export interface Env extends Cloudflare.Env {
 	POLICY_AUD: string;
 	TEAM_DOMAIN: string;
+	/**
+	 * Optional CrowdSec CTI API key. When unset, deep-scan's CTI enrichment
+	 * stage no-ops — deploys without a key still work; they just don't get
+	 * the enrichment signal. Set with `wrangler secret put CROWDSEC_CTI_API_KEY`.
+	 */
+	CROWDSEC_CTI_API_KEY?: string;
 }


### PR DESCRIPTION
## Summary

- Adds a `workers/intel/crowdsec-cti.ts` client exposing `lookupIp(env, ip)` against the CrowdSec CTI `smoke` endpoint, normalising the response down to `{classifications, behaviors, scores, reputation}`.
- Wires CTI into `workers/intel/deep-scan.ts` as a peer stage to `scanUrls`/`scanAttachments`. After URL resolution, each unique resolved hostname is resolved to A records via DoH (`cloudflare-dns.com`), each unique IP is queried against CTI, and the signals are aggregated into deep-scan's reasons + score with a +25 per-inbound cap.
- Async-only by design — free-tier CTI is rate-limited and never sits on the synchronous mail-receive path.

## Behavior

- **Score deltas (per IP, take the largest single match per category):** behaviors matching `phishing`/`exploit` → +25; reputation `malicious` → +15; reputation `suspicious` or classifications `tor`/`vpn:public`/`data_center` → +10. Per-inbound CTI cap: +25 (composes inside the existing `DEEP_SCAN_MAX_ADD = 40`).
- **DoH budget:** max 8 unique hostnames, 2s per-host timeout, max 2 A-records per host. Strict dotted-quad validation on results before the IP is interpolated into the CTI URL.
- **Caching (`BLOOM_KV`):** 12h TTL on 200 responses; 1h TTL miss-sentinel on 404s (so clean residential IPs don't get re-queried every email); 429s and network errors are NEVER cached. Cache key: `cti:crowdsec:{ip}`.
- **Optional secret:** `CROWDSEC_CTI_API_KEY` (typed as optional on `Env`). Missing key → CTI stage no-ops, no DoH or CTI HTTP calls. Set with `wrangler secret put CROWDSEC_CTI_API_KEY`.

## Test plan

- [x] `crowdsec-cti.test.ts` — 10 tests covering: missing key → null + zero fetches; 200 → normalised summary + cache populated; second call → cache hit, no second fetch; 404 → null + miss sentinel cached; 429 → null + warning + cache NOT poisoned; network error → null + cache NOT poisoned; `x-api-key` header sent; `normalize()` projects representative payload + handles missing/unrecognised fields.
- [x] `deep-scan-cti.test.ts` — 2 end-to-end tests with global `fetch` stubbed: CTI-malicious redirect target produces `redirect target IP <ip> behavior=crowdsec:http:phishing` reason and bumps score by +25; missing API key produces zero CTI/DoH calls and deep-scan still completes.
- [x] Full vitest run: **238 passing, 0 failing** (was 226 before; +12 new). The 13 errors reported are pre-existing frontend tests that require `jsdom` (not installed) and are unrelated to this change.
- [x] `tsc -b` clean for all touched files; only pre-existing unrelated `virtual:react-router/server-build` error remains.
- [x] README "Async deep-scan" section updated to document the secret, free-tier behavior, signal map, and cache TTLs.

Closes #78