### PR TITLE
feat(intel): Spamhaus DROP feed for redirect-target IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Weekends: flagged when weekdays_only is on
 | Auth header parse | µs | SPF/DKIM/DMARC from `Authentication-Results`; gated by trusted authserv-ids |
 | URL extract + homograph/shortener check | ms | Levenshtein vs a high-value-domain list |
 | Sender reputation | ms | Rolling avg score per mailbox; flagged-sender fast path |
-| Threat-intel bloom lookup | ms | Against [workers/intel/feeds.ts](workers/intel/feeds.ts) (URLhaus, PhishDestroy, configurable) |
+| Threat-intel bloom lookup | ms | Against [workers/intel/feeds.ts](workers/intel/feeds.ts) (URLhaus, PhishDestroy, configurable; Spamhaus DROP/EDROP CIDR feeds consumed in deep-scan) |
 | Triage short-circuits | µs | Hard-block on confirmed intel / flagged sender; hard-allow on DMARC pass + allowlist or trusted history |
 | LLM classifier | seconds (5s cap) | Workers AI; fail-closed to `suspicious` on timeout |
 | Verdict aggregation | µs | Pure scoring function; thresholds configurable per mailbox |
@@ -170,6 +170,7 @@ Fires after the sync verdict is stored and only ever *tightens* the decision (sy
 - **Redirect-chain resolution** — follows `bit.ly`-style wrappers up to 5 hops so downstream checks see the real destination.
 - **RDAP domain age** — queries `rdap.org` for registration date. Domains <7d get +20, <30d get +10. Fails silently on flaky RDAP servers.
 - **CrowdSec CTI enrichment** — *optional, async-only*. When `CROWDSEC_CTI_API_KEY` is set, redirect-target hostnames are resolved via DoH (`cloudflare-dns.com`) and each unique IP is looked up against [CrowdSec CTI](https://docs.crowdsec.net/u/cti_api/intro). Signals: `behaviors` matching `phishing`/`exploit` (+25), `reputation=malicious` (+15), `reputation=suspicious` or `classifications` containing `tor`/`vpn:public`/`data_center` (+10). Capped at +25 per inbound. Responses cached in `BLOOM_KV` for 12h (1h for 404s); 429 rate-limits return `null` without poisoning the cache. Free-tier CTI is rate-limited, so this stage **never runs on the synchronous receive path**. Set the secret with `wrangler secret put CROWDSEC_CTI_API_KEY`; deploys without it just no-op the stage.
+- **Spamhaus DROP / EDROP** — *no-auth IP feed*. The cron refresher pulls [Spamhaus DROP](https://www.spamhaus.org/drop/drop.txt) and [EDROP](https://www.spamhaus.org/drop/edrop.txt) every 12h and stores the parsed CIDR list in `BLOOM_KV`. In deep-scan, every redirect-target hostname is resolved via DoH and each unique IP is checked for membership against the DROP/EDROP CIDR set; a match adds +20 (capped at +25 per inbound) and a `redirect target IP <ip> (<cidr>) on Spamhaus DROP` reason. CIDR membership is implemented as a linear scan with IPv4-as-uint32 masking (the lists are small — a few thousand entries — so no index is needed). DoH resolution is shared with the CrowdSec CTI stage so we don't double-spend DNS queries; deploys without DROP feeds and without a CTI key skip DoH entirely.
 - **Attachment heuristics** — dangerous extensions, macro-enabled Office, `.pdf.exe`-style double extensions, MIME/extension mismatches, archives that advertise a payload in the filename.
 
 ### Threat-intel hub

--- a/test/fixtures/security/spamhaus-drop.txt
+++ b/test/fixtures/security/spamhaus-drop.txt
@@ -1,0 +1,10 @@
+; Spamhaus DROP List 2026/01/01 — synthetic test fixture
+; Mirrors the live format: https://www.spamhaus.org/drop/drop.txt
+; Comment lines start with `;` and must be ignored.
+;
+1.10.16.0/20 ; SBL233763
+5.45.207.0/24 ; SBL219423
+not-a-cidr ; SBL000000
+192.0.2.42 ; SBL000001
+;
+46.183.220.0/22 ; SBL301321

--- a/test/security/spamhaus-drop.test.ts
+++ b/test/security/spamhaus-drop.test.ts
@@ -1,0 +1,350 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Spamhaus DROP feed coverage.
+ *
+ * Three layers:
+ *   1. Parser — `parseCidrFeedBody` must skip comment lines, blank lines,
+ *      and malformed entries (warn-and-skip, never throw) while keeping
+ *      well-formed CIDR/IP entries with trailing `; SBLxxx` references.
+ *   2. Lookup — `checkIpAgainstFeeds` must report a hit for an IP that
+ *      sits inside any DROP CIDR, and miss for an IP outside every CIDR.
+ *      Boundary IPs (network address, broadcast address) must hit the
+ *      same CIDR — catches mask off-by-one errors.
+ *   3. Integration — `runDeepScan` with a redirect target whose A-record
+ *      is in DROP must surface the new reason and contribute the IP-feed
+ *      score bump.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseCidrFeedBody } from "../../workers/intel/feeds";
+import { checkIpAgainstFeeds } from "../../workers/intel/feeds";
+import { runDeepScan } from "../../workers/intel/deep-scan";
+import type { Env } from "../../workers/types";
+
+const FIXTURE_PATH = resolve(__dirname, "../fixtures/security/spamhaus-drop.txt");
+const FIXTURE = readFileSync(FIXTURE_PATH, "utf8");
+
+// ── Test KV / mailbox stub helpers ────────────────────────────────
+
+interface FakeKv {
+	store: Map<string, string>;
+	get: (key: string, type?: "text" | "arrayBuffer") => Promise<string | null>;
+	put: (key: string, value: string, opts?: { expirationTtl?: number }) => Promise<void>;
+}
+
+function makeKv(): FakeKv {
+	const store = new Map<string, string>();
+	return {
+		store,
+		async get(key) {
+			return store.get(key) ?? null;
+		},
+		async put(key, value) {
+			store.set(key, value);
+		},
+	};
+}
+
+interface FakeBucket {
+	get: (key: string) => Promise<{ json: () => Promise<unknown> } | null>;
+}
+
+function makeBucket(mailboxJson: unknown): FakeBucket {
+	return {
+		async get(_key: string) {
+			return {
+				async json() {
+					return mailboxJson;
+				},
+			};
+		},
+	};
+}
+
+interface FakeUrlRow {
+	id: string;
+	url: string;
+	resolved_url?: string | null;
+}
+
+function makeStub(urls: FakeUrlRow[]) {
+	const reasonsAccum: string[] = [];
+	const stub = {
+		async getStoredVerdict(_emailId: string) {
+			return {
+				verdict: JSON.stringify({
+					action: "tag",
+					score: 30,
+					triage: "score",
+					signals: ["base"],
+					explanation: "base",
+				}),
+				score: 30,
+			};
+		},
+		async getUrlsForEmail(_emailId: string) {
+			return urls;
+		},
+		async updateUrlScan() {},
+		async getAttachmentsForEmail() {
+			return [];
+		},
+		async updateAttachmentScan() {},
+		async persistSecurityVerdict() {},
+		async moveEmail() {},
+		async updateDeepScanStatus() {},
+	};
+	return { stub, reasonsAccum };
+}
+
+function makeEnv(opts: {
+	apiKey?: string;
+	kv?: FakeKv;
+	bucket?: FakeBucket;
+	stub: unknown;
+}): Env {
+	const mailboxNs = {
+		idFromName(_n: string) {
+			return { toString: () => _n } as unknown as DurableObjectId;
+		},
+		get(_id: DurableObjectId) {
+			return opts.stub as unknown as DurableObjectStub;
+		},
+	} as unknown as DurableObjectNamespace;
+	return {
+		CROWDSEC_CTI_API_KEY: opts.apiKey,
+		BLOOM_KV: opts.kv as unknown as KVNamespace | undefined,
+		BUCKET: opts.bucket as unknown as R2Bucket | undefined,
+		MAILBOX: mailboxNs,
+	} as unknown as Env;
+}
+
+function makeFetchMock(handlers: Array<(url: string) => Response | Promise<Response> | null>) {
+	return vi.fn(async (input: string | URL | Request) => {
+		const url = typeof input === "string" ? input : input.toString();
+		for (const h of handlers) {
+			const out = await h(url);
+			if (out) return out;
+		}
+		return new Response("not mocked: " + url, { status: 404 });
+	});
+}
+
+/**
+ * Materialise the DROP fixture into the fake KV under `intel:spamhaus-drop:cidrs`,
+ * matching the storage shape `feeds.ts` writes during refresh.
+ */
+function seedDropFeed(kv: FakeKv): void {
+	const cidrs = parseCidrFeedBody(FIXTURE, "spamhaus-drop");
+	const serialized = JSON.stringify(
+		cidrs.map((c) => ({ n: c.network, m: c.mask, p: c.prefix })),
+	);
+	kv.store.set("intel:spamhaus-drop:cidrs", serialized);
+}
+
+// ── Parser tests ──────────────────────────────────────────────────
+
+describe("parseCidrFeedBody (Spamhaus DROP)", () => {
+	it("skips comments, blanks, and malformed entries while keeping valid CIDRs/IPs", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const cidrs = parseCidrFeedBody(FIXTURE, "spamhaus-drop");
+			// 4 valid entries: 1.10.16.0/20, 5.45.207.0/24, 192.0.2.42 (/32), 46.183.220.0/22
+			expect(cidrs.length).toBe(4);
+			expect(cidrs[0]).toEqual(expect.objectContaining({ prefix: 20 }));
+			expect(cidrs[1]).toEqual(expect.objectContaining({ prefix: 24 }));
+			// Bare IP becomes /32
+			expect(cidrs[2]).toEqual(expect.objectContaining({ prefix: 32 }));
+			expect(cidrs[3]).toEqual(expect.objectContaining({ prefix: 22 }));
+			// `not-a-cidr` is malformed — must be warn-and-skip, NOT throw.
+			expect(warn).toHaveBeenCalled();
+			expect(
+				warn.mock.calls.some((c) => String(c[0]).includes("not-a-cidr")),
+			).toBe(true);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it("does not throw on a feed of only comments and blank lines", () => {
+		const empty = `; just a header\n;\n\n; nothing to see\n`;
+		expect(() => parseCidrFeedBody(empty, "spamhaus-drop")).not.toThrow();
+		expect(parseCidrFeedBody(empty, "spamhaus-drop")).toEqual([]);
+	});
+});
+
+// ── Lookup tests ──────────────────────────────────────────────────
+
+describe("checkIpAgainstFeeds (Spamhaus DROP)", () => {
+	it("returns a match for an IP inside a DROP CIDR", async () => {
+		const kv = makeKv();
+		seedDropFeed(kv);
+		const env = makeEnv({
+			kv,
+			bucket: makeBucket({}),
+			stub: {},
+		});
+		// 1.10.16.0/20 covers 1.10.16.0 .. 1.10.31.255
+		const match = await checkIpAgainstFeeds(env, "m@x", "1.10.20.5");
+		expect(match).not.toBeNull();
+		expect(match?.feedId).toBe("spamhaus-drop");
+		expect(match?.cidr).toBe("1.10.16.0/20");
+	});
+
+	it("matches both the network address and the broadcast address of a CIDR", async () => {
+		const kv = makeKv();
+		seedDropFeed(kv);
+		const env = makeEnv({ kv, bucket: makeBucket({}), stub: {} });
+		// 1.10.16.0/20 → network 1.10.16.0, broadcast 1.10.31.255
+		const lo = await checkIpAgainstFeeds(env, "m@x", "1.10.16.0");
+		const hi = await checkIpAgainstFeeds(env, "m@x", "1.10.31.255");
+		expect(lo?.cidr).toBe("1.10.16.0/20");
+		expect(hi?.cidr).toBe("1.10.16.0/20");
+	});
+
+	it("matches a /32 entry exactly", async () => {
+		const kv = makeKv();
+		seedDropFeed(kv);
+		const env = makeEnv({ kv, bucket: makeBucket({}), stub: {} });
+		const exact = await checkIpAgainstFeeds(env, "m@x", "192.0.2.42");
+		expect(exact?.cidr).toBe("192.0.2.42/32");
+		// Adjacent IP is NOT in the /32 entry.
+		const adjacent = await checkIpAgainstFeeds(env, "m@x", "192.0.2.43");
+		expect(adjacent).toBeNull();
+	});
+
+	it("returns null for an IP outside every CIDR", async () => {
+		const kv = makeKv();
+		seedDropFeed(kv);
+		const env = makeEnv({ kv, bucket: makeBucket({}), stub: {} });
+		// 8.8.8.8 is not in the fixture.
+		const miss = await checkIpAgainstFeeds(env, "m@x", "8.8.8.8");
+		expect(miss).toBeNull();
+	});
+
+	it("returns null for a malformed IP input", async () => {
+		const kv = makeKv();
+		seedDropFeed(kv);
+		const env = makeEnv({ kv, bucket: makeBucket({}), stub: {} });
+		expect(await checkIpAgainstFeeds(env, "m@x", "not-an-ip")).toBeNull();
+	});
+});
+
+// ── Integration with runDeepScan ──────────────────────────────────
+
+describe("runDeepScan + Spamhaus DROP", () => {
+	let originalFetch: typeof fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	it("redirect target IP listed in DROP fires the new reason", async () => {
+		const fetchMock = makeFetchMock([
+			(url) => {
+				if (new URL(url).hostname === "phish.example.com") {
+					return new Response("<html><title>Login</title></html>", {
+						status: 200,
+						headers: { "content-type": "text/html" },
+					});
+				}
+				return null;
+			},
+			// RDAP — empty response, no signal contribution.
+			(url) => (new URL(url).hostname === "rdap.org" ? new Response("{}", { status: 200 }) : null),
+			// DoH resolves the redirect host to an IP that sits in 1.10.16.0/20.
+			(url) => {
+				const parsed = new URL(url);
+				if (parsed.hostname === "cloudflare-dns.com" && parsed.pathname.startsWith("/dns-query")) {
+					return new Response(
+						JSON.stringify({
+							Answer: [{ name: "phish.example.com.", type: 1, TTL: 60, data: "1.10.20.5" }],
+						}),
+						{ status: 200, headers: { "content-type": "application/dns-json" } },
+					);
+				}
+				return null;
+			},
+		]);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const kv = makeKv();
+		seedDropFeed(kv);
+		const harness = makeStub([{ id: "u1", url: "https://phish.example.com/login" }]);
+		// No CTI key — DROP must work on its own without CrowdSec configured.
+		const env = makeEnv({
+			kv,
+			bucket: makeBucket({}),
+			stub: harness.stub,
+		});
+
+		const result = await runDeepScan({ env, mailboxId: "m@x", emailId: "e1" });
+
+		const reasonsBlob = result.reasons.join(" | ");
+		expect(reasonsBlob).toMatch(/redirect target IP 1\.10\.20\.5/);
+		expect(reasonsBlob).toMatch(/Spamhaus DROP/);
+		// Score bump from the IP-feed stage (+20) is included; URL-stage
+		// signals (redirect host change, resolved homograph) may or may not
+		// fire on this synthetic input, so we just bound below by the IP-feed
+		// per-hit weight to keep the assertion stable.
+		expect(result.added_score).toBeGreaterThanOrEqual(20);
+		// CTI was NOT called — no API key configured.
+		const ctiCalls = fetchMock.mock.calls.filter((c) =>
+			new URL(String(c[0])).hostname === "cti.api.crowdsec.net",
+		);
+		expect(ctiCalls.length).toBe(0);
+	});
+
+	it("redirect target IP NOT in any DROP CIDR produces no IP-feed reason", async () => {
+		const fetchMock = makeFetchMock([
+			(url) => {
+				if (new URL(url).hostname === "clean.example.com") {
+					return new Response("<html><title>OK</title></html>", {
+						status: 200,
+						headers: { "content-type": "text/html" },
+					});
+				}
+				return null;
+			},
+			(url) => (new URL(url).hostname === "rdap.org" ? new Response("{}", { status: 200 }) : null),
+			(url) => {
+				const parsed = new URL(url);
+				if (parsed.hostname === "cloudflare-dns.com" && parsed.pathname.startsWith("/dns-query")) {
+					return new Response(
+						JSON.stringify({
+							Answer: [{ name: "clean.example.com.", type: 1, TTL: 60, data: "8.8.8.8" }],
+						}),
+						{ status: 200, headers: { "content-type": "application/dns-json" } },
+					);
+				}
+				return null;
+			},
+		]);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const kv = makeKv();
+		seedDropFeed(kv);
+		const harness = makeStub([{ id: "u1", url: "https://clean.example.com/" }]);
+		const env = makeEnv({
+			kv,
+			bucket: makeBucket({}),
+			stub: harness.stub,
+		});
+
+		const result = await runDeepScan({ env, mailboxId: "m@x", emailId: "e2" });
+
+		const reasonsBlob = result.reasons.join(" | ");
+		expect(reasonsBlob).not.toMatch(/Spamhaus DROP/);
+		expect(reasonsBlob).not.toMatch(/redirect target IP 8\.8\.8\.8/);
+	});
+});

--- a/workers/intel/cidr.ts
+++ b/workers/intel/cidr.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Tiny IPv4-only CIDR helpers for IP-vs-feed membership testing.
+ *
+ * Why hand-rolled: `ipaddr.js`/`netmask` are not in deps and we don't need
+ * IPv6 — Spamhaus DROP/EDROP and the deep-scan A-record lookups are IPv4
+ * only. Keeping this in workers code avoids a runtime dependency for a few
+ * dozen lines of bit math.
+ *
+ * Strategy: an IPv4 address is encoded as an unsigned 32-bit integer; a CIDR
+ * is `{ network, mask }` where membership is `(ip & mask) === network`.
+ * Operators using `>>> 0` ensure unsigned semantics on V8 (JS bit-ops are
+ * normally signed-32). Parsers reject anything malformed and return `null`
+ * so callers can warn-and-skip rather than throw.
+ */
+
+/** Parse a dotted-quad IPv4 string to an unsigned 32-bit integer. */
+export function parseIpv4(s: string): number | null {
+	if (typeof s !== "string") return null;
+	const parts = s.split(".");
+	if (parts.length !== 4) return null;
+	let out = 0;
+	for (const p of parts) {
+		// Reject empty, non-digit, leading whitespace, or out-of-range octets.
+		if (p.length === 0 || p.length > 3) return null;
+		if (!/^\d+$/.test(p)) return null;
+		const n = Number(p);
+		if (!Number.isFinite(n) || n < 0 || n > 255) return null;
+		out = ((out << 8) | n) >>> 0;
+	}
+	return out;
+}
+
+export interface Ipv4Cidr {
+	/** Masked network address as uint32. */
+	network: number;
+	/** Subnet mask as uint32 (e.g. /24 → 0xFFFFFF00). */
+	mask: number;
+	/** Prefix length, 0..32. */
+	prefix: number;
+}
+
+/**
+ * Parse a `<ip>/<prefix>` (or bare `<ip>` treated as `/32`) into a normalized
+ * `Ipv4Cidr`. Network address is masked, so callers don't have to worry about
+ * "1.2.3.4/24" vs "1.2.3.0/24" — both end up with `network = 1.2.3.0`.
+ */
+export function parseCidr(s: string): Ipv4Cidr | null {
+	if (typeof s !== "string") return null;
+	const trimmed = s.trim();
+	if (!trimmed) return null;
+	const slash = trimmed.indexOf("/");
+	const ipPart = slash === -1 ? trimmed : trimmed.slice(0, slash);
+	const prefixPart = slash === -1 ? "32" : trimmed.slice(slash + 1);
+
+	const ip = parseIpv4(ipPart);
+	if (ip === null) return null;
+
+	if (!/^\d+$/.test(prefixPart)) return null;
+	const prefix = Number(prefixPart);
+	if (!Number.isFinite(prefix) || prefix < 0 || prefix > 32) return null;
+
+	// Build the mask. `prefix === 0` requires special-casing because
+	// `(0xFFFFFFFF << 32) >>> 0` is implementation-defined (and on V8 is a
+	// no-op shift by 0).
+	const mask = prefix === 0 ? 0 : ((0xffffffff << (32 - prefix)) >>> 0);
+	const network = (ip & mask) >>> 0;
+	return { network, mask, prefix };
+}
+
+/** Is `ip` (uint32) inside the given CIDR? */
+export function ipInCidr(ip: number, cidr: Ipv4Cidr): boolean {
+	return ((ip & cidr.mask) >>> 0) === cidr.network;
+}
+
+/**
+ * Linear-scan an IP against a list of CIDRs. Returns the first matching CIDR,
+ * or `null`. For the feed sizes we care about (a few thousand CIDRs) the
+ * linear scan is microseconds — no index needed.
+ */
+export function findCidrMatch(ip: number, cidrs: Ipv4Cidr[]): Ipv4Cidr | null {
+	for (const c of cidrs) {
+		if (ipInCidr(ip, c)) return c;
+	}
+	return null;
+}

--- a/workers/intel/deep-scan.ts
+++ b/workers/intel/deep-scan.ts
@@ -30,7 +30,8 @@ import type { Env } from "../types";
 import type { FinalVerdict, VerdictThresholds } from "../security/verdict";
 import { getMailboxStub } from "../lib/email-helpers";
 import { Folders } from "../../shared/folders";
-import { checkUrlAgainstFeeds } from "./feeds";
+import { checkIpAgainstFeeds, checkUrlAgainstFeeds } from "./feeds";
+import { DEFAULT_FEEDS } from "./defaults";
 import { lookupDomainAge } from "./rdap";
 import { resolveUrl } from "./url-resolver";
 import { lookupIp, type CtiSummary } from "./crowdsec-cti";
@@ -96,15 +97,45 @@ export async function runDeepScan(input: DeepScanInput): Promise<DeepScanResult>
 		console.error("deep-scan attachment stage failed:", (e as Error).message);
 	}
 
+	// Resolve the redirect-target hostnames once and share the IP set across
+	// the CTI and IP-feed stages — both consume the same A-record fan-out and
+	// we don't want to double the DoH spend.
+	//
+	// Skip DoH entirely when no consumer is configured: no CTI key AND no
+	// IP-CIDR feed materialised in BLOOM_KV. This keeps deploys without any
+	// IP-based intel from spending DNS queries with nothing to do.
+	let resolvedIps: string[] = [];
+	if (resolvedHosts.length > 0) {
+		const wantIpStage = await ipStageEnabled(env, mailboxId);
+		if (wantIpStage) {
+			try {
+				resolvedIps = await resolveHostsToIps(resolvedHosts);
+			} catch (e) {
+				console.error("deep-scan host resolution failed:", (e as Error).message);
+			}
+		}
+	}
+
 	// CTI runs as a peer stage (not nested inside scanUrls) so its own
 	// per-inbound cap composes with the URL cap rather than getting
 	// squashed by it. Gated on the API key — unconfigured deploys no-op.
 	try {
-		const ctiDelta = await scanCti(env, resolvedHosts);
+		const ctiDelta = await scanCti(env, resolvedIps);
 		added += ctiDelta.score;
 		reasons.push(...ctiDelta.reasons);
 	} catch (e) {
 		console.error("deep-scan CTI stage failed:", (e as Error).message);
+	}
+
+	// IP-CIDR feed lookup (Spamhaus DROP/EDROP and similar). Independent of
+	// CTI — runs even on deploys without `CROWDSEC_CTI_API_KEY`. Same per-IP
+	// set as CTI so the resolution work is amortised across both stages.
+	try {
+		const ipFeedDelta = await scanIpFeeds(env, mailboxId, resolvedIps);
+		added += ipFeedDelta.score;
+		reasons.push(...ipFeedDelta.reasons);
+	} catch (e) {
+		console.error("deep-scan IP-feed stage failed:", (e as Error).message);
 	}
 
 	added = Math.min(DEEP_SCAN_MAX_ADD, added);
@@ -283,24 +314,13 @@ interface CtiHit {
 }
 
 /**
- * Resolve A records for each unique hostname in the redirect-target set,
- * look each unique IP up in CrowdSec CTI, and aggregate the signals into
- * deep-scan reasons + a capped score delta. Best-effort; returns zero
- * contribution when the API key is missing, no hostnames were resolved,
- * or every lookup produced nothing.
+ * Resolve unique hostnames to a deduped IP list via DoH. Shared between the
+ * CTI and IP-CIDR-feed stages so we only spend the DoH budget once per
+ * inbound. Caps both the host fan-out and per-host A-record count.
  */
-async function scanCti(
-	env: Env,
-	hosts: string[],
-): Promise<{ score: number; reasons: string[] }> {
-	if (!env.CROWDSEC_CTI_API_KEY) return { score: 0, reasons: [] };
-	if (!hosts.length) return { score: 0, reasons: [] };
-
+async function resolveHostsToIps(hosts: string[]): Promise<string[]> {
 	const uniqueHosts = [...new Set(hosts)].slice(0, CTI_MAX_HOSTS);
-
-	// Resolve all hosts in parallel, each bounded by its own per-request
-	// timeout. The per-request timeout is set well below the overall stage
-	// budget so even N concurrent slow resolvers can't exceed it.
+	if (!uniqueHosts.length) return [];
 	const resolved = await Promise.all(uniqueHosts.map((h) => resolveHostA(h)));
 	const ips = new Set<string>();
 	for (const arr of resolved) {
@@ -308,10 +328,24 @@ async function scanCti(
 			ips.add(ip);
 		}
 	}
-	if (!ips.size) return { score: 0, reasons: [] };
+	return [...ips];
+}
+
+/**
+ * Look each unique IP up in CrowdSec CTI and aggregate the signals into
+ * deep-scan reasons + a capped score delta. Best-effort; returns zero
+ * contribution when the API key is missing, no IPs were resolved, or
+ * every lookup produced nothing.
+ */
+async function scanCti(
+	env: Env,
+	ips: string[],
+): Promise<{ score: number; reasons: string[] }> {
+	if (!env.CROWDSEC_CTI_API_KEY) return { score: 0, reasons: [] };
+	if (!ips.length) return { score: 0, reasons: [] };
 
 	const lookups = await Promise.all(
-		[...ips].map(async (ip): Promise<CtiHit | null> => {
+		ips.map(async (ip): Promise<CtiHit | null> => {
 			const summary = await lookupIp(env, ip).catch(() => null);
 			return summary ? { ip, summary } : null;
 		}),
@@ -359,6 +393,90 @@ async function scanCti(
 	}
 
 	return { score: Math.min(CTI_MAX_ADD, score), reasons };
+}
+
+/**
+ * Decide whether to spend DoH on resolving redirect-target hostnames. True
+ * if any IP-based stage has something to do: CTI is configured, or any
+ * default `ip-cidr` feed has been materialised into KV.
+ *
+ * We probe each default ip-cidr feed's key directly rather than `list({
+ * prefix })`-ing — KV `get` is cheap, the default-feed list is small, and
+ * we avoid a second code path for fakes/tests that mock only `get`/`put`.
+ * User-configured ip-cidr feeds will only enable the stage if they share
+ * an id with a default; that's a fine constraint while only Spamhaus
+ * DROP/EDROP ship by default.
+ */
+async function ipStageEnabled(env: Env, _mailboxId: string): Promise<boolean> {
+	if (env.CROWDSEC_CTI_API_KEY) return true;
+	if (!env.BLOOM_KV) return false;
+	const cidrFeedIds = DEFAULT_FEEDS.filter((f) => f.kind === "ip-cidr").map((f) => f.id);
+	for (const id of cidrFeedIds) {
+		try {
+			const present = await env.BLOOM_KV.get(`intel:${id}:cidrs`, "text");
+			if (present) return true;
+		} catch {
+			// Treat lookup error as "no signal" — the per-stage code is
+			// best-effort and we'd rather skip DoH than spam it.
+		}
+	}
+	return false;
+}
+
+// ── IP-CIDR feed stage ───────────────────────────────────────────
+
+/**
+ * Cap on the score the IP-feed stage can add per inbound. Sized to match
+ * the CTI cap so neither single stage can dominate the deep-scan budget;
+ * `DEEP_SCAN_MAX_ADD = 40` still bounds the combined contribution.
+ */
+const IP_FEED_MAX_ADD = 25;
+
+/**
+ * Per-IP score bump for an IP-feed match. Mirrors the URL feed-match weight
+ * (`+20` in `scanUrls`) so an IP-listed redirect target gets the same
+ * magnitude of signal as a URL-listed redirect target.
+ */
+const IP_FEED_PER_HIT = 20;
+
+/**
+ * Look each resolved IP up in `ip-cidr` feeds (Spamhaus DROP/EDROP and
+ * any user-configured equivalents). Independent of CTI — works on deploys
+ * without `CROWDSEC_CTI_API_KEY`.
+ *
+ * `checkIpAgainstFeeds` returns the first matching feed per IP; one match
+ * per IP is enough signal that we don't keep scanning the rest of the
+ * feed list for the same IP.
+ */
+async function scanIpFeeds(
+	env: Env,
+	mailboxId: string,
+	ips: string[],
+): Promise<{ score: number; reasons: string[] }> {
+	if (!ips.length) return { score: 0, reasons: [] };
+
+	const reasons: string[] = [];
+	let score = 0;
+	for (const ip of ips) {
+		const match = await checkIpAgainstFeeds(env, mailboxId, ip).catch(() => null);
+		if (!match) continue;
+		score += IP_FEED_PER_HIT;
+		// Feed name preference: human-readable description first word
+		// ("Spamhaus DROP — ..."), falling back to the feed id. The reason
+		// string is operator-facing so a recognizable name matters.
+		const feedLabel = feedDisplayName(match.feedDescription, match.feedId);
+		reasons.push(`redirect target IP ${match.ip} (${match.cidr}) on ${feedLabel}`);
+	}
+	return { score: Math.min(IP_FEED_MAX_ADD, score), reasons };
+}
+
+function feedDisplayName(description: string, fallback: string): string {
+	// Default-feed descriptions are formatted "Name — details"; take the
+	// portion before the em-dash if present.
+	const dash = description.indexOf("—");
+	const head = dash === -1 ? description : description.slice(0, dash);
+	const cleaned = head.trim();
+	return cleaned || fallback;
 }
 
 /**

--- a/workers/intel/defaults.ts
+++ b/workers/intel/defaults.ts
@@ -19,8 +19,17 @@
 export interface FeedDefinition {
 	id: string;
 	url: string;
-	/** `domain` feeds contain registrable hostnames; `url` feeds contain full URLs. */
-	kind: "domain" | "url";
+	/**
+	 * Content type of the feed:
+	 *   - `domain` — registrable hostnames, one per line
+	 *   - `url`    — full URLs, one per line
+	 *   - `ip-cidr` — IPv4 CIDRs (or single IPs treated as `/32`), one per line.
+	 *     Stored differently from `domain`/`url` feeds: bloom filters don't fit
+	 *     CIDR membership, so the refresher writes the parsed CIDR list as a
+	 *     single KV blob and lookup does a linear scan with IPv4-as-uint32
+	 *     masking. See `workers/intel/feeds.ts` for details.
+	 */
+	kind: "domain" | "url" | "ip-cidr";
 	refreshHours: number;
 	/** One-line human description. */
 	description: string;
@@ -45,5 +54,21 @@ export const DEFAULT_FEEDS: FeedDefinition[] = [
 		kind: "url",
 		refreshHours: 6,
 		description: "OpenPhish community phishing URL feed.",
+	},
+	{
+		id: "spamhaus-drop",
+		url: "https://www.spamhaus.org/drop/drop.txt",
+		kind: "ip-cidr",
+		refreshHours: 12,
+		description:
+			"Spamhaus DROP — hijacked netblocks and known spam operations (no auth).",
+	},
+	{
+		id: "spamhaus-edrop",
+		url: "https://www.spamhaus.org/drop/edrop.txt",
+		kind: "ip-cidr",
+		refreshHours: 12,
+		description:
+			"Spamhaus EDROP — extended DROP list of additional spammer netblocks (no auth).",
 	},
 ];

--- a/workers/intel/feeds.ts
+++ b/workers/intel/feeds.ts
@@ -30,12 +30,20 @@ import {
 	deserializeBloom,
 	serializeBloom,
 } from "./bloom";
+import { findCidrMatch, parseCidr, parseIpv4, type Ipv4Cidr } from "./cidr";
 import { getMailboxStub, listMailboxes } from "../lib/email-helpers";
 
 const EXACT_KEY_CAP = 2000; // per-feed cap — we only fast-path confirm up to this many
 
 function bloomKey(feedId: string) { return `intel:${feedId}:bloom`; }
 function exactKey(feedId: string, value: string) { return `intel:${feedId}:exact:${value}`; }
+/**
+ * Storage key for `ip-cidr` feeds. Bloom filters don't fit CIDR membership
+ * (an IP is checked against a *range*, not an exact string) so we materialise
+ * the whole list as a JSON blob and linear-scan on lookup. DROP-class feeds
+ * are a few thousand CIDRs — well under any KV size limit.
+ */
+function cidrKey(feedId: string) { return `intel:${feedId}:cidrs`; }
 
 export interface MailboxIntelSettings {
 	feeds?: Array<{
@@ -107,6 +115,46 @@ function parseFeedBody(body: string, kind: "domain" | "url"): string[] {
 	return out;
 }
 
+/**
+ * Parse a CIDR-per-line body (e.g. Spamhaus DROP/EDROP).
+ *
+ * Format expected:
+ *   - One CIDR (or bare IP) per line.
+ *   - Comment lines start with `;` (Spamhaus convention) or `#`.
+ *   - Each entry can have a trailing reference suffix separated by `;`,
+ *     e.g. `1.10.16.0/20 ; SBL233763` — strip everything from `;` onwards
+ *     and parse the leading token.
+ *   - Blank lines are skipped.
+ *
+ * A malformed entry is logged and skipped — a single bad line shouldn't
+ * poison the whole feed refresh.
+ */
+export function parseCidrFeedBody(
+	body: string,
+	feedId: string,
+): Ipv4Cidr[] {
+	const lines = body.split(/\r?\n/);
+	const out: Ipv4Cidr[] = [];
+	for (const raw of lines) {
+		const trimmed = raw.trim();
+		if (!trimmed) continue;
+		// Spamhaus uses `;` for comments; tolerate `#` too for foreign feeds.
+		if (trimmed.startsWith(";") || trimmed.startsWith("#")) continue;
+		// Strip trailing reference suffix. Each entry typically looks like
+		// `1.10.16.0/20 ; SBL233763`; `;` and anything after is metadata.
+		const semi = trimmed.indexOf(";");
+		const head = (semi === -1 ? trimmed : trimmed.slice(0, semi)).trim();
+		if (!head) continue;
+		const cidr = parseCidr(head);
+		if (!cidr) {
+			console.warn(`feed ${feedId}: skipping malformed CIDR entry ${JSON.stringify(head)}`);
+			continue;
+		}
+		out.push(cidr);
+	}
+	return out;
+}
+
 function normalizeDomain(s: string): string {
 	return s.toLowerCase().replace(/^https?:\/\//, "").split(/[\/?#]/)[0];
 }
@@ -159,6 +207,32 @@ async function refreshFeed(
 	if (!res.ok) throw new Error(`${feed.url} returned ${res.status}`);
 
 	const body = await res.text();
+	const ttlSeconds = Math.max(feed.refreshHours * 3600 * 4, 86400);
+
+	if (feed.kind === "ip-cidr") {
+		// CIDR feeds use a separate storage path: a JSON blob of
+		// `{ network, mask, prefix }` rows, scanned linearly on lookup. Bloom
+		// filters answer "is this exact string in the set" — they can't answer
+		// "is this IP inside any of these ranges". DROP-class feeds are a few
+		// thousand entries (well under any KV size limit) so JSON is fine.
+		const cidrs = parseCidrFeedBody(body, feed.id);
+		if (cidrs.length === 0) return { entries: 0 };
+		const serialized = JSON.stringify(
+			cidrs.map((c) => ({ n: c.network, m: c.mask, p: c.prefix })),
+		);
+		await env.BLOOM_KV.put(cidrKey(feed.id), serialized, {
+			expirationTtl: ttlSeconds,
+		});
+		await stub.upsertIntelFeedState(feed.id, {
+			url: feed.url,
+			last_fetched_at: new Date().toISOString(),
+			etag: res.headers.get("ETag") ?? null,
+			entry_count: cidrs.length,
+			bloom_kv_key: cidrKey(feed.id),
+		});
+		return { entries: cidrs.length };
+	}
+
 	const values = parseFeedBody(body, feed.kind);
 	if (values.length === 0) return { entries: 0 };
 
@@ -166,7 +240,7 @@ async function refreshFeed(
 	for (const v of values) addToBloom(bloom, v);
 	await env.BLOOM_KV.put(bloomKey(feed.id), serializeBloom(bloom), {
 		// Bounded TTL — a dead cron should eventually stop consulting stale data.
-		expirationTtl: Math.max(feed.refreshHours * 3600 * 4, 86400),
+		expirationTtl: ttlSeconds,
 	});
 
 	// Write a bounded subset of exact-match markers for secondary confirmation.
@@ -219,6 +293,10 @@ export async function checkUrlAgainstFeeds(
 	let bloomOnly: FeedMatch | null = null;
 
 	for (const feed of feeds) {
+		// URL/domain-feed lookup only — CIDR feeds use `checkIpAgainstFeeds`.
+		// Mixing them would bloom-test a URL string against IP ranges and
+		// emit nonsense.
+		if (feed.kind !== "domain" && feed.kind !== "url") continue;
 		const serialized = await env.BLOOM_KV.get(bloomKey(feed.id), "arrayBuffer");
 		if (!serialized) continue;
 		const filter = deserializeBloom(serialized);
@@ -232,4 +310,71 @@ export async function checkUrlAgainstFeeds(
 		}
 	}
 	return bloomOnly;
+}
+
+export interface IpFeedMatch {
+	matched: true;
+	feedId: string;
+	feedDescription: string;
+	ip: string;
+	cidr: string;
+}
+
+interface SerializedCidrRow { n: number; m: number; p: number; }
+
+/**
+ * Resolve and check an IPv4 address against every configured `ip-cidr` feed.
+ * Returns the first matching feed (feeds are checked in `resolveFeeds` order:
+ * defaults first, then user-configured) so callers don't double-score one IP.
+ *
+ * Membership is checked via masked IPv4-as-uint32 comparison — see
+ * `workers/intel/cidr.ts`. The serialized list is fetched once per feed per
+ * call; callers that loop over many IPs should memoise it themselves.
+ */
+export async function checkIpAgainstFeeds(
+	env: Env,
+	mailboxId: string,
+	ip: string,
+): Promise<IpFeedMatch | null> {
+	if (!env.BLOOM_KV) return null;
+	const ipNum = parseIpv4(ip);
+	if (ipNum === null) return null;
+	const settings = await loadMailboxIntelSettings(env, mailboxId);
+	const feeds = resolveFeeds(env, settings).filter((f) => f.kind === "ip-cidr");
+	for (const feed of feeds) {
+		const serialized = await env.BLOOM_KV.get(cidrKey(feed.id), "text");
+		if (!serialized) continue;
+		let rows: SerializedCidrRow[];
+		try {
+			rows = JSON.parse(serialized) as SerializedCidrRow[];
+		} catch {
+			continue;
+		}
+		if (!Array.isArray(rows)) continue;
+		const cidrs: Ipv4Cidr[] = rows.map((r) => ({
+			network: r.n >>> 0,
+			mask: r.m >>> 0,
+			prefix: r.p,
+		}));
+		const match = findCidrMatch(ipNum, cidrs);
+		if (match) {
+			const cidrText = formatCidr(match);
+			return {
+				matched: true,
+				feedId: feed.id,
+				feedDescription: feed.description,
+				ip,
+				cidr: cidrText,
+			};
+		}
+	}
+	return null;
+}
+
+function formatCidr(c: Ipv4Cidr): string {
+	const a = (c.network >>> 24) & 0xff;
+	const b = (c.network >>> 16) & 0xff;
+	const cc = (c.network >>> 8) & 0xff;
+	const d = c.network & 0xff;
+	return `${a}.${b}.${cc}.${d}/${c.prefix}`;
 }


### PR DESCRIPTION
## Summary

- Adds Spamhaus DROP + EDROP as default `ip-cidr` threat-intel feeds (no auth, refreshed every 12h). Closes #133.
- Extends the feed pipeline with a third `kind: "ip-cidr"`: refresher writes the parsed CIDR list as a JSON blob in `BLOOM_KV` (bloom filters can't answer range-membership), lookup is a linear masked-uint32 scan via a tiny new `workers/intel/cidr.ts` helper.
- Wires IP-feed lookup into deep-scan as a peer stage. Refactored `scanCti` to consume a shared resolved-IP set so DoH fans out once per inbound; deploys without a CTI key AND without any materialised ip-cidr feed skip DoH entirely.

## Files of note

- `workers/intel/defaults.ts` — `FeedDefinition.kind` extended; DROP + EDROP added
- `workers/intel/cidr.ts` — IPv4 parse + CIDR membership
- `workers/intel/feeds.ts` — `parseCidrFeedBody`, ip-cidr branch in `refreshFeed`, new `checkIpAgainstFeeds`, URL/domain feeds filtered to skip ip-cidr in `checkUrlAgainstFeeds`
- `workers/intel/deep-scan.ts` — peer `scanIpFeeds` stage at `+20` per match (parity with URL-feed weight), capped at `+25` per inbound (parity with CTI cap)
- `test/security/spamhaus-drop.test.ts` + `test/fixtures/security/spamhaus-drop.txt` — parser, lookup, and runDeepScan integration

## Test plan

- [x] Parser: comment lines (`;`), blank lines, trailing `; SBLxxx` suffix, and malformed entries (warn-and-skip, never throw)
- [x] Lookup: IP inside a CIDR matches; network and broadcast boundary IPs match (catches off-by-one in mask); `/32` entry matches exactly and adjacent IP misses; IP outside every CIDR returns null; malformed IP input returns null
- [x] Integration: redirect chain whose resolved IP is in DROP fires `redirect target IP <ip> (<cidr>) on Spamhaus DROP` reason and bumps score; clean redirect target produces no DROP reason
- [x] Existing CTI test (`test/security/deep-scan-cti.test.ts`) still passes after the `scanCti` refactor (now takes IPs instead of hosts, with shared `resolveHostsToIps` helper)
- [x] `npm test` — 270 passing / 0 failing (pre-existing jsdom missing-package errors on frontend tests are unrelated)
- [x] `npm run typecheck` — clean for `workers/intel/**` and `test/security/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)