### PR TITLE
perf(hub): per-contributor first_seen for accurate corroboration windows

### DIFF
--- a/hub/migrations/0005_corroboration_contributors_first_seen.sql
+++ b/hub/migrations/0005_corroboration_contributors_first_seen.sql
@@ -1,0 +1,36 @@
+-- Copyright (c) 2026 Cloudflare, Inc.
+-- Licensed under the Apache 2.0 license found in the LICENSE file or at:
+--     https://opensource.org/licenses/Apache-2.0
+
+-- Per-contributor join timestamp on `corroboration_contributors`. Lets
+-- /api/v1/corroboration answer the literal question "how many of MY
+-- attributes got a SECOND contributor in the last N hours" precisely,
+-- instead of approximating via `corroboration.last_seen` (which advances
+-- on every contribution to the row, not just on a new contributor join).
+-- See issue #131 for the counter-examples that motivated this.
+--
+-- Stored as epoch milliseconds (INTEGER) — directly usable from JS, and
+-- consistent with `cron_runs.last_run_at` (migration 0003).
+ALTER TABLE corroboration_contributors
+    ADD COLUMN first_seen INTEGER NOT NULL DEFAULT (unixepoch() * 1000);
+
+-- Backfill existing rows from `corroboration.last_seen` as the
+-- best-available estimate (the only timestamp recorded before this
+-- migration). `last_seen` is an ISO-8601 TEXT column ('YYYY-MM-DDTHH:MM:SS.sssZ');
+-- `unixepoch(text)` parses it and returns seconds, so we multiply for ms.
+UPDATE corroboration_contributors
+SET first_seen = (
+    SELECT unixepoch(c.last_seen) * 1000
+    FROM corroboration c
+    WHERE c.id = corroboration_contributors.corroboration_id
+)
+WHERE EXISTS (
+    SELECT 1 FROM corroboration c WHERE c.id = corroboration_contributors.corroboration_id
+);
+
+-- Index supports the JOIN in /api/v1/corroboration: we look up "other
+-- contributors of attribute X whose first_seen >= cutoff" once per
+-- candidate attribute, and `(orgc_uuid, first_seen)` lets the planner
+-- range-scan within an org.
+CREATE INDEX idx_corroboration_contributors_orgc_first_seen
+    ON corroboration_contributors(orgc_uuid, first_seen);

--- a/hub/src/routes/corroboration.ts
+++ b/hub/src/routes/corroboration.ts
@@ -8,17 +8,6 @@
  * Returns the number of attributes contributed by `orgUuid` that have
  * received at least one additional contributor on the hub within the
  * window `[since, now]`.
- *
- * Schema caveat (worth knowing as a reviewer):
- *   `corroboration_contributors` carries no per-row timestamp, so we cannot
- *   tell precisely *when* a second contributor arrived. The closest we can
- *   express is "rows where this org is a contributor AND ≥2 distinct
- *   contributors AND `last_seen >= since`". `last_seen` updates on any
- *   contribution to the row, so this is a reasonable proxy for "the row
- *   saw activity in the window" — including the case where the second
- *   contributor showed up earlier and our org re-submitted in-window. For
- *   a 24h dashboard widget that's fine; if drilldown lands later (out of
- *   scope here) we'd want a contributor timestamp column.
  */
 
 import { Hono } from "hono";
@@ -42,39 +31,36 @@ corroborationRoutes.get("/", async (c) => {
 	if (!orgUuid) return c.json({ error: "orgUuid required" }, 400);
 	if (!since) return c.json({ error: "since required" }, 400);
 
-	// Reject malformed `since` — must be parseable ISO-8601. `last_seen` is
-	// written by `applyCorroboration` as `new Date().toISOString()` (ISO with
-	// T and Z), so we compare against the same canonical form. SQLite text
-	// comparison is lexicographic, which sorts ISO-8601 timestamps correctly.
+	// Reject malformed `since` — must be parseable ISO-8601. We compare
+	// against `corroboration_contributors.first_seen`, which is epoch
+	// milliseconds (INTEGER), so convert here.
 	const sinceMs = Date.parse(since);
 	if (Number.isNaN(sinceMs)) {
 		return c.json({ error: "since must be a parseable ISO-8601 timestamp" }, 400);
 	}
-	const sinceSql = new Date(sinceMs).toISOString();
 
 	if (orgUuid !== c.var.org.uuid) {
 		return c.json({ error: "orgUuid must match authenticated org" }, 403);
 	}
 
-	// Count distinct corroboration rows where:
-	//  - this org is in `corroboration_contributors` (the row is "ours")
-	//  - the row has ≥2 distinct contributors total (someone else corroborated)
-	//  - the row was touched within the window
-	//
-	// The `last_seen >= ?` filter narrows the scan first; for a 24h window
-	// this is a small slice in practice. EXISTS short-circuits per row.
+	// Count distinct corroboration rows where MY org is a contributor
+	// AND some OTHER contributor joined within the window. The JOIN on
+	// `other.first_seen >= ?` is the precise expression of "got a second
+	// contributor in-window" — it doesn't conflate row-touch time
+	// (`corroboration.last_seen`) with contributor-join time the way the
+	// previous approximation did. See issue #131.
 	const row = await c.env.DB
 		.prepare(
-			`SELECT COUNT(*) AS n
+			`SELECT COUNT(DISTINCT c.id) AS n
 			 FROM corroboration c
-			 WHERE c.last_seen >= ?1
-			   AND c.contributor_count >= 2
-			   AND EXISTS (
-			     SELECT 1 FROM corroboration_contributors cc
-			     WHERE cc.corroboration_id = c.id AND cc.orgc_uuid = ?2
-			   )`,
+			 JOIN corroboration_contributors me
+			   ON me.corroboration_id = c.id AND me.orgc_uuid = ?1
+			 JOIN corroboration_contributors other
+			   ON other.corroboration_id = c.id
+			   AND other.orgc_uuid != ?1
+			   AND other.first_seen >= ?2`,
 		)
-		.bind(sinceSql, orgUuid)
+		.bind(orgUuid, sinceMs)
 		.first<{ n: number }>();
 
 	return c.json({ corroboratedCount: row?.n ?? 0 });

--- a/hub/tests/routes/corroboration.test.ts
+++ b/hub/tests/routes/corroboration.test.ts
@@ -51,13 +51,21 @@ function appReq(path: string, init?: RequestInit) {
 /**
  * Inserts a corroboration row + N contributors. `lastSeen` is an ISO-8601
  * timestamp (matches what `applyCorroboration` writes in production).
+ *
+ * Contributors may be specified as bare org UUIDs (in which case the
+ * contributor's `first_seen` defaults to the row's `lastSeen`, mirroring
+ * the migration's backfill heuristic) or as `{ org, firstSeenMs }` to
+ * pin a specific per-contributor join timestamp — needed to exercise
+ * the cases where row-touch time and contributor-join time diverge.
  */
+type ContributorSpec = string | { org: string; firstSeenMs: number };
+
 function seedCorroboration(opts: {
 	id: number;
 	type: string;
 	value: string;
 	lastSeen: string;
-	contributors: string[];
+	contributors: ContributorSpec[];
 }) {
 	db.raw
 		.prepare(
@@ -74,12 +82,16 @@ function seedCorroboration(opts: {
 			opts.contributors.length,
 			opts.contributors.length * 1.0,
 		);
-	for (const orgc of opts.contributors) {
+	const fallbackFirstSeenMs = Date.parse(opts.lastSeen);
+	for (const c of opts.contributors) {
+		const orgc = typeof c === "string" ? c : c.org;
+		const firstSeenMs = typeof c === "string" ? fallbackFirstSeenMs : c.firstSeenMs;
 		db.raw
 			.prepare(
-				`INSERT INTO corroboration_contributors (corroboration_id, orgc_uuid) VALUES (?, ?)`,
+				`INSERT INTO corroboration_contributors (corroboration_id, orgc_uuid, first_seen)
+				 VALUES (?, ?, ?)`,
 			)
-			.run(opts.id, orgc);
+			.run(opts.id, orgc, firstSeenMs);
 	}
 }
 
@@ -160,17 +172,28 @@ describe("GET /api/v1/corroboration", () => {
 		expect(body.corroboratedCount).toBe(0);
 	});
 
-	it("does not count attributes whose `last_seen` falls outside the window", async () => {
-		const outOfWindow = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+	it("does not count when the second contributor joined before the window even though `last_seen` advanced in-window (issue #131 counter-example)", async () => {
+		// Counter-example A from #131: row touched today (so `last_seen` is
+		// in-window) but the second contributor actually joined a week ago.
+		// The previous approximation counted this; the precise query must not.
+		const inWindow = new Date(Date.now() - 60 * 60 * 1000).toISOString();
 		const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+		const sinceMs = Date.parse(since);
+		const aWeekAgoMs = Date.now() - 7 * 24 * 60 * 60 * 1000;
 
 		seedCorroboration({
 			id: 1,
 			type: "domain",
-			value: "stale.example",
-			lastSeen: outOfWindow,
-			contributors: [SELF_ORG, OTHER_ORG],
+			value: "stale-second-contrib.example",
+			lastSeen: inWindow,
+			contributors: [
+				{ org: SELF_ORG, firstSeenMs: aWeekAgoMs - 60_000 },
+				{ org: OTHER_ORG, firstSeenMs: aWeekAgoMs },
+			],
 		});
+
+		// Sanity: the second contributor's first_seen really is before the cutoff.
+		expect(aWeekAgoMs).toBeLessThan(sinceMs);
 
 		const res = await appReq(
 			`/api/v1/corroboration?orgUuid=${SELF_ORG}&since=${encodeURIComponent(since)}`,
@@ -179,6 +202,36 @@ describe("GET /api/v1/corroboration", () => {
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as { corroboratedCount: number };
 		expect(body.corroboratedCount).toBe(0);
+	});
+
+	it("counts when the second contributor joined in-window even if `last_seen` predates the cutoff (issue #131 counter-example)", async () => {
+		// Counter-example B from #131: contributor join landed in-window but
+		// the row's `last_seen` happens to be older than the cutoff (e.g. a
+		// race between the contributor insert and the row's last_seen update,
+		// or simply a path that didn't bump last_seen). The previous
+		// approximation missed this; the precise query must catch it.
+		const outOfWindow = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+		const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+		const recentJoinMs = Date.now() - 60 * 60 * 1000;
+
+		seedCorroboration({
+			id: 1,
+			type: "domain",
+			value: "fresh-contrib-stale-row.example",
+			lastSeen: outOfWindow,
+			contributors: [
+				{ org: SELF_ORG, firstSeenMs: Date.parse(outOfWindow) },
+				{ org: OTHER_ORG, firstSeenMs: recentJoinMs },
+			],
+		});
+
+		const res = await appReq(
+			`/api/v1/corroboration?orgUuid=${SELF_ORG}&since=${encodeURIComponent(since)}`,
+			{ headers: { Authorization: SELF_KEY } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { corroboratedCount: number };
+		expect(body.corroboratedCount).toBe(1);
 	});
 
 	it("counts each corroborated attribute once even with three contributors", async () => {


### PR DESCRIPTION
## Summary

`/api/v1/corroboration` (the operations dashboard's "Hub corroboration · 24h" card from #72/#129) previously approximated the literal question. The proxy "row I'm in has >=2 contributors AND `last_seen >= since`" misclassifies two cases the issue body spelled out:

- Row touched today, but the second contributor joined a week ago — counted, but shouldn't be (`last_seen` advanced because of any re-contribution, not the second join).
- Row whose second contributor joined today, but `last_seen` happens to predate the cutoff — not counted, but should be.

This change records the per-contributor join time and switches to the precise query.

### What changed

- **Migration `0005_corroboration_contributors_first_seen.sql`** adds `first_seen INTEGER NOT NULL DEFAULT (unixepoch() * 1000)` to `corroboration_contributors`, backfills existing rows from `corroboration.last_seen` (best-available estimate; ISO TEXT parsed via `unixepoch()` and converted to ms), and adds `idx_corroboration_contributors_orgc_first_seen ON (orgc_uuid, first_seen)` to keep the JOIN fast.
- **`hub/src/routes/corroboration.ts`** switches to the JOIN-based query from the issue body — counts distinct attributes where `me.orgc_uuid = ?` AND `other.orgc_uuid != ? AND other.first_seen >= ?`. Bound parameter changed from ISO text to epoch-ms (matches the new column type). Caveat comment about approximation removed.
- **Tests** add the two counter-example fixtures from #131 (in-window `last_seen` with out-of-window contributor join → 0; out-of-window `last_seen` with in-window contributor join → 1). The seed helper now accepts per-contributor `first_seen` overrides; bare-string contributors fall back to the row's `lastSeen` (mirroring the migration's backfill heuristic). Removed the now-redundant "last_seen outside the window" test — counter-example B covers the inverse direction more precisely.
- `applyCorroboration` is unchanged: the new column's DEFAULT (`unixepoch() * 1000`) gives "first_seen = now" for new contributor inserts, which is exactly the production semantic.

Closes #131

## Test plan

- [x] `cd hub && npm test` — 64 passed (8 files), including 4 new/updated corroboration cases
- [x] `cd hub && npm run typecheck` — clean
- [x] `npm test` (root) — 503 passed (47 files)
- [x] `npm run typecheck` (root) — clean
- [ ] After merge: `wrangler d1 migrations apply ais-hub --remote` to roll the schema and backfill on the production hub DB