### PR TITLE
feat: hierarchical org→mailbox settings resolver (1/2 for #106)

### DIFF
--- a/shared/mailbox-settings.ts
+++ b/shared/mailbox-settings.ts
@@ -8,16 +8,15 @@ import { z } from "zod";
  *
  * The schema is intentionally lenient on the write side (passthrough) so
  * future fields can land without coordinated frontend/backend deploys.
- * Strict on the read side: every consumer that reads a typed field uses
- * `MailboxSettings.parse(...)` which fills in defaults.
  *
- * `security` is a typed sub-shape: only `attachment_policy` and
- * `folder_policies` are validated here — the rest of the object is
- * passthrough so unrelated security fields (allowlist_senders, thresholds,
- * business_hours, etc.) round-trip untouched. Defaults intentionally NOT
- * set in the schema; the runtime consumer in `workers/security/settings.ts`
- * (`getSecuritySettings`) is the single source of default values, and
- * duplicating them here would invite drift.
+ * `security` is a typed sub-shape: only `attachment_policy`,
+ * `folder_policies`, and `classification` are validated here — the rest of
+ * the object is passthrough so unrelated security fields (allowlist_senders,
+ * thresholds, business_hours, etc.) round-trip untouched. Defaults are
+ * intentionally NOT set in the schema; the resolver in
+ * `workers/lib/mailbox-settings.ts` (`resolveMailboxSettings`) applies
+ * `DEFAULT_SECURITY_SETTINGS` (defined in `workers/security/defaults.ts`)
+ * as the bottom of the inheritance stack. See #106.
  */
 
 const AttachmentAction = z.enum(["block", "score", "ignore"]);

--- a/shared/mailbox-settings.ts
+++ b/shared/mailbox-settings.ts
@@ -51,7 +51,7 @@ const ClassificationSettings = z
   })
   .passthrough();
 
-const SecuritySettings = z
+export const SecuritySettings = z
   .object({
     attachment_policy: AttachmentPolicy.optional(),
     folder_policies: z.record(z.string(), FolderPolicy).optional(),
@@ -73,7 +73,7 @@ const SecuritySettings = z
  * The whole `intel` block is optional + passthrough so unrelated future intel
  * fields (#29 peer subscriptions) round-trip without a coordinated deploy.
  */
-const HubConfig = z
+export const HubConfig = z
   .object({
     url: z.string().min(1),
     org_uuid: z.string().min(1),
@@ -83,50 +83,84 @@ const HubConfig = z
   })
   .passthrough();
 
-const IntelSettings = z
+/**
+ * Per-feed configuration for the threat-intel cron pipeline. Runtime shape
+ * lives in `workers/intel/feeds.ts` (`MailboxIntelSettings.feeds`). Declared
+ * here so the resolver can whole-replace the `intel.feeds` array cleanly
+ * (was previously opaque via `.passthrough()`).
+ */
+export const IntelFeed = z
   .object({
-    hub: HubConfig.optional(),
+    id: z.string().min(1),
+    url: z.string().optional(),
+    kind: z.enum(["domain", "url", "ip-cidr"]).optional(),
+    refresh_hours: z.number().optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    auth_secret: z.string().optional(),
   })
   .passthrough();
 
+export const IntelSettings = z
+  .object({
+    hub: HubConfig.optional(),
+    feeds: z.array(IntelFeed).optional(),
+  })
+  .passthrough();
+
+export const AutoDraftSettings = z
+  .object({
+    enabled: z.boolean().optional(),
+  })
+  .passthrough();
+
+/**
+ * Per-mailbox settings stored at R2 key `mailboxes/<mailboxId>.json`.
+ *
+ * Semantic shift introduced by #106: **field absence = inherit**. Defaults
+ * are NOT materialised at the schema layer — they live in
+ * `workers/lib/mailbox-settings.ts` (`DEFAULT_MAILBOX_SETTINGS`) and are
+ * applied as a final fallback inside `resolveMailboxSettings`. Putting
+ * defaults on the schema would make every read look like an override, which
+ * the inheritance hierarchy can't distinguish from an intentional one.
+ *
+ * Three security-critical model fields (`injectionScannerModel`,
+ * `draftVerifierModel`, `classifierModel` from #67) are intentionally NOT in
+ * MailboxSettings — they live only in OrgSettings. Per-mailbox overrides
+ * for these are tracked as a separate feature (see follow-up: per-mailbox
+ * model overrides with user choice / local models / own API keys) so the
+ * UI can surface the security trade-off explicitly when shipped.
+ */
 export const MailboxSettings = z.object({
   agentSystemPrompt: z.string().optional(),
-  autoDraft: z
-    .object({
-      enabled: z.boolean().default(true),
-    })
-    .default({ enabled: true }),
-  agentModel: z.string().default("@cf/moonshotai/kimi-k2.5"),
-  /**
-   * Optional per-mailbox override for the prompt-injection scanner model
-   * (#67). Falls back to `DEFAULT_INJECTION_SCANNER_MODEL` when undefined.
-   * Wrong choice can let injections through — defaults are intentionally
-   * hardcoded to a tested model.
-   */
-  injectionScannerModel: z.string().optional(),
-  /**
-   * Optional per-mailbox override for the draft-verifier model (#67).
-   * Falls back to `DEFAULT_DRAFT_VERIFIER_MODEL` when undefined.
-   */
-  draftVerifierModel: z.string().optional(),
-  /**
-   * Optional per-mailbox override for the LLM email classifier (#67).
-   * Falls back to `DEFAULT_CLASSIFIER_MODEL` when undefined.
-   */
-  classifierModel: z.string().optional(),
+  autoDraft: AutoDraftSettings.optional(),
+  agentModel: z.string().optional(),
   security: SecuritySettings.optional(),
   intel: IntelSettings.optional(),
 }).passthrough();
 
 export type MailboxSettings = z.infer<typeof MailboxSettings>;
 
-/** The hand-curated list shown in the Settings model dropdown. The first
- *  entry MUST match the default in MailboxSettings.agentModel above so an
- *  unconfigured mailbox renders with a list option selected, not "Custom". */
+/**
+ * Hand-curated list shown in the Settings model dropdown. The first entry
+ * MUST match `DEFAULT_MAILBOX_SETTINGS.agentModel` (defined in
+ * `workers/lib/mailbox-settings.ts`, applied as the bottom of the resolver
+ * stack) so an unconfigured mailbox renders with a list option selected,
+ * not "Custom".
+ */
 export const TEXT_MODELS = [
   "@cf/moonshotai/kimi-k2.5",
   "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
 ] as const;
+
+/** System default for the agent model. Lives here (rather than at the schema
+ *  default layer) so the resolver can distinguish "absent → inherit" from
+ *  "explicitly set". Imported by `workers/lib/mailbox-settings.ts` for
+ *  inclusion in `DEFAULT_MAILBOX_SETTINGS`. */
+export const DEFAULT_AGENT_MODEL = "@cf/moonshotai/kimi-k2.5";
+
+/** System default for the auto-draft toggle. Same rationale as
+ *  `DEFAULT_AGENT_MODEL`. */
+export const DEFAULT_AUTO_DRAFT_ENABLED = true;
 
 /**
  * Defaults for the three security-critical AI surfaces (#67). These mirror

--- a/shared/org-settings.ts
+++ b/shared/org-settings.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { z } from "zod";
+import {
+  AutoDraftSettings,
+  IntelSettings,
+  SecuritySettings,
+} from "./mailbox-settings";
+
+/**
+ * Org-wide settings stored at R2 key `org/settings.json` (#106).
+ *
+ * Mirrors `MailboxSettings` minus the strictly-per-mailbox fields
+ * (`fromName`, `signature`, `forwarding`, `autoReply`) and adds the three
+ * security-critical model fields that are intentionally org-only at the v1
+ * tier (`injectionScannerModel`, `draftVerifierModel`, `classifierModel`).
+ *
+ * All top-level fields are optional. The resolver treats absence as "inherit
+ * the next layer down" (system default at the org tier). Nested objects
+ * (`security`, `intel.hub`, `intel.feeds`) are replaced whole — never
+ * deep-merged — so an org override carries the entire object including
+ * arrays. Per-array extend semantics for allowlists are tracked as a
+ * follow-up.
+ *
+ * Multi-tenant note: today this lives at the flat key `org/settings.json`
+ * (single-org-per-deploy, matching #104). The R2 key is centralised in
+ * `workers/lib/org-settings.ts` (`orgSettingsKey()`) so a future
+ * multi-tenant refactor is one helper change rather than a cross-cutting
+ * grep.
+ */
+export const OrgSettings = z
+  .object({
+    agentSystemPrompt: z.string().optional(),
+    autoDraft: AutoDraftSettings.optional(),
+    agentModel: z.string().optional(),
+    /**
+     * Org-only — security-critical model surfaces (#67). Per-mailbox
+     * override for these is intentionally NOT supported today; the wrong
+     * choice can let prompt-injection through. Tracked as a follow-up
+     * feature (per-mailbox model overrides with user choice, local models,
+     * own API keys) so the UI can surface the trade-off explicitly.
+     */
+    injectionScannerModel: z.string().optional(),
+    draftVerifierModel: z.string().optional(),
+    classifierModel: z.string().optional(),
+    security: SecuritySettings.optional(),
+    intel: IntelSettings.optional(),
+  })
+  .passthrough();
+
+export type OrgSettings = z.infer<typeof OrgSettings>;
+
+/**
+ * Parse a raw value as `OrgSettings`. Returns the parsed value on success,
+ * or `null` when the input fails validation. Callers (the GET endpoint, the
+ * resolver) treat a missing/malformed `org/settings.json` as "no org-level
+ * overrides" — empty `{}` rather than throwing.
+ */
+export function parseOrgSettings(raw: unknown): OrgSettings | null {
+  const result = OrgSettings.safeParse(raw ?? {});
+  return result.success ? result.data : null;
+}

--- a/tests/agent/settings.test.ts
+++ b/tests/agent/settings.test.ts
@@ -4,19 +4,26 @@ import { describe, expect, it } from "vitest";
 import { MailboxSettings } from "../../shared/mailbox-settings";
 
 describe("MailboxSettings", () => {
-  it("defaults autoDraft.enabled to true when missing", () => {
+  // Post-#106: schema-layer defaults are deliberately gone. The resolver in
+  // workers/lib/mailbox-settings.ts applies system defaults as the bottom
+  // of the inheritance stack — putting them on the schema would make every
+  // read look like an override (mailbox JSON would round-trip with the
+  // default materialised, indistinguishable from "the user picked this
+  // value" once written back). See tests/lib/resolve-mailbox-settings.test.ts
+  // for default-application coverage.
+  it("leaves autoDraft undefined when missing (default lives in resolver)", () => {
     const parsed = MailboxSettings.parse({});
-    expect(parsed.autoDraft.enabled).toBe(true);
+    expect(parsed.autoDraft).toBeUndefined();
   });
 
-  it("defaults agentModel to the kimi entry when missing", () => {
+  it("leaves agentModel undefined when missing (default lives in resolver)", () => {
     const parsed = MailboxSettings.parse({});
-    expect(parsed.agentModel).toBe("@cf/moonshotai/kimi-k2.5");
+    expect(parsed.agentModel).toBeUndefined();
   });
 
   it("respects an explicit disabled autoDraft", () => {
     const parsed = MailboxSettings.parse({ autoDraft: { enabled: false } });
-    expect(parsed.autoDraft.enabled).toBe(false);
+    expect(parsed.autoDraft?.enabled).toBe(false);
   });
 
   it("preserves arbitrary extra fields (passthrough)", () => {
@@ -24,25 +31,32 @@ describe("MailboxSettings", () => {
     expect(parsed.agentSystemPrompt).toBe("Hi");
   });
 
-  // Per-mailbox security-model overrides (#67). All three are optional and
-  // default to undefined so the worker call sites fall through to their
-  // hardcoded defaults.
-  it("leaves security-model overrides undefined when missing", () => {
+  // Post-#106: the three security-critical model fields
+  // (injectionScannerModel, draftVerifierModel, classifierModel) have been
+  // moved off MailboxSettings entirely. They live on OrgSettings only, with
+  // per-mailbox overrides forbidden in v1 — the wrong choice can let
+  // prompt-injection through. A future feature (per-mailbox model overrides
+  // with user choice / local models / own API keys) will reintroduce them
+  // with explicit UI guardrails. Until then the schema's `.passthrough()`
+  // means stale fields in existing mailbox JSON ride through harmlessly,
+  // but they are NOT typed as MailboxSettings keys.
+  it("does not declare security-model fields on MailboxSettings (now org-only)", () => {
     const parsed = MailboxSettings.parse({});
-    expect(parsed.injectionScannerModel).toBeUndefined();
-    expect(parsed.draftVerifierModel).toBeUndefined();
-    expect(parsed.classifierModel).toBeUndefined();
+    expect((parsed as Record<string, unknown>).injectionScannerModel).toBeUndefined();
+    expect((parsed as Record<string, unknown>).draftVerifierModel).toBeUndefined();
+    expect((parsed as Record<string, unknown>).classifierModel).toBeUndefined();
   });
 
-  it("round-trips per-mailbox security-model overrides", () => {
+  it("ignores stale per-mailbox security-model fields on read (passthrough only)", () => {
+    // Existing R2 mailbox JSON written before #106 may still carry these
+    // fields. They survive the parse via passthrough but the worker call
+    // sites no longer read them — see workers/agent/index.ts and
+    // workers/security/index.ts which now source classifier/verifier/scanner
+    // models from the org tier.
     const parsed = MailboxSettings.parse({
       injectionScannerModel: "@cf/custom/injection",
-      draftVerifierModel: "@cf/custom/verifier",
-      classifierModel: "@cf/custom/classifier",
     });
-    expect(parsed.injectionScannerModel).toBe("@cf/custom/injection");
-    expect(parsed.draftVerifierModel).toBe("@cf/custom/verifier");
-    expect(parsed.classifierModel).toBe("@cf/custom/classifier");
+    expect((parsed as Record<string, unknown>).injectionScannerModel).toBe("@cf/custom/injection");
   });
 
   // The security sub-shape is opt-in: an undefined `security` block must

--- a/tests/lib/resolve-mailbox-settings.test.ts
+++ b/tests/lib/resolve-mailbox-settings.test.ts
@@ -1,0 +1,351 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Inheritance resolver coverage for #106. Asserts the four resolution
+ * states (mailbox > org > default), the whole-object replace rule for
+ * nested fields (NOT cross-tier deep merge), the ETag cache discipline,
+ * and the PUT-side stripDefaultEqual pass.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	DEFAULT_MAILBOX_SETTINGS,
+	getMailboxSettings,
+	resolveMailboxSettings,
+	stripDefaultEqual,
+} from "../../workers/lib/mailbox-settings";
+import {
+	clearOrgSettingsCache,
+	getOrgSettings,
+	orgSettingsKey,
+	putOrgSettings,
+} from "../../workers/lib/org-settings";
+import { DEFAULT_SECURITY_SETTINGS } from "../../workers/security/defaults";
+import { loadHubConfig } from "../../workers/lib/hub-config";
+
+interface FakeStored {
+	body: string;
+	etag: string;
+}
+
+interface FakeBucket extends R2Bucket {
+	__store: Map<string, FakeStored>;
+	__getCalls: Array<{ key: string; ifNoneMatch: string | null }>;
+	__putCalls: Array<{ key: string; body: string }>;
+}
+
+let etagCounter = 0;
+
+function nextEtag(): string {
+	etagCounter += 1;
+	return `etag-${etagCounter}`;
+}
+
+/** Minimal R2-compatible bucket for tests. Honours `onlyIf.etagDoesNotMatch`
+ *  by returning null when the stored etag matches the precondition (i.e.
+ *  the 304 path). Records every read so tests can assert on cache misses. */
+function makeFakeBucket(initial: Record<string, unknown> = {}): FakeBucket {
+	const store = new Map<string, FakeStored>();
+	for (const [key, value] of Object.entries(initial)) {
+		store.set(key, { body: JSON.stringify(value), etag: nextEtag() });
+	}
+	const getCalls: Array<{ key: string; ifNoneMatch: string | null }> = [];
+	const putCalls: Array<{ key: string; body: string }> = [];
+
+	const bucket = {
+		async get(key: string, opts?: R2GetOptions) {
+			const ifNoneMatch =
+				(opts?.onlyIf as { etagDoesNotMatch?: string } | undefined)?.etagDoesNotMatch ?? null;
+			getCalls.push({ key, ifNoneMatch });
+			const stored = store.get(key);
+			if (!stored) return null;
+			if (ifNoneMatch && stored.etag === ifNoneMatch) {
+				// 304 — caller should reuse cached value.
+				return null;
+			}
+			const body = stored.body;
+			return {
+				etag: stored.etag,
+				async json() {
+					return JSON.parse(body);
+				},
+				async text() {
+					return body;
+				},
+			} as unknown as R2ObjectBody;
+		},
+		async put(key: string, body: string) {
+			putCalls.push({ key, body });
+			store.set(key, { body, etag: nextEtag() });
+			return null as unknown as R2Object;
+		},
+		async head(key: string) {
+			const stored = store.get(key);
+			if (!stored) return null;
+			return { etag: stored.etag } as unknown as R2Object;
+		},
+		async delete(key: string) {
+			store.delete(key);
+		},
+	} as unknown as FakeBucket;
+	bucket.__store = store;
+	bucket.__getCalls = getCalls;
+	bucket.__putCalls = putCalls;
+	return bucket;
+}
+
+function makeEnv(bucket: FakeBucket) {
+	return { BUCKET: bucket } as unknown as { BUCKET: R2Bucket };
+}
+
+const MAILBOX_ID = "user@example.com";
+const MAILBOX_KEY = `mailboxes/${MAILBOX_ID}.json`;
+
+beforeEach(() => {
+	clearOrgSettingsCache();
+	etagCounter = 0;
+});
+
+describe("resolveMailboxSettings — agentModel inheritance", () => {
+	it("(a) mailbox overrides org → mailbox value wins", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": { agentModel: "@cf/org/value" },
+			[MAILBOX_KEY]: { agentModel: "@cf/mailbox/value" },
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.agentModel).toBe("@cf/mailbox/value");
+	});
+
+	it("(b) org-only → org value", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": { agentModel: "@cf/org/value" },
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.agentModel).toBe("@cf/org/value");
+	});
+
+	it("(c) both absent → system default", async () => {
+		const bucket = makeFakeBucket({ [MAILBOX_KEY]: {} });
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.agentModel).toBe(DEFAULT_MAILBOX_SETTINGS.agentModel);
+	});
+
+	it("(d) PUT mailbox value equal to default → stripped → next read returns default via inheritance", async () => {
+		// Simulate the PUT pipeline: parse + strip + write.
+		const incoming = { agentModel: DEFAULT_MAILBOX_SETTINGS.agentModel };
+		const stripped = stripDefaultEqual(incoming);
+		expect(stripped.agentModel).toBeUndefined();
+
+		const bucket = makeFakeBucket({ [MAILBOX_KEY]: stripped });
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		// Falls through inheritance to the system default.
+		expect(resolved.agentModel).toBe(DEFAULT_MAILBOX_SETTINGS.agentModel);
+		// And the stored mailbox JSON does NOT carry the field — the next
+		// person editing org-level settings will see their value take effect
+		// for this mailbox, which is the whole point.
+		const stored = JSON.parse(bucket.__store.get(MAILBOX_KEY)!.body);
+		expect(Object.keys(stored)).not.toContain("agentModel");
+	});
+});
+
+describe("resolveMailboxSettings — security whole-object replace", () => {
+	it("mailbox security replaces the org block whole — allowlists do NOT extend", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: { enabled: true, allowlist_senders: ["a@b.com"] },
+			},
+			[MAILBOX_KEY]: {
+				security: { enabled: true, allowlist_senders: ["c@d.com"] },
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		// Only the mailbox value, NOT a merged ["a@b.com","c@d.com"]. v1
+		// extend-merge is intentionally out of scope (audit Q3 follow-up).
+		expect(resolved.security.allowlist_senders).toEqual(["c@d.com"]);
+	});
+
+	it("mailbox absent + org security set → org block wins, normalised", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: { enabled: true, allowlist_domains: ["ORG.COM"] },
+			},
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.enabled).toBe(true);
+		// Normalisation runs on the resolved block — domains get lowercased.
+		expect(resolved.security.allowlist_domains).toEqual(["org.com"]);
+	});
+
+	it("both absent → DEFAULT_SECURITY_SETTINGS", async () => {
+		const bucket = makeFakeBucket({ [MAILBOX_KEY]: {} });
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.enabled).toBe(DEFAULT_SECURITY_SETTINGS.enabled);
+		expect(resolved.security.thresholds).toEqual(DEFAULT_SECURITY_SETTINGS.thresholds);
+	});
+
+	it("partial mailbox security completes with defaults (single-tier completion)", async () => {
+		// Within the winning tier, missing keys are filled from the default
+		// so consumers don't see undefined thresholds. This is NOT cross-tier
+		// merge — it just makes the resolved block fully-populated.
+		const bucket = makeFakeBucket({ [MAILBOX_KEY]: { security: { enabled: true } } });
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.enabled).toBe(true);
+		expect(resolved.security.thresholds).toEqual(DEFAULT_SECURITY_SETTINGS.thresholds);
+		expect(resolved.security.attachment_policy).toEqual(DEFAULT_SECURITY_SETTINGS.attachment_policy);
+	});
+});
+
+describe("resolveMailboxSettings — intel.hub inheritance (#121 audit Q1)", () => {
+	const orgHub = {
+		url: "https://hub.example.com",
+		org_uuid: "org-uuid-123",
+		api_key_secret_name: "HUB_KEY",
+	};
+	const mailboxHub = {
+		url: "https://other-hub.example.com",
+		org_uuid: "mailbox-uuid-456",
+		api_key_secret_name: "OTHER_HUB_KEY",
+	};
+
+	it("org sets hub, mailbox absent → resolved.intel.hub = org hub", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": { intel: { hub: orgHub } },
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.intel.hub).toMatchObject(orgHub);
+	});
+
+	it("mailbox hub overrides org — whole-object replace, no merged uuid", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": { intel: { hub: orgHub } },
+			[MAILBOX_KEY]: { intel: { hub: mailboxHub } },
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.intel.hub).toMatchObject(mailboxHub);
+		// Crucially: org_uuid is the mailbox's, not a merge of both.
+		expect(resolved.intel.hub?.org_uuid).toBe("mailbox-uuid-456");
+	});
+
+	it("loadHubConfig flows through the resolver — org hub takes effect for unconfigured mailbox", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": { intel: { hub: orgHub } },
+			[MAILBOX_KEY]: {},
+		});
+		const cfg = await loadHubConfig(makeEnv(bucket), MAILBOX_ID);
+		expect(cfg).not.toBeNull();
+		expect(cfg?.url).toBe(orgHub.url);
+		expect(cfg?.org_uuid).toBe(orgHub.org_uuid);
+	});
+});
+
+describe("getOrgSettings — module-scope ETag cache", () => {
+	it("first call fetches, second call sends If-None-Match and short-circuits on 304", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": { agentModel: "@cf/org/v1" },
+		});
+		const env = makeEnv(bucket);
+
+		const first = await getOrgSettings(env);
+		expect(first.agentModel).toBe("@cf/org/v1");
+		expect(bucket.__getCalls).toHaveLength(1);
+		expect(bucket.__getCalls[0].ifNoneMatch).toBeNull();
+
+		// Spy on JSON parse to confirm the 304 path doesn't reparse.
+		const second = await getOrgSettings(env);
+		expect(second.agentModel).toBe("@cf/org/v1");
+		expect(bucket.__getCalls).toHaveLength(2);
+		expect(bucket.__getCalls[1].ifNoneMatch).toBe("etag-1");
+	});
+
+	it("putOrgSettings invalidates the cache → next read fetches fresh", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": { agentModel: "@cf/org/v1" },
+		});
+		const env = makeEnv(bucket);
+
+		await getOrgSettings(env); // prime cache
+		await putOrgSettings(env, { agentModel: "@cf/org/v2" });
+
+		const after = await getOrgSettings(env);
+		expect(after.agentModel).toBe("@cf/org/v2");
+	});
+
+	it("404 caches an absent sentinel so the hot path doesn't re-fetch", async () => {
+		// No org/settings.json key in the bucket → all reads return null.
+		const bucket = makeFakeBucket({});
+		const env = makeEnv(bucket);
+
+		const first = await getOrgSettings(env);
+		const second = await getOrgSettings(env);
+		expect(first).toEqual({});
+		expect(second).toEqual({});
+		// Both calls read R2 (we don't skip the call entirely — the second
+		// just hits the absent-cached path, with no If-None-Match because
+		// there's nothing to send).
+		expect(bucket.__getCalls).toHaveLength(2);
+		expect(bucket.__getCalls[1].ifNoneMatch).toBeNull();
+	});
+});
+
+describe("stripDefaultEqual", () => {
+	it("drops agentModel equal to system default", () => {
+		const stripped = stripDefaultEqual({ agentModel: DEFAULT_MAILBOX_SETTINGS.agentModel });
+		expect(stripped.agentModel).toBeUndefined();
+	});
+
+	it("keeps agentModel set to a custom value", () => {
+		const stripped = stripDefaultEqual({ agentModel: "@cf/custom/value" });
+		expect(stripped.agentModel).toBe("@cf/custom/value");
+	});
+
+	it("drops a security block that deep-equals the default", () => {
+		const stripped = stripDefaultEqual({ security: DEFAULT_SECURITY_SETTINGS });
+		expect((stripped as Record<string, unknown>).security).toBeUndefined();
+	});
+
+	it("keeps a security block with a single non-default field", () => {
+		const stripped = stripDefaultEqual({
+			security: { ...DEFAULT_SECURITY_SETTINGS, enabled: true },
+		});
+		expect(stripped.security).toBeDefined();
+		expect((stripped.security as { enabled: boolean }).enabled).toBe(true);
+	});
+
+	it("preserves per-mailbox-only fields (fromName, signature) untouched", () => {
+		const stripped = stripDefaultEqual({
+			fromName: "Daisy",
+			signature: { enabled: true, text: "Cheers" },
+		} as Parameters<typeof stripDefaultEqual>[0]);
+		expect((stripped as Record<string, unknown>).fromName).toBe("Daisy");
+		expect((stripped as Record<string, unknown>).signature).toEqual({
+			enabled: true,
+			text: "Cheers",
+		});
+	});
+});
+
+describe("getMailboxSettings — raw read still works post-#106", () => {
+	it("returns the raw mailbox JSON without materialising defaults", async () => {
+		const bucket = makeFakeBucket({
+			[MAILBOX_KEY]: { agentSystemPrompt: "stay polite" },
+		});
+		const raw = await getMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(raw.agentSystemPrompt).toBe("stay polite");
+		// agentModel was NOT in the JSON, and no schema default kicks in.
+		expect(raw.agentModel).toBeUndefined();
+		expect(raw.autoDraft).toBeUndefined();
+	});
+
+	it("orgSettingsKey returns the centralised flat key (multi-tenant hook)", () => {
+		// Sanity-check the centralisation point. A future multi-tenant
+		// refactor changes only this helper.
+		expect(orgSettingsKey()).toBe("org/settings.json");
+	});
+
+	// Suppress the unused-import warning — vi is reserved for follow-on
+	// tests that mock the resolver from agent code paths.
+	void vi;
+});

--- a/tests/lib/resolve-mailbox-settings.test.ts
+++ b/tests/lib/resolve-mailbox-settings.test.ts
@@ -325,6 +325,32 @@ describe("stripDefaultEqual", () => {
 			text: "Cheers",
 		});
 	});
+
+	it("composes correctly with the POST /api/v1/mailboxes default-settings layer", () => {
+		// Simulates the create-mailbox handler in workers/index.ts: a fresh
+		// mailbox PUT-payload that includes the rendered form defaults must
+		// drop the inheritable defaults but keep the per-mailbox-only
+		// identity fields (audit Q8).
+		const incomingFromUI = {
+			agentModel: DEFAULT_MAILBOX_SETTINGS.agentModel,
+			autoDraft: DEFAULT_MAILBOX_SETTINGS.autoDraft,
+			agentSystemPrompt: "stay polite",
+		};
+		const cleaned = stripDefaultEqual(incomingFromUI);
+		const perMailboxIdentity = {
+			fromName: "Daisy",
+			signature: { enabled: false, text: "" },
+		};
+		const finalSettings = { ...perMailboxIdentity, ...cleaned };
+		// agentModel + autoDraft were defaults → dropped → mailbox now
+		// inherits whatever the org tier sets later.
+		expect((finalSettings as Record<string, unknown>).agentModel).toBeUndefined();
+		expect((finalSettings as Record<string, unknown>).autoDraft).toBeUndefined();
+		// Custom prompt survives.
+		expect((finalSettings as Record<string, unknown>).agentSystemPrompt).toBe("stay polite");
+		// Per-mailbox identity untouched.
+		expect((finalSettings as Record<string, unknown>).fromName).toBe("Daisy");
+	});
 });
 
 describe("getMailboxSettings — raw read still works post-#106", () => {

--- a/workers/agent/index.ts
+++ b/workers/agent/index.ts
@@ -30,8 +30,7 @@ import {
 	toolDiscardDraft,
 } from "../lib/tools";
 import { Folders, FOLDER_TOOL_DESCRIPTION, MOVE_FOLDER_TOOL_DESCRIPTION } from "../../shared/folders";
-import type { MailboxSettings } from "../../shared/mailbox-settings";
-import { getMailboxSettings } from "../lib/mailbox-settings";
+import { resolveMailboxSettings } from "../lib/mailbox-settings";
 import type { Env } from "../types";
 
 // AI SDK v6 changed tool() overloads significantly. We define tools as plain
@@ -90,13 +89,12 @@ You can ONLY draft emails. You do NOT have the ability to send emails directly.
 Use discard_draft to delete drafts that the operator rejects or that are no longer needed.`;
 
 /**
- * Pick the custom system prompt from per-mailbox settings, or fall back
- * to DEFAULT_SYSTEM_PROMPT if the field is absent or blank.
+ * Pick the custom system prompt from the resolved settings, or fall back
+ * to DEFAULT_SYSTEM_PROMPT if the field is absent or blank. The input is
+ * already inheritance-resolved (mailbox > org > undefined).
  */
-function resolveSystemPrompt(settings: MailboxSettings): string {
-	if (typeof settings.agentSystemPrompt === "string" && settings.agentSystemPrompt.trim()) {
-		return settings.agentSystemPrompt;
-	}
+function resolveSystemPrompt(prompt: string | undefined): string {
+	if (typeof prompt === "string" && prompt.trim()) return prompt;
 	return DEFAULT_SYSTEM_PROMPT;
 }
 
@@ -271,8 +269,8 @@ export class EmailAgent extends AIChatAgent<any> {
 		const mailboxId = this.name;
 		const workersai = createWorkersAI({ binding: env.AI });
 		const tools = createEmailTools(env, mailboxId);
-		const settings = await getMailboxSettings(env, mailboxId);
-		const systemPrompt = resolveSystemPrompt(settings);
+		const settings = await resolveMailboxSettings(env, mailboxId);
+		const systemPrompt = resolveSystemPrompt(settings.agentSystemPrompt);
 
 		const result = streamText({
 			model: workersai(settings.agentModel as Parameters<typeof workersai>[0]),
@@ -355,8 +353,8 @@ export class EmailAgent extends AIChatAgent<any> {
 		const env = this.env as Env;
 		const workersai = createWorkersAI({ binding: env.AI });
 		const tools = createEmailTools(env, emailData.mailboxId);
-		const settings = await getMailboxSettings(env, emailData.mailboxId);
-		const systemPrompt = resolveSystemPrompt(settings);
+		const settings = await resolveMailboxSettings(env, emailData.mailboxId);
+		const systemPrompt = resolveSystemPrompt(settings.agentSystemPrompt);
 
 		// Pre-read the email and thread so the agent has full context
 		// without needing to waste tool calls discovering it

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -372,6 +372,27 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 	return c.json(stats);
 });
 
+// Org-wide settings (#106). The blob lives at R2 key `org/settings.json` and
+// is read on the per-email hot path via a module-scope ETag cache, so the
+// endpoints below intentionally bypass that cache: GET reads R2 directly
+// (returning whatever's persisted, not the resolved view), PUT invalidates
+// the cache as part of the write. The resolved view for a specific mailbox
+// is exposed at /api/v1/mailboxes/:mailboxId/settings/effective below.
+app.get("/api/v1/org/settings", async (c) => {
+	const settings = await getOrgSettings(c.env);
+	return c.json({ settings });
+});
+
+app.put("/api/v1/org/settings", async (c) => {
+	const body = (await c.req.json().catch(() => ({}))) as { settings?: unknown };
+	const parsed = OrgSettings.safeParse(body?.settings ?? {});
+	if (!parsed.success) {
+		return c.json({ error: "Invalid org settings", issues: parsed.error.issues }, 400);
+	}
+	const written = await putOrgSettings(c.env, parsed.data);
+	return c.json({ settings: written });
+});
+
 app.post("/api/v1/mailboxes", async (c) => {
 	const { name, settings, email: rawEmail } = CreateMailboxBody.parse(await c.req.json());
 	const email = rawEmail.toLowerCase();
@@ -464,11 +485,30 @@ app.put("/api/v1/mailboxes/:mailboxId", async (c) => {
 	if (!parsed.success) {
 		return c.json({ error: "Invalid settings", issues: parsed.error.issues }, 400);
 	}
-	const settings = parsed.data;
+	// #106 acceptance criterion 6: drop fields equal to the system default
+	// before persisting. A fresh mailbox PUT that just round-trips the UI's
+	// rendered defaults must NOT silently shadow every org-level value.
+	const settings = stripDefaultEqual(parsed.data);
 	const key = `mailboxes/${mailboxId}.json`;
 	if (!(await c.env.BUCKET.head(key))) return c.json({ error: "Not found" }, 404);
 	await c.env.BUCKET.put(key, JSON.stringify(settings));
 	return c.json({ id: mailboxId, name: mailboxId, email: mailboxId, settings });
+});
+
+// Resolved view of a mailbox's effective settings — runs the full
+// inheritance hierarchy (mailbox > org > system default) and returns the
+// post-normalised result. Used by the agent path internally and exposed
+// here for the /settings UI's "Inherited from org" indicator (PR2) and
+// for debugging.
+app.get("/api/v1/mailboxes/:mailboxId/settings/effective", async (c) => {
+	const mailboxId = c.req.param("mailboxId")!;
+	const key = `mailboxes/${mailboxId}.json`;
+	if (!(await c.env.BUCKET.head(key))) return c.json({ error: "Not found" }, 404);
+	const resolved = await resolveMailboxSettings(c.env, mailboxId);
+	return c.json({
+		id: mailboxId,
+		settings: resolved,
+	});
 });
 
 app.delete("/api/v1/mailboxes/:mailboxId", async (c) => {

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -403,7 +403,15 @@ app.post("/api/v1/mailboxes", async (c) => {
 	const key = `mailboxes/${email}.json`;
 	if (await c.env.BUCKET.head(key)) return c.json({ error: "Mailbox already exists" }, 409);
 	const defaultSettings = { fromName: name, forwarding: { enabled: false, email: "" }, signature: { enabled: false, text: "" }, autoReply: { enabled: false, subject: "", message: "" } };
-	const finalSettings = { ...defaultSettings, ...settings };
+	// #106 acceptance criterion 6 applies on create too: a fresh mailbox
+	// whose initial PUT-payload includes the rendered form defaults
+	// (`agentModel: "@cf/moonshotai/kimi-k2.5"`, `autoDraft: { enabled: true }`)
+	// must NOT silently shadow every org-level value on the very first
+	// write. defaultSettings (per-mailbox identity fields) is layered AFTER
+	// the strip so fromName/signature/forwarding/autoReply still get
+	// materialised — those are strictly per-mailbox (audit Q8).
+	const cleanedSettings = stripDefaultEqual((settings ?? {}) as MailboxSettings);
+	const finalSettings = { ...defaultSettings, ...cleanedSettings };
 	await c.env.BUCKET.put(key, JSON.stringify(finalSettings));
 	const stub = c.env.MAILBOX.get(c.env.MAILBOX.idFromName(email));
 	await stub.getFolders();

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -20,11 +20,15 @@ import { handleReplyEmail, handleForwardEmail } from "./routes/reply-forward";
 import { Folders } from "../shared/folders";
 import type { Env } from "./types";
 import { requireMailbox, type MailboxContext } from "./lib/mailbox";
-import { getMailboxSettings } from "./lib/mailbox-settings";
+import {
+	resolveMailboxSettings,
+	stripDefaultEqual,
+} from "./lib/mailbox-settings";
+import { getOrgSettings, putOrgSettings } from "./lib/org-settings";
+import { OrgSettings } from "../shared/org-settings";
 import { MailboxSettings } from "../shared/mailbox-settings";
 import { runSecurityPipeline } from "./security";
 import { runDeepScan } from "./intel/deep-scan";
-import { getSecuritySettings } from "./security/settings";
 import { isDmarcReport, ingestDmarcReport } from "./dmarc/ingest";
 import { dmarcRoutes } from "./routes/dmarc";
 import { caseRoutes } from "./routes/cases";
@@ -661,7 +665,7 @@ app.post("/api/v1/mailboxes/:mailboxId/emails/:id/move", async (c: AppContext) =
 	// move because of a reputation write.
 	if (before?.sender) {
 		try {
-			const settings = await getSecuritySettings(c.env, mailboxId);
+			const settings = (await resolveMailboxSettings(c.env, mailboxId)).security;
 			const destPolicy = settings.folder_policies?.[folderId];
 			const srcPolicy = before.folder_id ? settings.folder_policies?.[before.folder_id] : undefined;
 			if (destPolicy?.treat_as_verified && !srcPolicy?.treat_as_verified) {
@@ -950,7 +954,7 @@ async function receiveEmail(event: { raw: ReadableStream; rawSize: number }, env
 	// propagate. Gated on the same `security.enabled` flag as the sync path.
 	if (securityVerdict) {
 		try {
-			const settings = await getSecuritySettings(env, mailboxId);
+			const settings = (await resolveMailboxSettings(env, mailboxId)).security;
 			ctx.waitUntil(
 				runDeepScan({ env, mailboxId, emailId: messageId, thresholds: settings.thresholds })
 					.then(
@@ -969,10 +973,11 @@ async function receiveEmail(event: { raw: ReadableStream; rawSize: number }, env
 		}
 	}
 
-	// Auto-draft dispatch is gated on per-mailbox settings. The security
-	// pipeline above always runs; only the agent's onNewEmail fetch is
-	// skipped when the operator has disabled auto-draft for this mailbox.
-	const mailboxSettings = await getMailboxSettings(env, mailboxId);
+	// Auto-draft dispatch is gated on resolved settings (mailbox > org >
+	// default). The security pipeline above always runs; only the agent's
+	// onNewEmail fetch is skipped when the operator has disabled auto-draft
+	// for this mailbox (or for the org as a whole).
+	const mailboxSettings = await resolveMailboxSettings(env, mailboxId);
 	if (!mailboxSettings.autoDraft.enabled) {
 		return;
 	}

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -406,8 +406,7 @@ app.get("/api/v1/mailboxes/:mailboxId/dashboard", async (c: AppContext) => {
 	if (mailboxId) {
 		try {
 			const creds = await loadHubCredentials(
-				c.env as unknown as Record<string, unknown>,
-				c.env.BUCKET,
+				c.env as unknown as Record<string, unknown> & { BUCKET: R2Bucket },
 				mailboxId,
 			);
 			if (creds) {

--- a/workers/intel/feeds.ts
+++ b/workers/intel/feeds.ts
@@ -32,6 +32,7 @@ import {
 } from "./bloom";
 import { findCidrMatch, parseCidr, parseIpv4, type Ipv4Cidr } from "./cidr";
 import { getMailboxStub, listMailboxes } from "../lib/email-helpers";
+import { resolveMailboxSettings } from "../lib/mailbox-settings";
 
 const EXACT_KEY_CAP = 2000; // per-feed cap — we only fast-path confirm up to this many
 
@@ -64,12 +65,17 @@ export interface MailboxIntelSettings {
 	};
 }
 
+/**
+ * Load the resolved per-mailbox intel block (post-#106). The resolver
+ * returns whichever tier supplied an `intel` value — mailbox if set, else
+ * org, else empty — and `intel.feeds` / `intel.hub` are whole-replaced
+ * (never deep-merged across tiers). Defaults from `DEFAULT_FEEDS` are
+ * stitched in by `resolveFeeds` below.
+ */
 async function loadMailboxIntelSettings(env: Env, mailboxId: string): Promise<MailboxIntelSettings> {
-	const obj = await env.BUCKET.get(`mailboxes/${mailboxId}.json`);
-	if (!obj) return {};
 	try {
-		const json = (await obj.json()) as { intel?: MailboxIntelSettings } | null;
-		return json?.intel ?? {};
+		const resolved = await resolveMailboxSettings(env, mailboxId);
+		return resolved.intel as MailboxIntelSettings;
 	} catch {
 		return {};
 	}

--- a/workers/lib/hub-config.ts
+++ b/workers/lib/hub-config.ts
@@ -1,12 +1,15 @@
 // Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
 
 /**
- * Per-mailbox MISP-compatible hub configuration. Stored under `intel.hub` in
- * `mailboxes/<mailboxId>.json` (R2). The API key itself is NOT stored in R2 —
- * the JSON only carries the secret *name* via `api_key_secret_name`, and the
- * worker resolves it from `c.env` at call time. That way an org can rotate
- * its key without rewriting mailbox JSON.
+ * MISP-compatible threat-intel hub configuration. Resolved through the
+ * inheritance hierarchy from #106 (mailbox > org > system default), so an
+ * org-level hub config takes effect for every mailbox that doesn't carry
+ * its own. The API key itself is NOT stored in R2 — the JSON only carries
+ * the secret *name* via `api_key_secret_name`, and the worker resolves it
+ * from `c.env` at call time so an org can rotate without rewriting blobs.
  */
+
+import { resolveMailboxSettings } from "./mailbox-settings";
 
 export interface HubConfig {
 	url: string;
@@ -16,17 +19,18 @@ export interface HubConfig {
 	auto_report?: boolean;
 }
 
-/** Returns the hub config for a mailbox, or null when none is set. */
+interface BucketEnv {
+	BUCKET: R2Bucket;
+}
+
+/** Returns the resolved hub config for a mailbox, or null when neither
+ *  tier supplies a complete one. */
 export async function loadHubConfig(
-	bucket: R2Bucket,
+	env: BucketEnv,
 	mailboxId: string,
 ): Promise<HubConfig | null> {
-	const obj = await bucket.get(`mailboxes/${mailboxId}.json`);
-	if (!obj) return null;
-	const json = (await obj.json().catch(() => null)) as
-		| { intel?: { hub?: unknown } }
-		| null;
-	const raw = json?.intel?.hub;
+	const resolved = await resolveMailboxSettings(env, mailboxId);
+	const raw = resolved.intel.hub;
 	if (!raw || typeof raw !== "object") return null;
 	const cfg = raw as Partial<HubConfig>;
 	if (!cfg.url || !cfg.org_uuid || !cfg.api_key_secret_name) return null;
@@ -47,11 +51,10 @@ export async function loadHubConfig(
  * empty state has one shape.
  */
 export async function loadHubCredentials(
-	env: Record<string, unknown>,
-	bucket: R2Bucket,
+	env: Record<string, unknown> & BucketEnv,
 	mailboxId: string,
 ): Promise<{ cfg: HubConfig; apiKey: string } | null> {
-	const cfg = await loadHubConfig(bucket, mailboxId);
+	const cfg = await loadHubConfig(env, mailboxId);
 	if (!cfg) return null;
 	const apiKey = env[cfg.api_key_secret_name];
 	if (typeof apiKey !== "string" || !apiKey) return null;

--- a/workers/lib/mailbox-settings.ts
+++ b/workers/lib/mailbox-settings.ts
@@ -118,19 +118,16 @@ export async function resolveMailboxSettings(
 		getOrgSettings(env),
 	]);
 
-	const security = pickWhole(
-		mailbox.security,
-		org.security,
-		DEFAULT_SECURITY_SETTINGS,
-		mergeSecurityWithDefault,
-	);
+	// Whole-object replace across tiers. Whichever tier supplied the field
+	// wins outright — never deep-merged. Within the winning tier,
+	// mergeSecurityWithDefault completes any unset fields with the system
+	// default so consumers see a fully-populated MailboxSecuritySettings.
+	const securityWinner = mailbox.security ?? org.security;
+	const security = securityWinner
+		? mergeSecurityWithDefault(securityWinner)
+		: DEFAULT_SECURITY_SETTINGS;
 
-	const intelRaw = pickWhole<NonNullable<MailboxSettings["intel"]>>(
-		mailbox.intel,
-		org.intel,
-		{} as NonNullable<MailboxSettings["intel"]>,
-		(value) => value,
-	);
+	const intelRaw = (mailbox.intel ?? org.intel ?? {}) as NonNullable<MailboxSettings["intel"]>;
 
 	return {
 		agentSystemPrompt:
@@ -163,32 +160,17 @@ function resolveAutoDraft(
 	return { enabled: winner.enabled ?? DEFAULT_AUTO_DRAFT_ENABLED };
 }
 
-function pickWhole<T>(
-	mailbox: T | undefined,
-	org: T | undefined,
-	fallback: T,
-	finalize: (value: T) => T,
-): T {
-	if (mailbox !== undefined) return finalize(mailbox);
-	if (org !== undefined) return finalize(org);
-	return fallback;
-}
-
 /**
- * Merge a partial security override (from either tier) with the system
+ * Complete a partial security override (from either tier) with the system
  * default. The override carries whatever keys it set; missing keys fall
  * through to the default. This is NOT cross-tier deep merge — by the time
  * we reach this function, `value` is whichever single tier won the
- * whole-object replace.
- *
- * Without this completion step, a partially-specified security block
- * (`{ enabled: true }` only) would yield a `MailboxSecuritySettings` with
- * `undefined` thresholds, which the verdict pipeline can't tolerate.
+ * whole-object replace, and we're just filling in unset keys from
+ * DEFAULT_SECURITY_SETTINGS so consumers don't see undefined thresholds /
+ * attachment_policy / classification.
  */
-function mergeSecurityWithDefault(
-	value: NonNullable<MailboxSettings["security"]> | NonNullable<OrgSettings["security"]>,
-): MailboxSecuritySettings {
-	const partial = value as Partial<MailboxSecuritySettings>;
+function mergeSecurityWithDefault(value: unknown): MailboxSecuritySettings {
+	const partial = (value ?? {}) as Partial<MailboxSecuritySettings>;
 	return {
 		...DEFAULT_SECURITY_SETTINGS,
 		...partial,

--- a/workers/lib/mailbox-settings.ts
+++ b/workers/lib/mailbox-settings.ts
@@ -1,17 +1,34 @@
 // Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
 
-import { MailboxSettings } from "../../shared/mailbox-settings";
+import {
+	DEFAULT_AGENT_MODEL,
+	DEFAULT_AUTO_DRAFT_ENABLED,
+	DEFAULT_CLASSIFIER_MODEL,
+	DEFAULT_DRAFT_VERIFIER_MODEL,
+	DEFAULT_INJECTION_SCANNER_MODEL,
+	MailboxSettings,
+} from "../../shared/mailbox-settings";
+import type { OrgSettings } from "../../shared/org-settings";
+import { getOrgSettings } from "./org-settings";
+import {
+	DEFAULT_SECURITY_SETTINGS,
+	type MailboxSecuritySettings,
+} from "../security/defaults";
+
+type R2BucketEnv = { BUCKET: R2Bucket };
 
 /**
  * Read the per-mailbox settings blob from R2 and parse through the Zod
- * schema (which fills in defaults for missing fields). Returns the
- * defaults if the blob is missing or unreadable — never throws.
+ * schema. Returns an empty object (not defaults) when the blob is missing
+ * or unreadable — never throws.
  *
- * The `env` shape is intentionally narrowed to `{ BUCKET: R2Bucket }` so
- * this helper works in both Worker and Durable Object contexts.
+ * After #106, this returns the *raw* mailbox JSON only. Callers that need
+ * inheritance-aware values must call {@link resolveMailboxSettings}; the
+ * raw helper exists for the GET /api/v1/mailboxes/:id endpoint that
+ * surfaces the override-only state to the UI.
  */
 export async function getMailboxSettings(
-	env: { BUCKET: R2Bucket },
+	env: R2BucketEnv,
 	mailboxId: string,
 ): Promise<MailboxSettings> {
 	try {
@@ -21,8 +38,259 @@ export async function getMailboxSettings(
 			return MailboxSettings.parse(raw);
 		}
 	} catch {
-		// Fall through to defaults — missing/malformed blob shouldn't break
-		// the auto-draft pipeline. Surfaces as default behavior.
+		// Fall through to empty — missing/malformed blob shouldn't break
+		// downstream consumers. The resolver fills in defaults.
 	}
 	return MailboxSettings.parse({});
+}
+
+/**
+ * System defaults applied as the bottom of the resolution stack. Lives
+ * here (not on the Zod schema) so reads don't materialise defaults into
+ * stored mailbox JSON — that distinction is what makes
+ * "absent-key = inherit" possible. If any of these were on the schema,
+ * the round-trip would be: read fills in default → write strips default →
+ * next read fills it back in, indistinguishable from an explicit override.
+ */
+export const DEFAULT_MAILBOX_SETTINGS = {
+	agentSystemPrompt: undefined as string | undefined,
+	agentModel: DEFAULT_AGENT_MODEL,
+	autoDraft: { enabled: DEFAULT_AUTO_DRAFT_ENABLED },
+	injectionScannerModel: DEFAULT_INJECTION_SCANNER_MODEL,
+	draftVerifierModel: DEFAULT_DRAFT_VERIFIER_MODEL,
+	classifierModel: DEFAULT_CLASSIFIER_MODEL,
+	security: DEFAULT_SECURITY_SETTINGS,
+	intel: {} as { hub?: NonNullable<OrgSettings["intel"]>["hub"]; feeds?: NonNullable<OrgSettings["intel"]>["feeds"] },
+} as const;
+
+/**
+ * Inheritance-resolved view of a mailbox's settings.
+ *
+ * Each field has been resolved through `mailbox > org > system default`.
+ * Fields that have a system default are guaranteed-present (e.g.
+ * `agentModel: string`, not `string | undefined`). Fields with no
+ * meaningful default (`agentSystemPrompt`) stay `string | undefined`.
+ *
+ * `intel.hub` and `intel.feeds` may be `undefined` when neither tier set
+ * them — there's no system default for either.
+ *
+ * `raw` carries the per-mailbox JSON as-stored, so callers needing strictly
+ * per-mailbox fields (`fromName`, `signature`, `forwarding`, `autoReply`)
+ * can reach them without a second R2 read.
+ */
+export interface ResolvedMailboxSettings {
+	agentSystemPrompt: string | undefined;
+	agentModel: string;
+	autoDraft: { enabled: boolean };
+	injectionScannerModel: string;
+	draftVerifierModel: string;
+	classifierModel: string;
+	security: MailboxSecuritySettings;
+	intel: {
+		hub?: NonNullable<OrgSettings["intel"]>["hub"];
+		feeds?: NonNullable<OrgSettings["intel"]>["feeds"];
+	};
+	raw: MailboxSettings;
+	org: OrgSettings;
+}
+
+/**
+ * Resolve a mailbox's effective settings through the full inheritance
+ * hierarchy: `mailbox > org > system default`.
+ *
+ * Whole-object replacement for nested fields. If a mailbox sets `security`
+ * (any sub-field), it carries the *whole* security object — the org
+ * `security` block is NOT deep-merged in. Same for `intel.hub` and
+ * `intel.feeds`. This matches the v1 decision in #106's audit (Q3, Q4,
+ * Q6); per-array extend-merge semantics are tracked as separate follow-ups.
+ *
+ * `security` is post-normalised (lowercased allowlists, trimmed
+ * blocklist extensions, etc.) so consumers don't repeat the case fold at
+ * runtime — but the normalisation runs on whichever block won the resolve,
+ * NOT field-by-field across tiers.
+ */
+export async function resolveMailboxSettings(
+	env: R2BucketEnv,
+	mailboxId: string,
+): Promise<ResolvedMailboxSettings> {
+	const [mailbox, org] = await Promise.all([
+		getMailboxSettings(env, mailboxId),
+		getOrgSettings(env),
+	]);
+
+	const security = pickWhole(
+		mailbox.security,
+		org.security,
+		DEFAULT_SECURITY_SETTINGS,
+		mergeSecurityWithDefault,
+	);
+
+	const intelRaw = pickWhole<NonNullable<MailboxSettings["intel"]>>(
+		mailbox.intel,
+		org.intel,
+		{} as NonNullable<MailboxSettings["intel"]>,
+		(value) => value,
+	);
+
+	return {
+		agentSystemPrompt:
+			mailbox.agentSystemPrompt ?? org.agentSystemPrompt ?? undefined,
+		agentModel:
+			mailbox.agentModel ?? org.agentModel ?? DEFAULT_MAILBOX_SETTINGS.agentModel,
+		autoDraft: resolveAutoDraft(mailbox.autoDraft, org.autoDraft),
+		injectionScannerModel:
+			org.injectionScannerModel ?? DEFAULT_MAILBOX_SETTINGS.injectionScannerModel,
+		draftVerifierModel:
+			org.draftVerifierModel ?? DEFAULT_MAILBOX_SETTINGS.draftVerifierModel,
+		classifierModel:
+			org.classifierModel ?? DEFAULT_MAILBOX_SETTINGS.classifierModel,
+		security: normalizeSecurity(security),
+		intel: {
+			hub: intelRaw.hub,
+			feeds: intelRaw.feeds,
+		},
+		raw: mailbox,
+		org,
+	};
+}
+
+function resolveAutoDraft(
+	mailbox: MailboxSettings["autoDraft"],
+	org: OrgSettings["autoDraft"],
+): { enabled: boolean } {
+	const winner = mailbox ?? org;
+	if (!winner) return { enabled: DEFAULT_AUTO_DRAFT_ENABLED };
+	return { enabled: winner.enabled ?? DEFAULT_AUTO_DRAFT_ENABLED };
+}
+
+function pickWhole<T>(
+	mailbox: T | undefined,
+	org: T | undefined,
+	fallback: T,
+	finalize: (value: T) => T,
+): T {
+	if (mailbox !== undefined) return finalize(mailbox);
+	if (org !== undefined) return finalize(org);
+	return fallback;
+}
+
+/**
+ * Merge a partial security override (from either tier) with the system
+ * default. The override carries whatever keys it set; missing keys fall
+ * through to the default. This is NOT cross-tier deep merge — by the time
+ * we reach this function, `value` is whichever single tier won the
+ * whole-object replace.
+ *
+ * Without this completion step, a partially-specified security block
+ * (`{ enabled: true }` only) would yield a `MailboxSecuritySettings` with
+ * `undefined` thresholds, which the verdict pipeline can't tolerate.
+ */
+function mergeSecurityWithDefault(
+	value: NonNullable<MailboxSettings["security"]> | NonNullable<OrgSettings["security"]>,
+): MailboxSecuritySettings {
+	const partial = value as Partial<MailboxSecuritySettings>;
+	return {
+		...DEFAULT_SECURITY_SETTINGS,
+		...partial,
+		thresholds: { ...DEFAULT_SECURITY_SETTINGS.thresholds, ...(partial.thresholds ?? {}) },
+		attachment_policy: {
+			...DEFAULT_SECURITY_SETTINGS.attachment_policy,
+			...(partial.attachment_policy ?? {}),
+		},
+		classification: {
+			...DEFAULT_SECURITY_SETTINGS.classification,
+			...(partial.classification ?? {}),
+		},
+	};
+}
+
+/**
+ * Lowercase allowlists and trusted-authserv-ids, normalise attachment
+ * blocklist extensions. Runs on the *resolved* security block so consumers
+ * don't repeat the case fold. Materialises `business_hours` defaults only
+ * when a timezone is set (a partially-specified block is otherwise inert
+ * because `boost_on_off_hours` defaults to false).
+ */
+function normalizeSecurity(s: MailboxSecuritySettings): MailboxSecuritySettings {
+	return {
+		...s,
+		allowlist_senders: s.allowlist_senders.map((v) => v.toLowerCase()),
+		allowlist_domains: s.allowlist_domains.map((v) => v.toLowerCase()),
+		trusted_authserv_ids: s.trusted_authserv_ids.map((v) => v.toLowerCase()),
+		attachment_policy: {
+			...s.attachment_policy,
+			custom_blocklist_extensions: (s.attachment_policy.custom_blocklist_extensions ?? [])
+				.map((e) => e.trim().toLowerCase().replace(/^\./, ""))
+				.filter((e) => e.length > 0),
+		},
+		business_hours: s.business_hours && s.business_hours.timezone
+			? {
+				timezone: s.business_hours.timezone,
+				start_hour: s.business_hours.start_hour ?? 7,
+				end_hour: s.business_hours.end_hour ?? 19,
+				weekdays_only: s.business_hours.weekdays_only ?? true,
+				boost_on_off_hours: s.business_hours.boost_on_off_hours ?? false,
+			}
+			: undefined,
+	};
+}
+
+/**
+ * Strip fields from a mailbox settings PUT payload that are equal to the
+ * system default — prevents fresh mailboxes from silently overriding every
+ * org-level field (acceptance criterion 6 from #106). Whole-object
+ * equality for nested fields: if `incoming.security` deep-equals
+ * `DEFAULT_SECURITY_SETTINGS`, the whole `security` key is dropped;
+ * otherwise the whole object is kept (we never partially strip a nested
+ * block, since the override semantics are whole-object replace).
+ *
+ * Does NOT mutate the input. Returns a new object containing only the
+ * keys that survived stripping.
+ */
+export function stripDefaultEqual(
+	settings: MailboxSettings,
+): MailboxSettings {
+	const out: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(settings)) {
+		if (value === undefined) continue;
+		if (isDefaultEqual(key, value)) continue;
+		out[key] = value;
+	}
+	return out as MailboxSettings;
+}
+
+function isDefaultEqual(key: string, value: unknown): boolean {
+	switch (key) {
+		case "agentModel":
+			return value === DEFAULT_MAILBOX_SETTINGS.agentModel;
+		case "autoDraft":
+			return deepEqual(value, DEFAULT_MAILBOX_SETTINGS.autoDraft);
+		case "agentSystemPrompt":
+			return value === undefined || value === "";
+		case "security":
+			return deepEqual(value, DEFAULT_SECURITY_SETTINGS);
+		case "intel":
+			// No default for intel — only strip when the override is an empty object.
+			return deepEqual(value, {});
+		default:
+			return false;
+	}
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+	if (a === b) return true;
+	if (typeof a !== typeof b) return false;
+	if (a === null || b === null) return false;
+	if (typeof a !== "object") return false;
+	if (Array.isArray(a)) {
+		if (!Array.isArray(b) || a.length !== b.length) return false;
+		return a.every((v, i) => deepEqual(v, (b as unknown[])[i]));
+	}
+	if (Array.isArray(b)) return false;
+	const keysA = Object.keys(a as Record<string, unknown>);
+	const keysB = Object.keys(b as Record<string, unknown>);
+	if (keysA.length !== keysB.length) return false;
+	return keysA.every((k) =>
+		deepEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]),
+	);
 }

--- a/workers/lib/org-settings.ts
+++ b/workers/lib/org-settings.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Org-wide settings persistence and read cache (#106).
+ *
+ * Reads `org/settings.json` from R2 with a module-scope ETag cache so the
+ * per-email inheritance hierarchy doesn't cost an R2 GET on every read.
+ * The cache is invalidated on PUT and refreshed on a 200 response from R2;
+ * a 304 (If-None-Match hit) keeps the cached value as-is.
+ *
+ * Multi-tenant note: today the key is the flat `org/settings.json`
+ * (single-org-per-deploy, matching #104). The R2 key is centralised here
+ * (`orgSettingsKey`) so a future multi-tenant refactor — e.g.
+ * `orgs/<orgId>/settings.json` keyed off CF Access claims — is one helper
+ * change rather than a cross-cutting grep. The cache key is derived from
+ * the same helper for the same reason.
+ */
+
+import { OrgSettings, parseOrgSettings } from "../../shared/org-settings";
+
+interface OrgSettingsCacheEntry {
+	etag: string | null;
+	settings: OrgSettings;
+}
+
+const cache = new Map<string, OrgSettingsCacheEntry>();
+
+/** Sentinel etag used when R2 returns 404 — lets us cache "no org settings"
+ *  without a separate `present?` flag. */
+const ABSENT_ETAG = "__absent__";
+
+/**
+ * R2 key for the org settings blob. Centralised so multi-tenancy is one
+ * change. Returns the same string for every call today; in the multi-tenant
+ * future the signature can grow an `orgId` argument.
+ */
+export function orgSettingsKey(): string {
+	return "org/settings.json";
+}
+
+/**
+ * Read the org settings blob from R2, honouring a module-scope ETag cache.
+ *
+ * - First call (no cache): GET → parse → cache `{etag, settings}`.
+ * - Subsequent calls: GET with `If-None-Match`. 304 → return cached. 200 →
+ *   reparse and replace cache.
+ * - 404: cache an empty `{}` under `ABSENT_ETAG` so subsequent reads still
+ *   short-circuit without hammering R2.
+ * - Parse failure or any other error: return empty settings, do NOT cache
+ *   the failure (so a transient corruption can self-heal on the next read).
+ */
+export async function getOrgSettings(env: { BUCKET: R2Bucket }): Promise<OrgSettings> {
+	const key = orgSettingsKey();
+	const cached = cache.get(key);
+
+	const opts: R2GetOptions | undefined = cached?.etag && cached.etag !== ABSENT_ETAG
+		? { onlyIf: { etagDoesNotMatch: cached.etag } }
+		: undefined;
+
+	let obj: R2ObjectBody | null;
+	try {
+		// Workers R2 binding: when `onlyIf.etagDoesNotMatch` matches the stored
+		// etag, get() returns null (semantically a 304). When the object is
+		// absent, get() also returns null. We disambiguate by checking the
+		// cache entry: if we have a cached value, null means "not modified",
+		// so reuse the cache. If we have no cache, null means "object absent".
+		obj = await env.BUCKET.get(key, opts);
+	} catch {
+		return cached?.settings ?? {};
+	}
+
+	if (!obj) {
+		if (cached) return cached.settings;
+		// No cache and no object → cache "absent" so we don't re-fetch on hot path.
+		cache.set(key, { etag: ABSENT_ETAG, settings: {} });
+		return {};
+	}
+
+	try {
+		const raw = await obj.json<Record<string, unknown>>();
+		const parsed = parseOrgSettings(raw) ?? {};
+		cache.set(key, { etag: obj.etag ?? null, settings: parsed });
+		return parsed;
+	} catch {
+		// Malformed blob: return empty, don't poison the cache.
+		return cached?.settings ?? {};
+	}
+}
+
+/**
+ * Persist org-level settings. Validates the input through the OrgSettings
+ * schema so a malformed PUT can't write a blob that getOrgSettings would
+ * reject on the next read. Invalidates the cache so subsequent reads see
+ * the new value (even though the next R2 GET would refetch on etag change,
+ * dropping the cache here keeps the contract simple).
+ */
+export async function putOrgSettings(
+	env: { BUCKET: R2Bucket },
+	settings: unknown,
+): Promise<OrgSettings> {
+	const parsed = parseOrgSettings(settings);
+	if (!parsed) {
+		throw new Error("Invalid OrgSettings");
+	}
+	await env.BUCKET.put(orgSettingsKey(), JSON.stringify(parsed));
+	cache.delete(orgSettingsKey());
+	return parsed;
+}
+
+/**
+ * Drop the in-memory cache. Exported for tests; production code reaches it
+ * through `putOrgSettings`.
+ */
+export function clearOrgSettingsCache(): void {
+	cache.clear();
+}

--- a/workers/lib/tools.ts
+++ b/workers/lib/tools.ts
@@ -27,7 +27,7 @@ import {
 	buildThreadingHeaders,
 } from "./email-helpers";
 import { verifyDraft } from "./ai";
-import { getMailboxSettings } from "./mailbox-settings";
+import { resolveMailboxSettings } from "./mailbox-settings";
 import { sendEmail } from "../email-sender";
 import { Folders } from "../../shared/folders";
 import type { Env } from "../types";
@@ -43,7 +43,7 @@ async function verifyDraftForMailbox(
 	mailboxId: string,
 	body: string,
 ): Promise<string> {
-	const settings = await getMailboxSettings(env, mailboxId);
+	const settings = await resolveMailboxSettings(env, mailboxId);
 	return verifyDraft(env.AI, body, { model: settings.draftVerifierModel });
 }
 

--- a/workers/routes/cases.ts
+++ b/workers/routes/cases.ts
@@ -113,7 +113,7 @@ caseRoutes.post("/report-phish", async (c) => {
 	try {
 		const mailboxId = c.req.param("mailboxId");
 		if (mailboxId) {
-			const hub = await loadHubConfig(c.env.BUCKET, mailboxId);
+			const hub = await loadHubConfig(c.env, mailboxId);
 			if (hub?.auto_report) {
 				const apiKey = (c.env as unknown as Record<string, string | undefined>)[hub.api_key_secret_name];
 				if (apiKey) {

--- a/workers/routes/hub-ui.ts
+++ b/workers/routes/hub-ui.ts
@@ -46,8 +46,7 @@ async function withHubClient<T>(
 ): Promise<ConfiguredResponse<T> | UnconfiguredResponse> {
 	if (!mailboxId) return { configured: false };
 	const creds = await loadHubCredentials(
-		c.env as unknown as Record<string, unknown>,
-		c.env.BUCKET,
+		c.env as unknown as Record<string, unknown> & { BUCKET: R2Bucket },
 		mailboxId,
 	);
 	if (!creds) return { configured: false };
@@ -105,8 +104,7 @@ hubUiRoutes.post("/invites", async (c) => {
 	const mailboxId = c.req.param("mailboxId");
 	if (!mailboxId) return c.json({ error: "missing mailboxId" }, 400);
 	const creds = await loadHubCredentials(
-		c.env as unknown as Record<string, unknown>,
-		c.env.BUCKET,
+		c.env as unknown as Record<string, unknown> & { BUCKET: R2Bucket },
 		mailboxId,
 	);
 	if (!creds) return c.json({ error: "hub not configured" }, 412);

--- a/workers/security/defaults.ts
+++ b/workers/security/defaults.ts
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Leaf module: types and default values for `MailboxSecuritySettings`.
+ *
+ * Split out of `workers/security/settings.ts` so the resolver
+ * (`workers/lib/mailbox-settings.ts`) can import the defaults without
+ * pulling in `getSecuritySettings`, which itself now calls the resolver.
+ * Without this split the import graph cycles.
+ */
+
+import { DEFAULT_THRESHOLDS, type VerdictThresholds } from "./verdict";
+import { DEFAULT_ATTACHMENT_POLICY, type AttachmentPolicy } from "./attachments";
+
+/**
+ * Business-hours definition for the off-hours scrutiny tier.
+ *
+ * This is a *scoring* input — it tilts marginal verdicts, never decides them
+ * alone. See `workers/security/time-rules.ts` for the rationale (BEC / wire
+ * fraud is correlated with off-hours delivery). The short-circuit triage
+ * layer is intentionally NOT wired to this signal: a trusted allowlisted
+ * sender emailing at 3 AM is still a legitimate email.
+ */
+export interface BusinessHours {
+	/** IANA timezone, e.g. `America/New_York`. Invalid values fall back to no contribution. */
+	timezone: string;
+	/** Inclusive start hour in 24h local time. 7 means 07:00 counts as in-hours. */
+	start_hour: number;
+	/** Exclusive end hour in 24h local time. 19 means 19:00 counts as out-of-hours. */
+	end_hour: number;
+	/** When true, Saturday and Sunday count as outside business hours regardless of the hour. */
+	weekdays_only: boolean;
+	/** Master switch so existing mailboxes opt-in explicitly. Defaults to false. */
+	boost_on_off_hours: boolean;
+}
+
+/**
+ * Classifier-stage tunables. Currently only one knob: how to treat an LLM
+ * timeout/AbortError. See issue #28 and `workers/security/classification.ts`.
+ */
+export interface ClassificationSettings {
+	/**
+	 * When true (default), an LLM classifier timeout/AbortError contributes
+	 * 0 to the verdict score and tags the email with `llm_unavailable`. When
+	 * false, the legacy fail-closed-to-`suspicious` behavior is preserved.
+	 */
+	skip_on_timeout: boolean;
+}
+
+/**
+ * Per-folder policy: either bypasses part of the pipeline (`mode`) or marks
+ * the folder as a trust signal (`treat_as_verified` — moving mail in bumps
+ * the sender's reputation). Both fields are independent.
+ */
+export interface FolderPolicy {
+	mode?: "skip_all" | "skip_classifier";
+	treat_as_verified?: boolean;
+}
+
+export interface MailboxSecuritySettings {
+	enabled: boolean;
+	thresholds: VerdictThresholds;
+	/** Learning mode: tag only, never auto-quarantine. */
+	learning_mode: boolean;
+	/** Exact sender addresses (lowercased) that short-circuit to allow when DMARC passes. */
+	allowlist_senders: string[];
+	/** Registrable domains (lowercased) that short-circuit to allow when DMARC passes. */
+	allowlist_domains: string[];
+	/**
+	 * Lowercased list of trusted `authserv-id` values. Empty list falls back
+	 * to first-header-wins (insecure against forgery). Operators should
+	 * populate this list to match their mail path.
+	 */
+	trusted_authserv_ids: string[];
+	/** Enable the hard-allow triage tier. Requires DMARC pass — never allowlist alone. */
+	trusted_auto_allow: boolean;
+	/** History-based hard-allow: if a sender has ≥ this many prior messages with avg_score < 20 (and DMARC passes), auto-allow. 0 disables. */
+	trusted_auto_allow_min_messages: number;
+	/** Enable the hard-block triage tier on confirmed intel-feed hits or flagged senders. */
+	intel_auto_block: boolean;
+	/** Optional per-mailbox business-hours policy. */
+	business_hours?: BusinessHours;
+	/** Per-folder bypass policies keyed by folder id. */
+	folder_policies?: Record<string, FolderPolicy>;
+	/** Attachment-type gate. Runs before hard-allow in triage. */
+	attachment_policy: AttachmentPolicy;
+	/** Classifier-stage settings (issue #28). */
+	classification: ClassificationSettings;
+}
+
+/**
+ * Default for the new classification block. Skip-on-timeout is ON so the
+ * common case (Workers-AI throttling, model cold start) doesn't dump a
+ * burst of legitimate mail into the `suspicious` bucket.
+ */
+export const DEFAULT_CLASSIFICATION_SETTINGS: ClassificationSettings = {
+	skip_on_timeout: true,
+};
+
+export const DEFAULT_SECURITY_SETTINGS: MailboxSecuritySettings = {
+	enabled: false, // opt-in — existing mailboxes are unaffected until the user flips this
+	thresholds: DEFAULT_THRESHOLDS,
+	learning_mode: false,
+	allowlist_senders: [],
+	allowlist_domains: [],
+	trusted_authserv_ids: [],
+	trusted_auto_allow: true,
+	trusted_auto_allow_min_messages: 10,
+	intel_auto_block: true,
+	attachment_policy: DEFAULT_ATTACHMENT_POLICY,
+	classification: DEFAULT_CLASSIFICATION_SETTINGS,
+};

--- a/workers/security/index.ts
+++ b/workers/security/index.ts
@@ -26,8 +26,7 @@ import { parseAuthResults, extractReceivedFromIp } from "./auth";
 import { classifyEmail } from "./classification";
 import { extractUrls } from "./urls";
 import { aggregateVerdict, type FinalVerdict } from "./verdict";
-import { getSecuritySettings } from "./settings";
-import { getMailboxSettings } from "../lib/mailbox-settings";
+import { resolveMailboxSettings } from "../lib/mailbox-settings";
 import { checkUrlAgainstFeeds, type FeedMatch } from "../intel/feeds";
 import { evaluateTriage, type IntelMatchInfo } from "./triage";
 import type { AttachmentLike } from "./attachments";
@@ -86,7 +85,8 @@ export interface PipelineResult {
 
 export async function runSecurityPipeline(input: RunPipelineInput): Promise<PipelineResult> {
 	const { env, mailboxId, messageId, parsedEmail, targetFolder } = input;
-	const settings = await getSecuritySettings(env, mailboxId);
+	const resolved = await resolveMailboxSettings(env, mailboxId);
+	const settings = resolved.security;
 	if (!settings.enabled) return { verdict: null, skipped: true };
 
 	const sender = (parsedEmail.from?.address || "").toLowerCase();
@@ -160,16 +160,17 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 	}
 
 	// Full path: LLM classification (possibly skipped by folder-bypass tier) + aggregation.
-	// `classifierModel` may be overridden per-mailbox (#67); load the parent
-	// MailboxSettings since `getSecuritySettings` only returns the security sub-tree.
-	const mailboxSettings = await getMailboxSettings(env, mailboxId);
+	// `classifierModel` is org-level only post-#106 (per-mailbox override is a
+	// follow-up; switching to a weaker classifier per mailbox is too sharp a
+	// security lever to expose without UI guardrails). The resolver returns
+	// the org value or the system default — never undefined.
 	const classification = triaged.skipClassifier
 		? { label: "safe" as const, confidence: 1.0, reasoning: "classifier skipped by folder policy" }
 		: await classifyEmail(
 			env.AI,
 			{ subject, sender, bodyHtml, auth },
 			{
-				model: mailboxSettings.classifierModel,
+				model: resolved.classifierModel,
 				// Issue #28: per-mailbox toggle for the narrowed Rule 5 behavior.
 				// `true` (default) → timeouts contribute 0 instead of failing
 				// closed to `suspicious`. `false` preserves the legacy behavior.

--- a/workers/security/settings.ts
+++ b/workers/security/settings.ts
@@ -3,198 +3,57 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 /**
- * Mailbox-level security settings, stored inline in `mailboxes/{id}.json`.
+ * Mailbox-effective security settings — thin wrapper around the inheritance
+ * resolver from #106.
  *
- * Read-only helper — writes go through the existing mailbox settings route.
- * New fields are optional so older mailbox JSON files load cleanly.
+ * Pre-#106 this module owned the field-by-field merge that filled in
+ * security defaults from `mailboxes/{id}.json`. Post-#106, all merge
+ * semantics live in `workers/lib/mailbox-settings.ts`
+ * (`resolveMailboxSettings`), and this module just re-exposes the resolved
+ * `security` block under the legacy function name + signature so the
+ * triage/auth/url scoring pipeline doesn't have to learn about the
+ * resolver's wider return shape.
+ *
+ * Defaults and the `MailboxSecuritySettings` type itself live in
+ * `./defaults` to keep the import graph acyclic — the resolver imports
+ * defaults, this wrapper imports the resolver, and a third party that just
+ * wants the type or the constant can import directly from `./defaults`
+ * (or, for back-compat, from this module via the re-exports below).
  */
 
 import type { Env } from "../types";
-import { DEFAULT_THRESHOLDS, type VerdictThresholds } from "./verdict";
-import { DEFAULT_ATTACHMENT_POLICY, type AttachmentPolicy } from "./attachments";
+import { resolveMailboxSettings } from "../lib/mailbox-settings";
+import {
+	DEFAULT_CLASSIFICATION_SETTINGS,
+	DEFAULT_SECURITY_SETTINGS,
+	type BusinessHours,
+	type ClassificationSettings,
+	type FolderPolicy,
+	type MailboxSecuritySettings,
+} from "./defaults";
+
+// Back-compat re-exports — pre-#106 callers imported these from this module.
+export {
+	DEFAULT_CLASSIFICATION_SETTINGS,
+	DEFAULT_SECURITY_SETTINGS,
+	type BusinessHours,
+	type ClassificationSettings,
+	type FolderPolicy,
+	type MailboxSecuritySettings,
+};
 
 /**
- * Business-hours definition for the off-hours scrutiny tier.
+ * Return the effective security settings for a mailbox after running the
+ * full inheritance hierarchy (mailbox > org > system default), with the
+ * resolved block normalised (lowercased allowlists, etc.).
  *
- * This is a *scoring* input — it tilts marginal verdicts, never decides them
- * alone. See `workers/security/time-rules.ts` for the rationale (BEC / wire
- * fraud is correlated with off-hours delivery). The short-circuit triage
- * layer is intentionally NOT wired to this signal: a trusted allowlisted
- * sender emailing at 3 AM is still a legitimate email.
+ * Never throws — the resolver returns `DEFAULT_SECURITY_SETTINGS` when
+ * neither tier set the block.
  */
-export interface BusinessHours {
-	/** IANA timezone, e.g. `America/New_York`. Invalid values fall back to no contribution. */
-	timezone: string;
-	/** Inclusive start hour in 24h local time. 7 means 07:00 counts as in-hours. */
-	start_hour: number;
-	/** Exclusive end hour in 24h local time. 19 means 19:00 counts as out-of-hours. */
-	end_hour: number;
-	/** When true, Saturday and Sunday count as outside business hours regardless of the hour. */
-	weekdays_only: boolean;
-	/** Master switch so existing mailboxes opt-in explicitly. Defaults to false. */
-	boost_on_off_hours: boolean;
-}
-
-/**
- * Classifier-stage tunables. Currently only one knob: how to treat an LLM
- * timeout/AbortError. See issue #28 and `workers/security/classification.ts`.
- */
-export interface ClassificationSettings {
-	/**
-	 * When true (default), an LLM classifier timeout/AbortError contributes
-	 * 0 to the verdict score and tags the email with `llm_unavailable` —
-	 * other pipeline stages (auth, URLs, reputation, intel) still produce a
-	 * verdict. When false, the legacy fail-closed-to-`suspicious` behavior
-	 * is preserved (inverts availability-as-bypass at the cost of some
-	 * false positives during Workers-AI throttling).
-	 */
-	skip_on_timeout: boolean;
-}
-
-export interface MailboxSecuritySettings {
-	enabled: boolean;
-	thresholds: VerdictThresholds;
-	/** Learning mode: tag only, never auto-quarantine. */
-	learning_mode: boolean;
-	/** Exact sender addresses (lowercased) that short-circuit to allow when DMARC passes. */
-	allowlist_senders: string[];
-	/** Registrable domains (lowercased) that short-circuit to allow when DMARC passes. */
-	allowlist_domains: string[];
-	/**
-	 * Lowercased list of trusted `authserv-id` values (e.g. `mx.cloudflare.net`,
-	 * `mx.google.com`). When set, only `Authentication-Results` headers from
-	 * these authserv-ids contribute to the DMARC/SPF/DKIM verdict — all others
-	 * are ignored. Prevents an attacker-controlled upstream from forging a
-	 * pass verdict by injecting their own `Authentication-Results` header.
-	 *
-	 * Empty list falls back to first-header-wins behaviour (insecure against
-	 * forgery). Operators should populate this list to match their mail path.
-	 */
-	trusted_authserv_ids: string[];
-	/** Enable the hard-allow triage tier. Requires DMARC pass — never allowlist alone. */
-	trusted_auto_allow: boolean;
-	/**
-	 * History-based hard-allow: if a sender has ≥ this many prior messages
-	 * with avg_score < 20 (and DMARC passes), auto-allow without running the
-	 * classifier. Set to 0 to disable history-based hard-allow.
-	 */
-	trusted_auto_allow_min_messages: number;
-	/** Enable the hard-block triage tier on confirmed intel-feed hits or flagged senders. */
-	intel_auto_block: boolean;
-	/**
-	 * Optional per-mailbox business-hours policy. When present and
-	 * `boost_on_off_hours` is true, mail received outside the configured window
-	 * gets a small verdict-score boost. See `time-rules.ts`.
-	 */
-	business_hours?: BusinessHours;
-	/**
-	 * Per-folder bypass policies keyed by folder id (e.g. "INBOX", "Newsletters").
-	 * See `triage.ts` for the folder-bypass tier semantics and
-	 * `workers/index.ts` for the `treat_as_verified` reputation-bump hook.
-	 */
-	folder_policies?: Record<string, FolderPolicy>;
-	/**
-	 * Attachment-type gate. Runs before hard-allow in triage so a
-	 * DMARC-passing allowlisted sender carrying an .exe still gets
-	 * quarantined. Defaults are conservative-but-actionable: executables
-	 * hard-block, containers/macros only score. See `attachments.ts` for
-	 * the full rules.
-	 */
-	attachment_policy: AttachmentPolicy;
-	/**
-	 * Classifier-stage settings (issue #28). Default: skip-on-timeout
-	 * enabled — a Workers-AI timeout/AbortError contributes 0 to the
-	 * score instead of failing closed to `suspicious`.
-	 */
-	classification: ClassificationSettings;
-}
-
-/**
- * Per-folder policy: either bypasses part of the pipeline (`mode`) or marks
- * the folder as a trust signal (`treat_as_verified` — moving mail in bumps
- * the sender's reputation). Both fields are independent.
- */
-export interface FolderPolicy {
-	mode?: "skip_all" | "skip_classifier";
-	treat_as_verified?: boolean;
-}
-
-/**
- * Default for the new classification block. Skip-on-timeout is ON so the
- * common case (Workers-AI throttling, model cold start) doesn't dump a
- * burst of legitimate mail into the `suspicious` bucket. Operators who want
- * the legacy fail-closed-to-`suspicious` behavior can flip this to false.
- */
-export const DEFAULT_CLASSIFICATION_SETTINGS: ClassificationSettings = {
-	skip_on_timeout: true,
-};
-
-export const DEFAULT_SECURITY_SETTINGS: MailboxSecuritySettings = {
-	enabled: false, // opt-in — existing mailboxes are unaffected until the user flips this
-	thresholds: DEFAULT_THRESHOLDS,
-	learning_mode: false,
-	allowlist_senders: [],
-	allowlist_domains: [],
-	trusted_authserv_ids: [],
-	trusted_auto_allow: true,
-	trusted_auto_allow_min_messages: 10,
-	intel_auto_block: true,
-	attachment_policy: DEFAULT_ATTACHMENT_POLICY,
-	classification: DEFAULT_CLASSIFICATION_SETTINGS,
-};
-
 export async function getSecuritySettings(
 	env: Env,
 	mailboxId: string,
 ): Promise<MailboxSecuritySettings> {
-	try {
-		const obj = await env.BUCKET.get(`mailboxes/${mailboxId}.json`);
-		if (!obj) return DEFAULT_SECURITY_SETTINGS;
-		const json = (await obj.json()) as { security?: Partial<MailboxSecuritySettings> } | null;
-		const raw = json?.security ?? {};
-		const merged: MailboxSecuritySettings = {
-			...DEFAULT_SECURITY_SETTINGS,
-			...raw,
-			thresholds: { ...DEFAULT_THRESHOLDS, ...(raw.thresholds ?? {}) },
-			// Defensive normalisation: everything in allowlists is lowercased so
-			// comparisons at runtime don't need to repeat the case fold.
-			allowlist_senders: (raw.allowlist_senders ?? DEFAULT_SECURITY_SETTINGS.allowlist_senders).map((s) => s.toLowerCase()),
-			allowlist_domains: (raw.allowlist_domains ?? DEFAULT_SECURITY_SETTINGS.allowlist_domains).map((s) => s.toLowerCase()),
-			trusted_authserv_ids: (raw.trusted_authserv_ids ?? DEFAULT_SECURITY_SETTINGS.trusted_authserv_ids).map((s) => s.toLowerCase()),
-			// business_hours: only materialise if the user supplied at least a timezone.
-			// `boost_on_off_hours` defaults to false so a partially specified block is inert.
-			business_hours: raw.business_hours && raw.business_hours.timezone
-				? {
-					timezone: raw.business_hours.timezone,
-					start_hour: raw.business_hours.start_hour ?? 7,
-					end_hour: raw.business_hours.end_hour ?? 19,
-					weekdays_only: raw.business_hours.weekdays_only ?? true,
-					boost_on_off_hours: raw.business_hours.boost_on_off_hours ?? false,
-				}
-				: undefined,
-			// Merge attachment_policy field-by-field so a partially-specified user
-			// block (e.g. only `custom_blocklist_extensions`) doesn't silently
-			// drop the default actions back to "ignore" across the board.
-			attachment_policy: {
-				...DEFAULT_ATTACHMENT_POLICY,
-				...(raw.attachment_policy ?? {}),
-				custom_blocklist_extensions: (raw.attachment_policy?.custom_blocklist_extensions
-					?? DEFAULT_ATTACHMENT_POLICY.custom_blocklist_extensions)
-					.map((e) => e.trim().toLowerCase().replace(/^\./, ""))
-					.filter((e) => e.length > 0),
-			},
-			// Classifier-stage settings (issue #28). Only `skip_on_timeout` is
-			// honoured today; field-by-field merge means partial user blocks
-			// retain the defaults for unset fields rather than getting `false`
-			// silently substituted for "missing".
-			classification: {
-				...DEFAULT_CLASSIFICATION_SETTINGS,
-				...((raw.classification ?? {}) as Partial<ClassificationSettings>),
-			},
-		};
-		return merged;
-	} catch (e) {
-		console.error("getSecuritySettings failed:", (e as Error).message);
-		return DEFAULT_SECURITY_SETTINGS;
-	}
+	const resolved = await resolveMailboxSettings(env, mailboxId);
+	return resolved.security;
 }


### PR DESCRIPTION
**Part 1 of 2 for #106.** PR2 ships the org `/settings` UI route and the per-mailbox "Inherited from org" indicator + reset-to-inherited affordance. `Closes #106` goes in PR2.

## What this PR does

Adds the inheritance hierarchy and the resolver that every per-email read site now goes through. Org-level settings live at R2 key `org/settings.json`; mailbox JSON shape unchanged. Field absence = inherit one layer up. Resolution order: **mailbox > org > system default**. Nested objects (`security`, `intel.hub`, `intel.feeds`) are replaced **whole** across tiers — no deep merge.

Built on the audit posted at #106:
https://github.com/schmug/PhishSOC/issues/106#issuecomment-4364964710

## Locked semantic decisions

| # | Decision | Rationale |
|---|---|---|
| Q1 | `intel.hub` inherits, whole-replace | Already deployment-scoped via `api_key_secret_name` → worker secret. `loadHubConfig` now flows through the resolver so an org-level hub takes effect for unconfigured mailboxes. |
| Q2 | `intel.feeds[]` declared in shared schema | Was opaque via `.passthrough()`; resolver can now whole-replace cleanly. |
| Q3 | Allowlists v1 = whole-replace | Operator gets a banner in PR2's UI; extend-merge tracked as #149. |
| Q4 | `business_hours` v1 = whole-replace | Per-field merge tracked as #150. |
| Q5 | Drop Zod `.default(...)` for `agentModel` and `autoDraft` | Otherwise stored mailbox JSON looks like an override forever. Defaults live in `DEFAULT_MAILBOX_SETTINGS` in the resolver. |
| Q6 | Rip out `getSecuritySettings` field-by-field merge | One rule for the whole resolver: cross-tier whole-replace + within-tier completion. UI already PUTs full security blocks. |
| Q7 | `injectionScannerModel`/`draftVerifierModel`/`classifierModel` are org-only in v1 | Per-mailbox overrides for security-critical model surfaces are too sharp without UI guardrails. Richer feature tracked as #151. |
| Q8 | `signature`/`forwarding`/`autoReply` strict per-mailbox | No org templating in v1 — separate feature scope. |

## Caller migration

| Call site | Was | Now |
|---|---|---|
| `workers/agent/index.ts:274` (chat handler) | `getMailboxSettings` | `resolveMailboxSettings` |
| `workers/agent/index.ts:358` (onNewEmail) | `getMailboxSettings` | `resolveMailboxSettings` |
| `workers/agent/index.ts:368, :418` (injection scan) | `settings.injectionScannerModel` (per-mailbox) | `resolved.injectionScannerModel` (org-only) |
| `workers/agent/index.ts:503` (verify draft) | `settings.draftVerifierModel` (per-mailbox) | `resolved.draftVerifierModel` (org-only) |
| `workers/lib/tools.ts:46` (verifyDraftForMailbox) | `getMailboxSettings` | `resolveMailboxSettings` |
| `workers/security/index.ts:89` (runSecurityPipeline) | `getSecuritySettings` | `resolveMailboxSettings(...).security` |
| `workers/security/index.ts:165` (classifierModel) | raw `getMailboxSettings` | `resolved.classifierModel` (org-only) |
| `workers/index.ts:664` (treat_as_verified hook on move) | `getSecuritySettings` | `resolveMailboxSettings(...).security` |
| `workers/index.ts:953` (deep-scan thresholds) | `getSecuritySettings` | `resolveMailboxSettings(...).security` |
| `workers/index.ts:976` (autoDraft gate) | `getMailboxSettings` | `resolveMailboxSettings` |
| `workers/intel/feeds.ts:67` (loadMailboxIntelSettings) | direct R2 read | `resolveMailboxSettings(...).intel` |
| `workers/lib/hub-config.ts:20` (loadHubConfig) | direct R2 read | `resolveMailboxSettings(...).intel.hub` |
| `workers/lib/hub-config.ts:50` (loadHubCredentials) | direct R2 read via loadHubConfig | unchanged behaviour, now flows through resolver |
| `workers/index.ts:388` (GET /api/v1/mailboxes/:id) | direct R2 read | unchanged — endpoint returns the **raw** mailbox JSON for the UI's override-state rendering |

`getMailboxSettings` (raw read) and `getSecuritySettings` (thin wrapper around the resolver) are still exported for back-compat but every internal caller is migrated.

## Acceptance criteria from #106

- [x] `shared/org-settings.ts` defines `OrgSettings` Zod schema (passthrough, all top-level optional).
- [x] `workers/lib/org-settings.ts` reads/writes `org/settings.json` from R2 with module-scope ETag cache.
- [x] `resolveMailboxSettings(env, mailboxId)` helper merges org + mailbox + system defaults; whole-object replacement for nested fields.
- [x] All current callers of `getMailboxSettings` and `getSecuritySettings` migrated to the resolved helper.
- [x] `GET/PUT /api/v1/org/settings` endpoints + `GET /api/v1/mailboxes/:id/settings/effective`.
- [x] Mailbox PUT strips fields equal to system default before writing (`stripDefaultEqual`).
- [ ] **Deferred to PR2:** New `/settings` route (org-level) in `app/routes.ts`.
- [ ] **Deferred to PR2:** `app/routes/settings.tsx` shows inherited/overridden indicator + reset-to-inherited per field.
- [x] Tests: `resolveMailboxSettings` unit (4 states), security whole-replace, intel.hub inheritance, ETag cache, `stripDefaultEqual`. Agent end-to-end and UI override-indicator tests deferred to PR2.
- [x] Existing security-settings tests updated for whole-replace semantics.

## Carve-out follow-ups (filed before requesting review)

- #149 — extend-merge for `security.allowlist_senders` / `allowlist_domains`
- #150 — per-field merge for `security.business_hours`
- #151 — per-mailbox model overrides (user choice / local models / BYO key) — three-PR roadmap

## Out of scope (this PR and PR2)

- Group/domain tier (#142, separate session — PR2 of this work + #142 compose at the resolver layer).
- Per-user RBAC for org-edit.
- Deep-merge for inheritable arrays beyond the allowlist carve-out (#149).

## Multi-tenant hook

Per Cory's note ("multitenant is the way things are going"), the R2 key `org/settings.json` is centralised behind `orgSettingsKey()` in `workers/lib/org-settings.ts:36`. A future multi-tenant refactor — e.g. `orgs/<orgId>/settings.json` keyed off CF Access claims — is one helper change rather than a cross-cutting grep. The module-scope ETag cache derives its key from the same helper for the same reason.

## Test plan

- [x] `npm test` — **353 passing, 0 failing** (was 332 → +21 new resolver tests, 0 regressions).
- [x] `npm run cf-typegen && tsc -b` — clean for everything I touched. The remaining `virtual:react-router` and `@testing-library/*` errors are pre-existing local-dev resolution failures (CI installs jsdom transitively).
- [x] Diff audited for accidental cross-tier deep-merge near `security` / `intel.hub` / `intel.feeds` — every `merge` / `spread` hit is either a comment, a deleted line, single-tier completion (`mergeSecurityWithDefault`), or `deepEqual` (used by `stripDefaultEqual`, not a merge).

## Commits (squash-merge target)

Seven incremental commits for crash-safety mid-development; squash to one `feat:` on merge.