### PR TITLE
feat: per-field merge for security.business_hours

### DIFF
--- a/tests/lib/resolve-mailbox-settings.test.ts
+++ b/tests/lib/resolve-mailbox-settings.test.ts
@@ -405,6 +405,133 @@ describe("resolveMailboxSettings — security allowlist extend-merge (#149)", ()
 	});
 });
 
+describe("resolveMailboxSettings — security.business_hours per-field merge (#150)", () => {
+	const orgFullBH = {
+		timezone: "America/New_York",
+		start_hour: 9,
+		end_hour: 17,
+		weekdays_only: true,
+		boost_on_off_hours: true,
+	};
+
+	it("org full block + mailbox sets only timezone → merged per-field, mailbox wins per field", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: { enabled: true, business_hours: orgFullBH },
+			},
+			[MAILBOX_KEY]: {
+				security: { business_hours: { timezone: "Europe/London" } },
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.business_hours).toEqual({
+			timezone: "Europe/London",
+			start_hour: 9,
+			end_hour: 17,
+			weekdays_only: true,
+			boost_on_off_hours: true,
+		});
+	});
+
+	it("mailbox full block, org absent → resolved business_hours = mailbox", async () => {
+		const mailboxFullBH = {
+			timezone: "Asia/Tokyo",
+			start_hour: 8,
+			end_hour: 18,
+			weekdays_only: false,
+			boost_on_off_hours: true,
+		};
+		const bucket = makeFakeBucket({
+			[MAILBOX_KEY]: { security: { business_hours: mailboxFullBH } },
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.business_hours).toEqual(mailboxFullBH);
+	});
+
+	it("org full block, mailbox absent → resolved business_hours = org", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: { enabled: true, business_hours: orgFullBH },
+			},
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.business_hours).toEqual(orgFullBH);
+	});
+
+	it("both tiers absent → resolved.security.business_hours is undefined", async () => {
+		const bucket = makeFakeBucket({ [MAILBOX_KEY]: {} });
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.business_hours).toBeUndefined();
+	});
+
+	it("domain-only business_hours (mailbox+org absent) → resolved is undefined (domain tier deferred to follow-up)", async () => {
+		// Pins the spec interpretation: per-field merge applies to mailbox+org
+		// only. The domain tier is intentionally NOT consulted for
+		// business_hours here, even though it participates in the whole-tier
+		// replace for other security sub-fields. Tracked as a follow-up.
+		const bucket = makeFakeBucket({
+			[DOMAIN_KEY]: { security: { enabled: true, business_hours: orgFullBH } },
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.business_hours).toBeUndefined();
+	});
+
+	it("mailbox sets boost_on_off_hours=true while org has it false → mailbox flag wins", async () => {
+		// boost_on_off_hours is a field in BusinessHours and per-field merge
+		// applies to it like any other field (issue out-of-scope note: no UX
+		// flagging of the inversion, but the merge itself works).
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: {
+					enabled: true,
+					business_hours: { ...orgFullBH, boost_on_off_hours: false },
+				},
+			},
+			[MAILBOX_KEY]: {
+				security: { business_hours: { boost_on_off_hours: true } },
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.business_hours?.boost_on_off_hours).toBe(true);
+		// Other fields still inherited from org.
+		expect(resolved.security.business_hours?.timezone).toBe("America/New_York");
+	});
+
+	it("regression: other security sub-fields stay whole-replace (mailbox thresholds.tag does NOT inherit org thresholds.quarantine)", async () => {
+		// Per-field merge is business_hours-only. thresholds, attachment_policy,
+		// folder_policies, classification, trusted_authserv_ids, and the
+		// allowlists all continue to follow whole-tier replace + system-default
+		// completion (single-tier).
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: {
+					enabled: true,
+					thresholds: { quarantine: 99 },
+					trusted_authserv_ids: ["org.example.com"],
+				},
+			},
+			[MAILBOX_KEY]: {
+				security: {
+					thresholds: { tag: 42 },
+					trusted_authserv_ids: ["mailbox.example.com"],
+				},
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		// Mailbox tier wins whole-object replace; org's quarantine is NOT
+		// inherited per-field. The default's quarantine fills in for the
+		// missing key (single-tier completion via mergeSecurityWithDefault).
+		expect(resolved.security.thresholds.tag).toBe(42);
+		expect(resolved.security.thresholds.quarantine).toBe(
+			DEFAULT_SECURITY_SETTINGS.thresholds.quarantine,
+		);
+		// trusted_authserv_ids: mailbox wins whole, no merge with org.
+		expect(resolved.security.trusted_authserv_ids).toEqual(["mailbox.example.com"]);
+	});
+});
+
 describe("resolveMailboxSettings — intel.hub inheritance (#121 audit Q1)", () => {
 	const orgHub = {
 		url: "https://hub.example.com",

--- a/workers/lib/mailbox-settings.ts
+++ b/workers/lib/mailbox-settings.ts
@@ -14,6 +14,7 @@ import type { DomainSettings } from "../../shared/domain-settings";
 import { domainFromMailboxId, getDomainSettings } from "./domain-settings";
 import {
 	DEFAULT_SECURITY_SETTINGS,
+	type BusinessHours,
 	type MailboxSecuritySettings,
 } from "../security/defaults";
 
@@ -169,12 +170,21 @@ export async function resolveMailboxSettings(
 	// silently shadow upstream entries — which is the regression #149
 	// exists to prevent.
 	//
-	// Domain tier is NOT in the union (out of scope per #149's issue —
-	// tracked as #150). When `domain.security` wins because mailbox is
-	// absent, it whole-replaces org including allowlists, same as today.
-	const security = mailbox.security
+	// Domain tier is NOT in the union (out of scope per #149's issue).
+	// When `domain.security` wins because mailbox is absent, it
+	// whole-replaces org including allowlists, same as today.
+	const securityWithAllowlists = mailbox.security
 		? extendAllowlistsWithOrg(securityBase, org.security as RawSecurityAllowlists | undefined)
 		: securityBase;
+
+	// Post-resolve carve-out (#150): business_hours is the ONE security
+	// sub-field that merges per-field across tiers instead of whole-object
+	// replace. Mailbox value wins per field, then org fills in the rest;
+	// if neither tier set it, the resolved value stays undefined (we don't
+	// materialise an inert default block). Domain tier is intentionally
+	// not consulted here — tracked as #164 follow-up. Every other
+	// security sub-field continues to follow the whole-tier replace rule.
+	const security = mergeBusinessHoursAcrossTiers(securityWithAllowlists, mailbox, org);
 
 	const intelRaw = (mailbox.intel ?? domain.intel ?? org.intel ?? {}) as NonNullable<MailboxSettings["intel"]>;
 
@@ -256,9 +266,8 @@ function mergeSecurityWithDefault(value: unknown): MailboxSecuritySettings {
  * surface the org's allowlist entries; that's the regression this fix
  * exists to prevent.
  *
- * Domain tier is intentionally NOT in the union — see resolveMailboxSettings
- * docstring for the #150 follow-up rationale. Strictly per-array, not a
- * generic deep-merge.
+ * Domain tier is intentionally NOT in the union. Strictly per-array, not
+ * a generic deep-merge.
  */
 /** Allowlist arrays as carried by the raw passthrough Zod blobs — the Zod
  *  schemas only nominally know `attachment_policy` / `folder_policies` /
@@ -299,6 +308,56 @@ function unionLowerStable(...lists: Array<readonly string[] | undefined>): strin
 		}
 	}
 	return out;
+}
+
+/**
+ * Per-field merge for `security.business_hours` across tiers (#150).
+ *
+ * Unlike the rest of `security`, `business_hours` resolves field-by-field:
+ * mailbox value wins per field, org fills the rest. The motivating case is
+ * a mailbox that wants its own `timezone` without having to re-state all
+ * five fields from the org tier.
+ *
+ * Important asymmetries vs the whole-object replace path:
+ *
+ *  - Domain tier is intentionally NOT consulted here. The
+ *    `securityResolved.business_hours` value at the time of overlay
+ *    *might* have been picked up from the domain tier via the whole-object
+ *    replace; this function discards it deliberately so the contract is
+ *    "mailbox > org > undefined" exactly as the acceptance specifies.
+ *    Domain-tier participation tracked as #164.
+ *  - Both tiers absent → `business_hours` stays `undefined`. We do NOT
+ *    materialise a default block; `boost_on_off_hours: false` would make
+ *    it inert anyway, but the absence shape is the contract so consumers
+ *    can detect "never configured" vs "configured but disabled".
+ *
+ * The `securityResolved` argument is the post-`mergeSecurityWithDefault`
+ * block (with the #149 allowlist overlay already applied); we replace only
+ * its `business_hours` slot. Every other sub-field (`thresholds`,
+ * `attachment_policy`, `folder_policies`, `classification`,
+ * `trusted_authserv_ids`, allowlists) is untouched by this overlay.
+ */
+function mergeBusinessHoursAcrossTiers(
+	securityResolved: MailboxSecuritySettings,
+	mailbox: MailboxSettings,
+	org: OrgSettings,
+): MailboxSecuritySettings {
+	const mailboxBH = (mailbox.security as { business_hours?: Partial<BusinessHours> } | undefined)
+		?.business_hours;
+	const orgBH = (org.security as { business_hours?: Partial<BusinessHours> } | undefined)
+		?.business_hours;
+
+	if (!mailboxBH && !orgBH) {
+		// Both tiers absent — drop whatever the whole-object replace might
+		// have surfaced (e.g. from the domain tier) and leave undefined.
+		return { ...securityResolved, business_hours: undefined };
+	}
+
+	const merged: Partial<BusinessHours> = { ...(orgBH ?? {}), ...(mailboxBH ?? {}) };
+	// Without a timezone the block is inert (normalizeSecurity drops it
+	// anyway). Pass through whatever fields the tiers set; normalize fills
+	// the rest from sensible defaults if a timezone exists.
+	return { ...securityResolved, business_hours: merged as BusinessHours };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Mailbox/org per-field merge for `security.business_hours` only (mailbox value wins per field, org fills the rest, both absent → undefined). Every other security sub-field stays whole-tier replace + single-tier default completion.
- Implemented as a post-resolve overlay (`mergeBusinessHoursAcrossTiers`) in `workers/lib/mailbox-settings.ts` — same structural shape as #149's allowlist extend-merge, leaving the whole-object replace path untouched.
- Domain tier is intentionally NOT consulted for `business_hours` here, per the issue's out-of-scope note. Pinned by a regression test (`domain-only business_hours → resolved is undefined`) so future drift is caught.

Closes #150.

## Test plan

- [x] `npm test` — 489 / 489 passing.
- [x] `npm run typecheck` — clean.
- [x] New tests in `tests/lib/resolve-mailbox-settings.test.ts`:
  - org full + mailbox sets only `timezone` → merged per-field
  - mailbox full, org absent → resolved = mailbox
  - org full, mailbox absent → resolved = org
  - both absent → `resolved.security.business_hours` is `undefined`
  - domain-only `business_hours` (mailbox+org absent) → `undefined` (pins the spec interpretation)
  - mailbox `boost_on_off_hours: true` over org `false` → mailbox wins per field, other fields still inherited
  - regression: mailbox `thresholds.tag` does NOT inherit org `thresholds.quarantine` (other security sub-fields still whole-replace)

## Coordination note

May conflict with #161 (issue #149) on `workers/lib/mailbox-settings.ts` and `tests/lib/resolve-mailbox-settings.test.ts`; both PRs add disjoint post-resolve overlays so resolution is straightforward.

## Follow-up

- Domain-tier participation in `business_hours` per-field merge is out of scope per the issue and will be filed as a separate Claude Code-formatted prompt.