### PR TITLE
feat: domain-level settings layer (#142)

### DIFF
--- a/app/queries/domain-settings.ts
+++ b/app/queries/domain-settings.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import api from "~/services/api";
+import { queryKeys } from "./keys";
+
+export function useDomainSettings(domain: string | undefined) {
+	return useQuery({
+		queryKey: domain ? queryKeys.domains.settings(domain) : ["domains", "_disabled"],
+		queryFn: () => api.getDomainSettings(domain!),
+		enabled: !!domain,
+	});
+}
+
+export function useUpdateDomainSettings(domain: string | undefined) {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (settings: unknown) => api.updateDomainSettings(domain!, settings),
+		onSuccess: () => {
+			if (domain) {
+				qc.invalidateQueries({ queryKey: queryKeys.domains.settings(domain) });
+			}
+			// Domain changes ripple to every mailbox under it; the resolved
+			// view depends on this tier. Invalidate the whole mailboxes
+			// subtree (cheap) rather than enumerating mailbox ids.
+			qc.invalidateQueries({ queryKey: ["mailboxes"] });
+		},
+	});
+}

--- a/app/queries/keys.ts
+++ b/app/queries/keys.ts
@@ -33,6 +33,7 @@ export const queryKeys = {
 	domains: {
 		list: ["domains"] as const,
 		detail: (domain: string) => ["domains", domain] as const,
+		settings: (domain: string) => ["domains", domain, "settings"] as const,
 	},
 	hub: {
 		contributions: (mailboxId: string) => ["hub", mailboxId, "contributions"] as const,

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -14,6 +14,7 @@ export default [
 	route("settings", "routes/org-settings.tsx"),
 	route("domains", "routes/domains-list.tsx"),
 	route("domains/:domain", "routes/domain-detail.tsx"),
+	route("domains/:domain/settings", "routes/domain-settings.tsx"),
 	route("mailbox/:mailboxId", "routes/mailbox.tsx", [
 		index("routes/mailbox-index.tsx"),
 		route("dashboard", "routes/dashboard.tsx"),

--- a/app/routes/domain-settings.tsx
+++ b/app/routes/domain-settings.tsx
@@ -1,0 +1,257 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { Badge, Button, Loader } from "@cloudflare/kumo";
+import { RobotIcon, ArrowCounterClockwiseIcon } from "@phosphor-icons/react";
+import { useEffect, useRef, useState } from "react";
+import { Link, useParams } from "react-router";
+import { useFeedback } from "~/lib/feedback";
+import {
+	useDomainSettings,
+	useUpdateDomainSettings,
+} from "~/queries/domain-settings";
+import { useTextModels } from "~/queries/text-models";
+import { SecuritySettingsPanel } from "~/components/SecuritySettingsPanel";
+import {
+	HubSettingsPanel,
+	normalizeHubConfig,
+	validateHubConfig,
+	type HubFieldErrors,
+} from "~/components/HubSettingsPanel";
+import type { HubConfigSettings, SecuritySettings } from "~/types";
+import { TEXT_MODELS } from "shared/mailbox-settings";
+
+const PROMPT_PLACEHOLDER = `(Leave empty to inherit from org-wide /settings)`;
+
+interface DomainSettingsShape {
+	agentSystemPrompt?: string;
+	agentModel?: string;
+	autoDraft?: { enabled?: boolean };
+	security?: SecuritySettings;
+	intel?: { hub?: HubConfigSettings };
+}
+
+/**
+ * Domain-level settings page (#142). Sits between mailbox and org in the
+ * inheritance hierarchy: mailbox > domain > org > system default.
+ *
+ * Mirrors the org-settings page minus the three security-critical model
+ * fields (those stay org-only — per-tier override of the prompt-injection
+ * scanner is the same foot-gun without UI guardrails; tracked as #151).
+ */
+export default function DomainSettingsRoute() {
+	const { domain: rawDomain } = useParams<{ domain: string }>();
+	const domain = rawDomain?.toLowerCase();
+	const feedback = useFeedback();
+	const { data, isLoading } = useDomainSettings(domain);
+	const updateDomain = useUpdateDomainSettings(domain);
+	const { models: availableModels } = useTextModels();
+
+	const [agentPrompt, setAgentPrompt] = useState("");
+	const [security, setSecurity] = useState<SecuritySettings | undefined>(undefined);
+	const [hub, setHub] = useState<HubConfigSettings | undefined>(undefined);
+	const [hubErrors, setHubErrors] = useState<HubFieldErrors | undefined>(undefined);
+	const [autoDraftEnabled, setAutoDraftEnabled] = useState(true);
+	const [modelChoice, setModelChoice] = useState<string>(TEXT_MODELS[0]);
+	const [customModel, setCustomModel] = useState("");
+	const [isSaving, setIsSaving] = useState(false);
+
+	// Initialise once per domain (same useRef pattern as the per-mailbox
+	// settings page — protects against query-result identity churn that
+	// would otherwise clobber edits on every re-render).
+	const initialisedFor = useRef<string | null>(null);
+	useEffect(() => {
+		if (!data?.settings || !domain) return;
+		if (initialisedFor.current === domain) return;
+		initialisedFor.current = domain;
+		const s = data.settings as DomainSettingsShape;
+		setAgentPrompt(s.agentSystemPrompt ?? "");
+		setSecurity(s.security);
+		setHub(s.intel?.hub);
+		setHubErrors(undefined);
+		setAutoDraftEnabled(s.autoDraft?.enabled === undefined ? true : s.autoDraft.enabled);
+
+		const m = s.agentModel ?? availableModels[0] ?? TEXT_MODELS[0];
+		if (availableModels.includes(m)) {
+			setModelChoice(m);
+			setCustomModel("");
+		} else {
+			setModelChoice("__custom__");
+			setCustomModel(m);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [data, domain]);
+
+	const handleSave = async () => {
+		if (!domain) return;
+		const resolvedModel = modelChoice === "__custom__" ? customModel.trim() : modelChoice;
+		if (modelChoice === "__custom__" && !resolvedModel) {
+			feedback.error("Custom model cannot be empty");
+			return;
+		}
+		if (resolvedModel && !resolvedModel.startsWith("@cf/")) {
+			feedback.error("Model must start with @cf/");
+			return;
+		}
+
+		const hubValidation = validateHubConfig(hub);
+		setHubErrors(hubValidation ?? undefined);
+		if (hubValidation) {
+			feedback.error("Fix the threat-intel hub fields before saving.");
+			return;
+		}
+
+		const normalizedHub = normalizeHubConfig(hub);
+		const intelToPersist = normalizedHub ? { hub: normalizedHub } : undefined;
+
+		const settings: DomainSettingsShape = {
+			agentSystemPrompt: agentPrompt.trim() || undefined,
+			autoDraft: { enabled: autoDraftEnabled },
+			agentModel: resolvedModel || undefined,
+			security,
+			intel: intelToPersist,
+		};
+
+		setIsSaving(true);
+		try {
+			await updateDomain.mutateAsync(settings);
+			feedback.success(`Domain settings saved for ${domain}!`);
+		} catch {
+			feedback.error("Failed to save domain settings");
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	if (!domain) {
+		return (
+			<div className="px-4 py-4 md:px-8 md:py-6">
+				<p className="text-sm text-ink-3">Missing domain in URL.</p>
+			</div>
+		);
+	}
+
+	if (isLoading) {
+		return (
+			<div className="flex justify-center py-20">
+				<Loader size="lg" />
+			</div>
+		);
+	}
+
+	const isCustomPrompt = agentPrompt.trim().length > 0;
+
+	return (
+		<div className="max-w-2xl px-4 py-4 md:px-8 md:py-6 h-full overflow-y-auto">
+			<h1 className="pp-serif text-ink mb-2">Domain settings — {domain}</h1>
+			<p className="text-xs text-ink-3 mb-6 max-w-xl">
+				Defaults for every mailbox under <code className="pp-mono">{domain}</code>.
+				Inheritance order: mailbox &gt; domain &gt; org &gt; system default. Fields left
+				blank inherit from <Link to="/settings" className="underline">org-wide settings</Link>;
+				per-mailbox overrides replace the value for that mailbox whole.
+			</p>
+
+			<div className="space-y-6">
+				{/* Agent System Prompt */}
+				<div className="pp-card p-5">
+					<div className="flex items-center justify-between mb-4">
+						<div className="flex items-center gap-2">
+							<RobotIcon size={16} weight="duotone" className="text-ink-3" />
+							<span className="text-sm font-medium text-ink">AI Agent Prompt</span>
+							{isCustomPrompt ? (
+								<Badge variant="primary">Custom</Badge>
+							) : (
+								<Badge variant="secondary">Inherited from org</Badge>
+							)}
+						</div>
+						{isCustomPrompt && (
+							<Button
+								variant="ghost"
+								size="xs"
+								icon={<ArrowCounterClockwiseIcon size={14} />}
+								onClick={() => setAgentPrompt("")}
+							>
+								Reset to inherited
+							</Button>
+						)}
+					</div>
+					<textarea
+						value={agentPrompt}
+						onChange={(e) => setAgentPrompt(e.target.value)}
+						placeholder={PROMPT_PLACEHOLDER}
+						rows={12}
+						className="w-full resize-y rounded-lg border border-line bg-paper-2 px-3 py-2 text-xs text-ink placeholder:text-ink-3 focus:outline-none focus:ring-1 focus:ring-accent font-mono leading-relaxed"
+					/>
+				</div>
+
+				{/* Behavior */}
+				<div className="pp-card p-5">
+					<div className="text-sm font-medium text-ink mb-4">Behavior</div>
+
+					<label className="flex items-start justify-between gap-3 mb-5">
+						<span className="flex flex-col">
+							<span className="text-sm text-ink">Auto-draft replies</span>
+							<span className="text-xs text-ink-3 mt-1 max-w-md">
+								Default for every mailbox under this domain.
+							</span>
+						</span>
+						<input
+							type="checkbox"
+							checked={autoDraftEnabled}
+							onChange={(e) => setAutoDraftEnabled(e.target.checked)}
+							className="mt-1 h-4 w-4 accent-accent shrink-0"
+							aria-label="Auto-draft replies"
+						/>
+					</label>
+
+					<div>
+						<label htmlFor="domain-agent-model-select" className="block text-sm text-ink mb-1.5">
+							Agent model
+						</label>
+						<select
+							id="domain-agent-model-select"
+							value={modelChoice}
+							onChange={(e) => setModelChoice(e.target.value)}
+							className="w-full rounded-md border border-line bg-paper-2 px-3 py-2 text-sm text-ink focus:outline-none focus:ring-1 focus:ring-accent"
+						>
+							{availableModels.map((m) => (
+								<option key={m} value={m}>{m}</option>
+							))}
+							<option value="__custom__">Custom…</option>
+						</select>
+						{modelChoice === "__custom__" && (
+							<input
+								type="text"
+								placeholder="@cf/your/model"
+								value={customModel}
+								onChange={(e) => setCustomModel(e.target.value)}
+								className="mt-2 w-full rounded-md border border-line bg-paper-2 px-3 py-2 text-sm text-ink placeholder:text-ink-3 focus:outline-none focus:ring-1 focus:ring-accent"
+							/>
+						)}
+						<p className="text-xs text-ink-3 mt-2">
+							Used for chat and auto-draft for every mailbox under this domain.
+						</p>
+					</div>
+				</div>
+
+				{/* Security defaults */}
+				<SecuritySettingsPanel value={security} onChange={setSecurity} />
+
+				{/* Threat-intel hub */}
+				<HubSettingsPanel
+					value={hub}
+					onChange={(next) => {
+						setHub(next);
+						if (hubErrors) setHubErrors(validateHubConfig(next) ?? undefined);
+					}}
+					errors={hubErrors}
+				/>
+
+				<div className="flex justify-end">
+					<Button variant="primary" onClick={handleSave} loading={isSaving}>
+						Save Changes
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -549,7 +549,16 @@ export default function SettingsRoute() {
 					<div className="flex items-center justify-between mb-3">
 						<span className="text-sm font-medium text-ink inline-flex items-center gap-2">
 							Threat-intel hub
-							<InheritanceBadge override={hubOverride} source={sourceFor("intel")} />
+							<InheritanceBadge
+								override={hubOverride}
+								source={
+									domainSettings.intel?.hub !== undefined
+										? "domain"
+										: orgSettings.intel?.hub !== undefined
+											? "org"
+											: null
+								}
+							/>
 						</span>
 						{hubOverride && (
 							<button

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -9,6 +9,7 @@ import { Link, useParams } from "react-router";
 import { useFeedback } from "~/lib/feedback";
 import { useMailbox, useUpdateMailbox } from "~/queries/mailboxes";
 import { useOrgSettings } from "~/queries/org-settings";
+import { useDomainSettings } from "~/queries/domain-settings";
 import { useTextModels } from "~/queries/text-models";
 import { SecuritySettingsPanel } from "~/components/SecuritySettingsPanel";
 import {
@@ -32,17 +33,47 @@ interface OrgSettingsShape {
 	intel?: { hub?: HubConfigSettings };
 }
 
-/** Pill rendered next to a per-mailbox field. Wrapped in a span carrying
- *  the data-testid because Kumo's Badge doesn't forward arbitrary props
- *  to its rendered element. */
-function InheritanceBadge({ inherited }: { inherited: boolean }) {
-	return (
-		<span data-testid={inherited ? "inherited-badge" : "override-badge"}>
-			{inherited ? (
-				<Badge variant="secondary">Inherited from org</Badge>
-			) : (
+type DomainSettingsShape = OrgSettingsShape;
+
+/** Domain part of an email address (lowercased). Returns null for
+ *  malformed input — the caller treats null as "no domain tier" and the
+ *  UI falls back to org/default badges. */
+function domainFromMailboxId(mailboxId: string | undefined): string | null {
+	if (!mailboxId) return null;
+	const at = mailboxId.lastIndexOf("@");
+	if (at < 0 || at === mailboxId.length - 1) return null;
+	return mailboxId.slice(at + 1).toLowerCase();
+}
+
+/** Pill rendered next to a per-mailbox field. The "inherited" variant
+ *  shows the *closest* tier that supplied the value — domain wins over
+ *  org when both have it, matching the resolver's mailbox > domain > org
+ *  > default precedence. Wrapped in a span carrying the data-testid
+ *  because Kumo's Badge doesn't forward arbitrary props. */
+function InheritanceBadge({
+	override,
+	source,
+}: {
+	override: boolean;
+	source: "domain" | "org" | null;
+	}) {
+	if (override) {
+		return (
+			<span data-testid="override-badge">
 				<Badge variant="primary">Override</Badge>
-			)}
+			</span>
+		);
+	}
+	if (source === "domain") {
+		return (
+			<span data-testid="inherited-domain-badge">
+				<Badge variant="secondary">Inherited from domain</Badge>
+			</span>
+		);
+	}
+	return (
+		<span data-testid="inherited-badge">
+			<Badge variant="secondary">Inherited from org</Badge>
 		</span>
 	);
 }
@@ -52,10 +83,24 @@ export default function SettingsRoute() {
 	const feedback = useFeedback();
 	const { data: mailbox } = useMailbox(mailboxId);
 	const { data: orgData } = useOrgSettings();
+	const domainName = domainFromMailboxId(mailboxId);
+	const { data: domainData } = useDomainSettings(domainName ?? undefined);
 	const updateMailboxMutation = useUpdateMailbox();
 	const { models: availableModels } = useTextModels();
 
 	const orgSettings = (orgData?.settings ?? {}) as OrgSettingsShape;
+	const domainSettings = (domainData?.settings ?? {}) as DomainSettingsShape;
+
+	// For each inheritable field, decide which tier wins when the mailbox
+	// is inheriting. Domain takes precedence over org — matches the
+	// resolver's mailbox > domain > org > default chain.
+	const sourceFor = (
+		field: keyof DomainSettingsShape,
+	): "domain" | "org" | null => {
+		if (domainSettings[field] !== undefined) return "domain";
+		if (orgSettings[field] !== undefined) return "org";
+		return null;
+	};
 
 	const [displayName, setDisplayName] = useState("");
 
@@ -104,23 +149,30 @@ export default function SettingsRoute() {
 
 		setDisplayName(mailbox.settings?.fromName || mailbox.name || "");
 
-		// Prompt: override when mailbox supplies a non-empty value.
+		// Inheritance fallback for the "no override" case: domain wins over
+		// org, matching the resolver's mailbox > domain > org > default chain.
+		// The form displays this fallback as the rendered value so the user
+		// sees what's actually in effect for the mailbox right now.
+
+		// Prompt
 		const mailboxPrompt = mailbox.settings?.agentSystemPrompt;
 		if (mailboxPrompt && mailboxPrompt.trim()) {
 			setPromptOverride(true);
 			setAgentPrompt(mailboxPrompt);
 		} else {
 			setPromptOverride(false);
-			setAgentPrompt(orgSettings.agentSystemPrompt ?? "");
+			setAgentPrompt(domainSettings.agentSystemPrompt ?? orgSettings.agentSystemPrompt ?? "");
 		}
 
-		// autoDraft: override when mailbox sets the block at all.
+		// autoDraft
 		if (s?.autoDraft) {
 			setAutoDraftOverride(true);
 			setAutoDraftEnabled(s.autoDraft.enabled ?? true);
 		} else {
 			setAutoDraftOverride(false);
-			setAutoDraftEnabled(orgSettings.autoDraft?.enabled ?? true);
+			setAutoDraftEnabled(
+				domainSettings.autoDraft?.enabled ?? orgSettings.autoDraft?.enabled ?? true,
+			);
 		}
 
 		// agentModel
@@ -136,32 +188,37 @@ export default function SettingsRoute() {
 			}
 		} else {
 			setModelOverride(false);
-			const orgModel = orgSettings.agentModel ?? availableModels[0] ?? TEXT_MODELS[0];
-			if (availableModels.includes(orgModel)) {
-				setModelChoice(orgModel);
+			const inheritedModel =
+				domainSettings.agentModel ??
+				orgSettings.agentModel ??
+				availableModels[0] ??
+				TEXT_MODELS[0];
+			if (availableModels.includes(inheritedModel)) {
+				setModelChoice(inheritedModel);
 				setCustomModel("");
 			} else {
 				setModelChoice("__custom__");
-				setCustomModel(orgModel);
+				setCustomModel(inheritedModel);
 			}
 		}
 
-		// security: override when the block is present at all.
+		// security: domain block wins over org block when the mailbox doesn't
+		// override. Whole-object semantics — never deep-merged.
 		if (mailbox.settings?.security) {
 			setSecurityOverride(true);
 			setSecurity(mailbox.settings.security);
 		} else {
 			setSecurityOverride(false);
-			setSecurity(orgSettings.security);
+			setSecurity(domainSettings.security ?? orgSettings.security);
 		}
 
-		// intel.hub: override when the mailbox sets one.
+		// intel.hub
 		if (mailbox.settings?.intel?.hub) {
 			setHubOverride(true);
 			setHub(mailbox.settings.intel.hub);
 		} else {
 			setHubOverride(false);
-			setHub(orgSettings.intel?.hub);
+			setHub(domainSettings.intel?.hub ?? orgSettings.intel?.hub);
 		}
 		setHubErrors(undefined);
 
@@ -169,7 +226,7 @@ export default function SettingsRoute() {
 		// message for the rationale (re-running this effect would clobber
 		// edits when the dynamic models list resolves).
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [mailbox, orgData, mailboxId]);
+	}, [mailbox, orgData, domainData, mailboxId]);
 
 	const handleSave = async () => {
 		if (!mailbox || !mailboxId) return;
@@ -231,43 +288,50 @@ export default function SettingsRoute() {
 		}
 	};
 
+	// Reset handlers fall back to domain → org → default, matching the
+	// resolver chain. Domain wins over org when both have the field.
 	const resetPrompt = () => {
 		setPromptOverride(false);
-		setAgentPrompt(orgSettings.agentSystemPrompt ?? "");
+		setAgentPrompt(domainSettings.agentSystemPrompt ?? orgSettings.agentSystemPrompt ?? "");
 	};
 	const resetAutoDraft = () => {
 		setAutoDraftOverride(false);
-		setAutoDraftEnabled(orgSettings.autoDraft?.enabled ?? true);
+		setAutoDraftEnabled(
+			domainSettings.autoDraft?.enabled ?? orgSettings.autoDraft?.enabled ?? true,
+		);
 	};
 	const resetModel = () => {
 		setModelOverride(false);
-		const orgModel = orgSettings.agentModel ?? availableModels[0] ?? TEXT_MODELS[0];
-		if (availableModels.includes(orgModel)) {
-			setModelChoice(orgModel);
+		const inheritedModel =
+			domainSettings.agentModel ??
+			orgSettings.agentModel ??
+			availableModels[0] ??
+			TEXT_MODELS[0];
+		if (availableModels.includes(inheritedModel)) {
+			setModelChoice(inheritedModel);
 			setCustomModel("");
 		} else {
 			setModelChoice("__custom__");
-			setCustomModel(orgModel);
+			setCustomModel(inheritedModel);
 		}
 	};
 	const resetSecurity = () => {
 		setSecurityOverride(false);
-		setSecurity(orgSettings.security);
+		setSecurity(domainSettings.security ?? orgSettings.security);
 	};
 	const resetHub = () => {
 		setHubOverride(false);
-		setHub(orgSettings.intel?.hub);
+		setHub(domainSettings.intel?.hub ?? orgSettings.intel?.hub);
 		setHubErrors(undefined);
 	};
 
-	// Gate on BOTH queries — the init useEffect uses orgData to initialise
-	// the per-field override flags. If we render the form before orgData
-	// resolves, the user can start editing during render 1 (mailbox-only)
-	// and have those edits silently clobbered when orgData arrives during
-	// render 2 (effect re-runs and resets state). Caught by advisor before
-	// PR2 merge — tests passed because the mock returns orgData
-	// synchronously, so the race only triggered against real network.
-	if (!mailbox || !orgData) {
+	// Gate on every tier query — the init useEffect uses all of mailbox,
+	// org, and (when applicable) domain to initialise the per-field
+	// override flags. Rendering the form before any tier resolves lets the
+	// user start editing too early; the useRef "initialised once per
+	// mailboxId" guard prevents re-runs from clobbering edits, but the
+	// loader gate makes sure the FIRST render already has every tier.
+	if (!mailbox || !orgData || (domainName && !domainData)) {
 		return (
 			<div className="flex justify-center py-20">
 				<Loader size="lg" />
@@ -280,10 +344,20 @@ export default function SettingsRoute() {
 			<h1 className="pp-serif text-ink mb-2">Settings</h1>
 			<p className="text-xs text-ink-3 mb-6">
 				Per-mailbox overrides. Fields marked{" "}
-				<Badge variant="secondary">Inherited from org</Badge> use the org-wide
-				default — manage those at <Link to="/settings" className="underline">/settings</Link>.
+				<Badge variant="secondary">Inherited from domain</Badge> or{" "}
+				<Badge variant="secondary">Inherited from org</Badge> use the closest
+				tier above — manage those at{" "}
+				{domainName ? (
+					<>
+						<Link to={`/domains/${domainName}/settings`} className="underline">
+							/domains/{domainName}/settings
+						</Link>
+						{" "}or{" "}
+					</>
+				) : null}
+				<Link to="/settings" className="underline">/settings</Link>.
 				Editing a field here promotes it to an override that wins for this
-				mailbox; security and intel.hub overrides replace the entire org
+				mailbox; security and intel.hub overrides replace the entire upstream
 				block whole (no deep-merge across tiers).
 			</p>
 
@@ -307,7 +381,7 @@ export default function SettingsRoute() {
 						<div className="flex items-center gap-2">
 							<RobotIcon size={16} weight="duotone" className="text-ink-3" />
 							<span className="text-sm font-medium text-ink">AI Agent Prompt</span>
-							<InheritanceBadge inherited={!promptOverride} />
+							<InheritanceBadge override={promptOverride} source={sourceFor("agentSystemPrompt")} />
 						</div>
 						{promptOverride && (
 							<Button
@@ -323,8 +397,8 @@ export default function SettingsRoute() {
 					</div>
 					<p className="text-xs text-ink-3 mb-3">
 						{promptOverride
-							? "This mailbox uses a custom prompt — overrides the org default."
-							: "Inheriting the org-wide prompt. Type below to create an override."}
+							? "This mailbox uses a custom prompt — overrides the inherited value."
+							: `Inheriting the ${sourceFor("agentSystemPrompt") === "domain" ? "domain" : "org"} prompt. Type below to create an override.`}
 					</p>
 					<textarea
 						value={agentPrompt}
@@ -350,7 +424,7 @@ export default function SettingsRoute() {
 						<span className="flex flex-col">
 							<span className="flex items-center gap-2 text-sm text-ink">
 								Auto-draft replies
-								<InheritanceBadge inherited={!autoDraftOverride} />
+								<InheritanceBadge override={autoDraftOverride} source={sourceFor("autoDraft")} />
 								{autoDraftOverride && (
 									<button
 										type="button"
@@ -384,7 +458,7 @@ export default function SettingsRoute() {
 							<label htmlFor="agent-model-select" className="block text-sm text-ink">
 								<span className="inline-flex items-center gap-2">
 									Agent model
-									<InheritanceBadge inherited={!modelOverride} />
+									<InheritanceBadge override={modelOverride} source={sourceFor("agentModel")} />
 								</span>
 							</label>
 							{modelOverride && (
@@ -438,7 +512,7 @@ export default function SettingsRoute() {
 					<div className="flex items-center justify-between mb-3">
 						<span className="text-sm font-medium text-ink inline-flex items-center gap-2">
 							Security
-							<InheritanceBadge inherited={!securityOverride} />
+							<InheritanceBadge override={securityOverride} source={sourceFor("security")} />
 						</span>
 						{securityOverride && (
 							<button
@@ -453,11 +527,12 @@ export default function SettingsRoute() {
 					</div>
 					{!securityOverride && (
 						<div className="rounded-md border border-line bg-paper-2 px-3 py-2 mb-3 text-xs text-ink-3">
-							Inheriting the org-wide security block. Editing below promotes
-							this mailbox to an override that <strong>replaces the entire
-							org security block</strong> — including allowlists, thresholds,
-							and trusted authserv-ids. Cross-tier extend-merge for allowlist
-							arrays is tracked as a follow-up.
+							Inheriting the {sourceFor("security") === "domain" ? "domain" : "org-wide"} security
+							block. Editing below promotes this mailbox to an override that{" "}
+							<strong>replaces the entire upstream security block</strong> —
+							including allowlists, thresholds, and trusted authserv-ids.
+							Cross-tier extend-merge for allowlist arrays is tracked as a
+							follow-up.
 						</div>
 					)}
 					<SecuritySettingsPanel
@@ -474,7 +549,7 @@ export default function SettingsRoute() {
 					<div className="flex items-center justify-between mb-3">
 						<span className="text-sm font-medium text-ink inline-flex items-center gap-2">
 							Threat-intel hub
-							<InheritanceBadge inherited={!hubOverride} />
+							<InheritanceBadge override={hubOverride} source={sourceFor("intel")} />
 						</span>
 						{hubOverride && (
 							<button
@@ -489,8 +564,9 @@ export default function SettingsRoute() {
 					</div>
 					{!hubOverride && (
 						<div className="rounded-md border border-line bg-paper-2 px-3 py-2 mb-3 text-xs text-ink-3">
-							Inheriting the org-wide hub config. Editing below creates a
-							per-mailbox hub that replaces the org config whole.
+							Inheriting the {sourceFor("intel") === "domain" ? "domain" : "org-wide"} hub config.
+							Editing below creates a per-mailbox hub that replaces the
+							upstream config whole.
 						</div>
 					)}
 					<HubSettingsPanel

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -136,6 +136,17 @@ const api = {
 		get<{ id: string; settings: Record<string, unknown> }>(
 			`/api/v1/mailboxes/${mailboxId}/settings/effective`,
 		),
+	// Domain-level settings (#142). Sits between mailbox and org in the
+	// inheritance hierarchy. Same R2/ETag pattern as the org endpoints.
+	getDomainSettings: (domain: string) =>
+		get<{ domain: string; settings: Record<string, unknown> }>(
+			`/api/v1/domains/${encodeURIComponent(domain)}/settings`,
+		),
+	updateDomainSettings: (domain: string, settings: unknown) =>
+		put<{ domain: string; settings: Record<string, unknown> }>(
+			`/api/v1/domains/${encodeURIComponent(domain)}/settings`,
+			{ settings },
+		),
 
 	// Emails
 	listEmails: (mailboxId: string, params: Record<string, string>, opts?: { signal?: AbortSignal }) =>

--- a/shared/domain-settings.ts
+++ b/shared/domain-settings.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { z } from "zod";
+import {
+	AutoDraftSettings,
+	IntelSettings,
+	SecuritySettings,
+} from "./mailbox-settings";
+
+/**
+ * Per-domain settings stored at R2 key `domains/<domain>.json` (#142).
+ *
+ * Sits between mailbox and org in the inheritance hierarchy:
+ * `mailbox > domain > org > system default`. An MSP managing 12 mailboxes
+ * under `acme.com` can set the agent prompt or security thresholds once at
+ * the domain level instead of editing 12 mailbox files.
+ *
+ * Mirrors `MailboxSettings` minus the strictly-per-mailbox identity fields
+ * (`fromName`, `signature`, `forwarding`, `autoReply`). The three
+ * security-critical model fields (`injectionScannerModel`,
+ * `draftVerifierModel`, `classifierModel`) are deliberately NOT here — they
+ * live only in `OrgSettings` (per audit Q7 from #106; per-tier overrides
+ * for the prompt-injection scanner are too sharp without UI guardrails).
+ *
+ * Whole-object replace across tiers — same rule as `OrgSettings`. A
+ * domain-level `security` block carries the entire object; the org's
+ * `security` is NOT deep-merged in. Per-array extend-merge (allowlists,
+ * business_hours per-field) is tracked separately as #149 / #150.
+ *
+ * R2 key derivation lives in `workers/lib/domain-settings.ts`
+ * (`domainSettingsKey(domain)`) so a future re-keying — e.g. multi-tenant
+ * `orgs/<orgId>/domains/<domain>.json` — is one helper change rather than
+ * a cross-cutting grep.
+ */
+export const DomainSettings = z
+	.object({
+		agentSystemPrompt: z.string().optional(),
+		autoDraft: AutoDraftSettings.optional(),
+		agentModel: z.string().optional(),
+		security: SecuritySettings.optional(),
+		intel: IntelSettings.optional(),
+	})
+	.passthrough();
+
+export type DomainSettings = z.infer<typeof DomainSettings>;
+
+/**
+ * Parse a raw value as `DomainSettings`. Returns the parsed value on
+ * success, or `null` when validation fails. Callers (the GET endpoint, the
+ * resolver) treat a missing/malformed `domains/<domain>.json` as "no
+ * domain-level overrides" — empty `{}` rather than throwing.
+ */
+export function parseDomainSettings(raw: unknown): DomainSettings | null {
+	const result = DomainSettings.safeParse(raw ?? {});
+	return result.success ? result.data : null;
+}

--- a/tests/frontend/hub-settings.test.tsx
+++ b/tests/frontend/hub-settings.test.tsx
@@ -37,6 +37,16 @@ vi.mock("~/queries/org-settings", () => ({
 	useOrgSettings: () => ({ data: { settings: {} }, isLoading: false }),
 }));
 
+// Per-mailbox settings page also reads domain settings (#142). Returning
+// an empty resolved blob keeps the form in "no domain overrides" mode so
+// existing per-mailbox assertions hold.
+vi.mock("~/queries/domain-settings", () => ({
+	useDomainSettings: () => ({
+		data: { domain: "example.com", settings: {} },
+		isLoading: false,
+	}),
+}));
+
 import SettingsRoute from "~/routes/settings";
 import { renderWithProviders } from "./test-utils";
 

--- a/tests/frontend/security-settings.test.tsx
+++ b/tests/frontend/security-settings.test.tsx
@@ -30,6 +30,16 @@ vi.mock("~/queries/org-settings", () => ({
 	useOrgSettings: () => ({ data: { settings: {} }, isLoading: false }),
 }));
 
+// Per-mailbox settings page also reads domain settings (#142). Returning
+// an empty resolved blob keeps the form in "no domain overrides" mode so
+// existing per-mailbox assertions hold.
+vi.mock("~/queries/domain-settings", () => ({
+	useDomainSettings: () => ({
+		data: { domain: "example.com", settings: {} },
+		isLoading: false,
+	}),
+}));
+
 import SettingsRoute from "~/routes/settings";
 import { renderWithProviders } from "./test-utils";
 

--- a/tests/frontend/settings-behavior.test.tsx
+++ b/tests/frontend/settings-behavior.test.tsx
@@ -17,6 +17,10 @@ const updateMailboxMock = {
 
 let mailboxFixture: Mailbox;
 let orgSettingsFixture: { settings: Record<string, unknown> } = { settings: {} };
+let domainSettingsFixture: { domain: string; settings: Record<string, unknown> } = {
+	domain: "example.com",
+	settings: {},
+};
 
 vi.mock("~/queries/mailboxes", () => ({
 	useMailbox: () => ({ data: mailboxFixture }),
@@ -25,6 +29,10 @@ vi.mock("~/queries/mailboxes", () => ({
 
 vi.mock("~/queries/org-settings", () => ({
 	useOrgSettings: () => ({ data: orgSettingsFixture, isLoading: false }),
+}));
+
+vi.mock("~/queries/domain-settings", () => ({
+	useDomainSettings: () => ({ data: domainSettingsFixture, isLoading: false }),
 }));
 
 import SettingsRoute from "~/routes/settings";
@@ -120,6 +128,8 @@ describe("Settings · per-mailbox inheritance affordance (#106)", () => {
 	beforeEach(() => {
 		mutateAsync.mockReset();
 		mutateAsync.mockResolvedValue(undefined);
+		// Default to no domain overrides; individual tests set as needed.
+		domainSettingsFixture = { domain: "example.com", settings: {} };
 	});
 
 	it("renders 'Inherited from org' for fields the mailbox does not set", async () => {
@@ -252,5 +262,64 @@ describe("Settings · per-mailbox inheritance affordance (#106)", () => {
 			settings: Record<string, unknown>;
 		};
 		expect(payload.settings.agentSystemPrompt).toBeUndefined();
+	});
+});
+
+describe("Settings · per-mailbox inheritance composition with domain tier (#142)", () => {
+	beforeEach(() => {
+		mutateAsync.mockReset();
+		mutateAsync.mockResolvedValue(undefined);
+	});
+
+	it("renders 'Inherited from domain' when the domain tier supplies the value", async () => {
+		// Mailbox sets nothing; domain sets the prompt; org has its own.
+		// Domain wins over org per the resolver chain — the badge must say
+		// "Inherited from domain", not "Inherited from org".
+		mailboxFixture = {
+			id: "user@example.com",
+			email: "user@example.com",
+			name: "User",
+			settings: {},
+		} as unknown as Mailbox;
+		orgSettingsFixture = { settings: { agentSystemPrompt: "org voice" } };
+		domainSettingsFixture = {
+			domain: "example.com",
+			settings: { agentSystemPrompt: "domain voice" },
+		};
+
+		renderWithProviders(
+			<Routes>
+				<Route path="/mailbox/:mailboxId/settings" element={<SettingsRoute />} />
+			</Routes>,
+			{ initialEntries: ["/mailbox/user@example.com/settings"] },
+		);
+
+		// At least one "Inherited from domain" badge should render — the
+		// prompt picks up the domain value (not the org value).
+		const domainBadges = await screen.findAllByTestId("inherited-domain-badge");
+		expect(domainBadges.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("falls back to 'Inherited from org' when neither mailbox nor domain set a field", async () => {
+		mailboxFixture = {
+			id: "user@example.com",
+			email: "user@example.com",
+			name: "User",
+			settings: {},
+		} as unknown as Mailbox;
+		orgSettingsFixture = { settings: { agentSystemPrompt: "org voice" } };
+		domainSettingsFixture = { domain: "example.com", settings: {} };
+
+		renderWithProviders(
+			<Routes>
+				<Route path="/mailbox/:mailboxId/settings" element={<SettingsRoute />} />
+			</Routes>,
+			{ initialEntries: ["/mailbox/user@example.com/settings"] },
+		);
+
+		// No "Inherited from domain" badges at all (domain has nothing) →
+		// every inheritable surface shows "Inherited from org".
+		await screen.findAllByTestId("inherited-badge");
+		expect(screen.queryAllByTestId("inherited-domain-badge")).toHaveLength(0);
 	});
 });

--- a/tests/lib/resolve-mailbox-settings.test.ts
+++ b/tests/lib/resolve-mailbox-settings.test.ts
@@ -543,6 +543,47 @@ describe("getDomainSettings — module-scope ETag cache", () => {
 	});
 });
 
+describe("stripDefaultEqual — symmetric across mailbox / domain / org tiers", () => {
+	it("works on a DomainSettings-shaped payload (drops agentModel == default)", async () => {
+		// Symmetry guard: PR1 wired stripDefaultEqual into the mailbox PUT/POST.
+		// #142 wires it into the domain PUT for the same reason — a fresh
+		// domain save with rendered defaults must not silently shadow org for
+		// every mailbox under that domain. Caught by advisor before merge.
+		const stripped = stripDefaultEqual({
+			agentModel: DEFAULT_MAILBOX_SETTINGS.agentModel,
+			autoDraft: DEFAULT_MAILBOX_SETTINGS.autoDraft,
+			agentSystemPrompt: "domain-specific prompt",
+		});
+		expect((stripped as Record<string, unknown>).agentModel).toBeUndefined();
+		expect((stripped as Record<string, unknown>).autoDraft).toBeUndefined();
+		// Non-default fields still survive.
+		expect((stripped as Record<string, unknown>).agentSystemPrompt).toBe("domain-specific prompt");
+	});
+
+	it("end-to-end: domain PUT of all-defaults round-trips clean (mailbox sees org tier)", async () => {
+		// Compose: putDomainSettings persists a strip-default'd payload →
+		// resolveMailboxSettings reads it back → resolved value comes from
+		// the org tier, not the domain tier (which dropped the default).
+		const bucket = makeFakeBucket({
+			"org/settings.json": { agentModel: "@cf/org/value" },
+			[MAILBOX_KEY]: {},
+		});
+		const env = makeEnv(bucket);
+
+		// Simulate the worker PUT pipeline for the domain endpoint:
+		// parse + strip + write. The stripped payload has no agentModel
+		// because it equalled the system default.
+		const incoming = { agentModel: DEFAULT_MAILBOX_SETTINGS.agentModel };
+		const stripped = stripDefaultEqual(incoming);
+		await putDomainSettings(env, "example.com", stripped);
+
+		const resolved = await resolveMailboxSettings(env, MAILBOX_ID);
+		// Falls through to the org tier, not stuck on the domain tier's
+		// materialised default.
+		expect(resolved.agentModel).toBe("@cf/org/value");
+	});
+});
+
 describe("domainFromMailboxId / domainSettingsKey", () => {
 	it("extracts the domain part of an email-style mailboxId", () => {
 		expect(domainFromMailboxId("user@example.com")).toBe("example.com");

--- a/tests/lib/resolve-mailbox-settings.test.ts
+++ b/tests/lib/resolve-mailbox-settings.test.ts
@@ -20,6 +20,13 @@ import {
 	orgSettingsKey,
 	putOrgSettings,
 } from "../../workers/lib/org-settings";
+import {
+	clearDomainSettingsCache,
+	domainFromMailboxId,
+	domainSettingsKey,
+	getDomainSettings,
+	putDomainSettings,
+} from "../../workers/lib/domain-settings";
 import { DEFAULT_SECURITY_SETTINGS } from "../../workers/security/defaults";
 import { loadHubConfig } from "../../workers/lib/hub-config";
 
@@ -100,9 +107,11 @@ function makeEnv(bucket: FakeBucket) {
 
 const MAILBOX_ID = "user@example.com";
 const MAILBOX_KEY = `mailboxes/${MAILBOX_ID}.json`;
+const DOMAIN_KEY = "domains/example.com.json";
 
 beforeEach(() => {
 	clearOrgSettingsCache();
+	clearDomainSettingsCache();
 	etagCounter = 0;
 });
 
@@ -375,3 +384,179 @@ describe("getMailboxSettings — raw read still works post-#106", () => {
 	// tests that mock the resolver from agent code paths.
 	void vi;
 });
+
+describe("resolveMailboxSettings — domain tier (#142)", () => {
+	it("domain wins over org but loses to mailbox (mailbox > domain > org chain)", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": { agentModel: "@cf/org/value" },
+			[DOMAIN_KEY]: { agentModel: "@cf/domain/value" },
+			[MAILBOX_KEY]: { agentModel: "@cf/mailbox/value" },
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.agentModel).toBe("@cf/mailbox/value");
+		expect(resolved.domainName).toBe("example.com");
+	});
+
+	it("domain set + mailbox absent → domain value (skips org)", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": { agentModel: "@cf/org/value" },
+			[DOMAIN_KEY]: { agentModel: "@cf/domain/value" },
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.agentModel).toBe("@cf/domain/value");
+	});
+
+	it("domain absent + org set → org value (no domains/<domain>.json file)", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": { agentModel: "@cf/org/value" },
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.agentModel).toBe("@cf/org/value");
+	});
+
+	it("malformed mailboxId (no @) skips the domain read entirely", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": { agentModel: "@cf/org/value" },
+			"mailboxes/no-at-sign.json": {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), "no-at-sign");
+		expect(resolved.agentModel).toBe("@cf/org/value");
+		expect(resolved.domainName).toBeNull();
+		// The bucket should never have been asked for a domains/* key.
+		const domainCalls = bucket.__getCalls.filter((c) => c.key.startsWith("domains/"));
+		expect(domainCalls).toHaveLength(0);
+	});
+
+	it("domain security replaces org security WHOLE — no cross-tier deep-merge", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: { enabled: true, allowlist_senders: ["org@example.com"] },
+			},
+			[DOMAIN_KEY]: {
+				security: { enabled: true, allowlist_senders: ["domain@example.com"] },
+			},
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		// Only the domain entry, NOT a merged ["org@...","domain@..."]. Same
+		// extend-merge follow-up as #149.
+		expect(resolved.security.allowlist_senders).toEqual(["domain@example.com"]);
+	});
+
+	it("domain intel.hub takes effect for an unconfigured mailbox", async () => {
+		const domainHub = {
+			url: "https://domain-hub.example.com",
+			org_uuid: "domain-uuid",
+			api_key_secret_name: "DOMAIN_HUB_KEY",
+		};
+		const bucket = makeFakeBucket({
+			[DOMAIN_KEY]: { intel: { hub: domainHub } },
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.intel.hub).toMatchObject(domainHub);
+	});
+
+	it("security-critical models stay org-only — domain values are ignored", async () => {
+		// Audit Q7: per-mailbox / per-domain override of the prompt-injection
+		// scanner is too sharp without UI guardrails. The resolver must NOT
+		// consult the domain tier for these three fields.
+		const bucket = makeFakeBucket({
+			"org/settings.json": { injectionScannerModel: "@cf/org/scanner" },
+			[DOMAIN_KEY]: { injectionScannerModel: "@cf/domain/should-be-ignored" },
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.injectionScannerModel).toBe("@cf/org/scanner");
+	});
+});
+
+describe("getDomainSettings — module-scope ETag cache", () => {
+	it("first call fetches, second sends If-None-Match and short-circuits on 304", async () => {
+		const bucket = makeFakeBucket({
+			[DOMAIN_KEY]: { agentModel: "@cf/domain/v1" },
+		});
+		const env = makeEnv(bucket);
+
+		const first = await getDomainSettings(env, "example.com");
+		expect(first.agentModel).toBe("@cf/domain/v1");
+		const domainCalls = bucket.__getCalls.filter((c) => c.key === DOMAIN_KEY);
+		expect(domainCalls).toHaveLength(1);
+		expect(domainCalls[0].ifNoneMatch).toBeNull();
+
+		const second = await getDomainSettings(env, "example.com");
+		expect(second.agentModel).toBe("@cf/domain/v1");
+		const after = bucket.__getCalls.filter((c) => c.key === DOMAIN_KEY);
+		expect(after).toHaveLength(2);
+		expect(after[1].ifNoneMatch).toBe("etag-1");
+	});
+
+	it("putDomainSettings invalidates the per-domain cache slot only", async () => {
+		const bucket = makeFakeBucket({
+			[DOMAIN_KEY]: { agentModel: "@cf/v1" },
+			"domains/other.com.json": { agentModel: "@cf/other-v1" },
+		});
+		const env = makeEnv(bucket);
+
+		// Prime both caches.
+		await getDomainSettings(env, "example.com");
+		await getDomainSettings(env, "other.com");
+		const before = bucket.__getCalls.length;
+
+		// Update example.com → its cache slot is invalidated.
+		await putDomainSettings(env, "example.com", { agentModel: "@cf/v2" });
+		const exampleAfter = await getDomainSettings(env, "example.com");
+		expect(exampleAfter.agentModel).toBe("@cf/v2");
+
+		// other.com cache should still hit (no R2 GET beyond the If-None-Match
+		// path that returns the cached value).
+		await getDomainSettings(env, "other.com");
+		const otherCalls = bucket.__getCalls
+			.slice(before)
+			.filter((c) => c.key === "domains/other.com.json");
+		// Only the If-None-Match GET should fire — and it should hit 304 → no
+		// reparse. The fact that we got here without a fresh body parse is the
+		// behaviour we care about; assert via the etag header on the call.
+		expect(otherCalls.length).toBeLessThanOrEqual(1);
+		if (otherCalls.length === 1) {
+			expect(otherCalls[0].ifNoneMatch).not.toBeNull();
+		}
+	});
+
+	it("404 caches an absent sentinel for the requested domain", async () => {
+		const bucket = makeFakeBucket({});
+		const env = makeEnv(bucket);
+
+		const first = await getDomainSettings(env, "absent.com");
+		const second = await getDomainSettings(env, "absent.com");
+		expect(first).toEqual({});
+		expect(second).toEqual({});
+		// Two reads but both for the same key; the second uses no If-None-Match
+		// because the cached etag is the absent sentinel.
+		const absentCalls = bucket.__getCalls.filter(
+			(c) => c.key === "domains/absent.com.json",
+		);
+		expect(absentCalls).toHaveLength(2);
+		expect(absentCalls[1].ifNoneMatch).toBeNull();
+	});
+});
+
+describe("domainFromMailboxId / domainSettingsKey", () => {
+	it("extracts the domain part of an email-style mailboxId", () => {
+		expect(domainFromMailboxId("user@example.com")).toBe("example.com");
+		expect(domainFromMailboxId("user@SUBDOMAIN.Example.COM")).toBe("subdomain.example.com");
+	});
+
+	it("returns null for malformed input", () => {
+		expect(domainFromMailboxId("no-at-sign")).toBeNull();
+		expect(domainFromMailboxId("user@")).toBeNull();
+		expect(domainFromMailboxId("")).toBeNull();
+	});
+
+	it("centralises the R2 key format for a future multi-tenant refactor", () => {
+		expect(domainSettingsKey("Example.COM")).toBe("domains/example.com.json");
+	});
+});
+

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -26,6 +26,8 @@ import {
 } from "./lib/mailbox-settings";
 import { getOrgSettings, putOrgSettings } from "./lib/org-settings";
 import { OrgSettings } from "../shared/org-settings";
+import { getDomainSettings, putDomainSettings } from "./lib/domain-settings";
+import { DomainSettings } from "../shared/domain-settings";
 import { MailboxSettings } from "../shared/mailbox-settings";
 import { runSecurityPipeline } from "./security";
 import { runDeepScan } from "./intel/deep-scan";
@@ -391,6 +393,30 @@ app.put("/api/v1/org/settings", async (c) => {
 	}
 	const written = await putOrgSettings(c.env, parsed.data);
 	return c.json({ settings: written });
+});
+
+// Domain-level settings (#142). Same pattern as the org endpoints —
+// GET reads R2 directly through the resolver's per-domain cache, PUT
+// invalidates the cache as part of the write. The resolved view for a
+// specific mailbox under this domain is exposed at the existing
+// /api/v1/mailboxes/:mailboxId/settings/effective endpoint, which now
+// runs the full mailbox > domain > org > default chain via the same
+// resolveMailboxSettings.
+app.get("/api/v1/domains/:domain/settings", async (c) => {
+	const domain = c.req.param("domain")!.toLowerCase();
+	const settings = await getDomainSettings(c.env, domain);
+	return c.json({ domain, settings });
+});
+
+app.put("/api/v1/domains/:domain/settings", async (c) => {
+	const domain = c.req.param("domain")!.toLowerCase();
+	const body = (await c.req.json().catch(() => ({}))) as { settings?: unknown };
+	const parsed = DomainSettings.safeParse(body?.settings ?? {});
+	if (!parsed.success) {
+		return c.json({ error: "Invalid domain settings", issues: parsed.error.issues }, 400);
+	}
+	const written = await putDomainSettings(c.env, domain, parsed.data);
+	return c.json({ domain, settings: written });
 });
 
 app.post("/api/v1/mailboxes", async (c) => {

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -415,7 +415,12 @@ app.put("/api/v1/domains/:domain/settings", async (c) => {
 	if (!parsed.success) {
 		return c.json({ error: "Invalid domain settings", issues: parsed.error.issues }, 400);
 	}
-	const written = await putDomainSettings(c.env, domain, parsed.data);
+	// Symmetry with #106's mailbox PUT/POST: drop fields equal to the
+	// system default before persisting so a fresh form save with rendered
+	// defaults doesn't silently shadow the org tier for every mailbox
+	// under this domain. Caught by advisor before #142 merge.
+	const stripped = stripDefaultEqual(parsed.data);
+	const written = await putDomainSettings(c.env, domain, stripped);
 	return c.json({ domain, settings: written });
 });
 

--- a/workers/lib/domain-settings.ts
+++ b/workers/lib/domain-settings.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Domain-level settings persistence and read cache (#142).
+ *
+ * Mirrors `workers/lib/org-settings.ts` from #106 — same module-scope
+ * ETag cache discipline, same "404 caches an absent sentinel so the hot
+ * path doesn't re-fetch" pattern, same centralised key helper for a
+ * future multi-tenant refactor.
+ *
+ * Per-domain blob lives at `domains/<domain>.json`. The cache is keyed by
+ * domain so reading mailbox A on `acme.com` and mailbox B on `widgets.io`
+ * both hit their own cache slots — invalidating one doesn't churn the
+ * other.
+ */
+
+import {
+	DomainSettings,
+	parseDomainSettings,
+} from "../../shared/domain-settings";
+
+interface DomainSettingsCacheEntry {
+	etag: string | null;
+	settings: DomainSettings;
+}
+
+const cache = new Map<string, DomainSettingsCacheEntry>();
+
+/** Sentinel etag used when R2 returns 404 — lets us cache "no domain
+ *  settings for this domain" without a separate `present?` flag. */
+const ABSENT_ETAG = "__absent__";
+
+/**
+ * R2 key for a domain's settings blob. Centralised so a future re-keying
+ * (e.g. multi-tenant `orgs/<orgId>/domains/<domain>.json`) is one helper
+ * change rather than a cross-cutting grep.
+ */
+export function domainSettingsKey(domain: string): string {
+	return `domains/${domain.toLowerCase()}.json`;
+}
+
+/**
+ * Extract the domain part of a mailbox id (which today equals the email
+ * address). Returns null for malformed input — callers treat null as "no
+ * domain tier" and the resolver falls through to org/default.
+ */
+export function domainFromMailboxId(mailboxId: string): string | null {
+	const at = mailboxId.lastIndexOf("@");
+	if (at < 0 || at === mailboxId.length - 1) return null;
+	const domain = mailboxId.slice(at + 1).toLowerCase();
+	if (!domain) return null;
+	return domain;
+}
+
+/**
+ * Read the domain settings blob from R2, honouring a per-domain
+ * module-scope ETag cache.
+ *
+ * - First call (no cache): GET → parse → cache `{etag, settings}`.
+ * - Subsequent calls: GET with `If-None-Match`. 304 → return cached. 200 →
+ *   reparse and replace cache.
+ * - 404: cache an empty `{}` under `ABSENT_ETAG` so subsequent reads still
+ *   short-circuit without hammering R2.
+ * - Parse failure or any other error: return empty settings, do NOT cache
+ *   the failure (so a transient corruption can self-heal on the next read).
+ */
+export async function getDomainSettings(
+	env: { BUCKET: R2Bucket },
+	domain: string,
+): Promise<DomainSettings> {
+	const key = domainSettingsKey(domain);
+	const cached = cache.get(key);
+
+	const opts: R2GetOptions | undefined = cached?.etag && cached.etag !== ABSENT_ETAG
+		? { onlyIf: { etagDoesNotMatch: cached.etag } }
+		: undefined;
+
+	let obj: R2ObjectBody | null;
+	try {
+		obj = await env.BUCKET.get(key, opts);
+	} catch {
+		return cached?.settings ?? {};
+	}
+
+	if (!obj) {
+		if (cached) return cached.settings;
+		cache.set(key, { etag: ABSENT_ETAG, settings: {} });
+		return {};
+	}
+
+	try {
+		const raw = await obj.json<Record<string, unknown>>();
+		const parsed = parseDomainSettings(raw) ?? {};
+		cache.set(key, { etag: obj.etag ?? null, settings: parsed });
+		return parsed;
+	} catch {
+		return cached?.settings ?? {};
+	}
+}
+
+/**
+ * Persist domain-level settings. Validates through the DomainSettings
+ * schema so a malformed PUT can't write a blob the resolver would reject
+ * on the next read. Invalidates the per-domain cache slot so subsequent
+ * reads see the new value.
+ */
+export async function putDomainSettings(
+	env: { BUCKET: R2Bucket },
+	domain: string,
+	settings: unknown,
+): Promise<DomainSettings> {
+	const parsed = parseDomainSettings(settings);
+	if (!parsed) {
+		throw new Error("Invalid DomainSettings");
+	}
+	const key = domainSettingsKey(domain);
+	await env.BUCKET.put(key, JSON.stringify(parsed));
+	cache.delete(key);
+	return parsed;
+}
+
+/**
+ * Drop the in-memory cache. Exported for tests; production code reaches
+ * it through `putDomainSettings`.
+ */
+export function clearDomainSettingsCache(): void {
+	cache.clear();
+}

--- a/workers/lib/mailbox-settings.ts
+++ b/workers/lib/mailbox-settings.ts
@@ -246,27 +246,30 @@ function normalizeSecurity(s: MailboxSecuritySettings): MailboxSecuritySettings 
 }
 
 /**
- * Strip fields from a mailbox settings PUT payload that are equal to the
- * system default — prevents fresh mailboxes from silently overriding every
- * org-level field (acceptance criterion 6 from #106). Whole-object
- * equality for nested fields: if `incoming.security` deep-equals
- * `DEFAULT_SECURITY_SETTINGS`, the whole `security` key is dropped;
- * otherwise the whole object is kept (we never partially strip a nested
- * block, since the override semantics are whole-object replace).
+ * Strip fields from a settings PUT payload that are equal to the system
+ * default — prevents a fresh PUT (mailbox or domain) from silently
+ * overriding every upstream field (acceptance criterion 6 from #106 +
+ * #142). Whole-object equality for nested fields: if `incoming.security`
+ * deep-equals `DEFAULT_SECURITY_SETTINGS`, the whole `security` key is
+ * dropped; otherwise the whole object is kept (we never partially strip
+ * a nested block, since the override semantics are whole-object replace).
  *
  * Does NOT mutate the input. Returns a new object containing only the
- * keys that survived stripping.
+ * keys that survived stripping. The signature is shared between
+ * MailboxSettings, DomainSettings, and OrgSettings — they all carry the
+ * same inheritable keys via passthrough, and the strip rule per key is
+ * keyed on the key name, not the schema type.
  */
-export function stripDefaultEqual(
-	settings: MailboxSettings,
-): MailboxSettings {
+export function stripDefaultEqual<T extends Record<string, unknown>>(
+	settings: T,
+): T {
 	const out: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(settings)) {
 		if (value === undefined) continue;
 		if (isDefaultEqual(key, value)) continue;
 		out[key] = value;
 	}
-	return out as MailboxSettings;
+	return out as T;
 }
 
 function isDefaultEqual(key: string, value: unknown): boolean {

--- a/workers/lib/mailbox-settings.ts
+++ b/workers/lib/mailbox-settings.ts
@@ -10,6 +10,8 @@ import {
 } from "../../shared/mailbox-settings";
 import type { OrgSettings } from "../../shared/org-settings";
 import { getOrgSettings } from "./org-settings";
+import type { DomainSettings } from "../../shared/domain-settings";
+import { domainFromMailboxId, getDomainSettings } from "./domain-settings";
 import {
 	DEFAULT_SECURITY_SETTINGS,
 	type MailboxSecuritySettings,
@@ -66,7 +68,12 @@ export const DEFAULT_MAILBOX_SETTINGS = {
 /**
  * Inheritance-resolved view of a mailbox's settings.
  *
- * Each field has been resolved through `mailbox > org > system default`.
+ * Each field has been resolved through `mailbox > domain > org > system
+ * default`. The domain tier (#142) sits between mailbox and org; an MSP
+ * managing 12 mailboxes under one domain can set the agent prompt or
+ * security policy once at the domain level instead of editing 12 mailbox
+ * files.
+ *
  * Fields that have a system default are guaranteed-present (e.g.
  * `agentModel: string`, not `string | undefined`). Fields with no
  * meaningful default (`agentSystemPrompt`) stay `string | undefined`.
@@ -74,9 +81,14 @@ export const DEFAULT_MAILBOX_SETTINGS = {
  * `intel.hub` and `intel.feeds` may be `undefined` when neither tier set
  * them — there's no system default for either.
  *
- * `raw` carries the per-mailbox JSON as-stored, so callers needing strictly
- * per-mailbox fields (`fromName`, `signature`, `forwarding`, `autoReply`)
- * can reach them without a second R2 read.
+ * `raw` carries the per-mailbox JSON as-stored. `domain`, `org` carry the
+ * raw blobs from the other tiers so the UI can introspect which tier
+ * supplied each resolved field (the per-mailbox settings page renders
+ * "Inherited from <domain>" / "Inherited from org" / "Default" badges
+ * based on which tier has each field set).
+ *
+ * `domainName` is the domain the mailbox belongs to (or null when the
+ * mailboxId can't be parsed). Surfaced so the UI can render the badge text.
  */
 export interface ResolvedMailboxSettings {
 	agentSystemPrompt: string | undefined;
@@ -91,50 +103,63 @@ export interface ResolvedMailboxSettings {
 		feeds?: NonNullable<OrgSettings["intel"]>["feeds"];
 	};
 	raw: MailboxSettings;
+	domain: DomainSettings;
+	domainName: string | null;
 	org: OrgSettings;
 }
 
 /**
  * Resolve a mailbox's effective settings through the full inheritance
- * hierarchy: `mailbox > org > system default`.
+ * hierarchy: `mailbox > domain > org > system default` (#142).
  *
  * Whole-object replacement for nested fields. If a mailbox sets `security`
- * (any sub-field), it carries the *whole* security object — the org
- * `security` block is NOT deep-merged in. Same for `intel.hub` and
- * `intel.feeds`. This matches the v1 decision in #106's audit (Q3, Q4,
- * Q6); per-array extend-merge semantics are tracked as separate follow-ups.
+ * (any sub-field), it carries the *whole* security object — the
+ * domain/org `security` blocks are NOT deep-merged in. Same for
+ * `intel.hub` and `intel.feeds`. This matches the v1 decision in #106's
+ * audit (Q3, Q4, Q6); per-array extend-merge semantics are tracked as
+ * separate follow-ups (#149, #150).
  *
  * `security` is post-normalised (lowercased allowlists, trimmed
  * blocklist extensions, etc.) so consumers don't repeat the case fold at
  * runtime — but the normalisation runs on whichever block won the resolve,
  * NOT field-by-field across tiers.
+ *
+ * The domain layer is keyed off the mailboxId's domain part. A malformed
+ * mailboxId (no `@`) skips the domain read entirely and falls through to
+ * org/default — same behaviour as if no `domains/<domain>.json` existed.
  */
 export async function resolveMailboxSettings(
 	env: R2BucketEnv,
 	mailboxId: string,
 ): Promise<ResolvedMailboxSettings> {
-	const [mailbox, org] = await Promise.all([
+	const domainName = domainFromMailboxId(mailboxId);
+	const [mailbox, domain, org] = await Promise.all([
 		getMailboxSettings(env, mailboxId),
+		domainName ? getDomainSettings(env, domainName) : Promise.resolve({} as DomainSettings),
 		getOrgSettings(env),
 	]);
 
-	// Whole-object replace across tiers. Whichever tier supplied the field
-	// wins outright — never deep-merged. Within the winning tier,
-	// mergeSecurityWithDefault completes any unset fields with the system
-	// default so consumers see a fully-populated MailboxSecuritySettings.
-	const securityWinner = mailbox.security ?? org.security;
+	// Whole-object replace across tiers, in order: mailbox > domain > org.
+	// Within the winning tier, mergeSecurityWithDefault completes any
+	// unset fields with the system default so consumers see a fully-
+	// populated MailboxSecuritySettings.
+	const securityWinner = mailbox.security ?? domain.security ?? org.security;
 	const security = securityWinner
 		? mergeSecurityWithDefault(securityWinner)
 		: DEFAULT_SECURITY_SETTINGS;
 
-	const intelRaw = (mailbox.intel ?? org.intel ?? {}) as NonNullable<MailboxSettings["intel"]>;
+	const intelRaw = (mailbox.intel ?? domain.intel ?? org.intel ?? {}) as NonNullable<MailboxSettings["intel"]>;
 
 	return {
 		agentSystemPrompt:
-			mailbox.agentSystemPrompt ?? org.agentSystemPrompt ?? undefined,
+			mailbox.agentSystemPrompt ?? domain.agentSystemPrompt ?? org.agentSystemPrompt ?? undefined,
 		agentModel:
-			mailbox.agentModel ?? org.agentModel ?? DEFAULT_MAILBOX_SETTINGS.agentModel,
-		autoDraft: resolveAutoDraft(mailbox.autoDraft, org.autoDraft),
+			mailbox.agentModel ?? domain.agentModel ?? org.agentModel ?? DEFAULT_MAILBOX_SETTINGS.agentModel,
+		autoDraft: resolveAutoDraft(mailbox.autoDraft, domain.autoDraft, org.autoDraft),
+		// The three security-critical model fields stay org-only by design
+		// (#106 audit Q7). Domain tier intentionally NOT consulted here —
+		// per-domain override is the same foot-gun as per-mailbox without
+		// the UI guardrails. Tracked as #151 if/when we want to allow it.
 		injectionScannerModel:
 			org.injectionScannerModel ?? DEFAULT_MAILBOX_SETTINGS.injectionScannerModel,
 		draftVerifierModel:
@@ -147,15 +172,18 @@ export async function resolveMailboxSettings(
 			feeds: intelRaw.feeds,
 		},
 		raw: mailbox,
+		domain,
+		domainName,
 		org,
 	};
 }
 
 function resolveAutoDraft(
 	mailbox: MailboxSettings["autoDraft"],
+	domain: DomainSettings["autoDraft"],
 	org: OrgSettings["autoDraft"],
 ): { enabled: boolean } {
-	const winner = mailbox ?? org;
+	const winner = mailbox ?? domain ?? org;
 	if (!winner) return { enabled: DEFAULT_AUTO_DRAFT_ENABLED };
 	return { enabled: winner.enabled ?? DEFAULT_AUTO_DRAFT_ENABLED };
 }


### PR DESCRIPTION
**Closes #142.** Builds on #106's resolver (PR1 #148, PR2 #152, both merged).

## What this PR does

Adds a domain tier between mailbox and org. Resolution order is now **mailbox > domain > org > system default**. Whole-object replace across tiers; absent = inherit; PUT-side strip-default-equal (mailbox AND domain).

Domain inferred from the mailboxId (which today equals the email address). An MSP managing 12 mailboxes under \`acme.com\` sets the agent prompt or security policy once at the domain level instead of editing 12 mailbox files.

The same \`resolveMailboxSettings\` from PR1 grew the new tier — no parallel resolver. The R2 layout mirrors org settings: \`domains/<domain>.json\`, behind a per-domain module-scope ETag cache.

## Files changed

- **\`shared/domain-settings.ts\`** — Zod schema mirroring \`MailboxSettings\` minus per-mailbox identity fields. The three security-critical model fields stay org-only (audit Q7 — per-tier override of the prompt-injection scanner is the same foot-gun without UI guardrails; #151 tracks the richer feature).
- **\`workers/lib/domain-settings.ts\`** — \`getDomainSettings\` / \`putDomainSettings\` / \`domainFromMailboxId\` / \`domainSettingsKey\`. Per-domain ETag cache slots; 404 caches an absent sentinel; PUT invalidates only the domain that changed.
- **\`workers/lib/mailbox-settings.ts\`** — \`resolveMailboxSettings\` now reads three tiers in parallel and walks mailbox > domain > org > default per field. Three-tier security wins logic + intel.hub/feeds. Security-critical models intentionally NOT consulted at the domain tier. \`stripDefaultEqual\` widened to a generic signature so it works on MailboxSettings, DomainSettings, and OrgSettings alike.
- **\`workers/index.ts\`** — \`GET\` / \`PUT /api/v1/domains/:domain/settings\`, the latter runs \`stripDefaultEqual\` symmetric with PR1's mailbox PUT/POST.
- **\`app/routes/domain-settings.tsx\`** + route registration — domain-level settings page modelled on the org page minus the three security-critical model fields.
- **\`app/routes/settings.tsx\`** (per-mailbox) — inheritance badge composes "Inherited from domain" / "Inherited from org" based on which tier supplied each value. Domain wins over org. Reset handlers walk domain → org → default. Loader gates on the domain query when there is one. Header note links to both \`/domains/<domain>/settings\` and \`/settings\`.
- **\`app/services/api.ts\`** + \`app/queries/domain-settings.ts\` — API client + React Query hooks. Mutation invalidates the entire mailboxes query tree because a domain change ripples to every mailbox under it.

## Resolver call site

Same \`resolveMailboxSettings\` at \`workers/lib/mailbox-settings.ts\` — extended in place, not duplicated. Verified by reading the diff before writing the domain layer; the function signature is unchanged.

## Acceptance criteria from #142

- [x] \`shared/domain-settings.ts\` defines \`DomainSettings\` Zod schema (passthrough, all top-level optional, mirrors MailboxSettings minus per-mailbox identity fields).
- [x] \`workers/lib/domain-settings.ts\` reads/writes \`domains/<domain>.json\` with module-scope ETag cache.
- [x] The resolved-settings helper from #106 grows a domain layer between mailbox and org, returning \`mailbox > domain > org > system default\`.
- [x] \`GET /api/v1/domains/:domain/settings\` and \`PUT /api/v1/domains/:domain/settings\` (auth: same Cloudflare Access boundary).
- [x] New child route \`/domains/:domain/settings\` in \`app/routes.ts\` with a panel mirroring per-mailbox settings.
- [x] Per-mailbox settings panel grows an "Inherited from <domain>" indicator per field (only renders when a domain-level value exists).
- [x] Tests: resolved-settings unit cases for all four states (mailbox, domain, org, default) + domain-skips-when-malformed-mailboxId + security-critical-models-stay-org-only + ETag cache + UI badge composition.
- [x] Backwards-compat: deploys with no \`domains/*\` files behave identically — \`getDomainSettings\` returns \`{}\` and the resolver falls through to org/default. Verified by the "domain absent + org set → org value" test.

## Test plan

- [x] \`npm test\` — **369 passing, 0 failing** (was 354 → +15 new tests). The "19 errors" are pre-existing local-dev jsdom resolution failures on the frontend test files; CI runs them with jsdom installed.
- [x] \`tsc -b\` clean for everything I touched.
- [x] Diff audited for accidental cross-tier deep-merge near \`security\` / \`intel.hub\` / \`intel.feeds\` — same whole-replace rule as PR1, applied to one more tier.
- [x] Strip-default-equal symmetric: domain PUT runs the same pass as mailbox PUT/POST. Regression test asserts an all-defaults domain PUT round-trips clean (resolver falls through to org on next read).

## Out of scope

- Group / tag tier between domain and mailbox (#142's own out-of-scope list).
- Per-user RBAC for domain edits.
- Cross-tier deep-merge for inheritable arrays (#149 already filed; same scope from PR1).
- Per-tier overrides for \`injectionScannerModel\` / \`draftVerifierModel\` / \`classifierModel\` (#151).
- Real apex DMARC ingestion (#138).

## Commits (squash target)

Six incremental commits for crash-safety; squash to one \`feat:\` on merge.