### PR TITLE
docs: seed CLAUDE.md with conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file is loaded into Claude Code sessions working on this repo. It captures
+conventions surfaced by real incidents so future agents inherit the lesson
+without re-discovering it. Keep entries grounded in observed events; this is a
+seed, not a comprehensive style guide.
+
+## Conventions
+
+### URL host checks in test mocks must parse, not substring
+
+When a test routes mock `fetch` responses by URL, do **not** match with
+`url.startsWith("https://example.com")` or `url.includes("example.com")`.
+CodeQL's `js/incomplete-url-substring-sanitization` rule (high severity) flags
+those patterns as an SSRF / redirect-bypass risk even in test-only code, and
+PRs are gated on CodeQL — the alert blocks merge.
+
+Parse the URL and compare the parsed `hostname` instead:
+
+```ts
+// BAD
+if (url.startsWith("https://cti.api.crowdsec.net")) { ... }
+
+// GOOD
+if (new URL(url).hostname === "cti.api.crowdsec.net") { ... }
+
+// GOOD (host + path)
+const u = new URL(url);
+if (u.hostname === "cti.api.crowdsec.net" && u.pathname.startsWith("/v2/smoke/")) {
+  ...
+}
+```
+
+This applies to both mock dispatchers (deciding which canned response to
+return) and assertions (`expect(call[0]).startsWith(...)` → use the parsed
+equivalent).
+
+Origin: PR #130 (CrowdSec CTI deep-scan) — five test-only URL substring checks
+tripped CodeQL and required a fixup commit.
+
+### Don't race a SECURITY_SPEC.md update against a parallel doc PR
+
+`SECURITY_SPEC.md` codifies invariants the security pipeline enforces. When a
+code change narrows or extends one of those invariants, the spec needs to
+follow — but if both the code change and a separate spec-document PR are open
+at the same time, editing the spec from inside the code PR guarantees a merge
+conflict on whichever lands second.
+
+Instead:
+
+1. Land the code change first with the new behavior.
+2. In that PR's body, note: `follows up: narrow SECURITY_SPEC.md Rule N once
+   #<spec-PR-num> lands.`
+3. After both predecessors are on `main`, file a small `docs:` PR doing the
+   narrowing.
+
+Origin: PR #132 (Closes #28) changed Rule 5's timeout-vs-parse-fail behavior,
+deferred the spec edit to avoid racing PR #119 (which introduced the spec),
+and PR #134 narrowed the rule once both had landed.


### PR DESCRIPTION
## Summary

Adds a top-level `CLAUDE.md` to the repo. Claude Code auto-loads `CLAUDE.md` into agent sessions, so conventions placed there reach future agents working on the repo without anyone having to remember to point them at a doc. The repo didn't have one yet — this PR seeds it.

Kept short on purpose: only entries grounded in real incidents from the May 2 sweep. Two conventions:

1. **URL host checks in test mocks must parse, not substring.** CodeQL's `js/incomplete-url-substring-sanitization` rule (high severity) flags `url.startsWith(...)` / `url.includes(...)` as an SSRF / redirect-bypass pattern even in test-only code, and PRs are gated on CodeQL — the alert blocks merge. Use `new URL(url).hostname === ...` instead. Origin: PR #130 (CrowdSec CTI deep-scan), where five test-only substring checks required a fixup commit.

2. **Don't race a `SECURITY_SPEC.md` update against a parallel doc PR.** When a code change adjusts an invariant the spec codifies, and the spec is also being edited in a separate open PR, do the spec narrowing in a follow-up `docs:` PR after both predecessors land — otherwise the second to land guarantees a merge conflict. Origin: PR #132 (Closes #28), which deferred its spec edit until PR #119 landed; the narrowing followed as PR #134.

## What's NOT in here

No "Style Guide" or "Architecture Overview" sections — those don't belong in a seed grounded in incidents. Future PRs can extend if other conventions surface from observed events. No code or test changes.

## Test plan

- [ ] Reviewer: confirm no files other than `CLAUDE.md` are touched
- [ ] CodeQL / CI green (docs-only change)