### PR TITLE
feat: per-domain stats + /domains/:domain route

### DIFF
--- a/app/components/phishsoc/Breadcrumb.tsx
+++ b/app/components/phishsoc/Breadcrumb.tsx
@@ -21,6 +21,7 @@ function segmentsFor(
 	pathname: string,
 	mailboxId: string | undefined,
 	mailboxLabel: string,
+	mailboxEmail: string | undefined,
 ): Segment[] | null {
 	if (pathname === "/" || pathname === "") return null;
 
@@ -30,31 +31,54 @@ function segmentsFor(
 		return [orgRoot, { label: "Mailboxes" }];
 	}
 
+	// `/domains` and `/domains/:domain` (#85). Read the domain from the path
+	// rather than a hook — the breadcrumb has no router param for these
+	// top-level routes. Decode in case a future caller percent-encodes.
+	if (pathname === "/domains" || pathname === "/domains/") {
+		return [orgRoot, { label: "Domains" }];
+	}
+	if (pathname.startsWith("/domains/")) {
+		const tail = pathname.slice("/domains/".length).replace(/\/$/, "");
+		const domain = decodeURIComponent(tail);
+		if (domain) {
+			return [orgRoot, { label: domain }];
+		}
+		return [orgRoot, { label: "Domains" }];
+	}
+
 	if (!mailboxId) return null;
 
 	const base = `/mailbox/${encodeURIComponent(mailboxId)}`;
 	const mailboxSegment: Segment = { label: mailboxLabel, to: base };
+	// Inject a domain segment between Org and the mailbox label when the
+	// mailbox query has resolved. Defensive on the loading case: skip the
+	// extra segment until `mailbox.email` is available so we don't flash
+	// "undefined". Links to the per-domain drill-down at `/domains/:domain`.
+	const domain = mailboxEmail?.split("@")[1]?.toLowerCase();
+	const orgChain: Segment[] = domain
+		? [orgRoot, { label: domain, to: `/domains/${encodeURIComponent(domain)}` }]
+		: [orgRoot];
 
 	const tail = pathname.slice(base.length);
 
 	if (tail === "" || tail === "/") {
-		return [orgRoot, { label: mailboxLabel }];
+		return [...orgChain, { label: mailboxLabel }];
 	}
 
 	if (tail.startsWith("/dashboard")) {
-		return [orgRoot, mailboxSegment, { label: "Dashboard" }];
+		return [...orgChain, mailboxSegment, { label: "Dashboard" }];
 	}
 	if (tail.startsWith("/settings")) {
-		return [orgRoot, mailboxSegment, { label: "Settings" }];
+		return [...orgChain, mailboxSegment, { label: "Settings" }];
 	}
 	if (tail.startsWith("/search")) {
-		return [orgRoot, mailboxSegment, { label: "Search" }];
+		return [...orgChain, mailboxSegment, { label: "Search" }];
 	}
 	if (tail.startsWith("/dmarc")) {
-		return [orgRoot, mailboxSegment, { label: "DMARC" }];
+		return [...orgChain, mailboxSegment, { label: "DMARC" }];
 	}
 	if (tail.startsWith("/hub")) {
-		return [orgRoot, mailboxSegment, { label: "Threat-intel hub" }];
+		return [...orgChain, mailboxSegment, { label: "Threat-intel hub" }];
 	}
 	if (tail.startsWith("/cases")) {
 		const casesSegment: Segment = { label: "Cases", to: `${base}/cases` };
@@ -63,17 +87,17 @@ function segmentsFor(
 		// parent route uses a wildcard match).
 		const caseId = tail.split("/")[2];
 		if (caseId) {
-			return [orgRoot, mailboxSegment, casesSegment, { label: caseId }];
+			return [...orgChain, mailboxSegment, casesSegment, { label: caseId }];
 		}
-		return [orgRoot, mailboxSegment, { label: "Cases" }];
+		return [...orgChain, mailboxSegment, { label: "Cases" }];
 	}
 	if (tail.startsWith("/emails/")) {
 		const folder = tail.split("/")[2] ?? "";
 		const folderLabel = FOLDER_LABELS[folder.toLowerCase()] ?? folder;
-		return [orgRoot, mailboxSegment, { label: folderLabel }];
+		return [...orgChain, mailboxSegment, { label: folderLabel }];
 	}
 
-	return [orgRoot, mailboxSegment];
+	return [...orgChain, mailboxSegment];
 }
 
 export default function Breadcrumb() {
@@ -82,7 +106,12 @@ export default function Breadcrumb() {
 	const { data: mailbox } = useMailbox(mailboxId);
 
 	const mailboxLabel = mailbox?.email ?? mailbox?.name ?? mailboxId ?? "Mailbox";
-	const segments = segmentsFor(location.pathname, mailboxId, mailboxLabel);
+	const segments = segmentsFor(
+		location.pathname,
+		mailboxId,
+		mailboxLabel,
+		mailbox?.email,
+	);
 
 	if (!segments || segments.length === 0) return null;
 

--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -6,6 +6,7 @@ import {
 	EnvelopeIcon,
 	GaugeIcon,
 	GearSixIcon,
+	GlobeIcon,
 	GraphIcon,
 	ListIcon,
 	MagnifyingGlassIcon,
@@ -178,6 +179,11 @@ function NavContents({
 					icon={<EnvelopeIcon size={16} />}
 					label="Mailboxes"
 					count={mailboxCount > 0 ? mailboxCount : undefined}
+				/>
+				<NavItem
+					to="/domains"
+					icon={<GlobeIcon size={16} />}
+					label="Domains"
 				/>
 				{mailboxId && (
 					<>

--- a/app/queries/domains.ts
+++ b/app/queries/domains.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { useQuery } from "@tanstack/react-query";
+import api from "~/services/api";
+import type { DomainListEntry, DomainStats } from "~/types";
+import { queryKeys } from "./keys";
+
+/**
+ * `/api/v1/domains` — domains list with aggregate stats (#85). The worker
+ * caches the merged result for 60s, so a 30s client stale window keeps
+ * navigation snappy without serving data older than ~90s.
+ */
+export function useDomains() {
+	return useQuery<DomainListEntry[]>({
+		queryKey: queryKeys.domains.list,
+		queryFn: ({ signal }) =>
+			api.listDomains({ signal }) as Promise<DomainListEntry[]>,
+		staleTime: 30_000,
+	});
+}
+
+export function useDomainStats(domain: string | undefined) {
+	return useQuery<DomainStats>({
+		queryKey: domain ? queryKeys.domains.detail(domain) : ["domains", "_disabled"],
+		queryFn: ({ signal }) =>
+			api.getDomainStats(domain!, { signal }) as Promise<DomainStats>,
+		enabled: !!domain,
+		staleTime: 30_000,
+	});
+}

--- a/app/queries/keys.ts
+++ b/app/queries/keys.ts
@@ -27,6 +27,10 @@ export const queryKeys = {
 	org: {
 		overview: ["org", "overview"] as const,
 	},
+	domains: {
+		list: ["domains"] as const,
+		detail: (domain: string) => ["domains", domain] as const,
+	},
 	hub: {
 		contributions: (mailboxId: string) => ["hub", mailboxId, "contributions"] as const,
 		destroylist: (mailboxId: string) => ["hub", mailboxId, "destroylist"] as const,

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -11,6 +11,8 @@ import {
 export default [
 	index("routes/home.tsx"),
 	route("mailboxes", "routes/mailboxes.tsx"),
+	route("domains", "routes/domains-list.tsx"),
+	route("domains/:domain", "routes/domain-detail.tsx"),
 	route("mailbox/:mailboxId", "routes/mailbox.tsx", [
 		index("routes/mailbox-index.tsx"),
 		route("dashboard", "routes/dashboard.tsx"),

--- a/app/routes/domain-detail.tsx
+++ b/app/routes/domain-detail.tsx
@@ -1,0 +1,308 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { Loader } from "@cloudflare/kumo";
+import {
+	BriefcaseIcon,
+	EnvelopeIcon,
+	ShieldCheckIcon,
+	WarningIcon,
+} from "@phosphor-icons/react";
+import { Link as RouterLink, useParams } from "react-router";
+import Shell from "~/components/phishsoc/Shell";
+import { useDomainStats } from "~/queries/domains";
+import type {
+	DomainStats,
+	OrgVerdictMix,
+} from "~/types";
+
+export function meta({ params }: { params: { domain?: string } }) {
+	return [{ title: `${params.domain ?? "Domain"} · PhishSOC` }];
+}
+
+export default function DomainDetailRoute() {
+	const { domain } = useParams<{ domain: string }>();
+	const { data, isLoading, isError, refetch } = useDomainStats(domain);
+
+	return (
+		<Shell>
+			<div className="px-6 md:px-10 py-8 max-w-[1280px] space-y-6">
+				<DomainHeader domain={domain ?? ""} data={data} />
+
+				{isLoading ? (
+					<div className="flex justify-center py-20">
+						<Loader size="lg" />
+					</div>
+				) : isError ? (
+					<DomainError onRetry={() => refetch()} />
+				) : data ? (
+					<DomainBody data={data} />
+				) : null}
+			</div>
+		</Shell>
+	);
+}
+
+function DomainHeader({
+	domain,
+	data,
+}: { domain: string; data: DomainStats | undefined }) {
+	const subtitle = data
+		? `${data.mailboxes.length} mailbox${data.mailboxes.length === 1 ? "" : "es"}`
+		: "Per-domain operations";
+	return (
+		<div>
+			<div className="text-[11px] uppercase tracking-[0.08em] text-ink-3 mb-1">
+				Domain · last 24 hours
+			</div>
+			<h1 className="pp-serif text-[40px] leading-none text-ink mb-2">
+				{domain}
+			</h1>
+			<p className="pp-serif text-[24px] leading-tight text-ink-3 max-w-2xl">
+				{subtitle}
+			</p>
+		</div>
+	);
+}
+
+function DomainError({ onRetry }: { onRetry: () => void }) {
+	return (
+		<div className="pp-card p-6 flex items-start gap-3">
+			<span className="flex h-8 w-8 items-center justify-center rounded-full bg-paper-2 text-ink-3 shrink-0">
+				<WarningIcon size={18} />
+			</span>
+			<div>
+				<div className="text-[14px] font-medium text-ink mb-1">
+					Couldn't load this domain
+				</div>
+				<p className="text-[12.5px] text-ink-3 leading-relaxed mb-2">
+					The domain stats endpoint didn't respond. Check the worker logs and retry.
+				</p>
+				<button
+					type="button"
+					onClick={onRetry}
+					className="text-[12px] underline text-accent hover:opacity-80"
+				>
+					Retry
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function DomainBody({ data }: { data: DomainStats }) {
+	return (
+		<>
+			<KpiGrid data={data} />
+			<div className="grid gap-4 lg:grid-cols-3">
+				<VerdictMixCard mix={data.verdictMix} />
+				<DmarcPostureCard posture={data.dmarcPosture} />
+			</div>
+			<MailboxList mailboxes={data.mailboxes} />
+			{data.recentCases.length > 0 && <RecentCasesList cases={data.recentCases} />}
+		</>
+	);
+}
+
+interface Kpi {
+	label: string;
+	value: string;
+}
+
+function KpiGrid({ data }: { data: DomainStats }) {
+	const kpis: Kpi[] = [
+		{ label: "Threats blocked · 24h", value: String(data.threatsBlocked24h) },
+		{ label: "Threats blocked · 7d", value: String(data.threatsBlocked7d) },
+		{ label: "Open cases", value: String(data.openCases) },
+		{ label: "Mailboxes", value: String(data.mailboxes.length) },
+	];
+	return (
+		<div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-4">
+			{kpis.map((k) => (
+				<div key={k.label} className="pp-card p-4">
+					<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-2">
+						{k.label}
+					</div>
+					<div className="pp-serif text-[36px] leading-none text-ink">
+						{k.value}
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}
+
+const VERDICT_LABEL: Record<keyof OrgVerdictMix, string> = {
+	safe: "Safe",
+	suspicious: "Suspicious",
+	phishing: "Phishing",
+	spam: "Spam",
+	bec: "BEC",
+};
+
+function VerdictMixCard({ mix }: { mix: OrgVerdictMix }) {
+	const entries = (Object.keys(VERDICT_LABEL) as Array<keyof OrgVerdictMix>).map(
+		(k) => ({ key: k, label: VERDICT_LABEL[k], count: mix[k] }),
+	);
+	const total = entries.reduce((sum, e) => sum + e.count, 0);
+	return (
+		<div className="pp-card p-5 lg:col-span-2 flex flex-col gap-3">
+			<div className="flex items-baseline justify-between gap-3">
+				<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 flex items-center gap-1.5">
+					<ShieldCheckIcon size={12} />
+					Verdict mix · 24h
+				</div>
+				<div className="text-[12px] text-ink-3">{total} classified</div>
+			</div>
+			{total === 0 ? (
+				<p className="text-[12.5px] text-ink-3">
+					No classified mail in the window.
+				</p>
+			) : (
+				<ul className="space-y-2">
+					{entries.map((e) => {
+						const pct = total === 0 ? 0 : (e.count / total) * 100;
+						return (
+							<li key={e.key} className="flex items-center gap-3">
+								<div className="text-[12px] text-ink-2 w-24 shrink-0">
+									{e.label}
+								</div>
+								<div className="flex-1 h-1.5 rounded-full bg-paper-3 overflow-hidden">
+									<div
+										className="h-full bg-accent"
+										style={{ width: `${pct}%` }}
+										aria-hidden
+									/>
+								</div>
+								<div className="pp-mono text-[11px] text-ink-3 tabular-nums w-10 text-right">
+									{e.count}
+								</div>
+							</li>
+						);
+					})}
+				</ul>
+			)}
+		</div>
+	);
+}
+
+function DmarcPostureCard({
+	posture,
+}: { posture: DomainStats["dmarcPosture"] }) {
+	// All-null posture is the v1 norm — real DMARC report ingestion at the
+	// apex-domain level isn't shipping in this iteration. Render an
+	// "unavailable" affordance rather than misleading defaults.
+	const allNull =
+		posture.p === null &&
+		posture.sp === null &&
+		posture.pct === null &&
+		posture.ruaConfigured === null &&
+		posture.alignmentRate === null;
+	return (
+		<div className="pp-card p-5">
+			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-3 flex items-center gap-1.5">
+				<ShieldCheckIcon size={12} />
+				DMARC posture
+			</div>
+			{allNull ? (
+				<p className="text-[12.5px] text-ink-3">
+					Apex-domain DMARC posture isn't ingested yet. The per-mailbox DMARC
+					dashboard surfaces the report rollups available today.
+				</p>
+			) : (
+				<dl className="space-y-1.5 text-[12.5px]">
+					<PostureRow label="p" value={posture.p ?? "—"} />
+					<PostureRow label="sp" value={posture.sp ?? "—"} />
+					<PostureRow
+						label="pct"
+						value={posture.pct === null ? "—" : `${posture.pct}%`}
+					/>
+					<PostureRow
+						label="rua"
+						value={
+							posture.ruaConfigured === null
+								? "—"
+								: posture.ruaConfigured
+									? "configured"
+									: "not configured"
+						}
+					/>
+					<PostureRow
+						label="alignment"
+						value={
+							posture.alignmentRate === null
+								? "—"
+								: `${Math.round(posture.alignmentRate * 100)}%`
+						}
+					/>
+				</dl>
+			)}
+		</div>
+	);
+}
+
+function PostureRow({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="flex items-baseline justify-between gap-3">
+			<dt className="text-ink-3">{label}</dt>
+			<dd className="pp-mono text-ink-2 tabular-nums">{value}</dd>
+		</div>
+	);
+}
+
+function MailboxList({
+	mailboxes,
+}: { mailboxes: DomainStats["mailboxes"] }) {
+	return (
+		<div className="pp-card p-5">
+			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-3 flex items-center gap-1.5">
+				<EnvelopeIcon size={12} />
+				Mailboxes
+			</div>
+			{mailboxes.length === 0 ? (
+				<p className="text-[12.5px] text-ink-3">
+					No mailboxes for this domain.
+				</p>
+			) : (
+				<ul className="divide-y divide-line">
+					{mailboxes.map((m) => (
+						<li key={m.id} className="py-2">
+							<RouterLink
+								to={`/mailbox/${encodeURIComponent(m.id)}/dashboard`}
+								className="flex items-center justify-between gap-3 text-[13px] text-ink hover:text-accent transition-colors"
+							>
+								<span className="truncate">{m.email}</span>
+								<span className="text-[11px] text-ink-3">Dashboard</span>
+							</RouterLink>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}
+
+function RecentCasesList({
+	cases,
+}: { cases: DomainStats["recentCases"] }) {
+	return (
+		<div className="pp-card p-5">
+			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-3 flex items-center gap-1.5">
+				<BriefcaseIcon size={12} />
+				Recent cases
+			</div>
+			<ul className="divide-y divide-line">
+				{cases.map((c) => (
+					<li
+						key={c.id}
+						className="py-2 flex items-baseline justify-between gap-3"
+					>
+						<span className="text-[13px] text-ink truncate">{c.title}</span>
+						<span className="pp-mono text-[11px] text-ink-3 tabular-nums shrink-0">
+							{c.status}
+						</span>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}

--- a/app/routes/domains-list.tsx
+++ b/app/routes/domains-list.tsx
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { Loader } from "@cloudflare/kumo";
+import { BuildingsIcon, WarningIcon } from "@phosphor-icons/react";
+import { Link as RouterLink } from "react-router";
+import Shell from "~/components/phishsoc/Shell";
+import { useDomains } from "~/queries/domains";
+import type { DomainListEntry } from "~/types";
+
+export function meta() {
+	return [{ title: "Domains · PhishSOC" }];
+}
+
+export default function DomainsListRoute() {
+	const { data, isLoading, isError, refetch } = useDomains();
+
+	return (
+		<Shell>
+			<div className="px-6 md:px-10 py-8 max-w-[1280px] space-y-6">
+				<DomainsHeader count={data?.length ?? 0} />
+
+				{isLoading ? (
+					<div className="flex justify-center py-20">
+						<Loader size="lg" />
+					</div>
+				) : isError ? (
+					<DomainsError onRetry={() => refetch()} />
+				) : data ? (
+					data.length === 0 ? (
+						<EmptyDomains />
+					) : (
+						<DomainsTable domains={data} />
+					)
+				) : null}
+			</div>
+		</Shell>
+	);
+}
+
+function DomainsHeader({ count }: { count: number }) {
+	return (
+		<div>
+			<div className="text-[11px] uppercase tracking-[0.08em] text-ink-3 mb-1">
+				Org · domains
+			</div>
+			<h1 className="pp-serif text-[40px] leading-none text-ink mb-2">
+				Domains.
+			</h1>
+			<p className="pp-serif text-[24px] leading-tight text-ink-3 max-w-2xl">
+				{count > 0
+					? `${count} domain${count === 1 ? "" : "s"} provisioned.`
+					: "No domains provisioned yet."}
+			</p>
+		</div>
+	);
+}
+
+function DomainsError({ onRetry }: { onRetry: () => void }) {
+	return (
+		<div className="pp-card p-6 flex items-start gap-3">
+			<span className="flex h-8 w-8 items-center justify-center rounded-full bg-paper-2 text-ink-3 shrink-0">
+				<WarningIcon size={18} />
+			</span>
+			<div>
+				<div className="text-[14px] font-medium text-ink mb-1">
+					Couldn't load the domains list
+				</div>
+				<p className="text-[12.5px] text-ink-3 leading-relaxed mb-2">
+					The domains endpoint didn't respond. Check the worker logs and retry.
+				</p>
+				<button
+					type="button"
+					onClick={onRetry}
+					className="text-[12px] underline text-accent hover:opacity-80"
+				>
+					Retry
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function EmptyDomains() {
+	return (
+		<div className="pp-card py-16 px-6">
+			<div className="flex flex-col items-center text-center">
+				<div className="mb-4">
+					<BuildingsIcon size={48} weight="thin" className="text-ink-3" />
+				</div>
+				<h3 className="text-base font-semibold text-ink mb-1.5">
+					No domains yet
+				</h3>
+				<p className="text-sm text-ink-3 max-w-sm mb-5">
+					Provision a mailbox to start aggregating domain-level threat activity.
+				</p>
+				<RouterLink
+					to="/mailboxes"
+					className="text-[13px] underline text-accent hover:opacity-80"
+				>
+					Go to Mailboxes
+				</RouterLink>
+			</div>
+		</div>
+	);
+}
+
+function DomainsTable({ domains }: { domains: DomainListEntry[] }) {
+	return (
+		<div className="pp-card overflow-hidden">
+			<table className="w-full text-[13px]">
+				<thead>
+					<tr className="text-left text-[10.5px] uppercase tracking-[0.06em] text-ink-3 border-b border-line">
+						<th className="px-4 py-2.5 font-normal">Domain</th>
+						<th className="px-4 py-2.5 font-normal text-right">Mailboxes</th>
+						<th className="px-4 py-2.5 font-normal text-right">
+							Threats blocked · 24h
+						</th>
+						<th className="px-4 py-2.5 font-normal text-right">Open cases</th>
+					</tr>
+				</thead>
+				<tbody>
+					{domains.map((d) => (
+						<tr
+							key={d.domain}
+							className="border-b border-line last:border-b-0 hover:bg-paper-2 transition-colors"
+						>
+							<td className="px-4 py-3">
+								<RouterLink
+									to={`/domains/${encodeURIComponent(d.domain)}`}
+									className="text-ink hover:text-accent transition-colors"
+								>
+									{d.domain}
+								</RouterLink>
+							</td>
+							<td className="px-4 py-3 text-right pp-mono tabular-nums text-ink-2">
+								{d.mailboxesCount}
+							</td>
+							<td className="px-4 py-3 text-right pp-mono tabular-nums text-ink-2">
+								{d.threatsBlocked24h}
+							</td>
+							<td className="px-4 py-3 text-right pp-mono tabular-nums text-ink-2">
+								{d.openCases}
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -4,6 +4,8 @@
 
 import type {
 	DashboardSummary,
+	DomainListEntry,
+	DomainStats,
 	Email,
 	Folder,
 	HubContributionsResponse,
@@ -179,6 +181,16 @@ const api = {
 	// Org overview
 	getOrgOverview: (opts?: { signal?: AbortSignal }) =>
 		get<OrgOverview>("/api/v1/org/overview", { signal: opts?.signal }),
+
+	// Domains (#85). Domain identifiers are hostname-shaped (a-z, 0-9, hyphen,
+	// dot); they don't need encodeURIComponent for those characters, but we
+	// still encode defensively in case future IDN handling lands.
+	listDomains: (opts?: { signal?: AbortSignal }) =>
+		get<DomainListEntry[]>("/api/v1/domains", { signal: opts?.signal }),
+	getDomainStats: (domain: string, opts?: { signal?: AbortSignal }) =>
+		get<DomainStats>(`/api/v1/domains/${encodeURIComponent(domain)}/stats`, {
+			signal: opts?.signal,
+		}),
 
 	// Hub
 	getHubContributions: (mailboxId: string, opts?: { signal?: AbortSignal }) =>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -235,6 +235,49 @@ export interface OrgOverview {
 	hubContributions24h: number;
 }
 
+/**
+ * DMARC posture surfaced on the per-domain dashboard (#85). v1 best-effort:
+ * we don't have a real DMARC TXT-record / aggregate-report ingestion pipeline
+ * scoped to the apex domain yet, so all fields are nullable. Real ingestion
+ * is out of scope for #85 and tracked separately.
+ */
+export interface DmarcPosture {
+	p: string | null;
+	sp: string | null;
+	pct: number | null;
+	ruaConfigured: boolean | null;
+	alignmentRate: number | null;
+}
+
+/** One row in the `/api/v1/domains` list. */
+export interface DomainListEntry {
+	domain: string;
+	mailboxesCount: number;
+	threatsBlocked24h: number;
+	openCases: number;
+	verdictMix: OrgVerdictMix;
+}
+
+/** Mailbox row inside a `/api/v1/domains/:domain/stats` payload. */
+export interface DomainMailboxRef {
+	id: string;
+	email: string;
+	name: string;
+}
+
+/** `/api/v1/domains/:domain/stats` payload — drill-down dashboard for one domain. */
+export interface DomainStats {
+	now: string;
+	domain: string;
+	mailboxes: DomainMailboxRef[];
+	threatsBlocked24h: number;
+	threatsBlocked7d: number;
+	openCases: number;
+	verdictMix: OrgVerdictMix;
+	dmarcPosture: DmarcPosture;
+	recentCases: DashboardCase[];
+}
+
 export interface HubContribution {
 	uuid: string;
 	info: string;

--- a/tests/frontend/breadcrumb.test.tsx
+++ b/tests/frontend/breadcrumb.test.tsx
@@ -18,6 +18,8 @@ function renderBreadcrumb(initialEntry: string) {
 		<Routes>
 			<Route path="/" element={<Breadcrumb />} />
 			<Route path="/mailboxes" element={<Breadcrumb />} />
+			<Route path="/domains" element={<Breadcrumb />} />
+			<Route path="/domains/:domain" element={<Breadcrumb />} />
 			<Route path="/mailbox/:mailboxId/*" element={<Breadcrumb />} />
 		</Routes>,
 		{ initialEntries: [initialEntry] },
@@ -49,16 +51,22 @@ describe("Breadcrumb", () => {
 		);
 	});
 
-	it("renders Org › alice@acme.com › Cases › CASE-1 on /mailbox/m1/cases/CASE-1", () => {
+	it("renders Org › acme.com › alice@acme.com › Cases › CASE-1 on /mailbox/m1/cases/CASE-1 (#85)", () => {
 		renderBreadcrumb("/mailbox/m1/cases/CASE-1");
 		const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
 		const items = within(nav).getAllByRole("listitem");
-		expect(items).toHaveLength(4);
+		// Org / domain / mailbox / Cases / CASE-1
+		expect(items).toHaveLength(5);
 
 		// Org → / link.
 		expect(within(nav).getByRole("link", { name: "Org" })).toHaveAttribute(
 			"href",
 			"/",
+		);
+		// Domain segment links to the per-domain drill-down.
+		expect(within(nav).getByRole("link", { name: "acme.com" })).toHaveAttribute(
+			"href",
+			"/domains/acme.com",
 		);
 		// Mailbox link uses email.
 		expect(
@@ -77,9 +85,42 @@ describe("Breadcrumb", () => {
 		);
 	});
 
+	it("renders Org › Domains on /domains (#85)", () => {
+		renderBreadcrumb("/domains");
+		const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
+		const items = within(nav).getAllByRole("listitem");
+		expect(items).toHaveLength(2);
+		expect(within(nav).getByRole("link", { name: "Org" })).toHaveAttribute(
+			"href",
+			"/",
+		);
+		expect(within(nav).getByText("Domains")).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+	});
+
+	it("renders Org › acme.com on /domains/acme.com (#85)", () => {
+		renderBreadcrumb("/domains/acme.com");
+		const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
+		const items = within(nav).getAllByRole("listitem");
+		expect(items).toHaveLength(2);
+		expect(within(nav).getByRole("link", { name: "Org" })).toHaveAttribute(
+			"href",
+			"/",
+		);
+		expect(within(nav).queryByRole("link", { name: "acme.com" })).toBeNull();
+		expect(within(nav).getByText("acme.com")).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+	});
+
 	it("uses a monospaced separator between segments", () => {
 		const { container } = renderBreadcrumb("/mailbox/m1/dashboard");
-		// Three segments → two separators.
+		// Org / acme.com / mailbox / Dashboard → at least three separators
+		// once the domain segment is injected (#85). The lower bound stays
+		// permissive so the test doesn't drift on future segment changes.
 		const separators = container.querySelectorAll(".pp-mono");
 		expect(separators.length).toBeGreaterThanOrEqual(2);
 		separators.forEach((sep) => {

--- a/tests/frontend/domain-detail.test.tsx
+++ b/tests/frontend/domain-detail.test.tsx
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+import type { DomainStats } from "~/types";
+
+const refetch = vi.fn();
+let queryState: {
+	data: DomainStats | undefined;
+	isLoading: boolean;
+	isError: boolean;
+};
+
+vi.mock("~/queries/domains", () => ({
+	useDomainStats: () => ({ ...queryState, refetch }),
+}));
+
+// Shell pulls in mailbox/dashboard data — keep these stubs identical to
+// `home.test.tsx` so we render the route in isolation rather than fanning
+// out to real fetchers.
+vi.mock("~/queries/mailboxes", () => ({
+	useMailboxes: () => ({ data: [], refetch: vi.fn(), isFetched: true }),
+	useMailbox: () => ({ data: undefined }),
+}));
+
+vi.mock("~/queries/dashboard", () => ({
+	useDashboardSummary: () => ({ data: undefined }),
+}));
+
+import DomainDetailRoute from "~/routes/domain-detail";
+import { renderWithProviders } from "./test-utils";
+
+function renderDomainDetail(domain: string) {
+	return renderWithProviders(
+		<Routes>
+			<Route path="/domains/:domain" element={<DomainDetailRoute />} />
+			<Route
+				path="/mailbox/:mailboxId/dashboard"
+				element={<div>Mailbox dashboard</div>}
+			/>
+		</Routes>,
+		{ initialEntries: [`/domains/${encodeURIComponent(domain)}`] },
+	);
+}
+
+const populated: DomainStats = {
+	now: "2026-04-29T12:00:00Z",
+	domain: "acme.com",
+	mailboxes: [
+		{ id: "alice@acme.com", email: "alice@acme.com", name: "Alice" },
+		{ id: "bob@acme.com", email: "bob@acme.com", name: "Bob" },
+	],
+	threatsBlocked24h: 12,
+	threatsBlocked7d: 84,
+	openCases: 5,
+	verdictMix: { safe: 50, suspicious: 6, phishing: 3, spam: 8, bec: 1 },
+	dmarcPosture: {
+		p: null,
+		sp: null,
+		pct: null,
+		ruaConfigured: null,
+		alignmentRate: null,
+	},
+	recentCases: [
+		{
+			id: "C1",
+			title: "Suspicious wire transfer",
+			status: "open",
+			updated_at: "2026-04-29T11:00:00Z",
+		},
+	],
+};
+
+describe("DomainDetailRoute", () => {
+	beforeEach(() => {
+		refetch.mockReset();
+	});
+
+	it("renders the loader while the query is pending", () => {
+		queryState = { data: undefined, isLoading: true, isError: false };
+		renderDomainDetail("acme.com");
+		// Domain header is always shown (also appears in the breadcrumb);
+		// KPIs only after data lands.
+		expect(screen.getAllByText("acme.com").length).toBeGreaterThanOrEqual(1);
+		expect(screen.getByRole("heading", { name: "acme.com" })).toBeInTheDocument();
+		expect(screen.queryByText(/threats blocked · 24h/i)).not.toBeInTheDocument();
+	});
+
+	it("renders error UI with a working retry when the query fails", async () => {
+		queryState = { data: undefined, isLoading: false, isError: true };
+		renderDomainDetail("acme.com");
+		expect(screen.getByText(/couldn't load this domain/i)).toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+		expect(refetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders KPIs, mailbox links, and DMARC null-posture affordance", () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderDomainDetail("acme.com");
+
+		// KPIs.
+		expect(screen.getByText(/threats blocked · 24h/i)).toBeInTheDocument();
+		expect(screen.getByText("12")).toBeInTheDocument();
+		expect(screen.getByText("84")).toBeInTheDocument();
+		// Open cases = 5.
+		expect(screen.getByText("5")).toBeInTheDocument();
+
+		// Each mailbox links to its per-mailbox dashboard.
+		const aliceLink = screen.getByRole("link", { name: /alice@acme.com/i });
+		expect(aliceLink).toHaveAttribute(
+			"href",
+			"/mailbox/alice%40acme.com/dashboard",
+		);
+		const bobLink = screen.getByRole("link", { name: /bob@acme.com/i });
+		expect(bobLink).toHaveAttribute(
+			"href",
+			"/mailbox/bob%40acme.com/dashboard",
+		);
+
+		// DMARC posture v1 is all-null — the UI explains why rather than
+		// rendering misleading defaults.
+		expect(
+			screen.getByText(/apex-domain dmarc posture isn't ingested yet/i),
+		).toBeInTheDocument();
+
+		// Recent cases panel.
+		expect(screen.getByText(/recent cases/i)).toBeInTheDocument();
+		expect(screen.getByText(/suspicious wire transfer/i)).toBeInTheDocument();
+	});
+
+	it("renders the DMARC fields when posture data is present (forward-compatible)", () => {
+		queryState = {
+			data: {
+				...populated,
+				dmarcPosture: {
+					p: "reject",
+					sp: "reject",
+					pct: 100,
+					ruaConfigured: true,
+					alignmentRate: 0.97,
+				},
+			},
+			isLoading: false,
+			isError: false,
+		};
+		renderDomainDetail("acme.com");
+		// Both `p` and `sp` show "reject"; assert via the DOM list rather than
+		// counting matches so the test stays readable.
+		const dmarcCard = screen
+			.getByText(/dmarc posture/i)
+			.closest(".pp-card") as HTMLElement;
+		expect(within(dmarcCard).getAllByText("reject")).toHaveLength(2);
+		expect(within(dmarcCard).getByText("100%")).toBeInTheDocument();
+		expect(within(dmarcCard).getByText("configured")).toBeInTheDocument();
+		expect(within(dmarcCard).getByText("97%")).toBeInTheDocument();
+	});
+});

--- a/tests/lib/domain-aggregation.test.ts
+++ b/tests/lib/domain-aggregation.test.ts
@@ -1,0 +1,307 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, expect, it } from "vitest";
+import {
+	aggregateDomainStats,
+	aggregateDomainsList,
+	domainOf,
+	emptyDmarcPosture,
+	type DomainMailboxSummary,
+	type OrgMailboxSummary,
+} from "../../workers/lib/dashboard-aggregation";
+
+const NOW = new Date("2026-04-29T12:00:00Z");
+
+function verdictRow(action: string, label: string, date = NOW.toISOString()) {
+	return {
+		date,
+		security_verdict: JSON.stringify({
+			action,
+			classification: { label },
+		}),
+	};
+}
+
+function summary(partial: Partial<OrgMailboxSummary> = {}): OrgMailboxSummary {
+	return {
+		threatsBlocked: 0,
+		threatsBlocked7d: 0,
+		openCases: 0,
+		hubContributions: 0,
+		pipelineScan: { completed: 0, failed: 0 },
+		verdictRows: [],
+		...partial,
+	};
+}
+
+function domainSummary(
+	partial: Partial<DomainMailboxSummary> = {},
+): DomainMailboxSummary {
+	return {
+		threatsBlocked: 0,
+		threatsBlocked7d: 0,
+		openCases: 0,
+		hubContributions: 0,
+		pipelineScan: { completed: 0, failed: 0 },
+		verdictRows: [],
+		...partial,
+	};
+}
+
+describe("domainOf", () => {
+	it("lowercases the part after the last @", () => {
+		expect(domainOf("Alice@Acme.COM")).toBe("acme.com");
+	});
+
+	it("returns null for malformed input", () => {
+		expect(domainOf("noatsymbol")).toBeNull();
+		expect(domainOf("trailing@")).toBeNull();
+		// Empty local part is also rejected — `@nopart` is not a valid address.
+		expect(domainOf("@nopart")).toBeNull();
+		expect(domainOf("")).toBeNull();
+	});
+});
+
+describe("emptyDmarcPosture", () => {
+	it("returns an all-null posture sentinel", () => {
+		expect(emptyDmarcPosture()).toEqual({
+			p: null,
+			sp: null,
+			pct: null,
+			ruaConfigured: null,
+			alignmentRate: null,
+		});
+	});
+});
+
+describe("aggregateDomainsList", () => {
+	it("returns empty list when no mailboxes are provisioned", () => {
+		expect(aggregateDomainsList({ mailboxes: [], summaries: [] })).toEqual([]);
+	});
+
+	it("groups mailboxes by lower-cased domain and sums counts", () => {
+		const list = aggregateDomainsList({
+			mailboxes: [
+				{ id: "alice@ACME.com", email: "alice@ACME.com" },
+				{ id: "bob@acme.com", email: "bob@acme.com" },
+				{ id: "carol@example.org", email: "carol@example.org" },
+			],
+			summaries: [
+				summary({
+					threatsBlocked: 3,
+					openCases: 2,
+					verdictRows: [
+						verdictRow("block", "phishing"),
+						verdictRow("tag", "spam"),
+					],
+				}),
+				summary({
+					threatsBlocked: 1,
+					openCases: 1,
+					verdictRows: [verdictRow("quarantine", "phishing")],
+				}),
+				summary({
+					threatsBlocked: 0,
+					openCases: 0,
+					verdictRows: [verdictRow("allow", "safe")],
+				}),
+			],
+		});
+
+		expect(list).toHaveLength(2);
+
+		// Sorted alphabetically by domain.
+		const acme = list.find((d) => d.domain === "acme.com")!;
+		expect(acme).toMatchObject({
+			domain: "acme.com",
+			mailboxesCount: 2,
+			threatsBlocked24h: 4,
+			openCases: 3,
+		});
+		expect(acme.verdictMix).toEqual({
+			safe: 0,
+			suspicious: 0,
+			phishing: 2,
+			spam: 1,
+			bec: 0,
+		});
+
+		const example = list.find((d) => d.domain === "example.org")!;
+		expect(example).toMatchObject({
+			domain: "example.org",
+			mailboxesCount: 1,
+			threatsBlocked24h: 0,
+			openCases: 0,
+		});
+		expect(example.verdictMix).toEqual({
+			safe: 1,
+			suspicious: 0,
+			phishing: 0,
+			spam: 0,
+			bec: 0,
+		});
+	});
+
+	it("treats null (failed) summaries as zero contributions but still counts the mailbox", () => {
+		const list = aggregateDomainsList({
+			mailboxes: [
+				{ id: "a@x.com", email: "a@x.com" },
+				{ id: "b@x.com", email: "b@x.com" },
+			],
+			summaries: [
+				summary({ threatsBlocked: 5, openCases: 1 }),
+				null, // DO call failed
+			],
+		});
+		expect(list).toHaveLength(1);
+		expect(list[0]).toMatchObject({
+			domain: "x.com",
+			mailboxesCount: 2,
+			threatsBlocked24h: 5,
+			openCases: 1,
+		});
+	});
+
+	it("skips mailboxes whose email has no domain part", () => {
+		const list = aggregateDomainsList({
+			mailboxes: [{ id: "malformed", email: "malformed" }],
+			summaries: [summary({ threatsBlocked: 99 })],
+		});
+		expect(list).toEqual([]);
+	});
+});
+
+describe("aggregateDomainStats", () => {
+	it("returns null when no mailboxes match the domain", () => {
+		expect(
+			aggregateDomainStats({
+				domain: "acme.com",
+				mailboxes: [],
+				summaries: [],
+				now: NOW.toISOString(),
+			}),
+		).toBeNull();
+	});
+
+	it("sums per-mailbox counters and includes the mailbox roster", () => {
+		const result = aggregateDomainStats({
+			domain: "acme.com",
+			mailboxes: [
+				{ id: "alice@acme.com", email: "alice@acme.com", name: "Alice" },
+				{ id: "bob@acme.com", email: "bob@acme.com", name: "Bob" },
+			],
+			summaries: [
+				domainSummary({
+					threatsBlocked: 3,
+					threatsBlocked7d: 21,
+					openCases: 2,
+					verdictRows: [
+						verdictRow("block", "phishing"),
+						verdictRow("tag", "spam"),
+					],
+					recentCases: [
+						{
+							id: "C2",
+							title: "Newer case",
+							status: "open",
+							updated_at: "2026-04-29T10:00:00Z",
+						},
+					],
+				}),
+				domainSummary({
+					threatsBlocked: 1,
+					threatsBlocked7d: 7,
+					openCases: 0,
+					verdictRows: [verdictRow("quarantine", "phishing")],
+					recentCases: [
+						{
+							id: "C1",
+							title: "Older case",
+							status: "open",
+							updated_at: "2026-04-28T10:00:00Z",
+						},
+					],
+				}),
+			],
+			now: NOW.toISOString(),
+		});
+
+		expect(result).not.toBeNull();
+		expect(result!.domain).toBe("acme.com");
+		expect(result!.mailboxes).toHaveLength(2);
+		expect(result!.threatsBlocked24h).toBe(4);
+		expect(result!.threatsBlocked7d).toBe(28);
+		expect(result!.openCases).toBe(2);
+		expect(result!.verdictMix).toEqual({
+			safe: 0,
+			suspicious: 0,
+			phishing: 2,
+			spam: 1,
+			bec: 0,
+		});
+		// Recent cases are merged across mailboxes and sorted newest-first.
+		expect(result!.recentCases.map((c) => c.id)).toEqual(["C2", "C1"]);
+	});
+
+	it("returns an all-null DMARC posture (v1 best-effort)", () => {
+		const result = aggregateDomainStats({
+			domain: "acme.com",
+			mailboxes: [
+				{ id: "alice@acme.com", email: "alice@acme.com", name: "Alice" },
+			],
+			summaries: [domainSummary()],
+			now: NOW.toISOString(),
+		});
+		expect(result!.dmarcPosture).toEqual({
+			p: null,
+			sp: null,
+			pct: null,
+			ruaConfigured: null,
+			alignmentRate: null,
+		});
+	});
+
+	it("tolerates null (failed) summaries as zero contributions", () => {
+		const result = aggregateDomainStats({
+			domain: "acme.com",
+			mailboxes: [
+				{ id: "alice@acme.com", email: "alice@acme.com", name: "Alice" },
+				{ id: "bob@acme.com", email: "bob@acme.com", name: "Bob" },
+			],
+			summaries: [
+				domainSummary({ threatsBlocked: 7, openCases: 4 }),
+				null,
+			],
+			now: NOW.toISOString(),
+		});
+		expect(result!.threatsBlocked24h).toBe(7);
+		expect(result!.openCases).toBe(4);
+		expect(result!.mailboxes).toHaveLength(2);
+	});
+
+	it("caps recentCases at 5", () => {
+		const cases = Array.from({ length: 10 }, (_, i) => ({
+			id: `C${i}`,
+			title: `Case ${i}`,
+			status: "open",
+			updated_at: `2026-04-${String(20 + i).padStart(2, "0")}T10:00:00Z`,
+		}));
+		const result = aggregateDomainStats({
+			domain: "acme.com",
+			mailboxes: [
+				{ id: "alice@acme.com", email: "alice@acme.com", name: "Alice" },
+			],
+			summaries: [domainSummary({ recentCases: cases })],
+			now: NOW.toISOString(),
+		});
+		expect(result!.recentCases).toHaveLength(5);
+		// Newest five (C9..C5).
+		expect(result!.recentCases.map((c) => c.id)).toEqual([
+			"C9",
+			"C8",
+			"C7",
+			"C6",
+			"C5",
+		]);
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -30,10 +30,17 @@ import { dmarcRoutes } from "./routes/dmarc";
 import { caseRoutes } from "./routes/cases";
 import { hubUiRoutes } from "./routes/hub-ui";
 import {
+	aggregateDomainStats,
+	aggregateDomainsList,
 	aggregateOrgOverview,
 	bucketThreatPressure,
 	computeP95,
+	domainOf,
 	pipelineSuccessRate,
+	type DomainListEntry,
+	type DomainMailboxRef,
+	type DomainMailboxSummary,
+	type DomainStats,
 	type OrgMailboxSummary,
 	type OrgOverview,
 } from "./lib/dashboard-aggregation";
@@ -186,6 +193,126 @@ app.get("/api/v1/org/overview", async (c) => {
 	}
 
 	return c.json(overview);
+});
+
+// -- Per-domain stats + drill-down (#85) ----------------------------
+
+/** Versioned KV keys — bumping the prefix on schema change is a clean rename. */
+const DOMAINS_LIST_CACHE_KEY = "domains:v1";
+const DOMAIN_STATS_CACHE_KEY_PREFIX = "domain-stats:v1:";
+const DOMAIN_CACHE_TTL_S = 60;
+
+/**
+ * Hostname-shape regex. Mirrors RFC 1035 / 5890 lite: at least two labels,
+ * each label 1–63 chars, alphanumeric with internal hyphens, total length
+ * ≤253. Lower-cased before matching. Rejects `acme..com`, `acme/foo`,
+ * IDNs (out of scope for v1), and anything with whitespace.
+ */
+const DOMAIN_REGEX =
+	/^(?=.{1,253}$)[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$/i;
+
+app.get("/api/v1/domains", async (c) => {
+	const cached = c.env.BLOOM_KV
+		? await c.env.BLOOM_KV.get(DOMAINS_LIST_CACHE_KEY, "json").catch(() => null)
+		: null;
+	if (cached) {
+		return c.json(cached as DomainListEntry[]);
+	}
+
+	const mailboxes = await listMailboxes(c.env.BUCKET);
+	const settled = await Promise.allSettled(
+		mailboxes.map((m) =>
+			c.env.MAILBOX
+				.get(c.env.MAILBOX.idFromName(m.id))
+				.getDashboardSummary(),
+		),
+	);
+	const summaries: Array<OrgMailboxSummary | null> = settled.map((r) => {
+		if (r.status !== "fulfilled") {
+			console.error("domains-list: mailbox summary failed:", (r.reason as Error)?.message);
+			return null;
+		}
+		const v = r.value as OrgMailboxSummary;
+		return { ...v, threatsBlocked7d: v.threatsBlocked7d ?? 0 };
+	});
+
+	const list = aggregateDomainsList({ mailboxes, summaries });
+
+	if (c.env.BLOOM_KV) {
+		c.executionCtx.waitUntil(
+			c.env.BLOOM_KV.put(DOMAINS_LIST_CACHE_KEY, JSON.stringify(list), {
+				expirationTtl: DOMAIN_CACHE_TTL_S,
+			}).catch((e) => console.error("domains-list cache write failed:", (e as Error).message)),
+		);
+	}
+
+	return c.json(list);
+});
+
+app.get("/api/v1/domains/:domain/stats", async (c) => {
+	const raw = c.req.param("domain") ?? "";
+	const domain = decodeURIComponent(raw).toLowerCase();
+	if (!DOMAIN_REGEX.test(domain)) {
+		return c.json({ error: "Malformed domain" }, 400);
+	}
+
+	const cacheKey = `${DOMAIN_STATS_CACHE_KEY_PREFIX}${domain}`;
+	const cached = c.env.BLOOM_KV
+		? await c.env.BLOOM_KV.get(cacheKey, "json").catch(() => null)
+		: null;
+	if (cached) {
+		return c.json(cached as DomainStats);
+	}
+
+	const allMailboxes = await listMailboxes(c.env.BUCKET);
+	const scoped = allMailboxes.filter((m) => domainOf(m.email) === domain);
+	if (scoped.length === 0) {
+		return c.json({ error: "Domain not found" }, 404);
+	}
+
+	const settled = await Promise.allSettled(
+		scoped.map((m) =>
+			c.env.MAILBOX
+				.get(c.env.MAILBOX.idFromName(m.id))
+				.getDashboardSummary(),
+		),
+	);
+	const summaries: Array<DomainMailboxSummary | null> = settled.map((r) => {
+		if (r.status !== "fulfilled") {
+			console.error("domain-stats: mailbox summary failed:", (r.reason as Error)?.message);
+			return null;
+		}
+		const v = r.value as DomainMailboxSummary;
+		return { ...v, threatsBlocked7d: v.threatsBlocked7d ?? 0 };
+	});
+
+	const mailboxRefs: DomainMailboxRef[] = scoped.map((m) => ({
+		id: m.id,
+		email: m.email,
+		name: m.id,
+	}));
+
+	const stats = aggregateDomainStats({
+		domain,
+		mailboxes: mailboxRefs,
+		summaries,
+	});
+	// `aggregateDomainStats` only returns null when `mailboxes.length === 0`,
+	// which we already guarded above with the 404 — but narrow the type
+	// defensively in case the helper's contract changes later.
+	if (!stats) {
+		return c.json({ error: "Domain not found" }, 404);
+	}
+
+	if (c.env.BLOOM_KV) {
+		c.executionCtx.waitUntil(
+			c.env.BLOOM_KV.put(cacheKey, JSON.stringify(stats), {
+				expirationTtl: DOMAIN_CACHE_TTL_S,
+			}).catch((e) => console.error("domain-stats cache write failed:", (e as Error).message)),
+		);
+	}
+
+	return c.json(stats);
 });
 
 app.post("/api/v1/mailboxes", async (c) => {

--- a/workers/lib/dashboard-aggregation.ts
+++ b/workers/lib/dashboard-aggregation.ts
@@ -395,3 +395,220 @@ export function aggregateOrgOverview(
 		hubContributions24h,
 	};
 }
+
+// ── Per-domain aggregation (#85) ─────────────────────────────────────
+
+/** Recent-case shape mirrored from the per-mailbox dashboard summary. */
+export interface DomainRecentCase {
+	id: string;
+	title: string;
+	status: string;
+	updated_at: string;
+}
+
+/** DMARC posture v1 — best-effort, all fields nullable.
+ *
+ * v1 best-effort — real DMARC report ingestion (parsing apex-domain TXT
+ * records / aggregating rua reports across mailboxes into a single posture)
+ * is out of scope (#85). Per-mailbox DMARC summaries already exist
+ * (`workers/routes/dmarc.ts`) but they're scoped to source-IP rollups, not
+ * apex-domain policy. Until that pipeline ships, we return null fields and
+ * the UI renders an "unavailable" affordance. */
+export interface DmarcPosture {
+	p: string | null;
+	sp: string | null;
+	pct: number | null;
+	ruaConfigured: boolean | null;
+	alignmentRate: number | null;
+}
+
+export interface DomainListEntry {
+	domain: string;
+	mailboxesCount: number;
+	threatsBlocked24h: number;
+	openCases: number;
+	verdictMix: VerdictMix;
+}
+
+export interface DomainMailboxRef {
+	id: string;
+	email: string;
+	name: string;
+}
+
+export interface DomainStats {
+	now: string;
+	domain: string;
+	mailboxes: DomainMailboxRef[];
+	threatsBlocked24h: number;
+	threatsBlocked7d: number;
+	openCases: number;
+	verdictMix: VerdictMix;
+	dmarcPosture: DmarcPosture;
+	recentCases: DomainRecentCase[];
+}
+
+/** Per-mailbox summary tail used by the org-overview path; we reuse the same
+ * shape here so the handler can pass through `getDashboardSummary()` results
+ * unchanged. `recentCases` lives on the live DO summary even though the org
+ * aggregator drops it. */
+export interface DomainMailboxSummary extends OrgMailboxSummary {
+	recentCases?: DomainRecentCase[];
+}
+
+/** Lower-cased domain extracted from an email address, or null when malformed.
+ *
+ * Requires a non-empty local part and a non-empty domain part — `@nopart`
+ * and `noatsymbol` both return null. */
+export function domainOf(email: string): string | null {
+	const at = email.lastIndexOf("@");
+	if (at <= 0 || at === email.length - 1) return null;
+	const domain = email.slice(at + 1).toLowerCase();
+	return domain || null;
+}
+
+/** Empty DMARC posture sentinel — every field null, signalling
+ * "no real ingestion yet" to the UI. */
+export function emptyDmarcPosture(): DmarcPosture {
+	return {
+		p: null,
+		sp: null,
+		pct: null,
+		ruaConfigured: null,
+		alignmentRate: null,
+	};
+}
+
+interface AggregateDomainsListInput {
+	mailboxes: OrgMailboxRef[];
+	/** Indices align with `mailboxes`. `null` = DO call failed → contributes 0. */
+	summaries: Array<OrgMailboxSummary | null>;
+}
+
+/**
+ * Reduce per-mailbox summaries into a per-domain list. Pure function —
+ * mailboxes whose email doesn't have a domain part are skipped silently.
+ */
+export function aggregateDomainsList(
+	input: AggregateDomainsListInput,
+): DomainListEntry[] {
+	const { mailboxes, summaries } = input;
+
+	interface Acc {
+		mailboxesCount: number;
+		threatsBlocked24h: number;
+		openCases: number;
+		verdictMix: VerdictMix;
+	}
+	const byDomain = new Map<string, Acc>();
+
+	for (let i = 0; i < mailboxes.length; i++) {
+		const m = mailboxes[i]!;
+		const domain = domainOf(m.email);
+		if (!domain) continue;
+
+		let acc = byDomain.get(domain);
+		if (!acc) {
+			acc = {
+				mailboxesCount: 0,
+				threatsBlocked24h: 0,
+				openCases: 0,
+				verdictMix: emptyVerdictMix(),
+			};
+			byDomain.set(domain, acc);
+		}
+		acc.mailboxesCount += 1;
+
+		const summary = summaries[i];
+		if (!summary) continue;
+		acc.threatsBlocked24h += summary.threatsBlocked;
+		acc.openCases += summary.openCases;
+
+		// 24h verdict mix — sum each mailbox's parsed `verdictRows`. Mirrors
+		// `aggregateOrgOverview`'s mix derivation so the per-domain numbers
+		// reconcile with the org-wide totals.
+		for (const row of summary.verdictRows) {
+			if (!row.security_verdict) continue;
+			const parsed = parseVerdict(row.security_verdict);
+			if (!parsed) continue;
+			const label = parsed.classification?.label;
+			if (
+				typeof label === "string" &&
+				(VERDICT_MIX_KEYS as readonly string[]).includes(label)
+			) {
+				acc.verdictMix[label as keyof VerdictMix] += 1;
+			}
+		}
+	}
+
+	return [...byDomain.entries()]
+		.map(([domain, acc]) => ({ domain, ...acc }))
+		.sort((a, b) => a.domain.localeCompare(b.domain));
+}
+
+interface AggregateDomainStatsInput {
+	domain: string;
+	mailboxes: DomainMailboxRef[];
+	/** Indices align with `mailboxes`. `null` = DO call failed → contributes 0. */
+	summaries: Array<DomainMailboxSummary | null>;
+	now?: string;
+}
+
+/**
+ * Reduce per-mailbox summaries scoped to a single domain. Caller is
+ * responsible for filtering `mailboxes` to only those whose domain matches
+ * (lower-cased). Returns `null` when the input is empty so the handler can
+ * 404 cleanly without rendering a "0 mailboxes" page.
+ */
+export function aggregateDomainStats(
+	input: AggregateDomainStatsInput,
+): DomainStats | null {
+	const { domain, mailboxes, summaries } = input;
+	if (mailboxes.length === 0) return null;
+	const now = input.now ?? new Date().toISOString();
+
+	let threatsBlocked24h = 0;
+	let threatsBlocked7d = 0;
+	let openCases = 0;
+	const verdictMix = emptyVerdictMix();
+	const recentCases: DomainRecentCase[] = [];
+
+	for (const summary of summaries) {
+		if (!summary) continue;
+		threatsBlocked24h += summary.threatsBlocked;
+		threatsBlocked7d += summary.threatsBlocked7d;
+		openCases += summary.openCases;
+
+		for (const row of summary.verdictRows) {
+			if (!row.security_verdict) continue;
+			const parsed = parseVerdict(row.security_verdict);
+			if (!parsed) continue;
+			const label = parsed.classification?.label;
+			if (
+				typeof label === "string" &&
+				(VERDICT_MIX_KEYS as readonly string[]).includes(label)
+			) {
+				verdictMix[label as keyof VerdictMix] += 1;
+			}
+		}
+
+		if (Array.isArray(summary.recentCases)) {
+			recentCases.push(...summary.recentCases);
+		}
+	}
+
+	// Most-recent first, then cap. ISO-8601 strings sort lexically.
+	recentCases.sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1));
+
+	return {
+		now,
+		domain,
+		mailboxes,
+		threatsBlocked24h,
+		threatsBlocked7d,
+		openCases,
+		verdictMix,
+		dmarcPosture: emptyDmarcPosture(),
+		recentCases: recentCases.slice(0, 5),
+	};
+}


### PR DESCRIPTION
## Summary

Phase 2 of the org → domain → mailbox nav hierarchy (#85). Domain is
derived from the lower-cased part after `@` in each mailbox email —
no `Domain` schema yet, just grouping.

- **Backend**: two new endpoints, both fan-out-and-cache (60s KV TTL)
  using the same pattern as `/api/v1/org/overview`.
  - `GET /api/v1/domains` — `[{domain, mailboxesCount, threatsBlocked24h, openCases, verdictMix}]`
  - `GET /api/v1/domains/:domain/stats` — full per-domain dashboard payload
  - Hostname regex validates `:domain` (malformed → 400, unknown → 404)
  - Pure aggregation helpers `aggregateDomainsList` + `aggregateDomainStats`
    in `workers/lib/dashboard-aggregation.ts` so the math is unit-testable
    without a SQL runtime.
- **Frontend**: `/domains` (table) and `/domains/:domain` (KPIs +
  verdict mix + DMARC posture + mailbox roster + recent cases). Each
  mailbox row links to `/mailbox/:id/dashboard`.
- **Breadcrumb**: extends to `Org / :domain / :email / ...` on
  mailbox routes (domain segment links to `/domains/:domain`), plus
  the two new top-level paths.
- **Sidebar**: new "Domains" entry next to "Mailboxes" so the route is
  discoverable.

### DMARC posture

`dmarcPosture` is returned with all fields `null` and a code comment
marking it v1 best-effort. Per-mailbox DMARC source today is
source-IP rollups (`workers/routes/dmarc.ts`), not apex-domain policy.
Real apex-domain ingestion is intentionally out of scope for #85; the
UI surfaces an "unavailable" affordance instead of misleading defaults.
Follow-up issue tracking the gap will be filed alongside this PR.

### Cache strategy

- `domains:v1` for the list endpoint (TTL 60s)
- `domain-stats:v1:<lowercased-domain>` for the stats endpoint (TTL 60s)
- Cache writes use `c.executionCtx.waitUntil` with `.catch` logging,
  exactly matching the org-overview handler.

## Test plan

- [x] `npm test` — **393 passing (375 baseline + 18 new)**
  - 11 new worker-side cases in `tests/lib/domain-aggregation.test.ts`
    (happy path with seeded mailboxes, null-summary tolerance,
    aggregation correctness, recentCases sort/cap, domain extraction,
    DMARC null posture)
  - 4 new frontend cases in `tests/frontend/domain-detail.test.tsx`
    (loading, error + retry, populated render with per-mailbox links,
    forward-compatible DMARC field rendering)
  - `tests/frontend/breadcrumb.test.tsx` updated to match the new shape
    (mailbox path now has 5 segments, plus 2 new cases for `/domains`
    and `/domains/:domain`)
- [x] `npm run typecheck` — clean
- [ ] Manual smoke: `wrangler dev`, hit `/domains` and `/domains/acme.com`
      with seeded mailboxes; confirm a malformed `:domain` returns 400
      and an unknown one returns 404.

## Out of scope

- Real apex-domain DMARC report ingestion (follow-up)
- Domain-level settings
- Nesting `/mailbox/:id` under `/domains/:domain`
- Sidebar nav adaptation to show only the current domain's mailboxes
  on `/domains/:domain` (the issue body mentioned this; a follow-up
  issue will track it)

Closes #85