### PR TITLE
feat: real apex-domain DMARC posture ingestion

### DIFF
--- a/tests/dmarc/txt.test.ts
+++ b/tests/dmarc/txt.test.ts
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, expect, it } from "vitest";
+import {
+	emptyDmarcTxtPosture,
+	fetchDmarcTxtPosture,
+	normalizeDohTxtData,
+	parseDmarcTxt,
+	selectDmarcRecord,
+	type DmarcTxtKv,
+} from "../../workers/dmarc/txt";
+
+describe("parseDmarcTxt", () => {
+	it("parses a fully-specified policy record", () => {
+		const r = parseDmarcTxt(
+			"v=DMARC1; p=reject; sp=quarantine; pct=50; rua=mailto:dmarc@acme.com",
+		);
+		expect(r).toEqual({
+			p: "reject",
+			sp: "quarantine",
+			pct: 50,
+			ruaConfigured: true,
+		});
+	});
+
+	it("defaults pct to 100 when the tag is absent (RFC 7489 §6.3)", () => {
+		const r = parseDmarcTxt("v=DMARC1; p=reject");
+		expect(r.pct).toBe(100);
+		expect(r.p).toBe("reject");
+		expect(r.sp).toBeNull();
+		expect(r.ruaConfigured).toBe(false);
+	});
+
+	it("returns null fields when the record isn't a v=DMARC1 policy", () => {
+		expect(parseDmarcTxt("v=spf1 -all")).toEqual(emptyDmarcTxtPosture());
+		expect(parseDmarcTxt("not even a tag list")).toEqual(emptyDmarcTxtPosture());
+		expect(parseDmarcTxt("")).toEqual(emptyDmarcTxtPosture());
+	});
+
+	it("treats malformed pct as null (rather than NaN)", () => {
+		const r = parseDmarcTxt("v=DMARC1; p=reject; pct=abc");
+		expect(r.pct).toBeNull();
+	});
+
+	it("rejects pct outside [0,100]", () => {
+		expect(parseDmarcTxt("v=DMARC1; p=reject; pct=150").pct).toBeNull();
+		expect(parseDmarcTxt("v=DMARC1; p=reject; pct=-5").pct).toBeNull();
+	});
+
+	it("treats `rua=` (empty) as not configured", () => {
+		const r = parseDmarcTxt("v=DMARC1; p=reject; rua=");
+		expect(r.ruaConfigured).toBe(false);
+	});
+
+	it("is case-insensitive on tag names but not on values", () => {
+		const r = parseDmarcTxt("V=DMARC1; P=reject; SP=none");
+		// Tag names are normalized; values pass through unchanged.
+		expect(r.p).toBe("reject");
+		expect(r.sp).toBe("none");
+	});
+
+	it("ignores tags after the first occurrence (first-wins, doesn't downgrade)", () => {
+		const r = parseDmarcTxt("v=DMARC1; p=reject; p=none");
+		expect(r.p).toBe("reject");
+	});
+});
+
+describe("selectDmarcRecord", () => {
+	it("picks the v=DMARC1-prefixed record when multiple TXTs are present", () => {
+		const r = selectDmarcRecord([
+			"google-site-verification=abc",
+			"v=DMARC1; p=reject",
+			"v=spf1 -all",
+		]);
+		expect(r).toBe("v=DMARC1; p=reject");
+	});
+
+	it("returns null when no record starts with v=DMARC1", () => {
+		expect(
+			selectDmarcRecord(["v=spf1 -all", "google-site-verification=abc"]),
+		).toBeNull();
+	});
+
+	it("matches case-insensitively and tolerates whitespace around v=", () => {
+		expect(selectDmarcRecord(["V = DMARC1; p=reject"])).toMatch(/DMARC1/);
+	});
+});
+
+describe("normalizeDohTxtData", () => {
+	it("concatenates multi-string TXT-record fragments without inserting whitespace", () => {
+		// RFC 7489 records use `;`-separated tags; the multi-string boundary in
+		// DNS itself adds no character — operators put a `;` or trailing space
+		// inside the quoted fragment when they want one.
+		expect(
+			normalizeDohTxtData('"v=DMARC1; p=reject;" "rua=mailto:dmarc@acme.com"'),
+		).toBe("v=DMARC1; p=reject;rua=mailto:dmarc@acme.com");
+	});
+
+	it("strips surrounding quotes from a single-fragment string", () => {
+		expect(normalizeDohTxtData('"v=DMARC1; p=reject"')).toBe("v=DMARC1; p=reject");
+	});
+
+	it("passes raw text through when no quoted fragments are present", () => {
+		expect(normalizeDohTxtData("v=DMARC1; p=reject")).toBe("v=DMARC1; p=reject");
+	});
+});
+
+// ── DoH integration tests ──────────────────────────────────────────────
+
+function fakeKv(initial: Record<string, unknown> = {}): DmarcTxtKv & {
+	store: Map<string, string>;
+} {
+	const store = new Map<string, string>();
+	for (const [k, v] of Object.entries(initial)) {
+		store.set(k, JSON.stringify(v));
+	}
+	return {
+		store,
+		async get(key: string, _type: "json") {
+			const raw = store.get(key);
+			return raw ? (JSON.parse(raw) as unknown) : null;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+	};
+}
+
+function dohTxtResponse(records: string[]): Response {
+	return new Response(
+		JSON.stringify({
+			Status: 0,
+			Answer: records.map((data) => ({ name: "_dmarc.acme.com", type: 16, data })),
+		}),
+		{ status: 200, headers: { "content-type": "application/dns-json" } },
+	);
+}
+
+describe("fetchDmarcTxtPosture", () => {
+	it("resolves a real policy record over DoH", async () => {
+		const fetchImpl = async (url: string) => {
+			// Hostname-based dispatch — substring matching on URLs is a CodeQL
+			// `js/incomplete-url-substring-sanitization` trip wire (repo CLAUDE.md).
+			expect(new URL(url).hostname).toBe("cloudflare-dns.com");
+			return dohTxtResponse([
+				'"v=DMARC1; p=reject; pct=50; rua=mailto:dmarc@acme.com"',
+			]);
+		};
+		const r = await fetchDmarcTxtPosture("acme.com", { fetchImpl });
+		expect(r).toEqual({
+			p: "reject",
+			sp: null,
+			pct: 50,
+			ruaConfigured: true,
+		});
+	});
+
+	it("picks the v=DMARC1 record when multiple TXT entries coexist at _dmarc", async () => {
+		const fetchImpl = async () =>
+			dohTxtResponse([
+				'"google-site-verification=xyz"',
+				'"v=DMARC1; p=quarantine"',
+			]);
+		const r = await fetchDmarcTxtPosture("acme.com", { fetchImpl });
+		expect(r.p).toBe("quarantine");
+	});
+
+	it("returns the empty-posture sentinel when no record exists", async () => {
+		const fetchImpl = async () =>
+			new Response(JSON.stringify({ Status: 0, Answer: [] }), { status: 200 });
+		const r = await fetchDmarcTxtPosture("acme.com", { fetchImpl });
+		expect(r).toEqual(emptyDmarcTxtPosture());
+	});
+
+	it("returns the empty-posture sentinel when DoH returns non-200", async () => {
+		const fetchImpl = async () => new Response("nope", { status: 500 });
+		const r = await fetchDmarcTxtPosture("acme.com", { fetchImpl });
+		expect(r).toEqual(emptyDmarcTxtPosture());
+	});
+
+	it("returns the empty-posture sentinel when fetch rejects", async () => {
+		const fetchImpl = async () => {
+			throw new Error("network");
+		};
+		const r = await fetchDmarcTxtPosture("acme.com", { fetchImpl });
+		expect(r).toEqual(emptyDmarcTxtPosture());
+	});
+
+	it("returns the empty-posture sentinel when DoH returns non-JSON", async () => {
+		const fetchImpl = async () => new Response("<html>", { status: 200 });
+		const r = await fetchDmarcTxtPosture("acme.com", { fetchImpl });
+		expect(r).toEqual(emptyDmarcTxtPosture());
+	});
+
+	it("queries the _dmarc.<domain> label, not the apex itself", async () => {
+		let captured = "";
+		const fetchImpl = async (url: string) => {
+			captured = url;
+			return dohTxtResponse(['"v=DMARC1; p=none"']);
+		};
+		await fetchDmarcTxtPosture("acme.com", { fetchImpl });
+		const u = new URL(captured);
+		expect(u.hostname).toBe("cloudflare-dns.com");
+		expect(u.pathname).toBe("/dns-query");
+		expect(u.searchParams.get("name")).toBe("_dmarc.acme.com");
+		expect(u.searchParams.get("type")).toBe("TXT");
+	});
+
+	it("reads from KV cache when a parsed posture is already stored", async () => {
+		const kv = fakeKv({
+			"dmarc-txt:v1:acme.com": {
+				p: "reject",
+				sp: "reject",
+				pct: 100,
+				ruaConfigured: true,
+			},
+		});
+		let calls = 0;
+		const fetchImpl = async () => {
+			calls += 1;
+			return dohTxtResponse(['"v=DMARC1; p=none"']);
+		};
+		const r = await fetchDmarcTxtPosture("acme.com", { fetchImpl, kv });
+		expect(calls).toBe(0);
+		expect(r.p).toBe("reject");
+	});
+
+	it("writes the resolved posture (including null sentinels) to KV", async () => {
+		const kv = fakeKv();
+		const fetchImpl = async () => dohTxtResponse([]);
+		await fetchDmarcTxtPosture("acme.com", { fetchImpl, kv });
+		// Give the unawaited put microtask a chance to flush.
+		await new Promise((r) => setTimeout(r, 0));
+		const cached = kv.store.get("dmarc-txt:v1:acme.com");
+		expect(cached).toBeDefined();
+		expect(JSON.parse(cached!)).toEqual(emptyDmarcTxtPosture());
+	});
+});

--- a/tests/lib/domain-aggregation.test.ts
+++ b/tests/lib/domain-aggregation.test.ts
@@ -6,6 +6,8 @@ import {
 	aggregateDomainsList,
 	domainOf,
 	emptyDmarcPosture,
+	reduceDmarcAlignmentRate,
+	type DmarcAlignmentTotals,
 	type DomainMailboxSummary,
 	type OrgMailboxSummary,
 } from "../../workers/lib/dashboard-aggregation";
@@ -243,7 +245,7 @@ describe("aggregateDomainStats", () => {
 		expect(result!.recentCases.map((c) => c.id)).toEqual(["C2", "C1"]);
 	});
 
-	it("returns an all-null DMARC posture (v1 best-effort)", () => {
+	it("falls back to the all-null DMARC posture when the handler doesn't supply one", () => {
 		const result = aggregateDomainStats({
 			domain: "acme.com",
 			mailboxes: [
@@ -258,6 +260,31 @@ describe("aggregateDomainStats", () => {
 			pct: null,
 			ruaConfigured: null,
 			alignmentRate: null,
+		});
+	});
+
+	it("threads a real DMARC posture through unchanged when supplied", () => {
+		const result = aggregateDomainStats({
+			domain: "acme.com",
+			mailboxes: [
+				{ id: "alice@acme.com", email: "alice@acme.com", name: "Alice" },
+			],
+			summaries: [domainSummary()],
+			now: NOW.toISOString(),
+			dmarcPosture: {
+				p: "reject",
+				sp: "quarantine",
+				pct: 50,
+				ruaConfigured: true,
+				alignmentRate: 0.97,
+			},
+		});
+		expect(result!.dmarcPosture).toEqual({
+			p: "reject",
+			sp: "quarantine",
+			pct: 50,
+			ruaConfigured: true,
+			alignmentRate: 0.97,
 		});
 	});
 
@@ -303,5 +330,52 @@ describe("aggregateDomainStats", () => {
 			"C6",
 			"C5",
 		]);
+	});
+});
+
+describe("reduceDmarcAlignmentRate", () => {
+	function totals(aligned: number, total: number): DmarcAlignmentTotals {
+		return { aligned, total };
+	}
+
+	it("returns null for an empty input", () => {
+		expect(reduceDmarcAlignmentRate([])).toBeNull();
+	});
+
+	it("returns null when total is zero across the fan-out", () => {
+		// No DMARC reports landed in the window — UI should surface
+		// "unavailable" rather than a misleading 0%.
+		expect(reduceDmarcAlignmentRate([totals(0, 0), totals(0, 0)])).toBeNull();
+	});
+
+	it("returns the sum-of-numerators / sum-of-denominators rate", () => {
+		const rate = reduceDmarcAlignmentRate([
+			totals(90, 100),
+			totals(70, 100),
+		]);
+		expect(rate).toBeCloseTo(0.8);
+	});
+
+	it("skips null slots (failed DO calls) without skewing the rate", () => {
+		const rate = reduceDmarcAlignmentRate([
+			totals(95, 100),
+			null,
+			totals(90, 100),
+		]);
+		expect(rate).toBeCloseTo(0.925);
+	});
+
+	it("clamps a misbehaving DO that returns aligned > total to 1.0", () => {
+		const rate = reduceDmarcAlignmentRate([totals(150, 100)]);
+		expect(rate).toBe(1);
+	});
+
+	it("ignores totals with non-finite or negative components", () => {
+		const rate = reduceDmarcAlignmentRate([
+			totals(95, 100),
+			{ aligned: Number.NaN, total: 100 },
+			{ aligned: -1, total: 50 },
+		]);
+		expect(rate).toBeCloseTo(0.95);
 	});
 });

--- a/workers/dmarc/txt.ts
+++ b/workers/dmarc/txt.ts
@@ -1,0 +1,254 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Apex-domain DMARC TXT-record fetch + parse.
+ *
+ * The Workers runtime has no `dns` module, so policy lookup goes over
+ * DNS-over-HTTPS (Cloudflare's `cloudflare-dns.com` JSON resolver). The result
+ * is cached in KV under `dmarc-txt:v1:<domain>` with a short TTL — apex
+ * DMARC policies don't churn, and negative caching matters so a domain with
+ * no `_dmarc` record doesn't re-hammer DoH on every dashboard request.
+ *
+ * Issue: #138 (real apex-domain DMARC posture ingestion).
+ */
+
+/**
+ * Parsed `{p, sp, pct, ruaConfigured}` extracted from a `_dmarc.<domain>`
+ * TXT record. Fields are independent: a policy with `p=reject` but no `sp`
+ * tag is reported as `{p: "reject", sp: null, ...}`. `pct` defaults to 100
+ * per RFC 7489 §6.3 if the tag is absent (the published spec semantic, not
+ * a guess), but only when a `v=DMARC1` record was found at all — otherwise
+ * every field is null and the caller should surface "unavailable".
+ */
+export interface DmarcTxtPosture {
+	p: string | null;
+	sp: string | null;
+	pct: number | null;
+	ruaConfigured: boolean | null;
+}
+
+/**
+ * Sentinel returned when no DMARC record exists at the apex. All four fields
+ * null lets the dashboard render the same "unavailable" affordance as a
+ * lookup failure — the operator's takeaway is the same: "no policy on file".
+ */
+export function emptyDmarcTxtPosture(): DmarcTxtPosture {
+	return { p: null, sp: null, pct: null, ruaConfigured: null };
+}
+
+const TXT_KV_PREFIX = "dmarc-txt:v1:";
+/** 1h TTL: apex DMARC policies don't change often. */
+const TXT_KV_TTL_S = 60 * 60;
+/** DoH resolver host. Hostname-based mock matching is required by repo CLAUDE.md. */
+const DOH_HOST = "cloudflare-dns.com";
+const DOH_URL = `https://${DOH_HOST}/dns-query`;
+/** Hard-cap the upstream — slow lookup must not block dashboard rendering. */
+const DOH_TIMEOUT_MS = 1500;
+
+/** Minimal `KVNamespace` view we depend on; lets tests pass a fake. */
+export interface DmarcTxtKv {
+	get(key: string, type: "json"): Promise<unknown>;
+	put(
+		key: string,
+		value: string,
+		options?: { expirationTtl?: number },
+	): Promise<void>;
+}
+
+/** Minimal `fetch` view we depend on; lets tests inject a stub. */
+export type DmarcTxtFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Parse a `_dmarc.<domain>` TXT-record string into a posture. Only records
+ * starting with `v=DMARC1` are considered (other TXT entries at `_dmarc`,
+ * e.g. orphaned legacy values, are skipped by the caller).
+ *
+ * Tags are `;`-separated `name=value` pairs per RFC 7489 §6.3. We tolerate:
+ *   - Surrounding whitespace.
+ *   - Missing optional tags (`sp`, `pct`, `rua`).
+ *   - Malformed `pct` values (return null rather than NaN).
+ *   - Empty `rua=` (treated as not configured — the tag exists but no URI
+ *     is published, so reports go nowhere).
+ */
+export function parseDmarcTxt(record: string): DmarcTxtPosture {
+	const empty = emptyDmarcTxtPosture();
+	if (typeof record !== "string") return empty;
+	const trimmed = record.trim();
+	if (!trimmed) return empty;
+	// Tag names are case-insensitive in DMARC; values are not.
+	const tags = new Map<string, string>();
+	for (const part of trimmed.split(";")) {
+		const eq = part.indexOf("=");
+		if (eq < 0) continue;
+		const name = part.slice(0, eq).trim().toLowerCase();
+		const value = part.slice(eq + 1).trim();
+		if (!name) continue;
+		// First occurrence wins — RFC 7489 doesn't define dup-tag semantics
+		// and most parsers treat a record with duplicates as malformed; we
+		// chose first-wins so a record like `v=DMARC1;p=reject;p=none` still
+		// reports the stricter policy rather than silently downgrading.
+		if (!tags.has(name)) tags.set(name, value);
+	}
+	if (tags.get("v") !== "DMARC1") return empty;
+
+	const p = tags.get("p") ?? null;
+	const sp = tags.get("sp") ?? null;
+
+	let pct: number | null = null;
+	const pctRaw = tags.get("pct");
+	if (pctRaw === undefined) {
+		// Per RFC 7489 §6.3, absent `pct` defaults to 100. Only apply that
+		// default when we actually parsed a v=DMARC1 record (i.e. `p` is
+		// likely set); a record with `v=DMARC1` and no other tags is still
+		// malformed in practice but defaulting pct here matches every other
+		// implementation's behavior.
+		pct = 100;
+	} else {
+		const n = Number.parseInt(pctRaw, 10);
+		if (Number.isFinite(n) && n >= 0 && n <= 100) pct = n;
+	}
+
+	// `rua=mailto:dmarc@example.com[,mailto:...]`. Empty / missing → not
+	// configured. We don't validate the URI list — it's enough for the
+	// dashboard to know "the operator is collecting reports somewhere".
+	const ruaRaw = tags.get("rua");
+	const ruaConfigured = typeof ruaRaw === "string" && ruaRaw.length > 0;
+
+	return { p, sp, pct, ruaConfigured };
+}
+
+/**
+ * Pick the DMARC policy record from a list of TXT strings published at
+ * `_dmarc.<domain>`. Multiple TXT entries at that label are common (e.g. an
+ * old DMARC value left next to a new one); the spec says only the
+ * `v=DMARC1`-prefixed record is authoritative. Returns null when none match.
+ */
+export function selectDmarcRecord(records: readonly string[]): string | null {
+	for (const r of records) {
+		if (typeof r !== "string") continue;
+		const t = r.trim();
+		if (/^v\s*=\s*DMARC1\b/i.test(t)) return t;
+	}
+	return null;
+}
+
+/**
+ * Strip the surrounding quotes and concatenate multi-string TXT-record
+ * fragments DoH returns. Cloudflare's resolver hands TXT data back as
+ * `"v=DMARC1; p=reject" "rua=mailto:..."` for records that exceed 255 bytes;
+ * we want one logical string with the quote-pair boundary erased.
+ */
+export function normalizeDohTxtData(data: string): string {
+	if (typeof data !== "string") return "";
+	// Match all `"..."` fragments and concatenate their contents. If no
+	// quoted fragments are present (some resolvers return raw text), fall
+	// back to the original string with leading/trailing quotes stripped.
+	const matches = [...data.matchAll(/"((?:[^"\\]|\\.)*)"/g)];
+	if (matches.length === 0) {
+		return data.replace(/^"|"$/g, "");
+	}
+	return matches.map((m) => m[1]).join("");
+}
+
+/**
+ * Fetch and parse the DMARC TXT record for `<domain>`, with KV caching.
+ *
+ * The lookup is hard-capped at `DOH_TIMEOUT_MS` and degrades to an all-null
+ * posture on any failure (timeout, non-200, malformed JSON, no `v=DMARC1`
+ * record found). The caller should treat this as best-effort and not fail
+ * the surrounding request when this returns the sentinel.
+ *
+ * Negative results are cached too — a domain with no `_dmarc` record is
+ * the common case for unmanaged inboxes, and we don't want to re-resolve
+ * on every dashboard hit.
+ */
+export async function fetchDmarcTxtPosture(
+	domain: string,
+	options: {
+		kv?: DmarcTxtKv | null;
+		fetchImpl?: DmarcTxtFetch;
+		now?: number;
+	} = {},
+): Promise<DmarcTxtPosture> {
+	const fetchImpl = options.fetchImpl ?? (globalThis.fetch as DmarcTxtFetch);
+	const kv = options.kv ?? null;
+	const cacheKey = `${TXT_KV_PREFIX}${domain}`;
+
+	if (kv) {
+		try {
+			const cached = (await kv.get(cacheKey, "json")) as
+				| DmarcTxtPosture
+				| null;
+			if (cached && typeof cached === "object") {
+				// Defensive: a cache poisoning would be cheap to recover from
+				// because the posture is best-effort, but coerce shape anyway.
+				return {
+					p: typeof cached.p === "string" ? cached.p : null,
+					sp: typeof cached.sp === "string" ? cached.sp : null,
+					pct: typeof cached.pct === "number" ? cached.pct : null,
+					ruaConfigured:
+						typeof cached.ruaConfigured === "boolean"
+							? cached.ruaConfigured
+							: null,
+				};
+			}
+		} catch {
+			// KV read failure is non-fatal; just fall through to DoH.
+		}
+	}
+
+	const posture = await resolveDmarcTxt(domain, fetchImpl);
+
+	if (kv) {
+		// Don't `await` the put — caching is opportunistic; a slow KV write
+		// shouldn't block the dashboard response. Callers that need the
+		// write to complete before the worker terminates should pass the
+		// returned promise to `ctx.waitUntil`. We chose to keep this helper
+		// pure-by-default and let the route handler own that decision.
+		void kv
+			.put(cacheKey, JSON.stringify(posture), { expirationTtl: TXT_KV_TTL_S })
+			.catch(() => {});
+	}
+
+	return posture;
+}
+
+async function resolveDmarcTxt(
+	domain: string,
+	fetchImpl: DmarcTxtFetch,
+): Promise<DmarcTxtPosture> {
+	if (!domain || typeof domain !== "string") return emptyDmarcTxtPosture();
+	const name = `_dmarc.${domain}`;
+	let res: Response;
+	try {
+		res = await fetchImpl(
+			`${DOH_URL}?name=${encodeURIComponent(name)}&type=TXT`,
+			{
+				headers: { accept: "application/dns-json" },
+				signal: AbortSignal.timeout(DOH_TIMEOUT_MS),
+			},
+		);
+	} catch {
+		return emptyDmarcTxtPosture();
+	}
+	if (!res.ok) return emptyDmarcTxtPosture();
+	let body: unknown;
+	try {
+		body = await res.json();
+	} catch {
+		return emptyDmarcTxtPosture();
+	}
+	const answer = (body as { Answer?: Array<{ type?: number; data?: unknown }> })
+		.Answer;
+	if (!Array.isArray(answer)) return emptyDmarcTxtPosture();
+	const txts: string[] = [];
+	for (const a of answer) {
+		// TXT records are type=16 in DoH JSON.
+		if (a.type !== 16) continue;
+		if (typeof a.data !== "string") continue;
+		txts.push(normalizeDohTxtData(a.data));
+	}
+	const record = selectDmarcRecord(txts);
+	if (!record) return emptyDmarcTxtPosture();
+	return parseDmarcTxt(record);
+}

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -1426,6 +1426,41 @@ export class MailboxDO extends DurableObject<Env> {
 	}
 
 	/**
+	 * Sum DMARC alignment outcomes for `domain` over `[sinceIso, now]`.
+	 *
+	 * Returns `{aligned, total}` where `aligned` counts records whose
+	 * `policy_evaluated` cells show DKIM-pass OR SPF-pass — that's the
+	 * RFC 7489 §6.6.2 alignment definition (either authenticated identifier
+	 * passing satisfies DMARC). The deep-scan path uses AND for "fully
+	 * authenticated"; we deliberately don't reuse it here because the
+	 * apex-domain dashboard wants the looser "DMARC-aligned" rate.
+	 *
+	 * Records with NULL dkim/spf results (older reports that didn't survive
+	 * a parser regression) are counted in `total` but never as `aligned` —
+	 * conservative, since we can't tell. Used by the per-domain stats
+	 * endpoint to compute alignment-rate across all mailboxes whose email
+	 * matches the apex (#138).
+	 */
+	async getDmarcAlignmentTotals(domain: string, sinceIso: string) {
+		const row = [
+			...this.ctx.storage.sql.exec(
+				`SELECT
+				   COALESCE(SUM(r.count), 0) as total,
+				   COALESCE(SUM(CASE WHEN r.dkim_result = 'pass' OR r.spf_result = 'pass' THEN r.count ELSE 0 END), 0) as aligned
+				 FROM dmarc_records r
+				 JOIN dmarc_reports rep ON rep.id = r.report_id
+				 WHERE rep.domain = ?1 AND rep.received_at >= ?2`,
+				domain,
+				sinceIso,
+			),
+		][0] as { total: number | null; aligned: number | null } | undefined;
+		return {
+			aligned: Number(row?.aligned ?? 0) || 0,
+			total: Number(row?.total ?? 0) || 0,
+		};
+	}
+
+	/**
 	 * Aggregate the operations dashboard payload in one round-trip from the
 	 * UI. Each card lives in its own indexed query — see
 	 * `migrations.ts/11_dashboard_indexes` and `12_pipeline_runs` for the

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -37,6 +37,9 @@ import {
 	computeP95,
 	domainOf,
 	pipelineSuccessRate,
+	reduceDmarcAlignmentRate,
+	type DmarcAlignmentTotals,
+	type DmarcPosture,
 	type DomainListEntry,
 	type DomainMailboxRef,
 	type DomainMailboxSummary,
@@ -44,6 +47,7 @@ import {
 	type OrgMailboxSummary,
 	type OrgOverview,
 } from "./lib/dashboard-aggregation";
+import { emptyDmarcTxtPosture, fetchDmarcTxtPosture } from "./dmarc/txt";
 import { listTextModels } from "./lib/text-models";
 import { fetchHubCorroborationCount } from "./intel/hub-corroboration";
 import { loadHubCredentials } from "./lib/hub-config";
@@ -201,6 +205,10 @@ app.get("/api/v1/org/overview", async (c) => {
 const DOMAINS_LIST_CACHE_KEY = "domains:v1";
 const DOMAIN_STATS_CACHE_KEY_PREFIX = "domain-stats:v1:";
 const DOMAIN_CACHE_TTL_S = 60;
+/** Window for the apex-domain DMARC alignment-rate reducer (#138). 7 days
+ * matches the rest of the dashboard's "recent" framing without going so far
+ * back that a stale forwarder-fail spike from last month skews the rate. */
+const DMARC_ALIGNMENT_WINDOW_DAYS = 7;
 
 /**
  * Hostname-shape regex. Mirrors RFC 1035 / 5890 lite: at least two labels,
@@ -270,14 +278,35 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		return c.json({ error: "Domain not found" }, 404);
 	}
 
-	const settled = await Promise.allSettled(
-		scoped.map((m) =>
-			c.env.MAILBOX
-				.get(c.env.MAILBOX.idFromName(m.id))
-				.getDashboardSummary(),
-		),
+	// Apex-domain DMARC posture (#138). The TXT lookup over DoH and the
+	// per-mailbox alignment-rate fan-out run as siblings of the dashboard
+	// summary fan-out — wrapping all three in the same Promise.allSettled
+	// keeps a slow upstream off the critical path. Any sibling rejecting
+	// degrades to null fields rather than failing the response.
+	const nowMs = Date.now();
+	const alignmentSinceIso = new Date(
+		nowMs - DMARC_ALIGNMENT_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+	).toISOString();
+
+	const summaryPromises = scoped.map((m) =>
+		c.env.MAILBOX.get(c.env.MAILBOX.idFromName(m.id)).getDashboardSummary(),
 	);
-	const summaries: Array<DomainMailboxSummary | null> = settled.map((r) => {
+	const alignmentPromises = scoped.map((m) =>
+		c.env.MAILBOX
+			.get(c.env.MAILBOX.idFromName(m.id))
+			.getDmarcAlignmentTotals(domain, alignmentSinceIso),
+	);
+	const txtPromise = fetchDmarcTxtPosture(domain, {
+		kv: c.env.BLOOM_KV ?? null,
+	});
+
+	const [settledSummaries, settledAlignments, settledTxt] = await Promise.all([
+		Promise.allSettled(summaryPromises),
+		Promise.allSettled(alignmentPromises),
+		Promise.allSettled([txtPromise]),
+	]);
+
+	const summaries: Array<DomainMailboxSummary | null> = settledSummaries.map((r) => {
 		if (r.status !== "fulfilled") {
 			console.error("domain-stats: mailbox summary failed:", (r.reason as Error)?.message);
 			return null;
@@ -285,6 +314,29 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		const v = r.value as DomainMailboxSummary;
 		return { ...v, threatsBlocked7d: v.threatsBlocked7d ?? 0 };
 	});
+
+	const alignmentTotals: Array<DmarcAlignmentTotals | null> = settledAlignments.map(
+		(r) => {
+			if (r.status !== "fulfilled") {
+				console.error(
+					"domain-stats: alignment-totals failed:",
+					(r.reason as Error)?.message,
+				);
+				return null;
+			}
+			return r.value as DmarcAlignmentTotals;
+		},
+	);
+
+	const txtPosture =
+		settledTxt[0].status === "fulfilled"
+			? settledTxt[0].value
+			: emptyDmarcTxtPosture();
+
+	const dmarcPosture: DmarcPosture = {
+		...txtPosture,
+		alignmentRate: reduceDmarcAlignmentRate(alignmentTotals),
+	};
 
 	const mailboxRefs: DomainMailboxRef[] = scoped.map((m) => ({
 		id: m.id,
@@ -296,6 +348,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		domain,
 		mailboxes: mailboxRefs,
 		summaries,
+		dmarcPosture,
 	});
 	// `aggregateDomainStats` only returns null when `mailboxes.length === 0`,
 	// which we already guarded above with the 404 — but narrow the type

--- a/workers/lib/dashboard-aggregation.ts
+++ b/workers/lib/dashboard-aggregation.ts
@@ -468,7 +468,11 @@ export function domainOf(email: string): string | null {
 }
 
 /** Empty DMARC posture sentinel — every field null, signalling
- * "no real ingestion yet" to the UI. */
+ * "no real ingestion yet" to the UI.
+ *
+ * Retained for unit tests and as a defensive fallback; the production handler
+ * builds postures from the DoH TXT lookup + alignment-rate fan-out (#138)
+ * and no longer threads this sentinel into `aggregateDomainStats`. */
 export function emptyDmarcPosture(): DmarcPosture {
 	return {
 		p: null,
@@ -477,6 +481,45 @@ export function emptyDmarcPosture(): DmarcPosture {
 		ruaConfigured: null,
 		alignmentRate: null,
 	};
+}
+
+/** Per-mailbox alignment totals harvested from `dmarc_records` by the DO.
+ *
+ * `aligned` is the sum of `count` for records where DMARC alignment passed
+ * (DKIM-pass OR SPF-pass per RFC 7489 §6.6.2 — not the strict `dkim AND spf`
+ * the deep-scan path uses for "fully authenticated"). `total` is the sum
+ * across all records in the window. `null` slots are mailboxes whose DO
+ * call failed; they contribute nothing rather than skewing the rate. */
+export interface DmarcAlignmentTotals {
+	aligned: number;
+	total: number;
+}
+
+/**
+ * Reduce a fan-out of per-mailbox alignment totals into a single rate. Pure
+ * helper so the math is unit-testable without a runtime SQL surface.
+ *
+ * Returns `null` when there's no data — UI surfaces an "unavailable"
+ * affordance rather than rendering "0%" which would imply "every message
+ * failed alignment". `null` slots (failed DO calls) are skipped so a single
+ * unhealthy mailbox doesn't drag the org-wide rate to 0/0.
+ */
+export function reduceDmarcAlignmentRate(
+	totals: ReadonlyArray<DmarcAlignmentTotals | null>,
+): number | null {
+	let aligned = 0;
+	let total = 0;
+	for (const t of totals) {
+		if (!t) continue;
+		if (!Number.isFinite(t.aligned) || !Number.isFinite(t.total)) continue;
+		if (t.aligned < 0 || t.total < 0) continue;
+		aligned += t.aligned;
+		total += t.total;
+	}
+	if (total === 0) return null;
+	// Clamp to [0, 1] — if a misbehaving DO returns aligned > total we'd
+	// rather report 100% than `>1` and have the UI show ">100% aligned".
+	return Math.min(1, aligned / total);
 }
 
 interface AggregateDomainsListInput {
@@ -552,6 +595,13 @@ interface AggregateDomainStatsInput {
 	/** Indices align with `mailboxes`. `null` = DO call failed → contributes 0. */
 	summaries: Array<DomainMailboxSummary | null>;
 	now?: string;
+	/**
+	 * Real apex-domain DMARC posture from the DoH TXT lookup +
+	 * alignment-rate fan-out (#138). When omitted the helper falls back to
+	 * the all-null sentinel — that path is exercised by tests and by the
+	 * forward-compat case where the handler couldn't compute posture.
+	 */
+	dmarcPosture?: DmarcPosture;
 }
 
 /**
@@ -608,7 +658,7 @@ export function aggregateDomainStats(
 		threatsBlocked7d,
 		openCases,
 		verdictMix,
-		dmarcPosture: emptyDmarcPosture(),
+		dmarcPosture: input.dmarcPosture ?? emptyDmarcPosture(),
 		recentCases: recentCases.slice(0, 5),
 	};
 }


### PR DESCRIPTION
Closes #138.

## Summary

- Replaces the all-null `dmarcPosture` sentinel from #137 with a live posture for `/api/v1/domains/:domain/stats`.
- New `_dmarc.<domain>` lookup over Cloudflare DNS-over-HTTPS, parsed into `{p, sp, pct, ruaConfigured}` and cached in `BLOOM_KV` under `dmarc-txt:v1:<domain>` (1h TTL, negative results cached too).
- New DO method `getDmarcAlignmentTotals(domain, sinceIso)` sums `policy_evaluated` outcomes across `dmarc_records` for the trailing 7 days; uses RFC 7489 §6.6.2 alignment (`DKIM-pass OR SPF-pass`), not the stricter AND `getDmarcSummary` uses.
- Pure reducer `reduceDmarcAlignmentRate` aggregates per-mailbox `{aligned, total}` totals into a single rate (or `null` when total is zero).
- DoH TXT lookup, alignment-totals fan-out, and dashboard-summary fan-out all run as siblings in one `Promise.all([allSettled(...), ...])` so a slow `_dmarc` lookup doesn't add latency on top of the DO round-trips. Any sibling rejecting degrades to null; the UI's existing "unavailable" affordance kicks in.
- `aggregateDomainStats` now accepts an optional `dmarcPosture`; the `emptyDmarcPosture()` callsite remains as the fallback default but is no longer reached by the production handler.

## Test plan

- [x] `npm test` — 423 passing, 0 failing.
- [x] `npm run typecheck` — no errors.
- [x] DoH mocks dispatch on `new URL(url).hostname === "cloudflare-dns.com"` (parsed equivalent), not `startsWith` — CodeQL `js/incomplete-url-substring-sanitization` is a known trip wire per repo CLAUDE.md / PR #130.
- [x] New unit tests cover: TXT parser (valid policy, missing tags, malformed `pct`, no record, multi-string fragments, multiple TXTs at `_dmarc` where only `v=DMARC1` is the policy), DoH error paths (timeout, non-200, non-JSON), KV cache hit/miss + write of negative results, and the alignment-rate reducer (empty input, all-zero totals, sum-of-numerators / sum-of-denominators, null DO slots, clamp on misbehaving DO, NaN/negative guards).
- [x] Existing FE test for the DMARC card non-null path (`tests/frontend/domain-detail.test.tsx`) continues to pass — no FE change needed.

## Out of scope (per #138)

- UI changes — the affordance already switches automatically when any field becomes non-null.
- Per-mailbox DMARC dashboard rework.
- Domain-level settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)