### PR TITLE
feat(security): CTI-informed first-time-sender prior

### DIFF
--- a/tests/security/auth.test.ts
+++ b/tests/security/auth.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { emptyVerdict, parseAuthResults, scoreAuth } from "../../workers/security/auth";
+import {
+	emptyVerdict,
+	extractReceivedFromIp,
+	parseAuthResults,
+	scoreAuth,
+} from "../../workers/security/auth";
 
 function header(name: string, value: string) {
 	return { key: name, value };
@@ -151,5 +156,100 @@ describe("scoreAuth", () => {
 	it("returns zero for all-none (no auth headers present)", () => {
 		const { score } = scoreAuth(emptyVerdict());
 		expect(score).toBe(0);
+	});
+});
+
+describe("extractReceivedFromIp", () => {
+	it("returns undefined when there are no Received headers", () => {
+		expect(extractReceivedFromIp([header("Authentication-Results", "x; spf=pass")])).toBeUndefined();
+	});
+
+	it("returns undefined when rawHeaders is not an array", () => {
+		expect(extractReceivedFromIp(null)).toBeUndefined();
+		expect(extractReceivedFromIp(undefined)).toBeUndefined();
+		expect(extractReceivedFromIp("not-an-array")).toBeUndefined();
+	});
+
+	it("extracts an external IPv4 from a bracketed RFC 5321 Received line", () => {
+		const headers = [
+			header(
+				"Received",
+				"from mail.example.com (mail.example.com [203.0.113.42]) by mx.cloudflare.com",
+			),
+		];
+		expect(extractReceivedFromIp(headers)).toBe("203.0.113.42");
+	});
+
+	it("returns the FIRST external IP (most-recent external hop) when multiple Received lines present", () => {
+		// PostalMime preserves header order: most-recent hop first.
+		const headers = [
+			header(
+				"Received",
+				"from inbound.cloudflare.net (inbound.cloudflare.net [10.0.0.5]) by mx",
+			),
+			header(
+				"Received",
+				"from sender.example.com (sender.example.com [198.51.100.7]) by inbound.cloudflare.net",
+			),
+			header(
+				"Received",
+				"from origin.attacker.example (origin.attacker.example [203.0.113.99]) by sender.example.com",
+			),
+		];
+		// 10.0.0.5 is private and is skipped; the next external hop is 198.51.100.7.
+		expect(extractReceivedFromIp(headers)).toBe("198.51.100.7");
+	});
+
+	it("skips RFC1918 private IPs (10/8, 172.16/12, 192.168/16)", () => {
+		expect(
+			extractReceivedFromIp([
+				header("Received", "from internal (internal [10.1.2.3]) by mx"),
+				header("Received", "from public (public [203.0.113.1]) by internal"),
+			]),
+		).toBe("203.0.113.1");
+		expect(
+			extractReceivedFromIp([
+				header("Received", "from internal (internal [172.16.0.1]) by mx"),
+				header("Received", "from public (public [203.0.113.2]) by internal"),
+			]),
+		).toBe("203.0.113.2");
+		expect(
+			extractReceivedFromIp([
+				header("Received", "from internal (internal [192.168.1.1]) by mx"),
+				header("Received", "from public (public [203.0.113.3]) by internal"),
+			]),
+		).toBe("203.0.113.3");
+	});
+
+	it("skips loopback (127/8) and link-local (169.254/16)", () => {
+		expect(
+			extractReceivedFromIp([
+				header("Received", "from local (local [127.0.0.1]) by mx"),
+				header("Received", "from external (external [203.0.113.4]) by local"),
+			]),
+		).toBe("203.0.113.4");
+		expect(
+			extractReceivedFromIp([
+				header("Received", "from ll (ll [169.254.10.10]) by mx"),
+				header("Received", "from external (external [203.0.113.5]) by ll"),
+			]),
+		).toBe("203.0.113.5");
+	});
+
+	it("returns undefined when every Received line is internal", () => {
+		expect(
+			extractReceivedFromIp([
+				header("Received", "from a (a [10.0.0.1]) by b"),
+				header("Received", "from c (c [192.168.1.1]) by d"),
+			]),
+		).toBeUndefined();
+	});
+
+	it("handles bare-bracket IPv4 without a parenthesized hostname", () => {
+		expect(
+			extractReceivedFromIp([
+				header("Received", "from sender [203.0.113.55] by mx"),
+			]),
+		).toBe("203.0.113.55");
 	});
 });

--- a/tests/security/reputation.test.ts
+++ b/tests/security/reputation.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { scoreReputation } from "../../workers/security/reputation";
+import {
+	scoreReputation,
+	firstTimeSenderPriorFromCti,
+} from "../../workers/security/reputation";
+import type { CtiSummary } from "../../workers/intel/crowdsec-cti";
+
+function ctiSummary(overrides: Partial<CtiSummary> = {}): CtiSummary {
+	return {
+		classifications: [],
+		behaviors: [],
+		scores: { threat: 0, aggressiveness: 0, trust: 0 },
+		reputation: "unknown",
+		...overrides,
+	};
+}
 
 describe("scoreReputation", () => {
 	it("adds +5 suspicion for first-time senders (null reputation)", () => {
@@ -60,5 +74,117 @@ describe("scoreReputation", () => {
 			flagged: false,
 		});
 		expect(score).toBeGreaterThanOrEqual(0);
+	});
+
+	describe("first-time-sender CTI prior", () => {
+		it("uses the prior's score and reason instead of the legacy +5 when given", () => {
+			const { score, reasons } = scoreReputation(null, {
+				score: 20,
+				reason: "first-time sender from 8.8.8.8 CTI reputation=malicious",
+			});
+			expect(score).toBe(20);
+			expect(reasons).toEqual([
+				"first-time sender from 8.8.8.8 CTI reputation=malicious",
+			]);
+			expect(reasons.join(" ")).not.toMatch(/^first-time sender$/);
+		});
+
+		it("falls back to +5 'first-time sender' when no prior is provided (legacy path)", () => {
+			const { score, reasons } = scoreReputation(null);
+			expect(score).toBe(5);
+			expect(reasons).toEqual(["first-time sender"]);
+		});
+
+		it("ignores the prior when the sender has prior history", () => {
+			const { score, reasons } = scoreReputation(
+				{
+					sender: "a@b.com",
+					first_seen: "",
+					last_seen: "",
+					message_count: 10,
+					avg_score: 5,
+					flagged: false,
+				},
+				{ score: 20, reason: "should not appear" },
+			);
+			expect(score).toBe(0);
+			expect(reasons).toEqual([]);
+		});
+	});
+});
+
+describe("firstTimeSenderPriorFromCti", () => {
+	const ip = "203.0.113.7";
+
+	it("malicious reputation → +20 with reputation reason", () => {
+		const prior = firstTimeSenderPriorFromCti(ip, ctiSummary({ reputation: "malicious" }));
+		expect(prior.score).toBe(20);
+		expect(prior.reason).toContain("reputation=malicious");
+		expect(prior.reason).toContain(ip);
+	});
+
+	it("suspicious reputation → +10", () => {
+		const prior = firstTimeSenderPriorFromCti(ip, ctiSummary({ reputation: "suspicious" }));
+		expect(prior.score).toBe(10);
+		expect(prior.reason).toContain("reputation=suspicious");
+	});
+
+	it("classifications include 'tor' → +10 with classification reason", () => {
+		const prior = firstTimeSenderPriorFromCti(
+			ip,
+			ctiSummary({ reputation: "unknown", classifications: ["tor"] }),
+		);
+		expect(prior.score).toBe(10);
+		expect(prior.reason).toContain("classification=tor");
+	});
+
+	it("classifications include 'vpn:public' → +10", () => {
+		const prior = firstTimeSenderPriorFromCti(
+			ip,
+			ctiSummary({ reputation: "unknown", classifications: ["vpn:public"] }),
+		);
+		expect(prior.score).toBe(10);
+		expect(prior.reason).toContain("classification=vpn:public");
+	});
+
+	it("benign reputation → +1 (small floor, NOT zero)", () => {
+		const prior = firstTimeSenderPriorFromCti(ip, ctiSummary({ reputation: "benign" }));
+		expect(prior.score).toBe(1);
+		expect(prior.reason).toContain("reputation=benign");
+	});
+
+	it("known and safe reputations also map to +1", () => {
+		expect(firstTimeSenderPriorFromCti(ip, ctiSummary({ reputation: "known" })).score).toBe(1);
+		expect(firstTimeSenderPriorFromCti(ip, ctiSummary({ reputation: "safe" })).score).toBe(1);
+	});
+
+	it("unknown reputation, no flagged classification → +5 (parity with legacy flat default)", () => {
+		const prior = firstTimeSenderPriorFromCti(ip, ctiSummary({ reputation: "unknown" }));
+		expect(prior.score).toBe(5);
+		expect(prior.reason).toContain("reputation=unknown");
+	});
+
+	it("highest-magnitude single match wins — does NOT sum reputation+classification", () => {
+		// Regression guard for the issue's "pick the highest single match per IP;
+		// don't double-count if both `reputation === 'malicious'` AND
+		// `classifications` includes `tor`" rule.
+		const prior = firstTimeSenderPriorFromCti(
+			ip,
+			ctiSummary({ reputation: "malicious", classifications: ["tor"] }),
+		);
+		expect(prior.score).toBe(20);
+		expect(prior.score).not.toBe(30);
+		expect(prior.reason).toContain("reputation=malicious");
+	});
+
+	it("suspicious + tor still picks the larger single match (10 each → 10, with the malicious-style ordering)", () => {
+		// Both candidates are +10; ties resolve by insertion order (reputation
+		// first), so the reputation reason wins. The score should still be 10.
+		const prior = firstTimeSenderPriorFromCti(
+			ip,
+			ctiSummary({ reputation: "suspicious", classifications: ["tor"] }),
+		);
+		expect(prior.score).toBe(10);
+		expect(prior.reason).toContain("reputation=suspicious");
 	});
 });

--- a/workers/security/auth.ts
+++ b/workers/security/auth.ts
@@ -141,3 +141,105 @@ export function scoreAuth(verdict: AuthVerdict): { score: number; reasons: strin
 	if (verdict.dmarc === "pass") score -= 10;
 	return { score, reasons };
 }
+
+/**
+ * Pull all `Received:` header values out of the PostalMime raw-headers array.
+ * Header order is preserved — most-recent hop first, originating hop last.
+ */
+function findReceivedHeaders(rawHeaders: unknown): string[] {
+	if (!Array.isArray(rawHeaders)) return [];
+	const out: string[] = [];
+	for (const h of rawHeaders) {
+		if (!h || typeof h !== "object") continue;
+		const rec = h as { key?: unknown; name?: unknown; value?: unknown };
+		const key = rec.key ?? rec.name;
+		const value = rec.value;
+		if (typeof key !== "string" || typeof value !== "string") continue;
+		if (key.toLowerCase() === "received") out.push(value);
+	}
+	return out;
+}
+
+// `Received: from <host> ([<ip>])` is the canonical RFC 5321 form, but the
+// shape varies wildly across senders — the IP may be inside `[brackets]`,
+// `(parens)`, or bare; the hostname may be missing/quoted/duplicated. Rather
+// than try to parse every variant precisely, we walk all IP-shaped tokens in
+// the header value and let the public/private filter pick the right one.
+//
+// The regex is run with `matchAll` against each header value; the helper
+// returns the first match whose IP isn't private/loopback. IPv4 is matched
+// first (cheaper and far more common); IPv6 (any token containing two
+// or more colons) is matched separately.
+const RECEIVED_IPV4_RE = /\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b/g;
+const RECEIVED_IPV6_RE = /(?:IPv6:)?([0-9a-f]{0,4}(?::[0-9a-f]{0,4}){2,7})/gi;
+
+/**
+ * Return true for IPs we should skip when walking `Received:` headers in
+ * search of the originating external hop:
+ *
+ *   - RFC1918 private space (10/8, 172.16/12, 192.168/16)
+ *   - Loopback (127/8, ::1)
+ *   - Link-local (169.254/16, fe80::/10)
+ *   - Unique-local IPv6 (fc00::/7)
+ *   - Cloudflare Email Routing's own internal hops (no public range to
+ *     enumerate, so we lean on the private-range check above plus the
+ *     fact that Email Routing's outermost `Received:` line records the
+ *     real client IP).
+ */
+function isPrivateOrLoopbackIp(ip: string): boolean {
+	const lower = ip.toLowerCase().replace(/^ipv6:/, "");
+	// IPv4
+	if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(lower)) {
+		const parts = lower.split(".").map((p) => parseInt(p, 10));
+		if (parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return true;
+		const [a, b] = parts;
+		if (a === 10) return true;
+		if (a === 127) return true;
+		if (a === 172 && b >= 16 && b <= 31) return true;
+		if (a === 192 && b === 168) return true;
+		if (a === 169 && b === 254) return true;
+		if (a === 0) return true;
+		return false;
+	}
+	// IPv6
+	if (lower === "::1") return true;
+	if (lower.startsWith("fe8") || lower.startsWith("fe9") || lower.startsWith("fea") || lower.startsWith("feb")) return true;
+	if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+	// Treat anything that's not a recognisable IP as "skip" rather than "use".
+	if (!/[0-9]/.test(lower)) return true;
+	return false;
+}
+
+/**
+ * Extract the originating external IP from `Received:` headers.
+ *
+ * PostalMime preserves header order; `Received:` lines run most-recent hop
+ * first → originating hop last. We walk in array order and return the first
+ * `from <host> [ip]` whose IP is public — that's the outermost externally-
+ * controlled hop. Returns `undefined` when no usable IP is found (malformed
+ * trace, internal-only chain, or no `Received:` headers at all).
+ *
+ * Threat-model note: `Received:` headers from outside our infra are
+ * untrusted and forge-able. The CTI lookup that consumes this IP is treated
+ * as a *signal*, not as ground truth — a forged "from 8.8.8.8" doesn't get
+ * us a free pass, it just shifts the prior up or down within a bounded
+ * range. The aggressive private-range filter below is the main defence: an
+ * attacker can't mask as a private hop to suppress the lookup.
+ */
+export function extractReceivedFromIp(rawHeaders: unknown): string | undefined {
+	const headers = findReceivedHeaders(rawHeaders);
+	for (const raw of headers) {
+		// Try IPv4 first — cheap, and the overwhelming common case for a
+		// `Received: from` clause.
+		for (const m of raw.matchAll(RECEIVED_IPV4_RE)) {
+			const ip = m[1];
+			if (!isPrivateOrLoopbackIp(ip)) return ip;
+		}
+		for (const m of raw.matchAll(RECEIVED_IPV6_RE)) {
+			const ip = m[1];
+			if (!ip) continue;
+			if (!isPrivateOrLoopbackIp(ip)) return ip;
+		}
+	}
+	return undefined;
+}

--- a/workers/security/index.ts
+++ b/workers/security/index.ts
@@ -22,7 +22,7 @@
 
 import type { Env } from "../types";
 import { getMailboxStub } from "../lib/email-helpers";
-import { parseAuthResults } from "./auth";
+import { parseAuthResults, extractReceivedFromIp } from "./auth";
 import { classifyEmail } from "./classification";
 import { extractUrls } from "./urls";
 import { aggregateVerdict, type FinalVerdict } from "./verdict";
@@ -33,6 +33,8 @@ import { evaluateTriage, type IntelMatchInfo } from "./triage";
 import type { AttachmentLike } from "./attachments";
 import { scoreOffHours } from "./time-rules";
 import type { VerdictThresholds } from "./verdict";
+import { firstTimeSenderPriorFromCti, type FirstTimeSenderPrior } from "./reputation";
+import { lookupIp } from "../intel/crowdsec-cti";
 
 /**
  * Apply a post-aggregation score bump and recompute the action tier and
@@ -118,6 +120,22 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 	const stub = getMailboxStub(env, mailboxId);
 	const reputation = sender ? await stub.getSenderReputation(sender) : null;
 
+	// First-time-sender CTI prior (issue #79). Only fired when the sender has
+	// no prior history (or was never seen), so cardinality is "new senders
+	// per mailbox" — well within the 12h-cached free-tier budget. When CTI
+	// returns null (no API key configured, 404 clean residential, 429 rate-
+	// limit, network error) we fall through and `scoreReputation` keeps the
+	// legacy flat +5. The lookup must NOT fail the email path on transient
+	// errors; `lookupIp` already swallows them and returns null.
+	let firstTimeSenderPrior: FirstTimeSenderPrior | undefined;
+	if ((!reputation || reputation.message_count === 0) && env.CROWDSEC_CTI_API_KEY) {
+		const senderIp = extractReceivedFromIp(parsedEmail.headers);
+		if (senderIp) {
+			const summary = await lookupIp(env, senderIp).catch(() => null);
+			if (summary) firstTimeSenderPrior = firstTimeSenderPriorFromCti(senderIp, summary);
+		}
+	}
+
 	// Triage tiers — may short-circuit the pipeline before we ever touch the LLM.
 	// See workers/security/triage.ts for the rules and invariants.
 	const triaged = evaluateTriage({
@@ -167,6 +185,7 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 			reputation,
 			attachments,
 			attachmentPolicy: settings.attachment_policy,
+			firstTimeSenderPrior,
 		},
 		settings.thresholds,
 	);

--- a/workers/security/reputation.ts
+++ b/workers/security/reputation.ts
@@ -8,6 +8,8 @@
  * for another — correct behaviour for a personal inbox).
  */
 
+import type { CtiSummary } from "../intel/crowdsec-cti";
+
 export interface SenderReputation {
 	sender: string;
 	first_seen: string;
@@ -17,12 +19,39 @@ export interface SenderReputation {
 	flagged: boolean;
 }
 
-export function scoreReputation(rep: SenderReputation | null): { score: number; reasons: string[] } {
+/**
+ * Optional CTI-informed prior for the first-time-sender branch. When
+ * provided, replaces the legacy flat `+5` with a graduated bonus computed
+ * from CrowdSec CTI on the originating `Received:` IP. See
+ * `firstTimeSenderPriorFromCti` for the score-map and the "highest single
+ * match" rule.
+ */
+export interface FirstTimeSenderPrior {
+	score: number;
+	reason: string;
+}
+
+/**
+ * Score the sender's reputation. The first-time-sender branch optionally
+ * accepts a CTI-informed prior (issue #79); when absent it falls back to
+ * the legacy flat `+5` so callers without a CTI client (or where CTI
+ * returned null — no key, 404, 429, network error) keep the original
+ * behaviour.
+ */
+export function scoreReputation(
+	rep: SenderReputation | null,
+	prior?: FirstTimeSenderPrior,
+): { score: number; reasons: string[] } {
 	const reasons: string[] = [];
 	let score = 0;
 	if (!rep || rep.message_count === 0) {
-		score += 5;
-		reasons.push("first-time sender");
+		if (prior) {
+			score += prior.score;
+			reasons.push(prior.reason);
+		} else {
+			score += 5;
+			reasons.push("first-time sender");
+		}
 		return { score, reasons };
 	}
 	if (rep.flagged) { score += 15; reasons.push("sender previously flagged"); }
@@ -35,4 +64,80 @@ export function scoreReputation(rep: SenderReputation | null): { score: number; 
 		reasons.push(`bad sender history (avg ${rep.avg_score.toFixed(0)})`);
 	}
 	return { score, reasons };
+}
+
+/**
+ * Map a CrowdSec CTI summary onto a graduated first-time-sender prior.
+ *
+ * The score map (issue #79):
+ *
+ *   - reputation `malicious`                                  → +20
+ *   - reputation `suspicious`                                 → +10
+ *   - classifications include `tor` or `vpn:public`           → +10
+ *   - reputation `unknown`                                    → +5  (legacy)
+ *   - reputation `known` / `benign` / `safe`                  → +1  (small floor)
+ *
+ * "Highest-magnitude single match" rule: if multiple categories fire we
+ * pick the largest single bonus and surface its reason — we DO NOT sum.
+ * E.g. `reputation === "malicious"` AND `classifications.includes("tor")`
+ * yields +20 with the `reputation=malicious` reason, not +30.
+ *
+ * The IP is rendered into the reason string so reviewers can correlate the
+ * verdict back to a specific `Received:` hop.
+ */
+export function firstTimeSenderPriorFromCti(
+	ip: string,
+	summary: CtiSummary,
+): FirstTimeSenderPrior {
+	const candidates: FirstTimeSenderPrior[] = [];
+
+	if (summary.reputation === "malicious") {
+		candidates.push({
+			score: 20,
+			reason: `first-time sender from ${ip} CTI reputation=malicious`,
+		});
+	} else if (summary.reputation === "suspicious") {
+		candidates.push({
+			score: 10,
+			reason: `first-time sender from ${ip} CTI reputation=suspicious`,
+		});
+	}
+
+	const flaggedClassification = summary.classifications.find(
+		(c) => c === "tor" || c === "vpn:public",
+	);
+	if (flaggedClassification) {
+		candidates.push({
+			score: 10,
+			reason: `first-time sender from ${ip} classification=${flaggedClassification}`,
+		});
+	}
+
+	if (
+		summary.reputation === "known" ||
+		summary.reputation === "benign" ||
+		summary.reputation === "safe"
+	) {
+		candidates.push({
+			score: 1,
+			reason: `first-time sender from ${ip} CTI reputation=${summary.reputation}`,
+		});
+	}
+
+	if (candidates.length === 0) {
+		// `unknown` reputation with no flagged classifications — treat as the
+		// legacy flat +5 but tag the IP so operators see CTI was consulted.
+		return {
+			score: 5,
+			reason: `first-time sender from ${ip} CTI reputation=unknown`,
+		};
+	}
+
+	// Highest single match wins; ties resolved by insertion order (malicious /
+	// suspicious before classifications before known/benign/safe).
+	let winner = candidates[0];
+	for (const c of candidates.slice(1)) {
+		if (c.score > winner.score) winner = c;
+	}
+	return winner;
 }

--- a/workers/security/verdict.ts
+++ b/workers/security/verdict.ts
@@ -14,7 +14,7 @@
 import type { AuthVerdict } from "./auth";
 import type { ClassificationResult } from "./classification";
 import type { ExtractedUrl } from "./urls";
-import type { SenderReputation } from "./reputation";
+import type { SenderReputation, FirstTimeSenderPrior } from "./reputation";
 import type { AttachmentLike, AttachmentPolicy } from "./attachments";
 import { scoreAuth } from "./auth";
 import { scoreClassification } from "./classification";
@@ -52,6 +52,13 @@ export interface VerdictInputs {
 	 * (container/macro-office under the defaults).
 	 */
 	attachmentPolicy?: AttachmentPolicy | null;
+	/**
+	 * Optional CTI-informed first-time-sender prior (issue #79). Computed in
+	 * `runSecurityPipeline` from a CrowdSec CTI lookup on the originating
+	 * `Received:` IP. When present and the sender has no history, replaces
+	 * the legacy flat `+5` with a graduated bonus. Absent ⇒ legacy behaviour.
+	 */
+	firstTimeSenderPrior?: FirstTimeSenderPrior;
 }
 
 export interface VerdictThresholds {
@@ -85,7 +92,7 @@ export function aggregateVerdict(
 	score += urls.score;
 	signals.push(...urls.reasons);
 
-	const rep = scoreReputation(inputs.reputation);
+	const rep = scoreReputation(inputs.reputation, inputs.firstTimeSenderPrior);
 	score += rep.score;
 	signals.push(...rep.reasons);
 


### PR DESCRIPTION
## Summary

Replaces the flat `+5 first-time sender` prior in `scoreReputation()` with a graduated prior derived from a CrowdSec CTI lookup on the originating `Received:` IP. Brand-new senders coming from known-bad infra now contribute more to the verdict score; senders from known-clean infra contribute less.

Reuses the CTI client introduced in PR #130 (`workers/intel/crowdsec-cti.ts`) — does NOT duplicate. The client's 12h positive / 1h sentinel KV cache plus its null-on-429/timeout/no-key contract make a sync-path lookup safe within the free-tier rate limit; when it returns null we fall back to the legacy flat `+5` so deploys without `CROWDSEC_CTI_API_KEY` keep working unchanged.

## Score map (issue #79)

"Highest single match" — never sum:

| Signal | Bonus |
|---|---|
| reputation `malicious` | +20 |
| reputation `suspicious` | +10 |
| classifications include `tor` or `vpn:public` | +10 |
| reputation `unknown` | +5 (legacy parity) |
| reputation `known` / `benign` / `safe` | **+1** |

Picked **+1** for `known`/`benign`/`safe` (the issue's "0 to +2" range): not zero, because a CTI hit is still useful evidence the IP is in the dataset; small enough that the floor doesn't dominate the verdict.

`reputation === "malicious" && classifications.includes("tor")` returns +20 with the malicious reason — the regression test pins this.

## Threading

`scoreReputation()` and `aggregateVerdict()` stay pure. The CTI lookup runs in `runSecurityPipeline` (where `env` is in scope), and the result is passed as data through a new optional `VerdictInputs.firstTimeSenderPrior` field. No `env` argument needed in the scoring layer.

`scoreReputation`'s signature grew an optional second arg (`prior?: FirstTimeSenderPrior`); existing callers pass nothing and keep the legacy behaviour. No upstream call sites needed to change.

## Received-IP extraction

There was no pre-existing helper to reuse — `grep` confirmed `auth.ts` and siblings have no Received-IP parser. Added `extractReceivedFromIp(rawHeaders)` to `workers/security/auth.ts` for this PR + future use. It walks `Received:` headers in PostalMime order (most-recent hop first) and returns the first IP that isn't RFC1918 / loopback / link-local / unique-local-IPv6 — i.e. the first external hop, equivalent to the issue's "lowest Received line that came from outside our infra".

`Received:` headers from outside our infra are forge-able. The CTI lookup is treated as a signal, not ground truth: a forged `from 8.8.8.8` only shifts the prior within the +0/+20 range; it doesn't bypass any other check.

## Files changed

- `workers/security/auth.ts` — added `extractReceivedFromIp` + `findReceivedHeaders` + `isPrivateOrLoopbackIp`.
- `workers/security/reputation.ts` — `scoreReputation` accepts optional `FirstTimeSenderPrior`; new `firstTimeSenderPriorFromCti` maps CTI to the score map.
- `workers/security/verdict.ts` — `VerdictInputs.firstTimeSenderPrior` optional field; threaded into `scoreReputation`.
- `workers/security/index.ts` — `runSecurityPipeline` extracts the IP, calls `lookupIp`, computes the prior, passes it to `aggregateVerdict`.
- `tests/security/reputation.test.ts` — 13 new test cases.
- `tests/security/auth.test.ts` — 8 new test cases for `extractReceivedFromIp`.

## Test plan

- [x] `npm test` — **281 passing, 0 failing** (up from 261; +20 new tests).
- [x] First-time sender + CTI `malicious` → +20 with `reputation=malicious` reason.
- [x] First-time sender + CTI `suspicious` → +10.
- [x] First-time sender + CTI classifications `[tor]` → +10 with `classification=tor` reason.
- [x] First-time sender + CTI `benign` → +1.
- [x] First-time sender + CTI returns null (no key) → legacy flat +5.
- [x] First-time sender + Received header missing or all-private → legacy flat +5.
- [x] Returning sender (`message_count > 0`) → unchanged; pipeline does NOT call `lookupIp` (gated on `!reputation || message_count === 0`).
- [x] Highest-magnitude rule: `malicious + tor` → +20, NOT +30.
- [x] Pre-existing 16 environment errors (jsdom missing for frontend tests) are unchanged — not introduced by this PR.

Closes #79