### PR TITLE
test(frontend): factor out shared mock for Shell-wide queries

### DIFF
--- a/tests/frontend/dashboard.test.tsx
+++ b/tests/frontend/dashboard.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Route, Routes } from "react-router";
 import type { DashboardSummary } from "~/types";
+import { shellDashboardMock } from "./shell-mocks";
 
 const refetch = vi.fn();
 let queryState: {
@@ -13,9 +14,16 @@ let queryState: {
 	isError: boolean;
 };
 
-vi.mock("~/queries/dashboard", () => ({
-	useDashboardSummary: () => ({ ...queryState, refetch }),
-}));
+// `DashboardRoute` consumes `useDashboardSummary` directly. The route is
+// rendered in isolation here (the parent `mailbox.tsx` layout that mounts
+// Shell isn't in the tree), so only the dashboard factory is needed — the
+// other Shell factories aren't load-bearing for this file. Using the shared
+// factory keeps the override pattern aligned with the Shell-rendering tests.
+vi.mock("~/queries/dashboard", () =>
+	shellDashboardMock({
+		useDashboardSummary: () => ({ ...queryState, refetch }),
+	}),
+);
 
 import DashboardRoute from "~/routes/dashboard";
 import { renderWithProviders } from "./test-utils";

--- a/tests/frontend/domain-detail.test.tsx
+++ b/tests/frontend/domain-detail.test.tsx
@@ -5,6 +5,11 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Route, Routes } from "react-router";
 import type { DomainStats } from "~/types";
+import {
+	shellDashboardMock,
+	shellDomainsMock,
+	shellMailboxesMock,
+} from "./shell-mocks";
 
 const refetch = vi.fn();
 let queryState: {
@@ -13,21 +18,21 @@ let queryState: {
 	isError: boolean;
 };
 
-vi.mock("~/queries/domains", () => ({
-	useDomainStats: () => ({ ...queryState, refetch }),
-}));
+// `useDomainStats` is the route's primary query and Shell's domain-scoped
+// sidebar source — both wire through the same hook, so the per-test
+// override here drives both.
+vi.mock("~/queries/domains", () =>
+	shellDomainsMock({
+		useDomainStats: () => ({ ...queryState, refetch }),
+	}),
+);
 
-// Shell pulls in mailbox/dashboard data — keep these stubs identical to
-// `home.test.tsx` so we render the route in isolation rather than fanning
-// out to real fetchers.
-vi.mock("~/queries/mailboxes", () => ({
-	useMailboxes: () => ({ data: [], refetch: vi.fn(), isFetched: true }),
-	useMailbox: () => ({ data: undefined }),
-}));
+// Shell pulls in mailbox/dashboard data — the shared factories return the
+// same empty-list / undefined defaults so we render the route in isolation
+// rather than fanning out to real fetchers.
+vi.mock("~/queries/mailboxes", () => shellMailboxesMock());
 
-vi.mock("~/queries/dashboard", () => ({
-	useDashboardSummary: () => ({ data: undefined }),
-}));
+vi.mock("~/queries/dashboard", () => shellDashboardMock());
 
 import DomainDetailRoute from "~/routes/domain-detail";
 import { renderWithProviders } from "./test-utils";

--- a/tests/frontend/domains-list.test.tsx
+++ b/tests/frontend/domains-list.test.tsx
@@ -5,6 +5,11 @@ import userEvent from "@testing-library/user-event";
 import { Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DomainListEntry } from "~/types";
+import {
+	shellDashboardMock,
+	shellDomainsMock,
+	shellMailboxesMock,
+} from "./shell-mocks";
 
 const refetch = vi.fn();
 let queryState: {
@@ -13,25 +18,18 @@ let queryState: {
 	isError: boolean;
 };
 
-vi.mock("~/queries/domains", () => ({
-	useDomains: () => ({ ...queryState, refetch }),
-	// Shell calls `useDomainStats` to drive the domain-scoped sidebar (#143);
-	// at `/domains` (the list route) it doesn't match so the hook is gated to
-	// `enabled: false`, but the import still has to resolve.
-	useDomainStats: () => ({ data: undefined, isLoading: false, isError: false }),
-}));
+vi.mock("~/queries/domains", () =>
+	shellDomainsMock({
+		useDomains: () => ({ ...queryState, refetch }),
+	}),
+);
 
-// Shell pulls in mailbox/dashboard data — keep these stubs identical to
-// `home.test.tsx` so we render the route in isolation rather than fanning
-// out to real fetchers.
-vi.mock("~/queries/mailboxes", () => ({
-	useMailboxes: () => ({ data: [], refetch: vi.fn(), isFetched: true }),
-	useMailbox: () => ({ data: undefined }),
-}));
+// Shell pulls in mailbox/dashboard data — the shared factories return the
+// same empty-list / undefined defaults so we render the route in isolation
+// rather than fanning out to real fetchers.
+vi.mock("~/queries/mailboxes", () => shellMailboxesMock());
 
-vi.mock("~/queries/dashboard", () => ({
-	useDashboardSummary: () => ({ data: undefined }),
-}));
+vi.mock("~/queries/dashboard", () => shellDashboardMock());
 
 import DomainsListRoute from "~/routes/domains-list";
 import { renderWithProviders } from "./test-utils";

--- a/tests/frontend/home.test.tsx
+++ b/tests/frontend/home.test.tsx
@@ -5,6 +5,11 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Route, Routes } from "react-router";
 import type { DomainListEntry, OrgOverview } from "~/types";
+import {
+	shellDashboardMock,
+	shellDomainsMock,
+	shellMailboxesMock,
+} from "./shell-mocks";
 
 const refetch = vi.fn();
 let queryState: {
@@ -20,35 +25,31 @@ vi.mock("~/queries/org", () => ({
 // `TopDomainsCard` (#141) consumes `useDomains()`. Default to an empty list
 // so existing assertions (which were written before the widget existed) keep
 // passing; tests that exercise the widget override `domainsState` per case.
+// `useDomainStats` is provided by `shellDomainsMock()` for Shell — at `/` it
+// gates on `enabled: false` but the import still has to resolve.
 let domainsState: {
 	data: DomainListEntry[] | undefined;
 	isLoading: boolean;
 	isError: boolean;
 } = { data: [], isLoading: false, isError: false };
 
-vi.mock("~/queries/domains", () => ({
-	useDomains: () => ({ ...domainsState, refetch: vi.fn() }),
-	// Shell calls `useDomainStats` to drive the domain-scoped sidebar (#143);
-	// at `/` the route doesn't match so the hook is gated to `enabled: false`,
-	// but the import still has to resolve.
-	useDomainStats: () => ({ data: undefined, isLoading: false, isError: false }),
-}));
+vi.mock("~/queries/domains", () =>
+	shellDomainsMock({
+		useDomains: () => ({ ...domainsState, refetch: vi.fn() }),
+	}),
+);
 
 // The org-overview home page renders an "N mailboxes" hint sourced from
-// `useMailboxes`. Provide a stable empty list so renders don't fan out to
-// the real fetcher. `useMailbox` is also stubbed because Shell consumes it.
-vi.mock("~/queries/mailboxes", () => ({
-	useMailboxes: () => ({ data: [], refetch: vi.fn(), isFetched: true }),
-	useMailbox: () => ({ data: undefined }),
-}));
+// `useMailboxes`; Shell also consumes `useMailbox`. The shared factory
+// returns the empty-list / undefined defaults that keep render fan-out out
+// of the real fetchers.
+vi.mock("~/queries/mailboxes", () => shellMailboxesMock());
 
 // Shell renders the per-mailbox dashboard summary into the pipeline pill;
 // at "/" mailboxId is undefined and the query is disabled, but the hook is
-// still imported, so stub it to keep the test independent of TanStack
-// internals.
-vi.mock("~/queries/dashboard", () => ({
-	useDashboardSummary: () => ({ data: undefined }),
-}));
+// still imported, so the shared default keeps the test independent of
+// TanStack internals.
+vi.mock("~/queries/dashboard", () => shellDashboardMock());
 
 // `useAutoProvisionMailboxes` reads config + mailboxes and may fire a POST
 // when EMAIL_ADDRESSES is set. The org-overview test doesn't exercise that

--- a/tests/frontend/shell-mocks.ts
+++ b/tests/frontend/shell-mocks.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+// Shared factories for the queries `Shell` (`app/components/phishsoc/Shell.tsx`)
+// consumes. Any test that renders Shell — directly or via a route element —
+// must mock every one of these so the render doesn't fan out to the real
+// fetcher. Today Shell calls `useMailbox`, `useMailboxes` (from
+// `~/queries/mailboxes`), `useDashboardSummary` (from `~/queries/dashboard`),
+// and `useDomainStats` (from `~/queries/domains`).
+//
+// **Adding a new query to Shell?** Update the matching factory below — every
+// test that calls the factory in its `vi.mock(...)` body picks up the new
+// export automatically. This was the gap that bit us in the May 2 sweep:
+// PR #143 added `useDomainStats` to Shell, and PR #145 (developed in
+// parallel) had to be patched after rebase because its `home.test.tsx` and
+// `domains-list.test.tsx` mocked `~/queries/domains` without exposing the
+// new hook.
+//
+// Usage:
+//
+//   vi.mock("~/queries/mailboxes", () => shellMailboxesMock());
+//   vi.mock("~/queries/dashboard", () => shellDashboardMock());
+//   vi.mock("~/queries/domains", () => shellDomainsMock({
+//     // Per-test override — the route under test exercises this hook with
+//     // varying state, so let the test thread the mutable closure in.
+//     useDomainStats: () => ({ ...queryState, refetch }),
+//   }));
+//
+// Each factory accepts an `overrides` object so individual tests can swap in
+// per-case behavior (e.g. `home.test.tsx` varies `useDomains` per test) while
+// keeping the Shell-baseline defaults for everything else.
+
+import { vi } from "vitest";
+
+/**
+ * Minimal subset of `useQuery`'s return shape that the Shell-rendering
+ * routes actually destructure. Helpers default these to "loading-resolved,
+ * empty / undefined" so the Shell render path doesn't fan out, and tests
+ * can override per-case.
+ */
+type QueryStub<T> = {
+	data: T | undefined;
+	isLoading?: boolean;
+	isError?: boolean;
+	refetch?: () => void;
+	isFetched?: boolean;
+};
+
+export interface ShellMailboxesMockOverrides {
+	useMailboxes?: () => QueryStub<unknown[]>;
+	useMailbox?: () => QueryStub<unknown>;
+	[key: string]: unknown;
+}
+
+/**
+ * Factory for `~/queries/mailboxes`. Defaults: empty mailbox list, undefined
+ * single mailbox. Pass extra exports through `overrides` if a route under
+ * test consumes a hook (e.g. `useUpdateMailbox`) that Shell itself doesn't.
+ */
+export function shellMailboxesMock(
+	overrides: ShellMailboxesMockOverrides = {},
+): Record<string, unknown> {
+	return {
+		useMailboxes: () => ({ data: [], refetch: vi.fn(), isFetched: true }),
+		useMailbox: () => ({ data: undefined }),
+		...overrides,
+	};
+}
+
+export interface ShellDashboardMockOverrides {
+	useDashboardSummary?: () => QueryStub<unknown>;
+	[key: string]: unknown;
+}
+
+/**
+ * Factory for `~/queries/dashboard`. Defaults: undefined summary so the
+ * pipeline pill renders the "No data" muted state.
+ */
+export function shellDashboardMock(
+	overrides: ShellDashboardMockOverrides = {},
+): Record<string, unknown> {
+	return {
+		useDashboardSummary: () => ({ data: undefined }),
+		...overrides,
+	};
+}
+
+export interface ShellDomainsMockOverrides {
+	useDomainStats?: () => QueryStub<unknown>;
+	useDomains?: () => QueryStub<unknown[]>;
+	[key: string]: unknown;
+}
+
+/**
+ * Factory for `~/queries/domains`. Defaults cover the Shell-consumed
+ * `useDomainStats` hook. `useDomains` is **not** consumed by Shell directly
+ * — it's a route-level concern (home + domains-list) — so it's omitted from
+ * the defaults. Tests that need it should pass an override; tests that
+ * don't shouldn't have to think about it.
+ */
+export function shellDomainsMock(
+	overrides: ShellDomainsMockOverrides = {},
+): Record<string, unknown> {
+	return {
+		useDomainStats: () => ({ data: undefined, isLoading: false, isError: false }),
+		...overrides,
+	};
+}


### PR DESCRIPTION
## Summary

- New `tests/frontend/shell-mocks.ts` exports per-module factories (`shellMailboxesMock`, `shellDashboardMock`, `shellDomainsMock`) covering every query `Shell` consumes today (`useMailbox`, `useMailboxes`, `useDashboardSummary`, `useDomainStats`).
- Migrated `home.test.tsx`, `domains-list.test.tsx`, `domain-detail.test.tsx`, and `dashboard.test.tsx` to call the factories from their `vi.mock(...)` bodies, with per-test overrides for the hooks each route varies (`useDomains`, `useDomainStats`, `useDashboardSummary`).
- Adding a new query to Shell now only requires editing `shell-mocks.ts`; every test that calls the factory picks up the new export automatically — closing the gap that bit PR #145 after PR #143 added `useDomainStats`.

Closes #147.

## Design notes

- `vi.mock` is hoisted per file, so the factories must be invoked from each test file's `vi.mock(...)` callback (not from the helper itself). The factories return a record of named hook stubs that vi merges into the mocked module.
- `useDomains` is a route-level concern (home + domains-list) and Shell does not consume it — kept it out of `shellDomainsMock`'s defaults; tests pass it as an override.
- `dashboard.test.tsx` renders `DashboardRoute` standalone (the parent `mailbox.tsx` layout that mounts Shell isn't in the test tree), so only the dashboard factory is load-bearing there. The migration aligns its override pattern with the Shell-rendering tests for consistency, per the issue's acceptance list.

## Test plan

- [x] `npm test` — 482 passing across 46 files (unchanged from `main`).
- [x] `npm run typecheck` — clean.
- [x] No production code changes (test infrastructure only).
- [x] Each migrated test still exercises the same per-case overrides (`queryState`, `domainsState`, `refetch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)