### PR TITLE
feat: extend-merge semantics for security allowlist arrays

### DIFF
--- a/app/components/SecuritySettingsPanel.tsx
+++ b/app/components/SecuritySettingsPanel.tsx
@@ -169,6 +169,13 @@ export function SecuritySettingsPanel({ value, onChange }: SecuritySettingsPanel
 					Matched senders skip the classifier and are allowed — <em>only</em> when DMARC also passes.
 					Without the DMARC requirement, the allowlist alone would let any attacker spoof a trusted From: address.
 				</p>
+				<p className="text-xs text-ink-3 mb-3">
+					<strong>Inheritance:</strong> per-mailbox entries here <em>extend</em>
+					the org allowlists rather than replacing them. Resolved list is the
+					deduped, lowercased union with org entries first. Every other security
+					field on this panel is whole-replace: setting it here shadows the
+					upstream tier's value entirely.
+				</p>
 				<div className="space-y-3">
 					<ListInput
 						label="Allowed senders (comma-separated)"

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -357,8 +357,12 @@ export default function SettingsRoute() {
 				) : null}
 				<Link to="/settings" className="underline">/settings</Link>.
 				Editing a field here promotes it to an override that wins for this
-				mailbox; security and intel.hub overrides replace the entire upstream
-				block whole (no deep-merge across tiers).
+				mailbox. Security and <code>intel.hub</code> overrides replace the
+				entire upstream block whole (no deep-merge across tiers) — with one
+				carve-out: <code>allowlist_senders</code> and{" "}
+				<code>allowlist_domains</code> extend the org allowlists rather than
+				replacing them (deduped, lowercased, org entries first) so a
+				per-mailbox entry adds to the org list instead of shadowing it.
 			</p>
 
 			<div className="space-y-6">

--- a/tests/lib/resolve-mailbox-settings.test.ts
+++ b/tests/lib/resolve-mailbox-settings.test.ts
@@ -159,7 +159,7 @@ describe("resolveMailboxSettings — agentModel inheritance", () => {
 });
 
 describe("resolveMailboxSettings — security whole-object replace", () => {
-	it("mailbox security replaces the org block whole — allowlists do NOT extend", async () => {
+	it("mailbox security extends the org allowlists — union, lowercased, upstream-first (#149)", async () => {
 		const bucket = makeFakeBucket({
 			"org/settings.json": {
 				security: { enabled: true, allowlist_senders: ["a@b.com"] },
@@ -169,9 +169,10 @@ describe("resolveMailboxSettings — security whole-object replace", () => {
 			},
 		});
 		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
-		// Only the mailbox value, NOT a merged ["a@b.com","c@d.com"]. v1
-		// extend-merge is intentionally out of scope (audit Q3 follow-up).
-		expect(resolved.security.allowlist_senders).toEqual(["c@d.com"]);
+		// #149 carve-out: allowlist_senders extends across tiers, NOT
+		// whole-replace. Order is upstream-first (org → mailbox) so audit
+		// logs stay comparable.
+		expect(resolved.security.allowlist_senders).toEqual(["a@b.com", "c@d.com"]);
 	});
 
 	it("mailbox absent + org security set → org block wins, normalised", async () => {
@@ -203,6 +204,204 @@ describe("resolveMailboxSettings — security whole-object replace", () => {
 		expect(resolved.security.enabled).toBe(true);
 		expect(resolved.security.thresholds).toEqual(DEFAULT_SECURITY_SETTINGS.thresholds);
 		expect(resolved.security.attachment_policy).toEqual(DEFAULT_SECURITY_SETTINGS.attachment_policy);
+	});
+});
+
+describe("resolveMailboxSettings — security allowlist extend-merge (#149)", () => {
+	it("org-only allowlist_senders → resolved = org list (lowercased)", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: { enabled: true, allowlist_senders: ["A@org.com"] },
+			},
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.allowlist_senders).toEqual(["a@org.com"]);
+	});
+
+	it("mailbox-only allowlist_senders → resolved = mailbox list (lowercased)", async () => {
+		const bucket = makeFakeBucket({
+			[MAILBOX_KEY]: {
+				security: { enabled: true, allowlist_senders: ["B@MAILBOX.com"] },
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.allowlist_senders).toEqual(["b@mailbox.com"]);
+	});
+
+	it("org + mailbox both set → union, deduped, lowercased, org first", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: {
+					enabled: true,
+					allowlist_senders: ["A@org.com", "shared@x.com"],
+					allowlist_domains: ["org.com", "shared.com"],
+				},
+			},
+			[MAILBOX_KEY]: {
+				security: {
+					enabled: true,
+					allowlist_senders: ["b@mailbox.com", "SHARED@x.com"],
+					allowlist_domains: ["mailbox.com", "SHARED.com"],
+				},
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.allowlist_senders).toEqual([
+			"a@org.com",
+			"shared@x.com",
+			"b@mailbox.com",
+		]);
+		expect(resolved.security.allowlist_domains).toEqual([
+			"org.com",
+			"shared.com",
+			"mailbox.com",
+		]);
+	});
+
+	it("mailbox security set with no allowlist arrays → org allowlists still surface (regression guard)", async () => {
+		// The whole point of #149: a mailbox that flips a single security
+		// switch must NOT silently drop org allowlists. This is the case
+		// the v1 whole-replace used to break.
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: { enabled: true, allowlist_senders: ["a@org.com"], allowlist_domains: ["org.com"] },
+			},
+			[MAILBOX_KEY]: {
+				security: { enabled: true, learning_mode: true },
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.allowlist_senders).toEqual(["a@org.com"]);
+		expect(resolved.security.allowlist_domains).toEqual(["org.com"]);
+		// And the rest of the security block is the mailbox's whole-replace winner.
+		expect(resolved.security.learning_mode).toBe(true);
+	});
+
+	it("domain tier is NOT in the union (#149 out-of-scope; tracked as #150)", async () => {
+		// When mailbox.security is set, only org+mailbox extend. The domain
+		// tier's allowlists are NOT pulled in — domain extend semantics are
+		// deferred to #150 per the issue's out-of-scope list. The complementary
+		// "domain wins whole-replace when mailbox is absent" path is covered by
+		// the #142 test below ("domain security replaces org security WHOLE").
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: { enabled: true, allowlist_senders: ["org@x.com"] },
+			},
+			[DOMAIN_KEY]: {
+				security: { enabled: true, allowlist_senders: ["domain@x.com"] },
+			},
+			[MAILBOX_KEY]: {
+				security: { enabled: true, allowlist_senders: ["mailbox@x.com"] },
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.allowlist_senders).toEqual([
+			"org@x.com",
+			"mailbox@x.com",
+		]);
+		expect(resolved.security.allowlist_senders).not.toContain("domain@x.com");
+	});
+
+	it("regression guard: thresholds stay whole-replace (NOT extended)", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: { enabled: true, thresholds: { tag: 10, quarantine: 50, block: 70 } },
+			},
+			[MAILBOX_KEY]: {
+				security: { enabled: true, thresholds: { tag: 25, quarantine: 65, block: 90 } },
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.thresholds).toEqual({ tag: 25, quarantine: 65, block: 90 });
+	});
+
+	it("regression guard: business_hours stays whole-replace", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: {
+					enabled: true,
+					business_hours: { timezone: "America/New_York", start_hour: 8, end_hour: 18, weekdays_only: true, boost_on_off_hours: true },
+				},
+			},
+			[MAILBOX_KEY]: {
+				security: {
+					enabled: true,
+					business_hours: { timezone: "Europe/London", start_hour: 9, end_hour: 17, weekdays_only: false, boost_on_off_hours: false },
+				},
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.business_hours?.timezone).toBe("Europe/London");
+		expect(resolved.security.business_hours?.start_hour).toBe(9);
+		expect(resolved.security.business_hours?.boost_on_off_hours).toBe(false);
+	});
+
+	it("regression guard: attachment_policy stays whole-replace (no field-merge across tiers)", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: {
+					enabled: true,
+					attachment_policy: { custom_blocklist_extensions: ["org-only"] },
+				},
+			},
+			[MAILBOX_KEY]: {
+				security: {
+					enabled: true,
+					attachment_policy: { custom_blocklist_extensions: ["mailbox-only"] },
+				},
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		// Only the mailbox value — no merged ["org-only","mailbox-only"].
+		expect(resolved.security.attachment_policy.custom_blocklist_extensions).toEqual(["mailbox-only"]);
+	});
+
+	it("regression guard: folder_policies stays whole-replace", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: {
+					enabled: true,
+					folder_policies: { Inbox: { mode: "skip_classifier" } },
+				},
+			},
+			[MAILBOX_KEY]: {
+				security: {
+					enabled: true,
+					folder_policies: { Spam: { mode: "skip_all" } },
+				},
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.folder_policies).toEqual({ Spam: { mode: "skip_all" } });
+		expect(resolved.security.folder_policies?.Inbox).toBeUndefined();
+	});
+
+	it("regression guard: classification stays whole-replace", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: { enabled: true, classification: { skip_on_timeout: false } },
+			},
+			[MAILBOX_KEY]: {
+				security: { enabled: true, classification: { skip_on_timeout: true } },
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.classification.skip_on_timeout).toBe(true);
+	});
+
+	it("regression guard: trusted_authserv_ids stays whole-replace (NOT extended like allowlists)", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: { enabled: true, trusted_authserv_ids: ["mx.cloudflare.net"] },
+			},
+			[MAILBOX_KEY]: {
+				security: { enabled: true, trusted_authserv_ids: ["mx.google.com"] },
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		// Only the mailbox value — trusted_authserv_ids is NOT in the carve-out.
+		expect(resolved.security.trusted_authserv_ids).toEqual(["mx.google.com"]);
 	});
 });
 

--- a/workers/lib/mailbox-settings.ts
+++ b/workers/lib/mailbox-settings.ts
@@ -116,13 +116,28 @@ export interface ResolvedMailboxSettings {
  * (any sub-field), it carries the *whole* security object — the
  * domain/org `security` blocks are NOT deep-merged in. Same for
  * `intel.hub` and `intel.feeds`. This matches the v1 decision in #106's
- * audit (Q3, Q4, Q6); per-array extend-merge semantics are tracked as
- * separate follow-ups (#149, #150).
+ * audit (Q3, Q4, Q6).
+ *
+ * Carve-out (#149): `security.allowlist_senders` and
+ * `security.allowlist_domains` extend across the org and mailbox tiers —
+ * the resolved arrays are `unique(lowercased(org ++ mailbox))` when both
+ * are set. Operator-as-extender is the right model for allowlists;
+ * operator-as-replacer is the right model for everything else
+ * (`thresholds`, `business_hours`, `attachment_policy`,
+ * `folder_policies`, `classification`, `trusted_authserv_ids` all stay
+ * whole-replace). This is per-field, not a generic deep-merge.
+ *
+ * Domain tier intentionally does NOT extend in this pass: when
+ * `domain.security` wins (mailbox absent), it whole-replaces
+ * `org.security` including allowlists. Domain-tier extend semantics
+ * under the same pattern are tracked as the follow-up #150 — pulled out
+ * of #149's scope per the issue's out-of-scope list.
  *
  * `security` is post-normalised (lowercased allowlists, trimmed
  * blocklist extensions, etc.) so consumers don't repeat the case fold at
- * runtime — but the normalisation runs on whichever block won the resolve,
- * NOT field-by-field across tiers.
+ * runtime — for the carve-out fields, normalisation runs on the
+ * post-extend union; for everything else, on whichever block won the
+ * resolve.
  *
  * The domain layer is keyed off the mailboxId's domain part. A malformed
  * mailboxId (no `@`) skips the domain read entirely and falls through to
@@ -144,9 +159,22 @@ export async function resolveMailboxSettings(
 	// unset fields with the system default so consumers see a fully-
 	// populated MailboxSecuritySettings.
 	const securityWinner = mailbox.security ?? domain.security ?? org.security;
-	const security = securityWinner
+	const securityBase = securityWinner
 		? mergeSecurityWithDefault(securityWinner)
 		: DEFAULT_SECURITY_SETTINGS;
+	// Per-field carve-out (#149): when the mailbox tier sets a security
+	// override, the two allowlist arrays extend with the org tier's
+	// allowlists rather than whole-replacing them. Pulled from the *raw*
+	// per-tier blobs (not from the winner) so a mailbox override doesn't
+	// silently shadow upstream entries — which is the regression #149
+	// exists to prevent.
+	//
+	// Domain tier is NOT in the union (out of scope per #149's issue —
+	// tracked as #150). When `domain.security` wins because mailbox is
+	// absent, it whole-replaces org including allowlists, same as today.
+	const security = mailbox.security
+		? extendAllowlistsWithOrg(securityBase, org.security as RawSecurityAllowlists | undefined)
+		: securityBase;
 
 	const intelRaw = (mailbox.intel ?? domain.intel ?? org.intel ?? {}) as NonNullable<MailboxSettings["intel"]>;
 
@@ -212,6 +240,65 @@ function mergeSecurityWithDefault(value: unknown): MailboxSecuritySettings {
 			...(partial.classification ?? {}),
 		},
 	};
+}
+
+/**
+ * Per-field carve-out (#149) for `allowlist_senders` and
+ * `allowlist_domains` only. Every other security sub-field stays
+ * whole-replace by the winner tier. Resolved value for each carve-out
+ * field is `unique(lowercased(org ++ mailbox))` with stable upstream-first
+ * order (org entries first, mailbox second) so audit logs remain
+ * comparable across tiers.
+ *
+ * Only invoked when the mailbox tier set a security override. Reads from
+ * the *raw* per-tier blobs because the whole-object winner (the mailbox
+ * block) has already discarded upstream entries — the union must still
+ * surface the org's allowlist entries; that's the regression this fix
+ * exists to prevent.
+ *
+ * Domain tier is intentionally NOT in the union — see resolveMailboxSettings
+ * docstring for the #150 follow-up rationale. Strictly per-array, not a
+ * generic deep-merge.
+ */
+/** Allowlist arrays as carried by the raw passthrough Zod blobs — the Zod
+ *  schemas only nominally know `attachment_policy` / `folder_policies` /
+ *  `classification`; the allowlist arrays travel via passthrough so we
+ *  reach for them with this hand-rolled view. */
+type RawSecurityAllowlists = {
+	allowlist_senders?: readonly string[];
+	allowlist_domains?: readonly string[];
+};
+
+function extendAllowlistsWithOrg(
+	base: MailboxSecuritySettings,
+	org: RawSecurityAllowlists | undefined,
+): MailboxSecuritySettings {
+	return {
+		...base,
+		allowlist_senders: unionLowerStable(org?.allowlist_senders, base.allowlist_senders),
+		allowlist_domains: unionLowerStable(org?.allowlist_domains, base.allowlist_domains),
+	};
+}
+
+/**
+ * Stable upstream-first union: concatenate all provided arrays in order,
+ * lowercase each entry, and dedupe by lowercased value (first occurrence
+ * wins so the upstream-first order is preserved). Empty/undefined arrays
+ * contribute nothing.
+ */
+function unionLowerStable(...lists: Array<readonly string[] | undefined>): string[] {
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const list of lists) {
+		if (!list) continue;
+		for (const raw of list) {
+			const v = raw.toLowerCase();
+			if (seen.has(v)) continue;
+			seen.add(v);
+			out.push(v);
+		}
+	}
+	return out;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `resolveMailboxSettings` now treats `security.allowlist_senders` and `security.allowlist_domains` as per-field extend-merge: when the mailbox tier sets a security override, the resolved arrays are `unique(lowercased(org ++ mailbox))` with stable upstream-first order (org entries first, mailbox second). Every other security sub-field stays whole-replace.
- Implemented as a per-field post-resolve overlay against the raw per-tier blobs in `workers/lib/mailbox-settings.ts` (no generic deep-merge). Reads from the *raw* per-tier blobs because the whole-object winner has already discarded upstream entries — surfacing org allowlists when the mailbox sets `security: {enabled: true}` with no allowlist arrays is exactly the regression #149 exists to prevent.
- UI: `SecuritySettingsPanel.tsx` allowlists section now carries an inheritance note distinguishing extend (allowlists) from replace (everything else); the per-mailbox `settings.tsx` page banner is updated to match.

Closes #149.

## Scope notes

- **Domain tier intentionally NOT in the union.** When `mailbox.security` is absent and `domain.security` wins the whole-object replace, it still whole-replaces `org.security` including allowlists — same as today. This matches the issue's explicit out-of-scope item ("Domain-tier (#142) extend semantics — that should follow this same pattern but lands in its own PR after both this and #142 are on main"), tracked as the #150 follow-up. The existing #142 test `domain security replaces org security WHOLE` is intentionally left as-is and now has a sibling test `domain tier is NOT in the union (#149 out-of-scope; tracked as #150)` pinning the asymmetry.
- **`extend: false` opt-out** (mailbox forces a hard replace) is still out of scope per the issue — no UX yet.
- **No write-path changes.** `stripDefaultEqual` invariant unchanged; the union is a read-time post-resolve overlay and never touches stored mailbox JSON.

## Test plan

- [x] `npm test` — 493 passed / 0 failed (was 493/0 pre-change, with the existing `mailbox security replaces the org block whole — allowlists do NOT extend` test flipped per Acceptance + 11 new tests covering the carve-out and the regression guards on every other security sub-field).
- [x] `npm run typecheck` — clean.
- [x] Acceptance walkthrough:
  - [x] org-only → resolved = org list (lowercased).
  - [x] mailbox-only → resolved = mailbox list (lowercased).
  - [x] both-set → union, deduped, lowercased, org first.
  - [x] regression: `thresholds`, `business_hours`, `attachment_policy`, `folder_policies`, `classification`, `trusted_authserv_ids` stay whole-replace.
  - [x] UI banner copy distinguishes extend vs replace in `SecuritySettingsPanel.tsx` and the per-mailbox settings page.
  - [x] Existing PR1 test flipped from "replaces" to "extends".
- [x] Manual sanity: regression-guard test for the foot-gun case (mailbox sets `security: {enabled: true}` with no allowlist arrays — org allowlists still surface).

## Deferred follow-ups

None new from this PR. The issue's own out-of-scope items remain tracked: #150 for domain-tier extend semantics; `extend: false` opt-out still pending UX work and not yet filed.