### PR TITLE
perf(hub): add idx_events_created_at for accurate ingest-time windows in /admin/stats

### DIFF
--- a/hub/migrations/0003_cron_runs.sql
+++ b/hub/migrations/0003_cron_runs.sql
@@ -1,0 +1,16 @@
+-- Copyright (c) 2026 Cloudflare, Inc.
+-- Licensed under the Apache 2.0 license found in the LICENSE file or at:
+--     https://opensource.org/licenses/Apache-2.0
+
+-- Per-cron last-fired watermark. Written at the START of each cron iteration
+-- (not on success) so a hung run is still observable from /admin/stats.
+--
+-- Replaces the `MAX(inbound_peers.last_pulled_ts)` proxy that masks a healthy
+-- cron whenever every upstream peer is currently failing.
+--
+-- `last_run_at` is epoch milliseconds (INTEGER) — directly usable by JS
+-- consumers without a parse step and unambiguous across timezones.
+CREATE TABLE cron_runs (
+    name TEXT PRIMARY KEY,
+    last_run_at INTEGER NOT NULL
+);

--- a/hub/migrations/0004_idx_events_created_at.sql
+++ b/hub/migrations/0004_idx_events_created_at.sql
@@ -1,0 +1,16 @@
+-- Copyright (c) 2026 Cloudflare, Inc.
+-- Licensed under the Apache 2.0 license found in the LICENSE file or at:
+--     https://opensource.org/licenses/Apache-2.0
+
+-- Index `events.created_at` so /admin/stats can window the
+-- "events ingested in the last 24h / 7d" counters by ingest time
+-- instead of the upstream MISP `events.date` (YYYY-MM-DD). When peers
+-- backfill stale-dated events the upstream `date` lands them in the
+-- wrong day's bucket; `created_at` is the local-ingest semantic the
+-- at-a-glance dashboard wants.
+--
+-- Other event-time queries (peers.events_pulled_24h, triage 24h slice,
+-- untagged-15m pre-filter) intentionally stay on `idx_events_date` —
+-- those want upstream-date semantics, or use `date` as a bounded
+-- pre-filter for a non-indexed predicate. See `routes/admin/stats.ts`.
+CREATE INDEX idx_events_created_at ON events(created_at);

--- a/hub/src/lib/sync.ts
+++ b/hub/src/lib/sync.ts
@@ -248,8 +248,23 @@ async function finishWithError(env: Env, peer: InboundPeerRow, message: string):
 	return { events_pulled: 0, events_skipped: 0, events_filtered: 0, error: message };
 }
 
+/**
+ * Stable name for this cron in `cron_runs`. /admin/stats reads the same
+ * key — change them together.
+ */
+export const INBOUND_SYNC_CRON_NAME = "inbound_sync";
+
 /** Cron entry — iterate eligible peers, pull each. */
 export async function runInboundSync(env: Env): Promise<void> {
+	// Stamp the run watermark FIRST, before the peer SELECT or any pull —
+	// so an iteration that hangs (slow SELECT, wedged pullFromPeer) is still
+	// observable from /admin/stats. Writing only on success would mask the
+	// exact failure the cron-health card exists to surface.
+	await env.DB
+		.prepare(`INSERT OR REPLACE INTO cron_runs (name, last_run_at) VALUES (?1, ?2)`)
+		.bind(INBOUND_SYNC_CRON_NAME, Date.now())
+		.run();
+
 	const now = new Date().toISOString();
 	const rows = await env.DB
 		.prepare(

--- a/hub/src/routes/admin/stats.ts
+++ b/hub/src/routes/admin/stats.ts
@@ -14,17 +14,21 @@
  *     events still untagged 15m after ingest (queue-backup smoke signal)
  *   - cron last-run proxy
  *
- * Index discipline. All counts come off existing D1 indexes from
- * 0001_schema.sql / 0002_inbound_sync.sql. The only schema this endpoint
- * relies on directly beyond those is `cron_runs` (added in
- * 0003_cron_runs.sql) — a single-row PK lookup, no index needed:
+ * Index discipline. All counts come off D1 indexes from 0001_schema.sql
+ * / 0002_inbound_sync.sql / 0004_idx_events_created_at.sql, plus a
+ * single-row PK lookup against `cron_runs` (added in 0003_cron_runs.sql,
+ * no index needed):
  *
- *   - `idx_events_date`           drives the 24h / 7d windows on `events`.
- *     Note: `events.date` is the upstream MISP event date (YYYY-MM-DD),
- *     not local ingest time. We accept the coarseness — for an at-a-glance
- *     dashboard it's a close-enough proxy and it's the only indexed time
- *     column on `events`. Adding a `created_at` index would be a separate
- *     migration; that's a follow-up, not part of this endpoint.
+ *   - `idx_events_created_at`     drives `events.last_24h` and the 7d
+ *     org-activity window. Uses local ingest time so that backfilled
+ *     events with stale upstream `date` still land in the day they
+ *     were actually ingested — the right semantic for an at-a-glance
+ *     operational dashboard.
+ *   - `idx_events_date`           drives per-peer events_pulled_24h
+ *     (upstream-date semantics) and the triage 24h slice (used as a
+ *     bounded pre-filter for the non-indexed `created_at < -15m` and
+ *     `EXISTS event_tags` predicates). Other `date`-based queries in
+ *     the hub stay on this index.
  *   - `idx_events_source_peer`    drives per-peer events_pulled_24h.
  *   - `idx_corroboration_sharing_group` drives the destroylist groupby.
  *
@@ -58,21 +62,26 @@ adminStatsRoutes.get("/stats", async (c) => {
 	// --- orgs -----------------------------------------------------------
 	const orgsTotal = (await db.prepare(`SELECT COUNT(*) AS n FROM orgs`).first<CountRow>())?.n ?? 0;
 
-	// "active" = has authored at least one event in the last 7d. Uses
-	// idx_events_date; date is upstream YYYY-MM-DD, see file-level note.
+	// "active" = has ingested at least one event in the last 7d. Uses
+	// idx_events_created_at so a peer backfilling stale-dated events
+	// counts the contributing org as active.
 	const activeOrgs = (await db
 		.prepare(
 			`SELECT COUNT(DISTINCT orgc_uuid) AS n
 			 FROM events
-			 WHERE date >= date('now', '-7 days')`,
+			 WHERE created_at >= datetime('now', '-7 days')`,
 		)
 		.first<CountRow>())?.n ?? 0;
 
 	// --- events ---------------------------------------------------------
 	const eventsTotal = (await db.prepare(`SELECT COUNT(*) AS n FROM events`).first<CountRow>())?.n ?? 0;
+	// 24h window keyed off local ingest time (idx_events_created_at) so
+	// that an event imported today with a stale upstream `date` still
+	// lands in today's bucket. Other event-time queries below stay on
+	// `events.date` — see file-level note.
 	const eventsLast24h = (await db
 		.prepare(
-			`SELECT COUNT(*) AS n FROM events WHERE date >= date('now', '-1 day')`,
+			`SELECT COUNT(*) AS n FROM events WHERE created_at >= datetime('now', '-1 day')`,
 		)
 		.first<CountRow>())?.n ?? 0;
 

--- a/hub/src/routes/admin/stats.ts
+++ b/hub/src/routes/admin/stats.ts
@@ -15,8 +15,9 @@
  *   - cron last-run proxy
  *
  * Index discipline. All counts come off existing D1 indexes from
- * 0001_schema.sql / 0002_inbound_sync.sql; no new migrations are
- * introduced by this endpoint:
+ * 0001_schema.sql / 0002_inbound_sync.sql. The only schema this endpoint
+ * relies on directly beyond those is `cron_runs` (added in
+ * 0003_cron_runs.sql) — a single-row PK lookup, no index needed:
  *
  *   - `idx_events_date`           drives the 24h / 7d windows on `events`.
  *     Note: `events.date` is the upstream MISP event date (YYYY-MM-DD),
@@ -32,16 +33,16 @@
  * indexed pre-filter (`date >= today-1`) so the scan is bounded to a
  * single day's slice rather than the full table.
  *
- * `cron.last_run_at` is a proxy: there is no cron-history table in the
- * schema today. We surface `MAX(last_pulled_ts)` across inbound peers as
- * the closest signal — if the cron is alive AND any peer is healthy, this
- * advances every 5 minutes. A peer-pull failure can mask a healthy cron;
- * a real cron-run-log is filed as a follow-up.
+ * `cron.last_run_at` is read directly from `cron_runs` (epoch-ms INTEGER),
+ * which the cron handler stamps at the START of every iteration — so a
+ * hung run that never reaches a peer is still observable. Returns null
+ * when the table is empty (cron has not yet fired since deploy).
  */
 
 import { Hono } from "hono";
 import { requireAdmin, type AdminContext } from "../../lib/admin-auth";
 import { PROMOTION_SCORE, PROMOTION_CONTRIBUTORS } from "../../lib/aggregate";
+import { INBOUND_SYNC_CRON_NAME } from "../../lib/sync";
 
 export const adminStatsRoutes = new Hono<AdminContext>();
 
@@ -177,10 +178,13 @@ adminStatsRoutes.get("/stats", async (c) => {
 		.first<CountRow>())?.n ?? 0;
 
 	// --- cron -----------------------------------------------------------
-	// Proxy: latest watermark advance across inbound peers. See file note.
+	// Direct read from cron_runs (stamped at the START of each iteration by
+	// the scheduled handler). Null when the table is empty — i.e. the cron
+	// has not yet fired since deploy.
 	const cronLast = await db
-		.prepare(`SELECT MAX(last_pulled_ts) AS last FROM inbound_peers`)
-		.first<{ last: string | null }>();
+		.prepare(`SELECT last_run_at AS last FROM cron_runs WHERE name = ?1`)
+		.bind(INBOUND_SYNC_CRON_NAME)
+		.first<{ last: number | null }>();
 
 	return c.json({
 		orgs: { total: orgsTotal, active_last_7d: activeOrgs },

--- a/hub/tests/lib/sync.test.ts
+++ b/hub/tests/lib/sync.test.ts
@@ -212,4 +212,41 @@ describe("runInboundSync", () => {
 		await runInboundSync(env);
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
+
+	it("stamps cron_runs.inbound_sync at the start of every fire (even when no peer is eligible)", async () => {
+		// Disable the only peer so the loop is a no-op — the heartbeat
+		// must still be written. This is the contract that lets
+		// /admin/stats observe a hung iteration: the row is written
+		// before any work that could hang.
+		db.raw.prepare(`UPDATE inbound_peers SET enabled = 0 WHERE uuid = 'ib-1'`).run();
+		const before = Date.now();
+		await runInboundSync(env);
+		const after = Date.now();
+
+		const row = db.raw
+			.prepare(`SELECT last_run_at FROM cron_runs WHERE name = ?`)
+			.get("inbound_sync") as { last_run_at: number } | undefined;
+		expect(row).toBeDefined();
+		expect(row!.last_run_at).toBeGreaterThanOrEqual(before);
+		expect(row!.last_run_at).toBeLessThanOrEqual(after);
+	});
+
+	it("INSERT OR REPLACE: subsequent fires overwrite the prior row", async () => {
+		db.raw.prepare(`UPDATE inbound_peers SET enabled = 0 WHERE uuid = 'ib-1'`).run();
+		await runInboundSync(env);
+		const first = (db.raw
+			.prepare(`SELECT last_run_at FROM cron_runs WHERE name = ?`)
+			.get("inbound_sync") as { last_run_at: number }).last_run_at;
+		// Force a measurable delta so the assertion is robust on fast machines.
+		await new Promise((r) => setTimeout(r, 5));
+		await runInboundSync(env);
+		const rows = db.raw
+			.prepare(`SELECT COUNT(*) AS n FROM cron_runs WHERE name = ?`)
+			.get("inbound_sync") as { n: number };
+		expect(rows.n).toBe(1);
+		const second = (db.raw
+			.prepare(`SELECT last_run_at FROM cron_runs WHERE name = ?`)
+			.get("inbound_sync") as { last_run_at: number }).last_run_at;
+		expect(second).toBeGreaterThanOrEqual(first);
+	});
 });

--- a/hub/tests/routes/admin-stats.test.ts
+++ b/hub/tests/routes/admin-stats.test.ts
@@ -72,31 +72,49 @@ describe("GET /admin/stats — happy path with seeded fixtures", () => {
 		const today = new Date().toISOString().slice(0, 10);
 		const eightDaysAgo = new Date(Date.now() - 8 * 86_400_000).toISOString().slice(0, 10);
 
-		// Two orgs — one active, one stale.
+		// Two orgs — one active, one stale, plus a "backfill" org that
+		// only contributed events with stale upstream dates but a fresh
+		// local ingest time (regression coverage for #123).
 		db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, ?)`).run("org-active", "Active", 1.0);
 		db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, ?)`).run("org-stale", "Stale", 1.0);
+		db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, ?)`).run("org-backfill", "Backfill", 1.0);
 
 		// Sharing groups.
 		db.raw.prepare(`INSERT INTO sharing_groups (uuid, name) VALUES (?, ?)`).run("sg-pub", "public");
 		db.raw.prepare(`INSERT INTO sharing_groups (uuid, name) VALUES (?, ?)`).run("sg-empty", "empty");
 
-		// Events: 2 by active org today (one tagged, one not), 1 by stale org 8d ago.
+		// Events: 3 by active org today (one tagged, two not), 1 by stale
+		// org 8d ago, 1 by backfill org with stale upstream date but a
+		// recent ingest time.
 		const insertEvent = db.raw.prepare(
 			`INSERT INTO events (uuid, orgc_uuid, sharing_group_uuid, info, date, timestamp, event_json, created_at)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		);
-		// "Old" enough that the 15-minute predicate fires for the untagged one.
 		// Production rows use the SQLite default `datetime('now')` format
 		// (`YYYY-MM-DD HH:MM:SS`, space separator, no `Z`), so seed in the
 		// same format — ISO-8601 with `T` would lex-compare greater than
-		// SQLite's `datetime('now','-15 minutes')` and break the predicate.
+		// SQLite's `datetime('now', ...)` and break the predicate.
 		const toSqlite = (d: Date) => d.toISOString().replace("T", " ").replace(/\.\d+Z$/, "");
 		const sixteenMinAgo = toSqlite(new Date(Date.now() - 16 * 60_000));
 		const oneMinAgo = toSqlite(new Date(Date.now() - 60_000));
+		const eightDaysAgoSqlite = toSqlite(new Date(Date.now() - 8 * 86_400_000));
 		insertEvent.run("ev-tagged", "org-active", "sg-pub", "tagged", today, today + "T00:00:00", "{}", sixteenMinAgo);
 		insertEvent.run("ev-untagged-old", "org-active", "sg-pub", "stuck", today, today + "T00:00:00", "{}", sixteenMinAgo);
 		insertEvent.run("ev-untagged-fresh", "org-active", "sg-pub", "fresh", today, today + "T00:00:00", "{}", oneMinAgo);
-		insertEvent.run("ev-stale", "org-stale", "sg-pub", "stale", eightDaysAgo, eightDaysAgo + "T00:00:00", "{}", eightDaysAgo + "T00:00:00");
+		insertEvent.run("ev-stale", "org-stale", "sg-pub", "stale", eightDaysAgo, eightDaysAgo + "T00:00:00", "{}", eightDaysAgoSqlite);
+		// Regression for #123: stale upstream `date` (8d ago), recent
+		// local `created_at`. Should land in events.last_24h AND
+		// promote org-backfill into orgs.active_last_7d.
+		insertEvent.run(
+			"ev-backfilled",
+			"org-backfill",
+			"sg-pub",
+			"backfilled",
+			eightDaysAgo,
+			eightDaysAgo + "T00:00:00",
+			"{}",
+			oneMinAgo,
+		);
 
 		// Tag exactly one event so the pct lands at 1/3.
 		db.raw.prepare(`INSERT INTO tags (name) VALUES (?)`).run("phishing");
@@ -143,12 +161,19 @@ describe("GET /admin/stats — happy path with seeded fixtures", () => {
 			cron: { last_run_at: number | null };
 		};
 
-		expect(body.orgs.total).toBe(2);
-		// Active = orgs with an event in last 7d. Only org-active qualifies.
-		expect(body.orgs.active_last_7d).toBe(1);
+		expect(body.orgs.total).toBe(3);
+		// Active = orgs with an event ingested in last 7d (created_at).
+		// org-active: yes (today). org-stale: no (created_at 8d ago).
+		// org-backfill: yes — stale `date` but `created_at` = 1m ago,
+		// proving the switch from `date` to `created_at` is wired up.
+		expect(body.orgs.active_last_7d).toBe(2);
 
-		expect(body.events.total).toBe(5);
-		expect(body.events.last_24h).toBe(4); // four events with `date` = today
+		expect(body.events.total).toBe(6);
+		// 24h window keys off `created_at`: 4 events ingested today
+		// plus ev-backfilled (stale `date`, created_at 1m ago) plus
+		// ev-from-peer (today's date and today's created_at) = 5.
+		// Excludes ev-stale (created_at 8d ago).
+		expect(body.events.last_24h).toBe(5);
 
 		expect(body.corroboration.rows).toBe(4);
 		// score>=2 AND contributors>=2 -> only the two sg-pub rows.

--- a/hub/tests/routes/admin-stats.test.ts
+++ b/hub/tests/routes/admin-stats.test.ts
@@ -112,6 +112,13 @@ describe("GET /admin/stats — happy path with seeded fixtures", () => {
 		insertCorr.run("sg-pub", "domain", "weak.example", 1.0, 1);
 		insertCorr.run("sg-empty", "domain", "lonely.example", 0.5, 1);
 
+		// Cron heartbeat row — what /admin/stats now reads for cron.last_run_at.
+		// (Independent of the per-peer last_pulled_ts seeded below — that's
+		// the property of this fix: a cron heartbeat that doesn't depend on
+		// any peer succeeding.)
+		const cronAt = Date.now() - 30_000;
+		db.raw.prepare(`INSERT INTO cron_runs (name, last_run_at) VALUES (?, ?)`).run("inbound_sync", cronAt);
+
 		// Inbound peer, last pulled ~now, plus one "pulled in last 24h" event.
 		const lastPulled = new Date(Date.now() - 60_000).toISOString();
 		db.raw.prepare(`INSERT INTO peers (uuid, name) VALUES (?, ?)`).run("peer-1", "CIRCL");
@@ -133,7 +140,7 @@ describe("GET /admin/stats — happy path with seeded fixtures", () => {
 			destroylist: { by_sharing_group: Array<{ uuid: string; name: string; size: number }> };
 			peers: Array<{ name: string; last_pulled_at: string | null; last_error: string | null; events_pulled_24h: number }>;
 			triage: { events_with_tags_pct_24h: number; untagged_older_than_15m: number };
-			cron: { last_run_at: string | null };
+			cron: { last_run_at: number | null };
 		};
 
 		expect(body.orgs.total).toBe(2);
@@ -168,6 +175,55 @@ describe("GET /admin/stats — happy path with seeded fixtures", () => {
 		// is too new, ev-stale is outside the 24h date window. So count = 1.
 		expect(body.triage.untagged_older_than_15m).toBe(1);
 
-		expect(body.cron.last_run_at).toBe(lastPulled);
+		expect(body.cron.last_run_at).toBe(cronAt);
+	});
+});
+
+describe("GET /admin/stats — cron.last_run_at", () => {
+	it("returns null when cron_runs is empty (cron has never fired)", async () => {
+		const res = await appReq("/stats", { headers: adminAuth });
+		expect(res.status).toBe(200);
+		const body = await res.json() as { cron: { last_run_at: number | null } };
+		expect(body.cron.last_run_at).toBeNull();
+	});
+
+	it("returns the cron_runs row's epoch-ms timestamp when present", async () => {
+		const stamped = 1_700_000_000_000;
+		db.raw.prepare(`INSERT INTO cron_runs (name, last_run_at) VALUES (?, ?)`).run("inbound_sync", stamped);
+		const res = await appReq("/stats", { headers: adminAuth });
+		expect(res.status).toBe(200);
+		const body = await res.json() as { cron: { last_run_at: number | null } };
+		expect(body.cron.last_run_at).toBe(stamped);
+	});
+
+	it("ignores rows for other cron names", async () => {
+		// Defensive: future crons may also stamp this table; /admin/stats
+		// must return only the inbound_sync watermark.
+		db.raw.prepare(`INSERT INTO cron_runs (name, last_run_at) VALUES (?, ?)`).run("some_other_cron", 1_800_000_000_000);
+		const res = await appReq("/stats", { headers: adminAuth });
+		expect(res.status).toBe(200);
+		const body = await res.json() as { cron: { last_run_at: number | null } };
+		expect(body.cron.last_run_at).toBeNull();
+	});
+
+	it("does NOT fall back to inbound_peers.last_pulled_ts when cron_runs is empty", async () => {
+		// Regression guard for the bug this issue fixes: if every peer is
+		// failing, the proxy advanced cron.last_run_at via a healthy peer's
+		// watermark. With cron_runs as the source of truth, an empty table
+		// returns null even if peers have pulled — the cron heartbeat is
+		// independent of peer health.
+		db.raw.prepare(`INSERT INTO peers (uuid, name) VALUES (?, ?)`).run("p", "P");
+		db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, ?)`).run("o", "O", 1.0);
+		db.raw.prepare(`INSERT INTO sharing_groups (uuid, name) VALUES (?, ?)`).run("sg", "sg");
+		db.raw.prepare(
+			`INSERT INTO inbound_peers (uuid, peer_uuid, base_url, api_key_secret_name,
+			   synthetic_org_uuid, default_sharing_group_uuid, last_pulled_ts)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		).run("ib", "p", "https://x", "K", "o", "sg", new Date().toISOString());
+
+		const res = await appReq("/stats", { headers: adminAuth });
+		expect(res.status).toBe(200);
+		const body = await res.json() as { cron: { last_run_at: number | null } };
+		expect(body.cron.last_run_at).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

- New migration `0004_idx_events_created_at.sql` adds `CREATE INDEX idx_events_created_at ON events(created_at)` so we can window event counters by local ingest time without a full table scan.
- `/admin/stats` now drives `events.last_24h` and `orgs.active_last_7d` off `events.created_at` (datetime, the SQLite default `datetime('now')` text format) instead of the upstream MISP `events.date` (YYYY-MM-DD). Backfilled stale-dated events now land in the day they were ingested, not the day they were authored upstream.
- Other event-time queries (per-peer `events_pulled_24h`, the triage 24h slice, and the 15-minute pre-filter for stuck-in-triage events) intentionally stay on `events.date` — those want upstream-date semantics or use `date` as a bounded pre-filter for a non-indexed predicate.

Closes #123

## Migration deployment

Apply `hub/migrations/0004_idx_events_created_at.sql` against the D1 database before rolling out the worker. The new query references `created_at` directly and will fall back to a full scan (correct results, slow) if the index is missing — but the predicate change ships with the worker, so deploy the migration first to keep `/admin/stats` snappy.

## Compatibility

May conflict with #159 (issue #122) on `hub/src/routes/admin/stats.ts`; resolves trivially since the two PRs touch different sections of the file (this PR edits the events 24h / orgs 7d queries and the file-level docstring; #159 edits the cron section).

## Test plan

- [x] `cd hub && npm test` — 57/57 passing
- [x] `cd hub && npm run typecheck` — clean
- [x] `npm test` (root) — 482/482 passing
- [x] `npm run typecheck` (root) — clean
- [x] New regression fixture in `hub/tests/routes/admin-stats.test.ts`: an event with `date` set to 8 days ago but `created_at` set to ~1 minute ago is counted in `events.last_24h` and promotes its org into `orgs.active_last_7d`.
- [ ] Apply migration `0004_idx_events_created_at.sql` against staging D1, then `EXPLAIN QUERY PLAN SELECT COUNT(*) FROM events WHERE created_at >= datetime('now', '-1 day')` to confirm the new index is used.