### PR TITLE
perf(hub): add idx_events_created_at for accurate ingest-time windows in /admin/stats

### DIFF
--- a/hub/migrations/0004_idx_events_created_at.sql
+++ b/hub/migrations/0004_idx_events_created_at.sql
@@ -1,0 +1,16 @@
+-- Copyright (c) 2026 Cloudflare, Inc.
+-- Licensed under the Apache 2.0 license found in the LICENSE file or at:
+--     https://opensource.org/licenses/Apache-2.0
+
+-- Index `events.created_at` so /admin/stats can window the
+-- "events ingested in the last 24h / 7d" counters by ingest time
+-- instead of the upstream MISP `events.date` (YYYY-MM-DD). When peers
+-- backfill stale-dated events the upstream `date` lands them in the
+-- wrong day's bucket; `created_at` is the local-ingest semantic the
+-- at-a-glance dashboard wants.
+--
+-- Other event-time queries (peers.events_pulled_24h, triage 24h slice,
+-- untagged-15m pre-filter) intentionally stay on `idx_events_date` —
+-- those want upstream-date semantics, or use `date` as a bounded
+-- pre-filter for a non-indexed predicate. See `routes/admin/stats.ts`.
+CREATE INDEX idx_events_created_at ON events(created_at);

--- a/hub/src/routes/admin/stats.ts
+++ b/hub/src/routes/admin/stats.ts
@@ -14,17 +14,21 @@
  *     events still untagged 15m after ingest (queue-backup smoke signal)
  *   - cron last-run proxy
  *
- * Index discipline. All counts come off existing D1 indexes from
- * 0001_schema.sql / 0002_inbound_sync.sql. The only schema this endpoint
- * relies on directly beyond those is `cron_runs` (added in
- * 0003_cron_runs.sql) — a single-row PK lookup, no index needed:
+ * Index discipline. All counts come off D1 indexes from 0001_schema.sql
+ * / 0002_inbound_sync.sql / 0004_idx_events_created_at.sql, plus a
+ * single-row PK lookup against `cron_runs` (added in 0003_cron_runs.sql,
+ * no index needed):
  *
- *   - `idx_events_date`           drives the 24h / 7d windows on `events`.
- *     Note: `events.date` is the upstream MISP event date (YYYY-MM-DD),
- *     not local ingest time. We accept the coarseness — for an at-a-glance
- *     dashboard it's a close-enough proxy and it's the only indexed time
- *     column on `events`. Adding a `created_at` index would be a separate
- *     migration; that's a follow-up, not part of this endpoint.
+ *   - `idx_events_created_at`     drives `events.last_24h` and the 7d
+ *     org-activity window. Uses local ingest time so that backfilled
+ *     events with stale upstream `date` still land in the day they
+ *     were actually ingested — the right semantic for an at-a-glance
+ *     operational dashboard.
+ *   - `idx_events_date`           drives per-peer events_pulled_24h
+ *     (upstream-date semantics) and the triage 24h slice (used as a
+ *     bounded pre-filter for the non-indexed `created_at < -15m` and
+ *     `EXISTS event_tags` predicates). Other `date`-based queries in
+ *     the hub stay on this index.
  *   - `idx_events_source_peer`    drives per-peer events_pulled_24h.
  *   - `idx_corroboration_sharing_group` drives the destroylist groupby.
  *
@@ -58,21 +62,26 @@ adminStatsRoutes.get("/stats", async (c) => {
 	// --- orgs -----------------------------------------------------------
 	const orgsTotal = (await db.prepare(`SELECT COUNT(*) AS n FROM orgs`).first<CountRow>())?.n ?? 0;
 
-	// "active" = has authored at least one event in the last 7d. Uses
-	// idx_events_date; date is upstream YYYY-MM-DD, see file-level note.
+	// "active" = has ingested at least one event in the last 7d. Uses
+	// idx_events_created_at so a peer backfilling stale-dated events
+	// counts the contributing org as active.
 	const activeOrgs = (await db
 		.prepare(
 			`SELECT COUNT(DISTINCT orgc_uuid) AS n
 			 FROM events
-			 WHERE date >= date('now', '-7 days')`,
+			 WHERE created_at >= datetime('now', '-7 days')`,
 		)
 		.first<CountRow>())?.n ?? 0;
 
 	// --- events ---------------------------------------------------------
 	const eventsTotal = (await db.prepare(`SELECT COUNT(*) AS n FROM events`).first<CountRow>())?.n ?? 0;
+	// 24h window keyed off local ingest time (idx_events_created_at) so
+	// that an event imported today with a stale upstream `date` still
+	// lands in today's bucket. Other event-time queries below stay on
+	// `events.date` — see file-level note.
 	const eventsLast24h = (await db
 		.prepare(
-			`SELECT COUNT(*) AS n FROM events WHERE date >= date('now', '-1 day')`,
+			`SELECT COUNT(*) AS n FROM events WHERE created_at >= datetime('now', '-1 day')`,
 		)
 		.first<CountRow>())?.n ?? 0;
 

--- a/hub/tests/routes/admin-stats.test.ts
+++ b/hub/tests/routes/admin-stats.test.ts
@@ -72,31 +72,49 @@ describe("GET /admin/stats — happy path with seeded fixtures", () => {
 		const today = new Date().toISOString().slice(0, 10);
 		const eightDaysAgo = new Date(Date.now() - 8 * 86_400_000).toISOString().slice(0, 10);
 
-		// Two orgs — one active, one stale.
+		// Two orgs — one active, one stale, plus a "backfill" org that
+		// only contributed events with stale upstream dates but a fresh
+		// local ingest time (regression coverage for #123).
 		db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, ?)`).run("org-active", "Active", 1.0);
 		db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, ?)`).run("org-stale", "Stale", 1.0);
+		db.raw.prepare(`INSERT INTO orgs (uuid, name, trust) VALUES (?, ?, ?)`).run("org-backfill", "Backfill", 1.0);
 
 		// Sharing groups.
 		db.raw.prepare(`INSERT INTO sharing_groups (uuid, name) VALUES (?, ?)`).run("sg-pub", "public");
 		db.raw.prepare(`INSERT INTO sharing_groups (uuid, name) VALUES (?, ?)`).run("sg-empty", "empty");
 
-		// Events: 2 by active org today (one tagged, one not), 1 by stale org 8d ago.
+		// Events: 3 by active org today (one tagged, two not), 1 by stale
+		// org 8d ago, 1 by backfill org with stale upstream date but a
+		// recent ingest time.
 		const insertEvent = db.raw.prepare(
 			`INSERT INTO events (uuid, orgc_uuid, sharing_group_uuid, info, date, timestamp, event_json, created_at)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		);
-		// "Old" enough that the 15-minute predicate fires for the untagged one.
 		// Production rows use the SQLite default `datetime('now')` format
 		// (`YYYY-MM-DD HH:MM:SS`, space separator, no `Z`), so seed in the
 		// same format — ISO-8601 with `T` would lex-compare greater than
-		// SQLite's `datetime('now','-15 minutes')` and break the predicate.
+		// SQLite's `datetime('now', ...)` and break the predicate.
 		const toSqlite = (d: Date) => d.toISOString().replace("T", " ").replace(/\.\d+Z$/, "");
 		const sixteenMinAgo = toSqlite(new Date(Date.now() - 16 * 60_000));
 		const oneMinAgo = toSqlite(new Date(Date.now() - 60_000));
+		const eightDaysAgoSqlite = toSqlite(new Date(Date.now() - 8 * 86_400_000));
 		insertEvent.run("ev-tagged", "org-active", "sg-pub", "tagged", today, today + "T00:00:00", "{}", sixteenMinAgo);
 		insertEvent.run("ev-untagged-old", "org-active", "sg-pub", "stuck", today, today + "T00:00:00", "{}", sixteenMinAgo);
 		insertEvent.run("ev-untagged-fresh", "org-active", "sg-pub", "fresh", today, today + "T00:00:00", "{}", oneMinAgo);
-		insertEvent.run("ev-stale", "org-stale", "sg-pub", "stale", eightDaysAgo, eightDaysAgo + "T00:00:00", "{}", eightDaysAgo + "T00:00:00");
+		insertEvent.run("ev-stale", "org-stale", "sg-pub", "stale", eightDaysAgo, eightDaysAgo + "T00:00:00", "{}", eightDaysAgoSqlite);
+		// Regression for #123: stale upstream `date` (8d ago), recent
+		// local `created_at`. Should land in events.last_24h AND
+		// promote org-backfill into orgs.active_last_7d.
+		insertEvent.run(
+			"ev-backfilled",
+			"org-backfill",
+			"sg-pub",
+			"backfilled",
+			eightDaysAgo,
+			eightDaysAgo + "T00:00:00",
+			"{}",
+			oneMinAgo,
+		);
 
 		// Tag exactly one event so the pct lands at 1/3.
 		db.raw.prepare(`INSERT INTO tags (name) VALUES (?)`).run("phishing");
@@ -143,12 +161,19 @@ describe("GET /admin/stats — happy path with seeded fixtures", () => {
 			cron: { last_run_at: number | null };
 		};
 
-		expect(body.orgs.total).toBe(2);
-		// Active = orgs with an event in last 7d. Only org-active qualifies.
-		expect(body.orgs.active_last_7d).toBe(1);
+		expect(body.orgs.total).toBe(3);
+		// Active = orgs with an event ingested in last 7d (created_at).
+		// org-active: yes (today). org-stale: no (created_at 8d ago).
+		// org-backfill: yes — stale `date` but `created_at` = 1m ago,
+		// proving the switch from `date` to `created_at` is wired up.
+		expect(body.orgs.active_last_7d).toBe(2);
 
-		expect(body.events.total).toBe(5);
-		expect(body.events.last_24h).toBe(4); // four events with `date` = today
+		expect(body.events.total).toBe(6);
+		// 24h window keys off `created_at`: 4 events ingested today
+		// plus ev-backfilled (stale `date`, created_at 1m ago) plus
+		// ev-from-peer (today's date and today's created_at) = 5.
+		// Excludes ev-stale (created_at 8d ago).
+		expect(body.events.last_24h).toBe(5);
 
 		expect(body.corroboration.rows).toBe(4);
 		// score>=2 AND contributors>=2 -> only the two sg-pub rows.


### PR DESCRIPTION
## Summary

- New `idx_events_created_at` index on the hub's `events.created_at` column.
- Switches `/admin/stats` `events.last_24h` + 7d-org-activity windows from `date >= ?` (upstream MISP date) to `created_at >= datetime('now', ...)` so backfilled events with stale upstream dates land in the day they were actually ingested.

Closes #123. Re-opens after #162 was auto-closed when its base branch (`claude/issue-122-cron-runs`) was deleted by #159's squash-merge. This branch has been rebased onto current `main` (which includes #159's squashed commit).

## Test plan

- [x] `hub/`: 63/63 passing
- [x] `npm run typecheck`: clean
- [x] Backfilled-event fixture (`ev-backfilled` with stale upstream `date` and fresh `created_at`) lands in the recent bucket
- [x] Existing `date`-based queries elsewhere in the hub remain on `idx_events_date` (no behaviour change)

## Notes

- Migration `0004_idx_events_created_at.sql` must be applied before deploying the code change.
- Schema is `created_at TEXT NOT NULL DEFAULT (datetime('now'))`, so the predicate change uses `datetime('now', '-1 day')` text comparison rather than epoch-ms (the issue body's "epoch-ms" wording was based on an assumed schema; actual schema is text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)