### PR TITLE
feat: top-level nav entry for org-wide /settings

### DIFF
--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -199,6 +199,16 @@ function NavContents({
 					icon={<GlobeIcon size={16} />}
 					label="Domains"
 				/>
+				{/* Org-wide settings (#153) — surfaced as a top-level entry so
+				    operators can reach `/settings` from a cold start, without
+				    first picking a mailbox. The per-mailbox `Settings` entry
+				    below is unaffected; that one stays mailbox-scoped. */}
+				<NavItem
+					to="/settings"
+					end
+					icon={<GearSixIcon size={16} />}
+					label="Org settings"
+				/>
 				{mailboxId && (
 					<>
 						<SectionLabel>This mailbox</SectionLabel>

--- a/tests/frontend/shell-org-settings-nav.test.tsx
+++ b/tests/frontend/shell-org-settings-nav.test.tsx
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+
+// Org-wide /settings nav entry (#153). Distinct from the per-mailbox
+// `/mailbox/:id/settings` entry which is gated on a mailbox being selected.
+// This entry must surface even when no mailbox has been picked, otherwise the
+// org settings page is undiscoverable from a cold start.
+
+interface MailboxFixture {
+	id: string;
+	email: string;
+	name: string;
+}
+
+let mailboxFixture: MailboxFixture | undefined = undefined;
+let mailboxesFixture: MailboxFixture[] = [];
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({ data: mailboxFixture }),
+	useMailboxes: () => ({ data: mailboxesFixture }),
+}));
+
+vi.mock("~/queries/domains", () => ({
+	useDomainStats: () => ({
+		data: undefined,
+		isLoading: false,
+		isError: false,
+	}),
+}));
+
+vi.mock("~/queries/dashboard", () => ({
+	useDashboardSummary: () => ({
+		data: undefined,
+		isLoading: false,
+		isError: false,
+	}),
+}));
+
+import Shell from "~/components/phishsoc/Shell";
+import { renderWithProviders } from "./test-utils";
+
+function renderShellAt(initialEntries: string[]) {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/settings"
+				element={
+					<Shell>
+						<div>org settings page</div>
+					</Shell>
+				}
+			/>
+			<Route
+				path="/mailbox/:mailboxId/*"
+				element={
+					<Shell>
+						<div>mailbox page</div>
+					</Shell>
+				}
+			/>
+			<Route
+				path="*"
+				element={
+					<Shell>
+						<div>fallback page</div>
+					</Shell>
+				}
+			/>
+		</Routes>,
+		{ initialEntries },
+	);
+}
+
+describe("Shell org-settings nav entry (#153)", () => {
+	beforeEach(() => {
+		mailboxFixture = undefined;
+		mailboxesFixture = [];
+	});
+
+	it("renders the 'Org settings' link even when no mailbox is selected", () => {
+		// Cold-start fixture: no mailbox in the route, no mailboxes loaded.
+		// The whole point of this entry is that the org settings page must
+		// be reachable before the operator picks a mailbox.
+		renderShellAt(["/"]);
+
+		const link = screen.getByRole("link", { name: /org settings/i });
+		expect(link).toHaveAttribute("href", "/settings");
+	});
+
+	it("highlights the Org settings nav entry when active on /settings", () => {
+		renderShellAt(["/settings"]);
+
+		const link = screen.getByRole("link", { name: /org settings/i });
+		// `NavLink` adds `aria-current="page"` on the active match. Asserting
+		// on aria-current keeps the test decoupled from styling classes.
+		expect(link).toHaveAttribute("aria-current", "page");
+	});
+
+	it("does not mark Org settings active on the per-mailbox /mailbox/:id/settings route", () => {
+		mailboxFixture = { id: "m1", email: "alice@acme.com", name: "Alice" };
+		mailboxesFixture = [mailboxFixture];
+
+		renderShellAt(["/mailbox/m1/settings"]);
+
+		const orgLink = screen.getByRole("link", { name: /^org settings$/i });
+		// `end` prop on the NavLink prevents `/settings` from matching as a
+		// prefix of `/mailbox/:id/settings`.
+		expect(orgLink).not.toHaveAttribute("aria-current", "page");
+	});
+});


### PR DESCRIPTION
## Summary

- Adds an **Org settings** entry to the persistent sidebar (sits with the other org-scoped items: Org overview, Mailboxes, Domains) so `/settings` is reachable from a cold start, before the operator picks a mailbox.
- Uses `GearSixIcon` to match the existing per-mailbox Settings entry in the "This mailbox" section.
- `end` prop on the `NavLink` keeps `/mailbox/:id/settings` from spuriously highlighting the org entry.

Closes #153

## Acceptance — line by line

- [x] Org `/settings` is reachable from the persistent sidebar (and from the mobile drawer, since both render the same `NavContents`).
- [x] The nav entry highlights when active (verified via `aria-current="page"` assertion).
- [x] No regression to per-mailbox settings link from `/mailbox/:id/settings` header note — that path is untouched.
- [x] No regression to existing nav layout tests — full frontend suite still green.

## Test plan

- [x] `npm test` — 485 passing, 0 failing (47 test files).
- [x] `npm run typecheck` — exit 0.
- [x] New `tests/frontend/shell-org-settings-nav.test.tsx`:
  - renders Org settings link when no mailbox is selected
  - active highlight on `/settings`
  - does NOT mark Org settings active on `/mailbox/:id/settings`
- [x] Existing `tests/frontend/shell-domain-nav.test.tsx`, `shell-mobile-drawer.test.tsx`, `shell-pipeline-pill.test.tsx`, `shell-search.test.tsx`, `shell-agent-panel.test.tsx` all still pass.

## Out of scope (per issue)

- Per-user RBAC for who can see / click the entry.
- Domain-tier nav surfaces (#142 owns those).
- Broader sidebar reorg.