### PR TITLE
feat: domain-scoped sidebar nav on /domains/:domain

### DIFF
--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -17,10 +17,12 @@ import {
 	XIcon,
 } from "@phosphor-icons/react";
 import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
-import { NavLink, useLocation, useNavigate, useParams } from "react-router";
+import { NavLink, useLocation, useMatch, useNavigate, useParams } from "react-router";
 import { useUIStore } from "~/hooks/useUIStore";
 import { useDashboardSummary } from "~/queries/dashboard";
+import { useDomainStats } from "~/queries/domains";
 import { useMailbox, useMailboxes } from "~/queries/mailboxes";
+import type { DomainMailboxRef } from "~/types";
 import AgentPanelSlot from "./AgentPanelSlot";
 import Breadcrumb from "./Breadcrumb";
 import Logo from "./Logo";
@@ -118,6 +120,16 @@ interface NavContentsProps {
 	onToggleTheme: () => void;
 	onSwitchOrg: () => void;
 	onPipelineClick: () => void;
+	/**
+	 * When the current route is `/domains/:domain`, the active domain plus
+	 * the mailboxes that belong to it (#139). Both fields are gated so other
+	 * routes never pay the network cost: `domain` is `undefined` off-route,
+	 * and `domainMailboxes` is `undefined` while the query is pending so the
+	 * sidebar can fall back to the org-level nav instead of flashing an
+	 * empty list.
+	 */
+	domain: string | undefined;
+	domainMailboxes: DomainMailboxRef[] | undefined;
 }
 
 // Shared sidebar contents — rendered inline on `md+` and inside the mobile
@@ -132,6 +144,8 @@ function NavContents({
 	onToggleTheme,
 	onSwitchOrg,
 	onPipelineClick,
+	domain,
+	domainMailboxes,
 }: NavContentsProps) {
 	const orgDomain = mailbox?.email?.split("@")[1] ?? "—";
 	const orgInitial = (mailbox?.name || mailbox?.email || "?")[0]?.toUpperCase();
@@ -214,6 +228,24 @@ function NavContents({
 							icon={<GearSixIcon size={16} />}
 							label="Settings"
 						/>
+					</>
+				)}
+				{/* Domain-scoped block (#139): on `/domains/:domain` surface the
+				    mailboxes that belong to the domain, mirroring the
+				    mailbox-scoped block above. Only render once the query has
+				    resolved — while pending we fall through to the org-level
+				    nav rather than flashing an empty list or "undefined". */}
+				{domain && domainMailboxes && domainMailboxes.length > 0 && (
+					<>
+						<SectionLabel>Mailboxes in {domain}</SectionLabel>
+						{domainMailboxes.map((mb) => (
+							<NavItem
+								key={mb.id}
+								to={`/mailbox/${encodeURIComponent(mb.id)}/dashboard`}
+								icon={<EnvelopeIcon size={16} />}
+								label={mb.email || mb.name || mb.id}
+							/>
+						))}
 					</>
 				)}
 			</nav>
@@ -301,6 +333,17 @@ export default function Shell({ children, rightPanel }: ShellProps) {
 	const { data: dashboardSummary } = useDashboardSummary(mailboxId);
 	const pipelineState = computePipelineState(dashboardSummary?.pipelineSuccess);
 
+	// `/domains/:domain` (#139). Use a route match rather than `useParams`
+	// because Shell can be rendered from either the per-domain route or the
+	// per-mailbox route; only the former should pull domain stats. The
+	// `useDomainStats` hook is `enabled: !!domain` internally, so passing
+	// `undefined` off-route is the gate that keeps other pages from paying
+	// the network cost.
+	const domainMatch = useMatch("/domains/:domain");
+	const rawDomain = domainMatch?.params.domain;
+	const activeDomain = rawDomain ? decodeURIComponent(rawDomain) : undefined;
+	const { data: domainStats } = useDomainStats(activeDomain);
+
 	const searchInputRef = useRef<HTMLInputElement>(null);
 	const [searchQuery, setSearchQuery] = useState("");
 
@@ -357,6 +400,8 @@ export default function Shell({ children, rightPanel }: ShellProps) {
 				closeSidebar();
 				navigate(`/mailbox/${encodeURIComponent(mailboxId)}/dashboard`);
 			}}
+			domain={activeDomain}
+			domainMailboxes={domainStats?.mailboxes}
 		/>
 	);
 

--- a/tests/frontend/domain-detail.test.tsx
+++ b/tests/frontend/domain-detail.test.tsx
@@ -107,13 +107,19 @@ describe("DomainDetailRoute", () => {
 		// Open cases = 5.
 		expect(screen.getByText("5")).toBeInTheDocument();
 
-		// Each mailbox links to its per-mailbox dashboard.
-		const aliceLink = screen.getByRole("link", { name: /alice@acme.com/i });
+		// Each mailbox links to its per-mailbox dashboard. Scope to the main
+		// content region — the domain-scoped sidebar nav (#139) also renders
+		// links to the same mailboxes, so the unscoped query would now match
+		// twice.
+		const main = screen.getByRole("main");
+		const aliceLink = within(main).getByRole("link", {
+			name: /alice@acme.com/i,
+		});
 		expect(aliceLink).toHaveAttribute(
 			"href",
 			"/mailbox/alice%40acme.com/dashboard",
 		);
-		const bobLink = screen.getByRole("link", { name: /bob@acme.com/i });
+		const bobLink = within(main).getByRole("link", { name: /bob@acme.com/i });
 		expect(bobLink).toHaveAttribute(
 			"href",
 			"/mailbox/bob%40acme.com/dashboard",

--- a/tests/frontend/shell-domain-nav.test.tsx
+++ b/tests/frontend/shell-domain-nav.test.tsx
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+import type { DomainStats } from "~/types";
+
+// Shared mutable state so individual tests can vary the domain query result
+// without reaching into the mock factory closure.
+let domainQueryState: {
+	data: DomainStats | undefined;
+	isLoading: boolean;
+	isError: boolean;
+} = { data: undefined, isLoading: false, isError: false };
+
+vi.mock("~/queries/domains", () => ({
+	useDomainStats: (domain: string | undefined) => {
+		// Mirror the production hook's `enabled: !!domain` gate so the test
+		// surfaces the same loading/empty contract.
+		if (!domain) {
+			return { data: undefined, isLoading: false, isError: false };
+		}
+		return domainQueryState;
+	},
+}));
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({
+		data: { id: "m1", email: "alice@acme.com", name: "Alice" },
+	}),
+	useMailboxes: () => ({
+		data: [{ id: "m1", email: "alice@acme.com", name: "Alice" }],
+	}),
+}));
+
+vi.mock("~/queries/dashboard", () => ({
+	useDashboardSummary: () => ({
+		data: undefined,
+		isLoading: false,
+		isError: false,
+	}),
+}));
+
+import Shell from "~/components/phishsoc/Shell";
+import { renderWithProviders } from "./test-utils";
+
+const populated: DomainStats = {
+	now: "2026-04-29T12:00:00Z",
+	domain: "acme.com",
+	mailboxes: [
+		{ id: "m1", email: "alice@acme.com", name: "Alice" },
+		{ id: "m2", email: "bob@acme.com", name: "Bob" },
+	],
+	threatsBlocked24h: 0,
+	threatsBlocked7d: 0,
+	openCases: 0,
+	verdictMix: { safe: 0, suspicious: 0, phishing: 0, spam: 0, bec: 0 },
+	dmarcPosture: {
+		p: null,
+		sp: null,
+		pct: null,
+		ruaConfigured: null,
+		alignmentRate: null,
+	},
+	recentCases: [],
+};
+
+function renderShellAt(initialEntries: string[]) {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/domains/:domain"
+				element={
+					<Shell>
+						<div>domain page</div>
+					</Shell>
+				}
+			/>
+			<Route
+				path="/mailbox/:mailboxId/*"
+				element={
+					<Shell>
+						<div>mailbox page</div>
+					</Shell>
+				}
+			/>
+			<Route
+				path="*"
+				element={
+					<Shell>
+						<div>fallback page</div>
+					</Shell>
+				}
+			/>
+		</Routes>,
+		{ initialEntries },
+	);
+}
+
+describe("Shell domain-scoped sidebar (#139)", () => {
+	it("renders 'Mailboxes in :domain' on /domains/:domain when stats have loaded", () => {
+		domainQueryState = { data: populated, isLoading: false, isError: false };
+		renderShellAt(["/domains/acme.com"]);
+
+		// Section label is present.
+		expect(screen.getByText(/mailboxes in acme\.com/i)).toBeInTheDocument();
+
+		// Each mailbox renders as a link to /mailbox/:id/dashboard.
+		const aliceLink = screen.getByRole("link", { name: /alice@acme\.com/i });
+		expect(aliceLink).toHaveAttribute("href", "/mailbox/m1/dashboard");
+		const bobLink = screen.getByRole("link", { name: /bob@acme\.com/i });
+		expect(bobLink).toHaveAttribute("href", "/mailbox/m2/dashboard");
+	});
+
+	it("falls back to org-level nav while the domain query is pending (no flash of 'undefined')", () => {
+		domainQueryState = { data: undefined, isLoading: true, isError: false };
+		const { container } = renderShellAt(["/domains/acme.com"]);
+
+		// No domain section header rendered.
+		expect(screen.queryByText(/mailboxes in/i)).toBeNull();
+		// And no leaked "undefined" text from a half-rendered list.
+		expect(container.textContent ?? "").not.toContain("undefined");
+
+		// Org-level nav still shows.
+		expect(screen.getByRole("link", { name: /org overview/i })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: /domains/i })).toBeInTheDocument();
+	});
+
+	it("does not render the domain section on /, /mailboxes, /domains, or /mailbox/:id/...", () => {
+		// Even if the (cached) query had data, the route match should keep
+		// the section out of the DOM on these other routes.
+		domainQueryState = { data: populated, isLoading: false, isError: false };
+
+		for (const path of [
+			"/",
+			"/mailboxes",
+			"/domains",
+			"/mailbox/m1/dashboard",
+		]) {
+			const { unmount } = renderShellAt([path]);
+			expect(
+				screen.queryByText(/mailboxes in acme\.com/i),
+				`should not render the domain section at ${path}`,
+			).toBeNull();
+			unmount();
+		}
+	});
+
+	it("URL-decodes the :domain route param in the section label", () => {
+		// Some callers might percent-encode the domain. The label should
+		// surface the human-readable form, matching the breadcrumb.
+		domainQueryState = {
+			data: { ...populated, domain: "héllo.example" },
+			isLoading: false,
+			isError: false,
+		};
+		renderShellAt([`/domains/${encodeURIComponent("héllo.example")}`]);
+		expect(screen.getByText(/mailboxes in héllo\.example/i)).toBeInTheDocument();
+	});
+
+	it("includes the domain mailboxes in the mobile drawer too", async () => {
+		domainQueryState = { data: populated, isLoading: false, isError: false };
+		const { default: userEvent } = await import("@testing-library/user-event");
+		const user = userEvent.setup();
+		renderShellAt(["/domains/acme.com"]);
+
+		// Open the drawer and confirm the same domain section is rendered
+		// inside it (the shared NavContents fragment runs in both places).
+		await user.click(screen.getByRole("button", { name: /open menu/i }));
+		const drawer = await screen.findByRole("dialog", {
+			name: /primary navigation/i,
+		});
+		expect(within(drawer).getByText(/mailboxes in acme\.com/i)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
Closes #139

## Summary

- At `/domains/:domain`, the sidebar now renders a "Mailboxes in :domain" section listing every mailbox in that domain. Each entry links to `/mailbox/:id/dashboard`, matching the per-domain dashboard's roster.
- The block is gated on a `useMatch("/domains/:domain")` route check, so other pages don't pay the `useDomainStats` network cost (the hook's internal `enabled: !!domain` is the gate when the match is null).
- While the query is pending the sidebar falls through to the existing org-level nav — no empty list and no "undefined" flash. Off-route (`/`, `/mailboxes`, `/domains`, `/mailbox/:id/...`) the sidebar is byte-for-byte identical to today.
- Picked up where PR #137 deferred this from #85.

## Test plan

- [x] `npm test` → **398 passing, 0 failing** (was 393; +5 from the new `shell-domain-nav.test.tsx`).
- [x] New `tests/frontend/shell-domain-nav.test.tsx` covers: section renders only on `/domains/:domain`; each item links to `/mailbox/:id/dashboard`; loading state falls back to org-level nav (no "undefined"); URL-decoded domain in the label; section also surfaces inside the mobile drawer.
- [x] `tests/frontend/domain-detail.test.tsx` updated to scope its mailbox-link assertions to `<main>` — the body and the new sidebar section now both link to the same mailboxes, so the unscoped query would match twice.
- [x] `npx tsc -b` is clean for `app/components/phishsoc/Shell.tsx` and the test files (existing `workers/*` `Env` errors are pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)