### PR TITLE
feat(ui): cross-domain comparison + drill-down from org overview

### DIFF
--- a/app/routes/domains-list.tsx
+++ b/app/routes/domains-list.tsx
@@ -2,6 +2,7 @@
 
 import { Loader } from "@cloudflare/kumo";
 import { BuildingsIcon, WarningIcon } from "@phosphor-icons/react";
+import { useMemo, useState } from "react";
 import { Link as RouterLink } from "react-router";
 import Shell from "~/components/phishsoc/Shell";
 import { useDomains } from "~/queries/domains";
@@ -11,8 +12,56 @@ export function meta() {
 	return [{ title: "Domains · PhishSOC" }];
 }
 
+/**
+ * Sort keys exposed in the cross-domain comparison UI (#141). All sorting is
+ * done client-side against the data already returned by `/api/v1/domains` —
+ * the list is bounded by the number of provisioned domains per org and is
+ * small enough that a backend pushdown would be premature optimisation.
+ */
+type SortKey = "name" | "threatsBlocked24h" | "openCases" | "mailboxesCount";
+
+const SORT_OPTIONS: ReadonlyArray<{ value: SortKey; label: string }> = [
+	{ value: "name", label: "Name (A→Z)" },
+	{ value: "threatsBlocked24h", label: "Threats blocked · 24h" },
+	{ value: "openCases", label: "Open cases" },
+	{ value: "mailboxesCount", label: "Mailboxes" },
+];
+
+function sortDomains(
+	domains: DomainListEntry[],
+	key: SortKey,
+): DomainListEntry[] {
+	const next = [...domains];
+	if (key === "name") {
+		// `localeCompare` so a domain like `école.fr` sorts predictably and
+		// we don't fall back to UTF-16 code-unit ordering.
+		next.sort((a, b) => a.domain.localeCompare(b.domain));
+	} else {
+		// Numeric sorts are descending — the operator is asking "which domain
+		// is having the worst day?" and the highest counts belong on top.
+		next.sort((a, b) => b[key] - a[key]);
+	}
+	return next;
+}
+
+function filterDomains(
+	domains: DomainListEntry[],
+	query: string,
+): DomainListEntry[] {
+	const q = query.trim().toLowerCase();
+	if (q === "") return domains;
+	return domains.filter((d) => d.domain.toLowerCase().includes(q));
+}
+
 export default function DomainsListRoute() {
 	const { data, isLoading, isError, refetch } = useDomains();
+	const [sortKey, setSortKey] = useState<SortKey>("name");
+	const [filter, setFilter] = useState("");
+
+	const visible = useMemo(() => {
+		if (!data) return [];
+		return sortDomains(filterDomains(data, filter), sortKey);
+	}, [data, filter, sortKey]);
 
 	return (
 		<Shell>
@@ -29,7 +78,19 @@ export default function DomainsListRoute() {
 					data.length === 0 ? (
 						<EmptyDomains />
 					) : (
-						<DomainsTable domains={data} />
+						<>
+							<DomainsControls
+								sortKey={sortKey}
+								onSortKeyChange={setSortKey}
+								filter={filter}
+								onFilterChange={setFilter}
+							/>
+							{visible.length === 0 ? (
+								<NoDomainsMatch query={filter} onClear={() => setFilter("")} />
+							) : (
+								<DomainsTable domains={visible} />
+							)}
+						</>
 					)
 				) : null}
 			</div>
@@ -100,6 +161,88 @@ function EmptyDomains() {
 					Go to Mailboxes
 				</RouterLink>
 			</div>
+		</div>
+	);
+}
+
+/**
+ * Distinct from `EmptyDomains` (which means "no domains provisioned"). This
+ * state means the operator filtered to a substring that didn't match any
+ * provisioned domain — the right call-to-action is "clear the filter", not
+ * "go provision more mailboxes".
+ */
+function NoDomainsMatch({
+	query,
+	onClear,
+}: { query: string; onClear: () => void }) {
+	return (
+		<div className="pp-card p-6 flex items-start gap-3">
+			<span className="flex h-8 w-8 items-center justify-center rounded-full bg-paper-2 text-ink-3 shrink-0">
+				<BuildingsIcon size={18} />
+			</span>
+			<div>
+				<div className="text-[14px] font-medium text-ink mb-1">
+					No domains match "{query}"
+				</div>
+				<p className="text-[12.5px] text-ink-3 leading-relaxed mb-2">
+					Try a different substring, or clear the filter to see every
+					provisioned domain.
+				</p>
+				<button
+					type="button"
+					onClick={onClear}
+					className="text-[12px] underline text-accent hover:opacity-80"
+				>
+					Clear filter
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function DomainsControls({
+	sortKey,
+	onSortKeyChange,
+	filter,
+	onFilterChange,
+}: {
+	sortKey: SortKey;
+	onSortKeyChange: (key: SortKey) => void;
+	filter: string;
+	onFilterChange: (value: string) => void;
+}) {
+	return (
+		<div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
+			<label className="flex items-center gap-2 text-[12px] text-ink-3">
+				<span className="uppercase tracking-[0.06em] text-[10.5px]">
+					Filter
+				</span>
+				<input
+					type="search"
+					value={filter}
+					onChange={(e) => onFilterChange(e.target.value)}
+					placeholder="domain substring"
+					aria-label="Filter domains by name"
+					className="rounded-md border border-line bg-paper px-2.5 py-1 text-[13px] text-ink placeholder:text-ink-3 focus:outline-none focus:ring-1 focus:ring-accent w-full sm:w-64"
+				/>
+			</label>
+			<label className="flex items-center gap-2 text-[12px] text-ink-3 sm:ml-auto">
+				<span className="uppercase tracking-[0.06em] text-[10.5px]">
+					Sort
+				</span>
+				<select
+					value={sortKey}
+					onChange={(e) => onSortKeyChange(e.target.value as SortKey)}
+					aria-label="Sort domains"
+					className="rounded-md border border-line bg-paper px-2 py-1 text-[13px] text-ink focus:outline-none focus:ring-1 focus:ring-accent"
+				>
+					{SORT_OPTIONS.map((opt) => (
+						<option key={opt.value} value={opt.value}>
+							{opt.label}
+						</option>
+					))}
+				</select>
+			</label>
 		</div>
 	);
 }

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -3,6 +3,7 @@
 import { Loader } from "@cloudflare/kumo";
 import {
 	BriefcaseIcon,
+	BuildingsIcon,
 	EnvelopeIcon,
 	ShieldCheckIcon,
 	WarningIcon,
@@ -11,6 +12,7 @@ import { useState } from "react";
 import { Link as RouterLink } from "react-router";
 import Shell from "~/components/phishsoc/Shell";
 import { useAutoProvisionMailboxes } from "~/hooks/useAutoProvisionMailboxes";
+import { useDomains } from "~/queries/domains";
 import { useMailboxes } from "~/queries/mailboxes";
 import { useOrgOverview } from "~/queries/org";
 import type { OrgOverview, OrgVerdictMix } from "~/types";
@@ -109,6 +111,7 @@ function OrgBody({
 				/>
 				<TopThreatsCard threats={data.topThreats} />
 			</div>
+			<TopDomainsCard domainsCount={data.domainsCount} />
 		</>
 	);
 }
@@ -140,6 +143,12 @@ function EmptyOrg() {
 interface Kpi {
 	label: string;
 	value: string;
+	/**
+	 * Optional drill-down target. When set, the KPI card renders as a link so
+	 * an operator scanning the org overview can click straight through to the
+	 * matching detail surface (e.g. `Domains` → `/domains`). Issue #141.
+	 */
+	to?: string;
 }
 
 function KpiGrid({ data }: { data: OrgOverview }) {
@@ -162,7 +171,11 @@ function KpiGrid({ data }: { data: OrgOverview }) {
 					: formatLatency(data.pipelineHealth.p95Ms),
 		},
 		{ label: "Mailboxes", value: String(data.mailboxesCount) },
-		{ label: "Domains", value: String(data.domainsCount) },
+		// Drill-down: home → /domains list (#141). Even with the dedicated
+		// "Top domains · 24h" widget below, the count itself is a low-cost
+		// secondary affordance for operators who land here looking for a
+		// domain they don't see in the top-N.
+		{ label: "Domains", value: String(data.domainsCount), to: "/domains" },
 		{
 			label: "Hub contributions · 24h",
 			value: String(data.hubContributions24h),
@@ -175,17 +188,34 @@ function KpiGrid({ data }: { data: OrgOverview }) {
 	return (
 		<div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
 			{kpis.map((k) => (
-				<div key={k.label} className="pp-card p-4">
-					<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-2">
-						{k.label}
-					</div>
-					<div className="pp-serif text-[36px] leading-none text-ink">
-						{k.value}
-					</div>
-				</div>
+				<KpiCard key={k.label} kpi={k} />
 			))}
 		</div>
 	);
+}
+
+function KpiCard({ kpi }: { kpi: Kpi }) {
+	const body = (
+		<>
+			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-2">
+				{kpi.label}
+			</div>
+			<div className="pp-serif text-[36px] leading-none text-ink">
+				{kpi.value}
+			</div>
+		</>
+	);
+	if (kpi.to) {
+		return (
+			<RouterLink
+				to={kpi.to}
+				className="pp-card p-4 block hover:bg-paper-2 transition-colors"
+			>
+				{body}
+			</RouterLink>
+		);
+	}
+	return <div className="pp-card p-4">{body}</div>;
 }
 
 const VERDICT_LABEL: Record<keyof OrgVerdictMix, string> = {
@@ -298,6 +328,70 @@ function TopThreatsCard({
 					))}
 				</ul>
 			)}
+		</div>
+	);
+}
+
+/**
+ * "Top domains · 24h" — a per-domain rollup widget that lets MSP-shape
+ * operators answer "which of my N domains is having the worst day?" without
+ * leaving home (#141). Sorts the same `/api/v1/domains` list the `/domains`
+ * route uses by `threatsBlocked24h` desc and renders the top three.
+ *
+ * Hidden when only one domain is configured: the widget exists to compare
+ * domains, and a single-row table doesn't earn its space. Also hidden while
+ * the underlying query is loading or errors out — those failure modes are
+ * already surfaced by the `/domains` route itself, so duplicating them here
+ * just adds noise to the home overview.
+ */
+const TOP_DOMAINS_LIMIT = 3;
+
+function TopDomainsCard({ domainsCount }: { domainsCount: number }) {
+	const { data, isLoading, isError } = useDomains();
+
+	// Hide entirely when there's only one (or zero) domains — the widget
+	// exists to compare domains, and a single-row table doesn't earn its
+	// space on the org overview. Issue #141 acceptance criteria.
+	if (domainsCount <= 1) return null;
+	if (isLoading || isError || !data) return null;
+
+	const sorted = [...data].sort(
+		(a, b) => b.threatsBlocked24h - a.threatsBlocked24h,
+	);
+	const top = sorted.slice(0, TOP_DOMAINS_LIMIT);
+
+	return (
+		<div className="pp-card p-5">
+			<div className="flex items-baseline justify-between gap-3 mb-3">
+				<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 flex items-center gap-1.5">
+					<BuildingsIcon size={12} />
+					Top domains · 24h
+				</div>
+				<RouterLink
+					to="/domains"
+					className="text-[12px] text-accent hover:opacity-80"
+				>
+					View all domains →
+				</RouterLink>
+			</div>
+			<ul className="space-y-1.5">
+				{top.map((d) => (
+					<li
+						key={d.domain}
+						className="flex items-baseline justify-between gap-3 py-1"
+					>
+						<RouterLink
+							to={`/domains/${encodeURIComponent(d.domain)}`}
+							className="text-[13px] text-ink hover:text-accent transition-colors truncate"
+						>
+							{d.domain}
+						</RouterLink>
+						<span className="pp-mono text-[12px] text-ink-3 tabular-nums">
+							{d.threatsBlocked24h}
+						</span>
+					</li>
+				))}
+			</ul>
 		</div>
 	);
 }

--- a/tests/frontend/domains-list.test.tsx
+++ b/tests/frontend/domains-list.test.tsx
@@ -15,6 +15,10 @@ let queryState: {
 
 vi.mock("~/queries/domains", () => ({
 	useDomains: () => ({ ...queryState, refetch }),
+	// Shell calls `useDomainStats` to drive the domain-scoped sidebar (#143);
+	// at `/domains` (the list route) it doesn't match so the hook is gated to
+	// `enabled: false`, but the import still has to resolve.
+	useDomainStats: () => ({ data: undefined, isLoading: false, isError: false }),
 }));
 
 // Shell pulls in mailbox/dashboard data — keep these stubs identical to

--- a/tests/frontend/domains-list.test.tsx
+++ b/tests/frontend/domains-list.test.tsx
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Route, Routes } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DomainListEntry } from "~/types";
+
+const refetch = vi.fn();
+let queryState: {
+	data: DomainListEntry[] | undefined;
+	isLoading: boolean;
+	isError: boolean;
+};
+
+vi.mock("~/queries/domains", () => ({
+	useDomains: () => ({ ...queryState, refetch }),
+}));
+
+// Shell pulls in mailbox/dashboard data — keep these stubs identical to
+// `home.test.tsx` so we render the route in isolation rather than fanning
+// out to real fetchers.
+vi.mock("~/queries/mailboxes", () => ({
+	useMailboxes: () => ({ data: [], refetch: vi.fn(), isFetched: true }),
+	useMailbox: () => ({ data: undefined }),
+}));
+
+vi.mock("~/queries/dashboard", () => ({
+	useDashboardSummary: () => ({ data: undefined }),
+}));
+
+import DomainsListRoute from "~/routes/domains-list";
+import { renderWithProviders } from "./test-utils";
+
+function renderDomainsList() {
+	return renderWithProviders(
+		<Routes>
+			<Route path="/domains" element={<DomainsListRoute />} />
+			<Route
+				path="/domains/:domain"
+				element={<div>Domain detail page</div>}
+			/>
+			<Route path="/mailboxes" element={<div>Mailboxes page</div>} />
+		</Routes>,
+		{ initialEntries: ["/domains"] },
+	);
+}
+
+const populated: DomainListEntry[] = [
+	{
+		domain: "zulu.example",
+		mailboxesCount: 1,
+		threatsBlocked24h: 3,
+		openCases: 1,
+		verdictMix: { safe: 5, suspicious: 0, phishing: 1, spam: 0, bec: 0 },
+	},
+	{
+		domain: "acme.com",
+		mailboxesCount: 5,
+		threatsBlocked24h: 42,
+		openCases: 7,
+		verdictMix: { safe: 10, suspicious: 4, phishing: 4, spam: 4, bec: 0 },
+	},
+	{
+		domain: "midco.example",
+		mailboxesCount: 3,
+		threatsBlocked24h: 9,
+		openCases: 2,
+		verdictMix: { safe: 6, suspicious: 1, phishing: 1, spam: 1, bec: 0 },
+	},
+];
+
+function rowDomains(): string[] {
+	const tableBody = screen.getByRole("table").querySelector("tbody");
+	if (!tableBody) return [];
+	return Array.from(tableBody.querySelectorAll("tr")).map(
+		(tr) => tr.querySelector("td")?.textContent?.trim() ?? "",
+	);
+}
+
+describe("DomainsListRoute (#141)", () => {
+	beforeEach(() => {
+		refetch.mockReset();
+	});
+
+	it("renders the loader while the query is pending", () => {
+		queryState = { data: undefined, isLoading: true, isError: false };
+		renderDomainsList();
+		expect(screen.getByText(/^Domains\.$/)).toBeInTheDocument();
+		expect(screen.queryByRole("table")).not.toBeInTheDocument();
+	});
+
+	it("renders the empty state when no domains are provisioned", () => {
+		queryState = { data: [], isLoading: false, isError: false };
+		renderDomainsList();
+		expect(screen.getByText(/no domains yet/i)).toBeInTheDocument();
+	});
+
+	it("defaults to alphabetical sort by domain name", () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderDomainsList();
+		expect(rowDomains()).toEqual([
+			"acme.com",
+			"midco.example",
+			"zulu.example",
+		]);
+	});
+
+	it("re-orders rows when the operator picks a numeric sort key", async () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderDomainsList();
+
+		const sort = screen.getByLabelText(/sort domains/i);
+		await userEvent.selectOptions(sort, "threatsBlocked24h");
+		// Highest threats-blocked first: acme(42) → midco(9) → zulu(3).
+		expect(rowDomains()).toEqual([
+			"acme.com",
+			"midco.example",
+			"zulu.example",
+		]);
+
+		await userEvent.selectOptions(sort, "openCases");
+		// Highest open-cases first: acme(7) → midco(2) → zulu(1).
+		expect(rowDomains()).toEqual([
+			"acme.com",
+			"midco.example",
+			"zulu.example",
+		]);
+
+		await userEvent.selectOptions(sort, "mailboxesCount");
+		// Highest mailbox count first: acme(5) → midco(3) → zulu(1).
+		expect(rowDomains()).toEqual([
+			"acme.com",
+			"midco.example",
+			"zulu.example",
+		]);
+
+		await userEvent.selectOptions(sort, "name");
+		// Back to alphabetical default.
+		expect(rowDomains()).toEqual([
+			"acme.com",
+			"midco.example",
+			"zulu.example",
+		]);
+	});
+
+	it("narrows the list when the operator types a substring filter (case-insensitive)", async () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderDomainsList();
+		const filter = screen.getByLabelText(/filter domains by name/i);
+
+		await userEvent.type(filter, "EXAMPLE");
+		// `acme.com` filtered out; the two `.example` domains remain.
+		expect(rowDomains()).toEqual(["midco.example", "zulu.example"]);
+
+		// Sort order is preserved across filter changes.
+		await userEvent.clear(filter);
+		await userEvent.type(filter, "mid");
+		expect(rowDomains()).toEqual(["midco.example"]);
+	});
+
+	it("renders 'no domains match' empty state when the filter excludes every row", async () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderDomainsList();
+		const filter = screen.getByLabelText(/filter domains by name/i);
+
+		await userEvent.type(filter, "nope");
+		expect(screen.queryByRole("table")).not.toBeInTheDocument();
+		expect(screen.getByText(/no domains match "nope"/i)).toBeInTheDocument();
+
+		// "Clear filter" affordance restores the full list.
+		await userEvent.click(
+			screen.getByRole("button", { name: /clear filter/i }),
+		);
+		expect(rowDomains()).toEqual([
+			"acme.com",
+			"midco.example",
+			"zulu.example",
+		]);
+	});
+
+	it("links each row to /domains/:domain", () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderDomainsList();
+		const link = screen.getByRole("link", { name: "acme.com" });
+		expect(link).toHaveAttribute("href", "/domains/acme.com");
+	});
+
+	it("does not regress: row count matches data length when no filter applied", () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderDomainsList();
+		const tbody = screen.getByRole("table").querySelector("tbody")!;
+		expect(within(tbody).getAllByRole("row")).toHaveLength(populated.length);
+	});
+});

--- a/tests/frontend/home.test.tsx
+++ b/tests/frontend/home.test.tsx
@@ -28,6 +28,10 @@ let domainsState: {
 
 vi.mock("~/queries/domains", () => ({
 	useDomains: () => ({ ...domainsState, refetch: vi.fn() }),
+	// Shell calls `useDomainStats` to drive the domain-scoped sidebar (#143);
+	// at `/` the route doesn't match so the hook is gated to `enabled: false`,
+	// but the import still has to resolve.
+	useDomainStats: () => ({ data: undefined, isLoading: false, isError: false }),
 }));
 
 // The org-overview home page renders an "N mailboxes" hint sourced from

--- a/tests/frontend/home.test.tsx
+++ b/tests/frontend/home.test.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
 
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Route, Routes } from "react-router";
-import type { OrgOverview } from "~/types";
+import type { DomainListEntry, OrgOverview } from "~/types";
 
 const refetch = vi.fn();
 let queryState: {
@@ -15,6 +15,19 @@ let queryState: {
 
 vi.mock("~/queries/org", () => ({
 	useOrgOverview: () => ({ ...queryState, refetch }),
+}));
+
+// `TopDomainsCard` (#141) consumes `useDomains()`. Default to an empty list
+// so existing assertions (which were written before the widget existed) keep
+// passing; tests that exercise the widget override `domainsState` per case.
+let domainsState: {
+	data: DomainListEntry[] | undefined;
+	isLoading: boolean;
+	isError: boolean;
+} = { data: [], isLoading: false, isError: false };
+
+vi.mock("~/queries/domains", () => ({
+	useDomains: () => ({ ...domainsState, refetch: vi.fn() }),
 }));
 
 // The org-overview home page renders an "N mailboxes" hint sourced from
@@ -48,6 +61,11 @@ function renderHome() {
 		<Routes>
 			<Route path="/" element={<HomeRoute />} />
 			<Route path="/mailboxes" element={<div>Mailboxes page</div>} />
+			<Route path="/domains" element={<div>Domains list page</div>} />
+			<Route
+				path="/domains/:domain"
+				element={<div>Domain detail page</div>}
+			/>
 		</Routes>,
 		{ initialEntries: ["/"] },
 	);
@@ -94,6 +112,10 @@ const empty: OrgOverview = {
 describe("HomeRoute (org overview)", () => {
 	beforeEach(() => {
 		refetch.mockReset();
+		// Reset the domains-query mock to its default empty state. Tests that
+		// exercise the "Top domains" widget override this explicitly so a
+		// stray fixture from a previous test can't bleed across cases.
+		domainsState = { data: [], isLoading: false, isError: false };
 	});
 
 	it("renders the loader while the query is pending", () => {
@@ -200,5 +222,118 @@ describe("HomeRoute (org overview)", () => {
 		};
 		renderHome();
 		expect(screen.getByText("1.5s")).toBeInTheDocument();
+	});
+
+	// ----- Cross-domain comparison + drill-down (#141) ---------------------
+
+	it("renders the Domains KPI as a link to /domains", () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderHome();
+		// "Domains" also appears in the Shell sidebar nav and elsewhere — scope
+		// the lookup to the KPI grid (the only place where the label and the
+		// numeric value are siblings inside the same card).
+		const links = screen
+			.getAllByRole("link")
+			.filter((el) => el.getAttribute("href") === "/domains");
+		// Expect at least one /domains link rendered by HomeRoute itself
+		// (Shell may add another from sidebar nav). The KPI card link wraps
+		// both the "Domains" label and its numeric value, so check for that.
+		const kpiLink = links.find(
+			(el) =>
+				el.textContent?.includes("Domains") &&
+				el.textContent?.includes(String(populated.domainsCount)),
+		);
+		expect(kpiLink).toBeTruthy();
+	});
+
+	it("hides the Top domains widget when only one domain is configured", () => {
+		queryState = {
+			data: { ...populated, domainsCount: 1 },
+			isLoading: false,
+			isError: false,
+		};
+		domainsState = {
+			data: [
+				{
+					domain: "acme.com",
+					mailboxesCount: 3,
+					threatsBlocked24h: 9,
+					openCases: 2,
+					verdictMix: { safe: 10, suspicious: 1, phishing: 1, spam: 1, bec: 0 },
+				},
+			],
+			isLoading: false,
+			isError: false,
+		};
+		renderHome();
+		expect(
+			screen.queryByText(/top domains · 24h/i),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders the Top domains widget sorted by threats blocked desc with per-row drill-down", () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		domainsState = {
+			data: [
+				{
+					domain: "low.example",
+					mailboxesCount: 1,
+					threatsBlocked24h: 1,
+					openCases: 0,
+					verdictMix: { safe: 5, suspicious: 0, phishing: 0, spam: 0, bec: 0 },
+				},
+				{
+					domain: "noisy.example",
+					mailboxesCount: 4,
+					threatsBlocked24h: 42,
+					openCases: 3,
+					verdictMix: { safe: 5, suspicious: 5, phishing: 5, spam: 5, bec: 0 },
+				},
+				{
+					domain: "mid.example",
+					mailboxesCount: 2,
+					threatsBlocked24h: 7,
+					openCases: 1,
+					verdictMix: { safe: 5, suspicious: 1, phishing: 1, spam: 0, bec: 0 },
+				},
+				{
+					domain: "tail.example",
+					mailboxesCount: 1,
+					threatsBlocked24h: 0,
+					openCases: 0,
+					verdictMix: { safe: 5, suspicious: 0, phishing: 0, spam: 0, bec: 0 },
+				},
+			],
+			isLoading: false,
+			isError: false,
+		};
+		renderHome();
+
+		const heading = screen.getByText(/top domains · 24h/i);
+		const card = heading.closest("div.pp-card") as HTMLElement;
+		expect(card).not.toBeNull();
+
+		// First three by threatsBlocked24h desc are noisy → mid → low. The
+		// `tail.example` row (count 0) is past the N=3 cap and should not
+		// appear.
+		const rows = within(card).getAllByRole("listitem");
+		expect(rows).toHaveLength(3);
+		expect(rows[0]).toHaveTextContent("noisy.example");
+		expect(rows[0]).toHaveTextContent("42");
+		expect(rows[1]).toHaveTextContent("mid.example");
+		expect(rows[2]).toHaveTextContent("low.example");
+		expect(within(card).queryByText("tail.example")).not.toBeInTheDocument();
+
+		// Each row is a drill-down link to /domains/:domain.
+		const noisyLink = within(rows[0]).getByRole("link", {
+			name: /noisy\.example/,
+		});
+		expect(noisyLink).toHaveAttribute("href", "/domains/noisy.example");
+
+		// Header has a "View all domains" affordance to /domains.
+		const viewAll = within(card).getByRole("link", {
+			name: /view all domains/i,
+		});
+		expect(viewAll).toHaveAttribute("href", "/domains");
 	});
 });


### PR DESCRIPTION
Closes #141.

## Summary
- Home (`/`): link the `Domains` KPI card to `/domains` and add a "Top domains · 24h" widget that surfaces the top 3 domains by `threatsBlocked24h`. Hidden when only one domain is configured. Each row drills into `/domains/:domain`, and the card header has a `View all domains →` link as the primary affordance.
- `/domains`: client-side sort (name asc default; `threatsBlocked24h`, `openCases`, `mailboxesCount` desc) and a free-text substring filter (case-insensitive). New `no domains match` empty state with a clear-filter button, distinct from the existing `no domains provisioned` empty state.
- All sort/filter is client-side against the data already returned by `/api/v1/domains` — no backend changes per the issue's no-new-aggregation-endpoints constraint.

## Test plan
- [x] `npm test` — 404 passing, 0 failing.
- [x] `npm run typecheck` — clean.
- [x] New `tests/frontend/domains-list.test.tsx` covers default alphabetical sort, switching to each numeric sort key, filter narrowing the list, the `no domains match` empty state + clear-filter affordance, and per-row `/domains/:domain` drill-down.
- [x] Extended `tests/frontend/home.test.tsx` covers: `Domains` KPI card links to `/domains`, top-domains widget hidden at `domainsCount === 1`, widget renders the top 3 by `threatsBlocked24h` desc with per-row drill-down + `View all domains →` link.
- [x] Existing tests in `home.test.tsx` and `domain-detail.test.tsx` still pass with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)