### PR TITLE
feat: per-field merge for security.business_hours at domain tier

### DIFF
--- a/shared/domain-settings.ts
+++ b/shared/domain-settings.ts
@@ -24,8 +24,10 @@ import {
  *
  * Whole-object replace across tiers — same rule as `OrgSettings`. A
  * domain-level `security` block carries the entire object; the org's
- * `security` is NOT deep-merged in. Per-array extend-merge (allowlists,
- * business_hours per-field) is tracked separately as #149 / #150.
+ * `security` is NOT deep-merged in. The per-field carve-outs are
+ * narrow and explicit: allowlist-array extend-merge (#149) and
+ * `business_hours` per-field merge across `mailbox > domain > org`
+ * (#150 / #164). Every other security sub-field stays whole-replace.
  *
  * R2 key derivation lives in `workers/lib/domain-settings.ts`
  * (`domainSettingsKey(domain)`) so a future re-keying — e.g. multi-tenant

--- a/tests/lib/resolve-mailbox-settings.test.ts
+++ b/tests/lib/resolve-mailbox-settings.test.ts
@@ -405,7 +405,7 @@ describe("resolveMailboxSettings — security allowlist extend-merge (#149)", ()
 	});
 });
 
-describe("resolveMailboxSettings — security.business_hours per-field merge (#150)", () => {
+describe("resolveMailboxSettings — security.business_hours per-field merge (#150, #164)", () => {
 	const orgFullBH = {
 		timezone: "America/New_York",
 		start_hour: 9,
@@ -465,15 +465,92 @@ describe("resolveMailboxSettings — security.business_hours per-field merge (#1
 		expect(resolved.security.business_hours).toBeUndefined();
 	});
 
-	it("domain-only business_hours (mailbox+org absent) → resolved is undefined (domain tier deferred to follow-up)", async () => {
-		// Pins the spec interpretation: per-field merge applies to mailbox+org
-		// only. The domain tier is intentionally NOT consulted for
-		// business_hours here, even though it participates in the whole-tier
-		// replace for other security sub-fields. Tracked as a follow-up.
+	it("domain-only business_hours (mailbox+org absent) → resolved = domain (#164)", async () => {
+		// Pins the #164 contract: domain participates in the per-field merge
+		// chain. With mailbox + org absent and a full domain block, the
+		// resolved business_hours is the domain block verbatim.
 		const bucket = makeFakeBucket({
 			[DOMAIN_KEY]: { security: { enabled: true, business_hours: orgFullBH } },
 			[MAILBOX_KEY]: {},
 		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.business_hours).toEqual(orgFullBH);
+	});
+
+	it("domain full + mailbox sets only timezone → mailbox timezone wins, other fields from domain (#164)", async () => {
+		// Mailbox > domain per field: mailbox supplies timezone, domain
+		// supplies the four other fields. Org is absent.
+		const domainFullBH = {
+			timezone: "America/Los_Angeles",
+			start_hour: 10,
+			end_hour: 20,
+			weekdays_only: false,
+			boost_on_off_hours: true,
+		};
+		const bucket = makeFakeBucket({
+			[DOMAIN_KEY]: { security: { enabled: true, business_hours: domainFullBH } },
+			[MAILBOX_KEY]: {
+				security: { business_hours: { timezone: "Europe/Berlin" } },
+			},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.business_hours).toEqual({
+			timezone: "Europe/Berlin",
+			start_hour: 10,
+			end_hour: 20,
+			weekdays_only: false,
+			boost_on_off_hours: true,
+		});
+	});
+
+	it("domain full + org full + mailbox absent → resolved = domain, org ignored (#164)", async () => {
+		// Domain has every field set, so org is shadowed per field. Mailbox
+		// is absent.
+		const domainFullBH = {
+			timezone: "America/Los_Angeles",
+			start_hour: 10,
+			end_hour: 20,
+			weekdays_only: false,
+			boost_on_off_hours: false,
+		};
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: { enabled: true, business_hours: orgFullBH },
+			},
+			[DOMAIN_KEY]: { security: { enabled: true, business_hours: domainFullBH } },
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.business_hours).toEqual(domainFullBH);
+	});
+
+	it("org full + domain sets only timezone + mailbox absent → domain timezone wins, other fields from org (#164)", async () => {
+		// Domain partial supplies one field; org fills the rest. Mailbox
+		// absent.
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				security: { enabled: true, business_hours: orgFullBH },
+			},
+			[DOMAIN_KEY]: {
+				security: { business_hours: { timezone: "Europe/Berlin" } },
+			},
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.security.business_hours).toEqual({
+			timezone: "Europe/Berlin",
+			start_hour: 9,
+			end_hour: 17,
+			weekdays_only: true,
+			boost_on_off_hours: true,
+		});
+	});
+
+	it("all three tiers absent → resolved.security.business_hours is undefined (#164)", async () => {
+		// Stronger restatement of the existing two-tier-absent contract:
+		// even with no domain settings either, business_hours stays
+		// undefined rather than materialising a default block.
+		const bucket = makeFakeBucket({ [MAILBOX_KEY]: {} });
 		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
 		expect(resolved.security.business_hours).toBeUndefined();
 	});

--- a/workers/lib/mailbox-settings.ts
+++ b/workers/lib/mailbox-settings.ts
@@ -177,14 +177,14 @@ export async function resolveMailboxSettings(
 		? extendAllowlistsWithOrg(securityBase, org.security as RawSecurityAllowlists | undefined)
 		: securityBase;
 
-	// Post-resolve carve-out (#150): business_hours is the ONE security
-	// sub-field that merges per-field across tiers instead of whole-object
-	// replace. Mailbox value wins per field, then org fills in the rest;
-	// if neither tier set it, the resolved value stays undefined (we don't
-	// materialise an inert default block). Domain tier is intentionally
-	// not consulted here — tracked as #164 follow-up. Every other
-	// security sub-field continues to follow the whole-tier replace rule.
-	const security = mergeBusinessHoursAcrossTiers(securityWithAllowlists, mailbox, org);
+	// Post-resolve carve-out (#150, extended in #164): business_hours is
+	// the ONE security sub-field that merges per-field across tiers
+	// instead of whole-object replace. Resolution per field is
+	// `mailbox > domain > org > undefined`; if all three tiers are absent
+	// the resolved value stays undefined (we don't materialise an inert
+	// default block). Every other security sub-field continues to follow
+	// the whole-tier replace rule.
+	const security = mergeBusinessHoursAcrossTiers(securityWithAllowlists, mailbox, domain, org);
 
 	const intelRaw = (mailbox.intel ?? domain.intel ?? org.intel ?? {}) as NonNullable<MailboxSettings["intel"]>;
 
@@ -311,25 +311,25 @@ function unionLowerStable(...lists: Array<readonly string[] | undefined>): strin
 }
 
 /**
- * Per-field merge for `security.business_hours` across tiers (#150).
+ * Per-field merge for `security.business_hours` across tiers (#150,
+ * extended to the domain tier in #164).
  *
- * Unlike the rest of `security`, `business_hours` resolves field-by-field:
- * mailbox value wins per field, org fills the rest. The motivating case is
- * a mailbox that wants its own `timezone` without having to re-state all
- * five fields from the org tier.
+ * Unlike the rest of `security`, `business_hours` resolves field-by-field
+ * across the full inheritance chain: `mailbox > domain > org > undefined`.
+ * The motivating case is a mailbox (or domain) that wants its own
+ * `timezone` without having to re-state all five fields from upstream.
  *
  * Important asymmetries vs the whole-object replace path:
  *
- *  - Domain tier is intentionally NOT consulted here. The
- *    `securityResolved.business_hours` value at the time of overlay
- *    *might* have been picked up from the domain tier via the whole-object
- *    replace; this function discards it deliberately so the contract is
- *    "mailbox > org > undefined" exactly as the acceptance specifies.
- *    Domain-tier participation tracked as #164.
- *  - Both tiers absent → `business_hours` stays `undefined`. We do NOT
- *    materialise a default block; `boost_on_off_hours: false` would make
- *    it inert anyway, but the absence shape is the contract so consumers
- *    can detect "never configured" vs "configured but disabled".
+ *  - The `securityResolved.business_hours` value at the time of overlay
+ *    might have been picked up from any tier via the whole-object replace;
+ *    this function discards it deliberately and rebuilds from the raw
+ *    per-tier blobs so the contract is "mailbox > domain > org > undefined"
+ *    exactly as the acceptance specifies.
+ *  - All three tiers absent → `business_hours` stays `undefined`. We do
+ *    NOT materialise a default block; `boost_on_off_hours: false` would
+ *    make it inert anyway, but the absence shape is the contract so
+ *    consumers can detect "never configured" vs "configured but disabled".
  *
  * The `securityResolved` argument is the post-`mergeSecurityWithDefault`
  * block (with the #149 allowlist overlay already applied); we replace only
@@ -340,20 +340,29 @@ function unionLowerStable(...lists: Array<readonly string[] | undefined>): strin
 function mergeBusinessHoursAcrossTiers(
 	securityResolved: MailboxSecuritySettings,
 	mailbox: MailboxSettings,
+	domain: DomainSettings,
 	org: OrgSettings,
 ): MailboxSecuritySettings {
 	const mailboxBH = (mailbox.security as { business_hours?: Partial<BusinessHours> } | undefined)
 		?.business_hours;
+	const domainBH = (domain.security as { business_hours?: Partial<BusinessHours> } | undefined)
+		?.business_hours;
 	const orgBH = (org.security as { business_hours?: Partial<BusinessHours> } | undefined)
 		?.business_hours;
 
-	if (!mailboxBH && !orgBH) {
-		// Both tiers absent — drop whatever the whole-object replace might
-		// have surfaced (e.g. from the domain tier) and leave undefined.
+	if (!mailboxBH && !domainBH && !orgBH) {
+		// All three tiers absent — drop whatever the whole-object replace
+		// might have surfaced and leave undefined.
 		return { ...securityResolved, business_hours: undefined };
 	}
 
-	const merged: Partial<BusinessHours> = { ...(orgBH ?? {}), ...(mailboxBH ?? {}) };
+	// Per-field precedence is mailbox > domain > org. Spread upstream-first
+	// so later spreads overwrite per field.
+	const merged: Partial<BusinessHours> = {
+		...(orgBH ?? {}),
+		...(domainBH ?? {}),
+		...(mailboxBH ?? {}),
+	};
 	// Without a timezone the block is inert (normalizeSecurity drops it
 	// anyway). Pass through whatever fields the tiers set; normalize fills
 	// the rest from sensible defaults if a timezone exists.


### PR DESCRIPTION
## Summary

- Extends `mergeBusinessHoursAcrossTiers` to include the domain tier so `security.business_hours` now resolves per-field across `mailbox > domain > org > undefined`, closing the #150 out-of-scope carve-out.
- Adds four pinning tests (domain-only resolves to domain, mailbox > domain per-field, domain > org per-field, three-tier absent stays undefined) and rewrites the prior `domain-only → undefined` pin to match the new contract.
- Updates the doc comment at `shared/domain-settings.ts` to note `business_hours` per-field merge now spans all three tiers.

Closes #164

## Test plan

- [x] `npm test` — 507 passing, 0 failing
- [x] `npm run typecheck` — clean (exit 0)
- [x] Acceptance bullet 1: resolver merges `business_hours` per-field across mailbox > domain > org > undefined
- [x] Acceptance bullet 2: domain full + mailbox sets only `timezone` → resolved keeps domain's other fields, mailbox `timezone` wins
- [x] Acceptance bullet 3: domain full + org full + mailbox absent → resolved = domain
- [x] Acceptance bullet 4: org full + domain sets only `timezone` + mailbox absent → resolved keeps org's other fields, domain `timezone` wins
- [x] Acceptance bullet 5: domain-only (mailbox + org absent) → resolved = domain (replaces the prior pin)
- [x] Acceptance bullet 6: all three absent → `resolved.security.business_hours` is `undefined`
- [x] Acceptance bullet 7: existing regression `regression: other security sub-fields stay whole-replace` still passes (untouched and still green; covers the mailbox-vs-org case — the mailbox > domain > org chain for whole-replace is exercised by the existing `domain` tests in the file)

## Out of scope / follow-ups

- `SECURITY_SPEC.md` narrowing for the `business_hours` rule is intentionally deferred to a separate `docs:` PR per CLAUDE.md (don't race a spec edit against a code change).
- No UX flagging of `boost_on_off_hours` polarity inversions across tiers (explicit out-of-scope in #164).
- No write-path touches (`stripDefaultEqual`, settings PUT/POST endpoints) — read-time resolver change only.