### PR TITLE
feat: persist per-case verdict score on cases table

### DIFF
--- a/app/routes/case-detail.tsx
+++ b/app/routes/case-detail.tsx
@@ -9,6 +9,7 @@ import {
 } from "@phosphor-icons/react";
 import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router";
+import ScoreRing from "~/components/phishsoc/ScoreRing";
 import VerdictPill from "~/components/phishsoc/VerdictPill";
 import { statusLabel, statusTone } from "~/components/phishsoc/verdict";
 import { useFeedback } from "~/lib/feedback";
@@ -24,6 +25,11 @@ interface CaseRecord {
 	notes: string | null;
 	shared_to_hub: number;
 	hub_event_uuid: string | null;
+	// Per-case verdict score (issue #126). Nullable: paths that don't
+	// carry a scored verdict (manual API create without `score`, or
+	// pre-#126 rows) leave it null — render a muted "—" instead of the
+	// ring.
+	score: number | null;
 	emails: CaseEmail[];
 	observables: CaseObservable[];
 }
@@ -121,11 +127,26 @@ export default function CaseDetailRoute() {
 				<ArrowLeftIcon size={12} /> Cases
 			</Link>
 
-			{/* Title bar — score badge intentionally omitted. The cases table
-			    doesn't yet persist a verdict score (see issue #87); rendering a
-			    fabricated value misled operators making release decisions, so
-			    we show status only until per-case scoring lands. */}
+			{/* Title bar — real verdict score (issue #126). `data.score` is
+			    populated at case-creation time from the originating email's
+			    FinalVerdict.score. When null/undefined (manual API create
+			    without score, or pre-#126 rows) we render a muted "—" in the
+			    same slot rather than fabricating a value. */}
 			<div className="pp-card p-5 flex items-start gap-5">
+				{data.score != null ? (
+					<div className="shrink-0">
+						<ScoreRing score={data.score} />
+					</div>
+				) : (
+					<div
+						className="shrink-0 inline-flex items-center justify-center rounded-full border border-line text-ink-3 pp-serif"
+						style={{ width: 80, height: 80, fontSize: 28 }}
+						aria-label="No score"
+						data-testid="case-score-empty"
+					>
+						—
+					</div>
+				)}
 				<div className="flex-1 min-w-0">
 					<div className="flex items-center gap-2 mb-1.5">
 						<VerdictPill tone={tone}>{statusLabel(data.status)}</VerdictPill>

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
 			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
 			"integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"json-schema": "^0.4.0"
 			},
@@ -229,6 +230,7 @@
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -752,13 +754,15 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
 			"integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@cloudflare/ai-chat": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/@cloudflare/ai-chat/-/ai-chat-0.1.8.tgz",
 			"integrity": "sha512-ukEKQGCnoqhE9OYiOW1MCWhYxomPQG6BCdFJ/JusyvbNZP4cYDNgfpo4vXd0dXtTnp24E1thDuCGaaWhRFM4xg==",
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@ai-sdk/react": "^3.0.0",
 				"agents": "^0.7.3",
@@ -931,7 +935,8 @@
 			"version": "4.20260426.1",
 			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260426.1.tgz",
 			"integrity": "sha512-cBYeQaWwv/jFV8ualmwp6wIxmAf0rDe2DPPQwPbslKmPHqgv861YpAvm45r05K40QboZgxNQVIPgNkmtHqZeJQ==",
-			"license": "MIT OR Apache-2.0"
+			"license": "MIT OR Apache-2.0",
+			"peer": true
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -1045,6 +1050,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			},
@@ -1093,6 +1099,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			}
@@ -1596,6 +1603,7 @@
 			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
 			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@floating-ui/core": "^1.7.5",
 				"@floating-ui/utils": "^0.2.11"
@@ -2230,6 +2238,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -2239,6 +2248,7 @@
 			"resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
 			"integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -3322,6 +3332,7 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.2.tgz",
 			"integrity": "sha512-zKW4LqZt+aNdvz9o4R0/j+D+gfhwzuFItwh7wbqz8g8bWi0jaV95VybeVFVKeg/KGTc3sAa4mm+hGgvgrY+Gvg==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -3583,6 +3594,7 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.20.2.tgz",
 			"integrity": "sha512-x9h1fDeaLah60WJTb6517nRbAKcbdBsTpmglqxQ9c827PUOUyiVEAu2o2cFEuOMw6Htvty4obOKBUgYi8EAgDA==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -3688,6 +3700,7 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.20.2.tgz",
 			"integrity": "sha512-jvVRtFdEJNjKgIL8wtMg3W4BJMlKyH9aF2jYNU2rf3jA9GJM0rtqtth3jjFnApZoyINtx6jr4o4Ot6+/5d0XYA==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -3714,6 +3727,7 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.20.2.tgz",
 			"integrity": "sha512-gzntns6z/kTgwrX89ydc3rNqDsv8D8sAkyl8HE9X+2D9wtdCgNljevIR6MBNcxG7bVm2+XnId1P9YciCZLuefg==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -3728,6 +3742,7 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.2.tgz",
 			"integrity": "sha512-tEMZlLy/6ms41PQtyjmniZ3tTd8elavd8htjYzHLPSHtz11zaYV9YjnmnwHK8gynhcSES1orO9z1U4nT4ZLpqg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"prosemirror-changeset": "^2.3.0",
 				"prosemirror-collab": "^1.3.1",
@@ -3821,8 +3836,7 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@types/chai": {
 			"version": "5.2.3",
@@ -3940,6 +3954,7 @@
 			"integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -3949,6 +3964,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
 			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -3958,6 +3974,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
@@ -4166,6 +4183,7 @@
 			"resolved": "https://registry.npmjs.org/agents/-/agents-0.7.6.tgz",
 			"integrity": "sha512-wR5L+3t+kIN1aog7AqAs5RBKfW4GhYtdSEE2thNvWefaZXrEZXDzN8NVaO2CMVEwNWAG+edqEfxzMOViMOlUJQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@cfworker/json-schema": "^4.1.1",
 				"@modelcontextprotocol/sdk": "1.26.0",
@@ -4245,6 +4263,7 @@
 			"resolved": "https://registry.npmjs.org/ai/-/ai-6.0.116.tgz",
 			"integrity": "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@ai-sdk/gateway": "3.0.66",
 				"@ai-sdk/provider": "3.0.8",
@@ -4445,6 +4464,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -4907,8 +4927,7 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/dompurify": {
 			"version": "3.4.0",
@@ -5756,6 +5775,7 @@
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
 			"integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -6464,7 +6484,6 @@
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -7881,7 +7900,6 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -7897,7 +7915,6 @@
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -7908,7 +7925,6 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -8038,6 +8054,7 @@
 			"resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
 			"integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"orderedmap": "^2.0.0"
 			}
@@ -8067,6 +8084,7 @@
 			"resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
 			"integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"prosemirror-model": "^1.0.0",
 				"prosemirror-transform": "^1.0.0",
@@ -8115,6 +8133,7 @@
 			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.6.tgz",
 			"integrity": "sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"prosemirror-model": "^1.20.0",
 				"prosemirror-state": "^1.0.0",
@@ -8197,6 +8216,7 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
 			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8228,6 +8248,7 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
 			"integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -8240,8 +8261,7 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/react-markdown": {
 			"version": "10.1.0",
@@ -8285,6 +8305,7 @@
 			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
 			"integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cookie": "^1.0.1",
 				"set-cookie-parser": "^2.6.0"
@@ -8934,7 +8955,6 @@
 			"resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
 			"integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"dequal": "^2.0.3",
 				"use-sync-external-store": "^1.6.0"
@@ -8992,7 +9012,6 @@
 			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
 			"integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -9143,8 +9162,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
 			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-			"license": "0BSD",
-			"peer": true
+			"license": "0BSD"
 		},
 		"node_modules/type-is": {
 			"version": "2.0.1",
@@ -9191,6 +9209,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -9228,6 +9247,7 @@
 			"integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"pathe": "^2.0.3"
 			}
@@ -9433,6 +9453,7 @@
 			"integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",
@@ -9749,6 +9770,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"workerd": "bin/workerd"
 			},
@@ -10426,6 +10448,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
 			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -10444,7 +10467,6 @@
 			"resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
 			"integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"tslib": "2.3.0"
 			}

--- a/tests/frontend/case-detail.test.tsx
+++ b/tests/frontend/case-detail.test.tsx
@@ -7,12 +7,10 @@ import { Route, Routes } from "react-router";
 import CaseDetailRoute from "~/routes/case-detail";
 import { renderWithProviders } from "./test-utils";
 
-// The case API today returns only the columns persisted on the `cases` table
-// (id, status, title, notes, …) plus the linked-emails and observables joins.
-// It does NOT return `score`, `summary`, or `stage_trace` — issue #87 is about
-// removing the placeholder UI that pretended otherwise. The mock mirrors that
-// real shape so the assertions below verify behavior under current data, not
-// a hypothetical future schema.
+// Per-case score is now persisted on the `cases` table at case-creation
+// time (issue #126). The API returns it as `score: number | null`. The
+// title bar renders <ScoreRing> when score is present and a muted "—"
+// when null/undefined.
 const baseCase = {
 	id: "case_abc123",
 	created_at: "2026-04-29T11:00:00Z",
@@ -22,6 +20,7 @@ const baseCase = {
 	notes: null,
 	shared_to_hub: 0,
 	hub_event_uuid: null,
+	score: null as number | null,
 	emails: [],
 	observables: [],
 };
@@ -47,7 +46,7 @@ function renderCaseDetail() {
 	);
 }
 
-describe("CaseDetailRoute (interim mitigation, issue #87)", () => {
+describe("CaseDetailRoute (issue #126 — real per-case score)", () => {
 	beforeEach(() => {
 		vi.unstubAllGlobals();
 	});
@@ -55,44 +54,49 @@ describe("CaseDetailRoute (interim mitigation, issue #87)", () => {
 		vi.unstubAllGlobals();
 	});
 
-	it("renders no fabricated score, no co-pilot placeholder, no pipeline-trace placeholder when the case API omits score/summary/stage_trace", async () => {
-		mockFetchOnce({ case: baseCase });
+	it("renders <ScoreRing> with the real score when data.score is present", async () => {
+		mockFetchOnce({ case: { ...baseCase, score: 75 } });
 		renderCaseDetail();
 
-		// Wait for the fetch-driven render to commit.
 		expect(
 			await screen.findByText(/Suspicious wire-transfer request/i),
 		).toBeInTheDocument();
 
-		// 1. No fabricated score badge. <ScoreRing> renders the literal
-		//    "/ 100" subtitle under the numeric score; if it's gone, the
-		//    title-bar fabrication is gone. We also confirm the
-		//    "open" → 80 / "closed-fp" → 30 numeric placeholders are absent.
-		expect(screen.queryByText(/\/\s*100/)).toBeNull();
-		expect(screen.queryByText(/^80$/)).toBeNull();
-		expect(screen.queryByText(/^30$/)).toBeNull();
-
-		// 2. No "Coming soon" co-pilot card.
-		expect(screen.queryByText(/coming soon/i)).toBeNull();
-		expect(screen.queryByText(/co-pilot summary/i)).toBeNull();
-
-		// 3. No pipeline-trace placeholder copy.
-		expect(
-			screen.queryByText(/stage-level scoring isn't surfaced/i),
-		).toBeNull();
-		expect(screen.queryByText(/pipeline trace/i)).toBeNull();
+		// ScoreRing renders the literal "/ 100" subtitle and the numeric
+		// rounded score. Confirm both, plus the absence of the empty-state
+		// glyph.
+		expect(screen.getByText(/\/\s*100/)).toBeInTheDocument();
+		expect(screen.getByText(/^75$/)).toBeInTheDocument();
+		expect(screen.queryByTestId("case-score-empty")).toBeNull();
 	});
 
-	it("still renders core case content (title, status, linked-emails empty state) so the page isn't blanked out", async () => {
-		mockFetchOnce({ case: { ...baseCase, status: "closed-fp" } });
+	it("renders a muted '—' in the score slot when data.score is null", async () => {
+		mockFetchOnce({ case: { ...baseCase, score: null } });
 		renderCaseDetail();
 
 		expect(
 			await screen.findByText(/Suspicious wire-transfer request/i),
 		).toBeInTheDocument();
-		// "closed-fp" maps to a "Released" / "Closed" verdict label via
-		// statusLabel(); we only need to confirm a status pill is present
-		// and the dangerous fabricated score isn't.
+
+		// No ring → no "/ 100" subtitle. Empty-state placeholder present.
+		expect(screen.queryByText(/\/\s*100/)).toBeNull();
+		expect(screen.getByTestId("case-score-empty")).toBeInTheDocument();
+
+		// And none of the legacy fabricated badges (status-derived
+		// 80 / 30 from the old PR #125 placeholder) leak through.
+		expect(screen.queryByText(/^80$/)).toBeNull();
+		expect(screen.queryByText(/^30$/)).toBeNull();
+	});
+
+	it("still renders core case content (title, status pill, id) even without a score", async () => {
+		mockFetchOnce({
+			case: { ...baseCase, status: "closed-fp", score: null },
+		});
+		renderCaseDetail();
+
+		expect(
+			await screen.findByText(/Suspicious wire-transfer request/i),
+		).toBeInTheDocument();
 		await waitFor(() => {
 			expect(screen.queryByText(/\/\s*100/)).toBeNull();
 		});

--- a/tests/routes/cases.test.ts
+++ b/tests/routes/cases.test.ts
@@ -1,0 +1,311 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Route-level tests for `workers/routes/cases.ts` covering the per-case
+ * verdict score plumbing added in issue #126:
+ *
+ *   1. POST /report-phish copies the originating email's
+ *      `security_score` onto the case record via `createCase`.
+ *   2. GET /:caseId surfaces the persisted `score` in the API response.
+ *
+ * The mailbox DO stub is hand-rolled here — these tests don't need real
+ * DO storage, only that the score field flows through `createCase`'s
+ * input and back out of `getCase`'s output. The schema-level test
+ * (column exists, nullable) lives implicitly in this round-trip:
+ * `score: null` and `score: 78` both pass through unchanged.
+ */
+
+import { Hono } from "hono";
+import { createMiddleware } from "hono/factory";
+import { describe, expect, it, vi } from "vitest";
+
+// Module mock: replace requireMailbox with a no-op so our parent
+// middleware can inject the fake stub before caseRoutes runs. Without
+// this, the real middleware would call `env.BUCKET.head()` and
+// `env.MAILBOX.get()` which we don't have stubs for in the unit-test
+// pool.
+vi.mock("../../workers/lib/mailbox", async (orig) => {
+	const original = await orig<typeof import("../../workers/lib/mailbox")>();
+	return {
+		...original,
+		requireMailbox: createMiddleware(async (_c, next) => {
+			await next();
+		}),
+	};
+});
+
+import { caseRoutes } from "../../workers/routes/cases";
+import type { MailboxContext } from "../../workers/lib/mailbox";
+
+interface FakeCaseRow {
+	id: string;
+	created_at: string;
+	updated_at: string;
+	status: string;
+	title: string;
+	notes: string | null;
+	shared_to_hub: number;
+	hub_event_uuid: string | null;
+	score: number | null;
+	emails: Array<{ case_id: string; email_id: string }>;
+	observables: Array<{ id: string; case_id: string; kind: string; value: string }>;
+}
+
+interface FakeEmailRow {
+	id: string;
+	subject: string | null;
+	sender: string;
+	body: string | null;
+	date: string;
+	security_score: number | null;
+}
+
+function makeStub(emails: Record<string, FakeEmailRow>) {
+	const cases = new Map<string, FakeCaseRow>();
+	const createCalls: Array<{
+		title: string;
+		notes?: string;
+		emailId?: string;
+		score?: number | null;
+	}> = [];
+
+	const stub = {
+		async getEmail(id: string) {
+			return emails[id] ?? null;
+		},
+		async createCase(input: {
+			title: string;
+			notes?: string;
+			emailId?: string;
+			observables?: Array<{ kind: string; value: string }>;
+			score?: number | null;
+		}) {
+			createCalls.push({
+				title: input.title,
+				notes: input.notes,
+				emailId: input.emailId,
+				score: input.score,
+			});
+			const id = `case_${cases.size + 1}`;
+			const now = "2026-05-03T00:00:00Z";
+			const row: FakeCaseRow = {
+				id,
+				created_at: now,
+				updated_at: now,
+				status: "open",
+				title: input.title.slice(0, 500),
+				notes: input.notes ?? null,
+				shared_to_hub: 0,
+				hub_event_uuid: null,
+				score: input.score ?? null,
+				emails: input.emailId
+					? [{ case_id: id, email_id: input.emailId }]
+					: [],
+				observables: (input.observables ?? []).map((o, i) => ({
+					id: `obs_${i}`,
+					case_id: id,
+					kind: o.kind,
+					value: o.value,
+				})),
+			};
+			cases.set(id, row);
+			return { id };
+		},
+		async getCase(id: string) {
+			return cases.get(id) ?? null;
+		},
+		async updateCase() { /* no-op for these tests */ },
+		async flagSender() { /* no-op */ },
+	};
+
+	return { stub, cases, createCalls };
+}
+
+function makeApp(stub: ReturnType<typeof makeStub>["stub"]) {
+	// Mount caseRoutes under the same prefix the real app uses so the
+	// `:mailboxId` path param is set when requireMailbox runs.
+	// caseRoutes.use("*", requireMailbox) runs against R2 — for these
+	// tests we need to short-circuit that, so we wrap caseRoutes in a
+	// thin parent app that injects the fake stub before the route's own
+	// middleware fires.
+	const app = new Hono<MailboxContext>();
+	app.use("*", async (c, next) => {
+		c.set("mailboxStub", stub as unknown as DurableObjectStub<never>);
+		await next();
+	});
+	app.route("/api/v1/mailboxes/:mailboxId/cases", caseRoutes);
+	return app;
+}
+
+// Minimal env stub.
+//   - BUCKET.head() must return truthy so requireMailbox doesn't 404.
+//   - BUCKET.get() returns null so the optional hub-config lookup
+//     inside report-phish short-circuits at "not configured".
+//   - MAILBOX is unused because we override `c.var.mailboxStub` before
+//     requireMailbox tries to instantiate a DO stub.
+const fakeEnv = {
+	BUCKET: {
+		async get() { return null; },
+		async head() {
+			return { key: "mailboxes/m1.json" };
+		},
+		async put() { /* no-op */ },
+	},
+	MAILBOX: {
+		idFromName() { return {}; },
+		get() { return {}; },
+	},
+} as unknown as Parameters<Hono["request"]>[2];
+
+describe("workers/routes/cases — issue #126 per-case score", () => {
+	it("report-phish: copies the email's security_score onto the case row", async () => {
+		const { stub, createCalls, cases } = makeStub({
+			"em_1": {
+				id: "em_1",
+				subject: "URGENT: wire transfer",
+				sender: "ceo@evil.example",
+				body: "<p>Click https://phish.example/login</p>",
+				date: "2026-05-01T00:00:00Z",
+				security_score: 78,
+			},
+		});
+		const app = makeApp(stub);
+
+		const res = await app.request(
+			"/api/v1/mailboxes/m1/cases/report-phish",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ emailId: "em_1" }),
+			},
+			fakeEnv,
+		);
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { caseId: string };
+		expect(body.caseId).toBeTruthy();
+
+		// createCase was called once, with the email's score plumbed through.
+		expect(createCalls).toHaveLength(1);
+		expect(createCalls[0].score).toBe(78);
+
+		// Persisted on the row.
+		expect(cases.get(body.caseId)?.score).toBe(78);
+	});
+
+	it("report-phish: persists score=null when the originating email has no security_score", async () => {
+		const { stub, createCalls, cases } = makeStub({
+			"em_unscored": {
+				id: "em_unscored",
+				subject: "newsletter",
+				sender: "list@example.com",
+				body: "hi",
+				date: "2026-05-01T00:00:00Z",
+				security_score: null,
+			},
+		});
+		const app = makeApp(stub);
+
+		const res = await app.request(
+			"/api/v1/mailboxes/m1/cases/report-phish",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ emailId: "em_unscored" }),
+			},
+			fakeEnv,
+		);
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { caseId: string };
+
+		expect(createCalls[0].score).toBeNull();
+		expect(cases.get(body.caseId)?.score).toBeNull();
+	});
+
+	it("GET /:caseId returns `score` in the response shape", async () => {
+		const { stub } = makeStub({});
+		// Seed a case directly through createCase so the row exists.
+		await stub.createCase({
+			title: "manual case",
+			emailId: undefined,
+			observables: [],
+			score: 42,
+		});
+		const app = makeApp(stub);
+
+		const res = await app.request(
+			"/api/v1/mailboxes/m1/cases/case_1",
+			undefined,
+			fakeEnv,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			case: { id: string; score: number | null };
+		};
+		expect(body.case.id).toBe("case_1");
+		expect(body.case.score).toBe(42);
+	});
+
+	it("GET /:caseId returns score: null when the case was created without one", async () => {
+		const { stub } = makeStub({});
+		await stub.createCase({
+			title: "manual case no score",
+			emailId: undefined,
+			observables: [],
+			// score omitted → createCase normalizes to null
+		});
+		const app = makeApp(stub);
+
+		const res = await app.request(
+			"/api/v1/mailboxes/m1/cases/case_1",
+			undefined,
+			fakeEnv,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			case: { score: number | null };
+		};
+		expect(body.case.score).toBeNull();
+	});
+
+	it("POST /cases accepts an explicit score in the request body", async () => {
+		const { stub, createCalls } = makeStub({});
+		const app = makeApp(stub);
+
+		const res = await app.request(
+			"/api/v1/mailboxes/m1/cases",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					title: "explicit-score case",
+					score: 55,
+				}),
+			},
+			fakeEnv,
+		);
+		expect(res.status).toBe(201);
+		expect(createCalls).toHaveLength(1);
+		expect(createCalls[0].score).toBe(55);
+	});
+
+	it("POST /cases rejects out-of-range scores", async () => {
+		const { stub, createCalls } = makeStub({});
+		const app = makeApp(stub);
+
+		const res = await app.request(
+			"/api/v1/mailboxes/m1/cases",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					title: "bad-score case",
+					score: 150, // outside 0..100
+				}),
+			},
+			fakeEnv,
+		);
+		expect(res.status).toBe(400);
+		expect(createCalls).toHaveLength(0);
+	});
+});
+

--- a/workers/db/schema.ts
+++ b/workers/db/schema.ts
@@ -149,6 +149,11 @@ export const cases = sqliteTable("cases", {
 	notes: text("notes"),
 	shared_to_hub: integer("shared_to_hub").notNull().default(0),
 	hub_event_uuid: text("hub_event_uuid"),
+	// Per-case verdict score copied from the originating email's
+	// FinalVerdict.score at case-creation time. Nullable: paths that
+	// don't carry a scored verdict (manual API create without `score`,
+	// or pre-#126 rows) leave it NULL.
+	score: integer("score"),
 });
 
 export const caseEmails = sqliteTable(

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -1290,6 +1290,13 @@ export class MailboxDO extends DurableObject<Env> {
 		notes?: string;
 		emailId?: string;
 		observables?: Array<{ kind: string; value: string }>;
+		/**
+		 * Per-case verdict score. Persisted onto the case row so the
+		 * case-detail page can render `<ScoreRing>` from real data
+		 * (issue #126). Null/undefined leaves the column NULL — the UI
+		 * renders a muted "—" in that case.
+		 */
+		score?: number | null;
 	}) {
 		const id = crypto.randomUUID();
 		const now = new Date().toISOString();
@@ -1304,6 +1311,7 @@ export class MailboxDO extends DurableObject<Env> {
 				notes: input.notes ?? null,
 				shared_to_hub: 0,
 				hub_event_uuid: null,
+				score: input.score ?? null,
 			})
 			.run();
 		if (input.emailId) {

--- a/workers/durableObject/migrations.ts
+++ b/workers/durableObject/migrations.ts
@@ -315,4 +315,16 @@ export const mailboxMigrations: Migration[] = [
             CREATE INDEX IF NOT EXISTS idx_pipeline_runs_started_at ON pipeline_runs(started_at);
         `,
 	},
+	{
+		// Per-case verdict score, populated at case-creation time from the
+		// security pipeline's FinalVerdict.score (already persisted on the
+		// originating email row as `security_score`). Nullable: cases created
+		// before this migration, or via paths where the originating email
+		// had no scored verdict, leave the column NULL — the UI renders a
+		// muted "—" in that case. Forward-only ALTER; existing rows get NULL.
+		name: "13_cases_score",
+		sql: `
+            ALTER TABLE cases ADD COLUMN score INTEGER;
+        `,
+	},
 ];

--- a/workers/routes/cases.ts
+++ b/workers/routes/cases.ts
@@ -34,6 +34,10 @@ const CreateCaseBody = z.object({
 		kind: z.string().min(1).max(32),
 		value: z.string().min(1).max(500),
 	})).optional(),
+	// Per-case verdict score (issue #126). Optional on this generic
+	// create path — `report-phish` derives it from the email's persisted
+	// security_score automatically.
+	score: z.number().int().min(0).max(100).nullable().optional(),
 });
 
 const UpdateCaseBody = z.object({
@@ -95,11 +99,21 @@ caseRoutes.post("/report-phish", async (c) => {
 		observables.push({ kind: "domain", value: u.hostname });
 	}
 
+	// Pull the verdict score off the originating email — the security
+	// pipeline persists `FinalVerdict.score` to `emails.security_score`
+	// during ingest, so by the time the user hits "Report phish" it's
+	// already on the row. Cast: EmailFull's `security_score` is nullable
+	// number; `createCase` accepts `number | null`.
+	const verdictScore =
+		typeof (email as { security_score?: number | null }).security_score === "number"
+			? (email as { security_score?: number | null }).security_score!
+			: null;
 	const { id } = await c.var.mailboxStub.createCase({
 		title: `Reported phish: ${email.subject || "(no subject)"}`,
 		notes: `Reported from email ${emailId}. Sender: ${email.sender}.`,
 		emailId,
 		observables,
+		score: verdictScore,
 	});
 
 	// Reputation penalty on the sender so the pipeline flags future mail.


### PR DESCRIPTION
## Summary

Restores the title-bar `<ScoreRing>` on the case-detail page with a real persisted score, replacing the interim "—" left by PR #125.

The security pipeline already writes `FinalVerdict.score` to each email row's `security_score`; case-creation now copies that onto a new `cases.score` column, and the case API surfaces it.

**Backend**
- Migration `13_cases_score`: forward-only `ALTER TABLE cases ADD COLUMN score INTEGER` (nullable; pre-#126 rows stay NULL).
- `workers/db/schema.ts` + `workers/durableObject/index.ts`: `createCase` accepts optional `score: number | null`; `getCase` returns it through the existing `select()`.
- `workers/routes/cases.ts`: `POST /cases/report-phish` reads `email.security_score` off the originating email and passes it through. `POST /cases` accepts an optional `score` (validated 0..100) for callers who want to populate it explicitly.

**Frontend**
- `app/routes/case-detail.tsx`: `CaseRecord.score: number | null`. Title bar renders `<ScoreRing>` when `data.score != null`, a muted "—" glyph in the same 80x80 slot when null/undefined. Drops the PR-#125 placeholder comment block.

**Tests**
- New `tests/routes/cases.test.ts` (route-level, hand-rolled stub via `vi.mock` of `requireMailbox`): 6 tests covering the round-trip — `report-phish` copies the email's score, plumbs `null` when the email has none, `GET /:caseId` returns `score`, `POST /cases` accepts/rejects scores.
- `tests/frontend/case-detail.test.tsx`: split into score-present (assert ring renders with `/ 100` and the numeric value) and score-null (assert the `case-score-empty` glyph is shown, no `/ 100`) branches.

## Acceptance (issue #126)

- [x] `cases` table has a nullable `score` column populated at case-creation time from the pipeline verdict.
- [x] `GET /api/v1/mailboxes/:mailboxId/cases/:caseId` includes the new `score` field.
- [x] `app/routes/case-detail.tsx` renders the real `<ScoreRing>` when `data.score` is present, and a muted "—" when null/undefined.
- [x] Backend test for the new column + API shape; frontend test updated to cover both branches.

Closes #126

## Related (not closed by this PR)

- #127 / #128 are tracking the related summary / pipeline-trace cards on the same page. Out of scope here — the placeholder comment blocks for those remain in `case-detail.tsx`.

## Test plan

- [x] `npm test` -> 510 passing, 0 failing.
- [x] `npm run typecheck` clean.
- [ ] Post-merge: confirm migration 13 applies on a fresh DO instance (pre-existing rows NULL out, new cases via `report-phish` get a populated score).
- [ ] Post-merge: smoke the case-detail page on a case with a real verdict score and one without — ring vs "—".

🤖 Generated with [Claude Code](https://claude.com/claude-code)