### PR TITLE
feat(posture): MTA-STS posture lookup for /domains/:domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ Fires after the sync verdict is stored and only ever *tightens* the decision (sy
 
 The [`hub/`](hub/) subdirectory is a MISP-compatible community threat-intel hub — mailboxes can push phishing reports (`workers/intel/report.ts`) and pull corroborated lists back via the destroylist feed. Trust-weighted so one org can't single-handedly promote its own intel.
 
+### Domain posture surfaces
+
+The per-domain page (`/domains/:domain`) surfaces published email-auth posture alongside threat verdicts. Today it shows DMARC apex policy + alignment rate and **MTA-STS** mode/mx/max_age (`_mta-sts.<domain>` TXT + `https://mta-sts.<domain>/.well-known/mta-sts.txt`, cached in KV by policy `id` so a roll auto-invalidates).
+
 ## Architecture
 
 ```

--- a/app/routes/domain-detail.tsx
+++ b/app/routes/domain-detail.tsx
@@ -97,6 +97,9 @@ function DomainBody({ data }: { data: DomainStats }) {
 				<VerdictMixCard mix={data.verdictMix} />
 				<DmarcPostureCard posture={data.dmarcPosture} />
 			</div>
+			<div className="grid gap-4 lg:grid-cols-3">
+				<MtaStsPostureCard posture={data.mtaStsPosture} />
+			</div>
 			<MailboxList mailboxes={data.mailboxes} />
 			{data.recentCases.length > 0 && <RecentCasesList cases={data.recentCases} />}
 		</>
@@ -234,6 +237,48 @@ function DmarcPostureCard({
 								: `${Math.round(posture.alignmentRate * 100)}%`
 						}
 					/>
+				</dl>
+			)}
+		</div>
+	);
+}
+
+function MtaStsPostureCard({
+	posture,
+}: { posture: DomainStats["mtaStsPosture"] }) {
+	const allNull =
+		posture.mode === null &&
+		posture.mx === null &&
+		posture.maxAge === null &&
+		posture.id === null;
+	return (
+		<div className="pp-card p-5">
+			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-3 flex items-center gap-1.5">
+				<ShieldCheckIcon size={12} />
+				MTA-STS posture
+			</div>
+			{allNull ? (
+				<p className="text-[12.5px] text-ink-3">
+					MTA-STS isn't published for this domain (or the lookup failed). Operators
+					configure it by publishing a `_mta-sts` TXT record plus a policy file at
+					`mta-sts.&lt;domain&gt;/.well-known/mta-sts.txt`.
+				</p>
+			) : (
+				<dl className="space-y-1.5 text-[12.5px]">
+					<PostureRow label="mode" value={posture.mode ?? "—"} />
+					<PostureRow
+						label="mx"
+						value={
+							posture.mx && posture.mx.length > 0
+								? posture.mx.join(", ")
+								: "—"
+						}
+					/>
+					<PostureRow
+						label="max_age"
+						value={posture.maxAge === null ? "—" : `${posture.maxAge}s`}
+					/>
+					<PostureRow label="id" value={posture.id ?? "—"} />
 				</dl>
 			)}
 		</div>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -249,6 +249,15 @@ export interface DmarcPosture {
 	alignmentRate: number | null;
 }
 
+/** MTA-STS posture (#165). All fields nullable; an all-null posture renders
+ * the same "unavailable / not configured" affordance as DMARC posture. */
+export interface MtaStsPosture {
+	mode: "enforce" | "testing" | "none" | null;
+	mx: readonly string[] | null;
+	maxAge: number | null;
+	id: string | null;
+}
+
 /** One row in the `/api/v1/domains` list. */
 export interface DomainListEntry {
 	domain: string;
@@ -275,6 +284,7 @@ export interface DomainStats {
 	openCases: number;
 	verdictMix: OrgVerdictMix;
 	dmarcPosture: DmarcPosture;
+	mtaStsPosture: MtaStsPosture;
 	recentCases: DashboardCase[];
 }
 

--- a/tests/frontend/domain-detail.test.tsx
+++ b/tests/frontend/domain-detail.test.tsx
@@ -68,6 +68,12 @@ const populated: DomainStats = {
 		ruaConfigured: null,
 		alignmentRate: null,
 	},
+	mtaStsPosture: {
+		mode: null,
+		mx: null,
+		maxAge: null,
+		id: null,
+	},
 	recentCases: [
 		{
 			id: "C1",

--- a/tests/frontend/shell-domain-nav.test.tsx
+++ b/tests/frontend/shell-domain-nav.test.tsx
@@ -62,6 +62,12 @@ const populated: DomainStats = {
 		ruaConfigured: null,
 		alignmentRate: null,
 	},
+	mtaStsPosture: {
+		mode: null,
+		mx: null,
+		maxAge: null,
+		id: null,
+	},
 	recentCases: [],
 };
 

--- a/tests/lib/domain-aggregation.test.ts
+++ b/tests/lib/domain-aggregation.test.ts
@@ -288,6 +288,46 @@ describe("aggregateDomainStats", () => {
 		});
 	});
 
+	it("falls back to the all-null MTA-STS posture when the handler doesn't supply one (#165)", () => {
+		const result = aggregateDomainStats({
+			domain: "acme.com",
+			mailboxes: [
+				{ id: "alice@acme.com", email: "alice@acme.com", name: "Alice" },
+			],
+			summaries: [domainSummary()],
+			now: NOW.toISOString(),
+		});
+		expect(result!.mtaStsPosture).toEqual({
+			mode: null,
+			mx: null,
+			maxAge: null,
+			id: null,
+		});
+	});
+
+	it("threads a real MTA-STS posture through unchanged when supplied (#165)", () => {
+		const result = aggregateDomainStats({
+			domain: "acme.com",
+			mailboxes: [
+				{ id: "alice@acme.com", email: "alice@acme.com", name: "Alice" },
+			],
+			summaries: [domainSummary()],
+			now: NOW.toISOString(),
+			mtaStsPosture: {
+				mode: "enforce",
+				mx: ["mail.acme.com"],
+				maxAge: 604800,
+				id: "20251102",
+			},
+		});
+		expect(result!.mtaStsPosture).toEqual({
+			mode: "enforce",
+			mx: ["mail.acme.com"],
+			maxAge: 604800,
+			id: "20251102",
+		});
+	});
+
 	it("tolerates null (failed) summaries as zero contributions", () => {
 		const result = aggregateDomainStats({
 			domain: "acme.com",

--- a/tests/mta-sts/posture.test.ts
+++ b/tests/mta-sts/posture.test.ts
@@ -1,0 +1,370 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, expect, it } from "vitest";
+import {
+	emptyMtaStsPosture,
+	fetchMtaStsPosture,
+	normalizeDohTxtData,
+	parseMtaStsPolicy,
+	parseMtaStsTxt,
+	selectMtaStsTxtRecord,
+	type MtaStsKv,
+} from "../../workers/mta-sts/posture";
+
+describe("parseMtaStsTxt", () => {
+	it("parses a v=STSv1 record with an id tag", () => {
+		expect(parseMtaStsTxt("v=STSv1; id=20251102T0000")).toEqual({
+			id: "20251102T0000",
+		});
+	});
+
+	it("returns null for non-STSv1 records", () => {
+		expect(parseMtaStsTxt("v=spf1 -all")).toBeNull();
+		expect(parseMtaStsTxt("not even a tag list")).toBeNull();
+		expect(parseMtaStsTxt("")).toBeNull();
+	});
+
+	it("returns null when the id tag is missing", () => {
+		expect(parseMtaStsTxt("v=STSv1")).toBeNull();
+	});
+
+	it("returns null when the id is over 32 chars or non-alphanumeric", () => {
+		expect(parseMtaStsTxt(`v=STSv1; id=${"x".repeat(33)}`)).toBeNull();
+		expect(parseMtaStsTxt("v=STSv1; id=has-dash")).toBeNull();
+		expect(parseMtaStsTxt("v=STSv1; id=has space")).toBeNull();
+	});
+
+	it("is case-insensitive on tag names but not on id values", () => {
+		const r = parseMtaStsTxt("V=STSv1; ID=ABC123");
+		expect(r).toEqual({ id: "ABC123" });
+	});
+
+	it("ignores duplicate tags after the first occurrence", () => {
+		const r = parseMtaStsTxt("v=STSv1; id=first; id=second");
+		expect(r?.id).toBe("first");
+	});
+});
+
+describe("selectMtaStsTxtRecord", () => {
+	it("picks the v=STSv1-prefixed record", () => {
+		const r = selectMtaStsTxtRecord([
+			"google-site-verification=abc",
+			"v=STSv1; id=20251102",
+			"v=spf1 -all",
+		]);
+		expect(r).toBe("v=STSv1; id=20251102");
+	});
+
+	it("returns null when no STSv1 record present", () => {
+		expect(selectMtaStsTxtRecord(["v=spf1 -all"])).toBeNull();
+	});
+
+	it("matches case-insensitively and tolerates whitespace around v=", () => {
+		expect(selectMtaStsTxtRecord(["V = STSv1; id=abc"])).toMatch(/STSv1/);
+	});
+});
+
+describe("parseMtaStsPolicy", () => {
+	it("parses a complete enforce-mode policy", () => {
+		const body = [
+			"version: STSv1",
+			"mode: enforce",
+			"mx: mail.example.com",
+			"mx: *.example.net",
+			"max_age: 604800",
+		].join("\n");
+		expect(parseMtaStsPolicy(body)).toEqual({
+			mode: "enforce",
+			mx: ["mail.example.com", "*.example.net"],
+			maxAge: 604800,
+		});
+	});
+
+	it("parses testing and none modes", () => {
+		const t = parseMtaStsPolicy(
+			"version: STSv1\nmode: testing\nmax_age: 86400",
+		);
+		expect(t?.mode).toBe("testing");
+		const n = parseMtaStsPolicy(
+			"version: STSv1\nmode: none\nmax_age: 86400",
+		);
+		expect(n?.mode).toBe("none");
+	});
+
+	it("tolerates CRLF line endings", () => {
+		const body = "version: STSv1\r\nmode: enforce\r\nmax_age: 86400";
+		expect(parseMtaStsPolicy(body)?.mode).toBe("enforce");
+	});
+
+	it("returns null when version is missing or wrong", () => {
+		expect(parseMtaStsPolicy("mode: enforce\nmax_age: 86400")).toBeNull();
+		expect(
+			parseMtaStsPolicy("version: STSv2\nmode: enforce\nmax_age: 86400"),
+		).toBeNull();
+	});
+
+	it("returns null when mode is invalid", () => {
+		expect(
+			parseMtaStsPolicy("version: STSv1\nmode: bogus\nmax_age: 86400"),
+		).toBeNull();
+		expect(
+			parseMtaStsPolicy("version: STSv1\nmax_age: 86400"),
+		).toBeNull();
+	});
+
+	it("returns null when max_age is missing or non-numeric", () => {
+		expect(parseMtaStsPolicy("version: STSv1\nmode: enforce")).toBeNull();
+		expect(
+			parseMtaStsPolicy("version: STSv1\nmode: enforce\nmax_age: forever"),
+		).toBeNull();
+	});
+
+	it("ignores comment lines and unknown keys", () => {
+		const body = [
+			"# comment line",
+			"version: STSv1",
+			"mode: enforce",
+			"max_age: 604800",
+			"some_future_key: ignored",
+		].join("\n");
+		const r = parseMtaStsPolicy(body);
+		expect(r).toEqual({ mode: "enforce", mx: [], maxAge: 604800 });
+	});
+});
+
+describe("normalizeDohTxtData", () => {
+	it("concatenates multi-string TXT-record fragments without inserting whitespace", () => {
+		expect(normalizeDohTxtData('"v=STSv1; " "id=abc123"')).toBe(
+			"v=STSv1; id=abc123",
+		);
+	});
+
+	it("strips surrounding quotes from a single-fragment string", () => {
+		expect(normalizeDohTxtData('"v=STSv1; id=abc"')).toBe("v=STSv1; id=abc");
+	});
+
+	it("passes raw text through when no quoted fragments are present", () => {
+		expect(normalizeDohTxtData("v=STSv1; id=abc")).toBe("v=STSv1; id=abc");
+	});
+});
+
+// ── DoH + HTTPS integration tests ─────────────────────────────────────────
+
+function fakeKv(initial: Record<string, unknown> = {}): MtaStsKv & {
+	store: Map<string, string>;
+} {
+	const store = new Map<string, string>();
+	for (const [k, v] of Object.entries(initial)) {
+		store.set(k, JSON.stringify(v));
+	}
+	return {
+		store,
+		async get(key: string, _type: "json") {
+			const raw = store.get(key);
+			return raw ? (JSON.parse(raw) as unknown) : null;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+	};
+}
+
+function dohTxtResponse(records: string[]): Response {
+	return new Response(
+		JSON.stringify({
+			Status: 0,
+			Answer: records.map((data) => ({
+				name: "_mta-sts.acme.com",
+				type: 16,
+				data,
+			})),
+		}),
+		{ status: 200, headers: { "content-type": "application/dns-json" } },
+	);
+}
+
+function policyResponse(body: string): Response {
+	return new Response(body, {
+		status: 200,
+		headers: { "content-type": "text/plain" },
+	});
+}
+
+describe("fetchMtaStsPosture", () => {
+	it("resolves a complete posture (TXT + enforce policy)", async () => {
+		// Hostname-based dispatch — substring matching on URLs is a CodeQL
+		// `js/incomplete-url-substring-sanitization` trip wire (repo CLAUDE.md).
+		const fetchImpl = async (url: string, init?: RequestInit) => {
+			const u = new URL(url);
+			if (u.hostname === "cloudflare-dns.com") {
+				expect(u.pathname).toBe("/dns-query");
+				expect(u.searchParams.get("name")).toBe("_mta-sts.acme.com");
+				return dohTxtResponse(['"v=STSv1; id=20251102"']);
+			}
+			if (u.hostname === "mta-sts.acme.com") {
+				expect(u.pathname).toBe("/.well-known/mta-sts.txt");
+				// MTA-STS clients must not follow redirects (RFC 8461 §3.3).
+				expect(init?.redirect).toBe("manual");
+				return policyResponse(
+					"version: STSv1\nmode: enforce\nmx: mail.acme.com\nmax_age: 604800",
+				);
+			}
+			throw new Error(`unexpected fetch host: ${u.hostname}`);
+		};
+		const r = await fetchMtaStsPosture("acme.com", { fetchImpl });
+		expect(r).toEqual({
+			mode: "enforce",
+			mx: ["mail.acme.com"],
+			maxAge: 604800,
+			id: "20251102",
+		});
+	});
+
+	it("returns the empty sentinel when no _mta-sts TXT record exists", async () => {
+		const fetchImpl = async () =>
+			new Response(JSON.stringify({ Status: 0, Answer: [] }), { status: 200 });
+		const r = await fetchMtaStsPosture("acme.com", { fetchImpl });
+		expect(r).toEqual(emptyMtaStsPosture());
+	});
+
+	it("returns posture with id but null mode/mx/maxAge when policy fetch fails", async () => {
+		const fetchImpl = async (url: string) => {
+			const u = new URL(url);
+			if (u.hostname === "cloudflare-dns.com") {
+				return dohTxtResponse(['"v=STSv1; id=abc"']);
+			}
+			// Policy fetch returns 404 — common during a partial misconfiguration.
+			return new Response("not found", { status: 404 });
+		};
+		const r = await fetchMtaStsPosture("acme.com", { fetchImpl });
+		expect(r).toEqual({ mode: null, mx: null, maxAge: null, id: "abc" });
+	});
+
+	it("returns posture with id but null fields when policy is malformed", async () => {
+		const fetchImpl = async (url: string) => {
+			const u = new URL(url);
+			if (u.hostname === "cloudflare-dns.com") {
+				return dohTxtResponse(['"v=STSv1; id=abc"']);
+			}
+			return policyResponse("<html>nope</html>");
+		};
+		const r = await fetchMtaStsPosture("acme.com", { fetchImpl });
+		expect(r.id).toBe("abc");
+		expect(r.mode).toBeNull();
+	});
+
+	it("returns the empty sentinel when DoH fetch rejects", async () => {
+		const fetchImpl = async () => {
+			throw new Error("network");
+		};
+		const r = await fetchMtaStsPosture("acme.com", { fetchImpl });
+		expect(r).toEqual(emptyMtaStsPosture());
+	});
+
+	it("returns posture with id but null fields when policy fetch times out (rejects)", async () => {
+		const fetchImpl = async (url: string) => {
+			const u = new URL(url);
+			if (u.hostname === "cloudflare-dns.com") {
+				return dohTxtResponse(['"v=STSv1; id=abc"']);
+			}
+			throw new Error("timeout");
+		};
+		const r = await fetchMtaStsPosture("acme.com", { fetchImpl });
+		expect(r).toEqual({ mode: null, mx: null, maxAge: null, id: "abc" });
+	});
+
+	it("rejects oversized policy bodies", async () => {
+		// 64 KiB + 1 byte should be refused.
+		const oversized = "version: STSv1\nmode: enforce\nmax_age: 86400\n".padEnd(
+			65 * 1024,
+			"# padding\n",
+		);
+		const fetchImpl = async (url: string) => {
+			const u = new URL(url);
+			if (u.hostname === "cloudflare-dns.com") {
+				return dohTxtResponse(['"v=STSv1; id=abc"']);
+			}
+			return policyResponse(oversized);
+		};
+		const r = await fetchMtaStsPosture("acme.com", { fetchImpl });
+		expect(r.id).toBe("abc");
+		expect(r.mode).toBeNull();
+	});
+
+	it("reads from KV cache keyed by policy id", async () => {
+		const cached = {
+			mode: "enforce",
+			mx: ["cached.acme.com"],
+			maxAge: 604800,
+			id: "20251102",
+		};
+		const kv = fakeKv({ "mta-sts:v1:acme.com:20251102": cached });
+		let httpsCalls = 0;
+		const fetchImpl = async (url: string) => {
+			const u = new URL(url);
+			if (u.hostname === "cloudflare-dns.com") {
+				return dohTxtResponse(['"v=STSv1; id=20251102"']);
+			}
+			httpsCalls += 1;
+			return policyResponse(
+				"version: STSv1\nmode: testing\nmax_age: 86400",
+			);
+		};
+		const r = await fetchMtaStsPosture("acme.com", { fetchImpl, kv });
+		// Cache hit — never touched the policy URL.
+		expect(httpsCalls).toBe(0);
+		expect(r.mode).toBe("enforce");
+		expect(r.mx).toEqual(["cached.acme.com"]);
+	});
+
+	it("re-fetches when the published id changes (cache buster works)", async () => {
+		// KV has an entry under the OLD id — when the operator publishes a new
+		// id, the cache key changes and we fetch fresh.
+		const kv = fakeKv({
+			"mta-sts:v1:acme.com:OLD": {
+				mode: "enforce",
+				mx: [],
+				maxAge: 86400,
+				id: "OLD",
+			},
+		});
+		const fetchImpl = async (url: string) => {
+			const u = new URL(url);
+			if (u.hostname === "cloudflare-dns.com") {
+				return dohTxtResponse(['"v=STSv1; id=NEW"']);
+			}
+			return policyResponse(
+				"version: STSv1\nmode: testing\nmax_age: 3600",
+			);
+		};
+		const r = await fetchMtaStsPosture("acme.com", { fetchImpl, kv });
+		expect(r.id).toBe("NEW");
+		expect(r.mode).toBe("testing");
+		expect(r.maxAge).toBe(3600);
+	});
+
+	it("caches negative results under a distinct key with short TTL", async () => {
+		const kv = fakeKv();
+		const fetchImpl = async () =>
+			new Response(JSON.stringify({ Status: 0, Answer: [] }), { status: 200 });
+		await fetchMtaStsPosture("acme.com", { fetchImpl, kv });
+		await new Promise((r) => setTimeout(r, 0));
+		expect(kv.store.get("mta-sts:v1:acme.com:none")).toBeDefined();
+	});
+
+	it("queries the _mta-sts.<domain> label, not the apex", async () => {
+		let captured = "";
+		const fetchImpl = async (url: string) => {
+			const u = new URL(url);
+			if (u.hostname === "cloudflare-dns.com") {
+				captured = url;
+				return dohTxtResponse([]);
+			}
+			return new Response("", { status: 404 });
+		};
+		await fetchMtaStsPosture("acme.com", { fetchImpl });
+		const u = new URL(captured);
+		expect(u.searchParams.get("name")).toBe("_mta-sts.acme.com");
+		expect(u.searchParams.get("type")).toBe("TXT");
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -54,6 +54,7 @@ import {
 	type OrgOverview,
 } from "./lib/dashboard-aggregation";
 import { emptyDmarcTxtPosture, fetchDmarcTxtPosture } from "./dmarc/txt";
+import { emptyMtaStsPosture, fetchMtaStsPosture } from "./mta-sts/posture";
 import { listTextModels } from "./lib/text-models";
 import { fetchHubCorroborationCount } from "./intel/hub-corroboration";
 import { loadHubCredentials } from "./lib/hub-config";
@@ -305,12 +306,17 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 	const txtPromise = fetchDmarcTxtPosture(domain, {
 		kv: c.env.BLOOM_KV ?? null,
 	});
+	const mtaStsPromise = fetchMtaStsPosture(domain, {
+		kv: c.env.BLOOM_KV ?? null,
+	});
 
-	const [settledSummaries, settledAlignments, settledTxt] = await Promise.all([
-		Promise.allSettled(summaryPromises),
-		Promise.allSettled(alignmentPromises),
-		Promise.allSettled([txtPromise]),
-	]);
+	const [settledSummaries, settledAlignments, settledTxt, settledMtaSts] =
+		await Promise.all([
+			Promise.allSettled(summaryPromises),
+			Promise.allSettled(alignmentPromises),
+			Promise.allSettled([txtPromise]),
+			Promise.allSettled([mtaStsPromise]),
+		]);
 
 	const summaries: Array<DomainMailboxSummary | null> = settledSummaries.map((r) => {
 		if (r.status !== "fulfilled") {
@@ -344,6 +350,11 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		alignmentRate: reduceDmarcAlignmentRate(alignmentTotals),
 	};
 
+	const mtaStsPosture =
+		settledMtaSts[0].status === "fulfilled"
+			? settledMtaSts[0].value
+			: emptyMtaStsPosture();
+
 	const mailboxRefs: DomainMailboxRef[] = scoped.map((m) => ({
 		id: m.id,
 		email: m.email,
@@ -355,6 +366,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		mailboxes: mailboxRefs,
 		summaries,
 		dmarcPosture,
+		mtaStsPosture,
 	});
 	// `aggregateDomainStats` only returns null when `mailboxes.length === 0`,
 	// which we already guarded above with the 404 — but narrow the type

--- a/workers/lib/dashboard-aggregation.ts
+++ b/workers/lib/dashboard-aggregation.ts
@@ -422,6 +422,17 @@ export interface DmarcPosture {
 	alignmentRate: number | null;
 }
 
+/** MTA-STS posture (#165) — `mode`/`mx`/`max_age`/`id` from the published
+ * policy at `https://mta-sts.<domain>/.well-known/mta-sts.txt`, gated by the
+ * `_mta-sts.<domain>` TXT marker. All fields nullable; null fields render the
+ * "unavailable" affordance shared with DMARC posture. */
+export interface MtaStsPostureView {
+	mode: "enforce" | "testing" | "none" | null;
+	mx: readonly string[] | null;
+	maxAge: number | null;
+	id: string | null;
+}
+
 export interface DomainListEntry {
 	domain: string;
 	mailboxesCount: number;
@@ -445,6 +456,9 @@ export interface DomainStats {
 	openCases: number;
 	verdictMix: VerdictMix;
 	dmarcPosture: DmarcPosture;
+	/** MTA-STS posture (#165). All-null when the upstream lookup failed or
+	 * the domain doesn't publish a policy. */
+	mtaStsPosture: MtaStsPostureView;
 	recentCases: DomainRecentCase[];
 }
 
@@ -481,6 +495,12 @@ export function emptyDmarcPosture(): DmarcPosture {
 		ruaConfigured: null,
 		alignmentRate: null,
 	};
+}
+
+/** Empty MTA-STS posture sentinel — every field null, rendered as
+ * "not configured / unavailable" (same affordance as DMARC). */
+export function emptyMtaStsPostureView(): MtaStsPostureView {
+	return { mode: null, mx: null, maxAge: null, id: null };
 }
 
 /** Per-mailbox alignment totals harvested from `dmarc_records` by the DO.
@@ -602,6 +622,11 @@ interface AggregateDomainStatsInput {
 	 * forward-compat case where the handler couldn't compute posture.
 	 */
 	dmarcPosture?: DmarcPosture;
+	/**
+	 * MTA-STS posture (#165) from the `_mta-sts.<domain>` TXT marker plus
+	 * the published policy file. Omitted defaults to the all-null sentinel.
+	 */
+	mtaStsPosture?: MtaStsPostureView;
 }
 
 /**
@@ -659,6 +684,7 @@ export function aggregateDomainStats(
 		openCases,
 		verdictMix,
 		dmarcPosture: input.dmarcPosture ?? emptyDmarcPosture(),
+		mtaStsPosture: input.mtaStsPosture ?? emptyMtaStsPostureView(),
 		recentCases: recentCases.slice(0, 5),
 	};
 }

--- a/workers/mta-sts/posture.ts
+++ b/workers/mta-sts/posture.ts
@@ -1,0 +1,361 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * MTA-STS posture lookup (RFC 8461).
+ *
+ * Two-step resolution: a `_mta-sts.<domain>` TXT record carries a `v=STSv1`
+ * marker plus a policy `id`, then `https://mta-sts.<domain>/.well-known/mta-sts.txt`
+ * carries the actual policy (`mode`, `mx`, `max_age`).
+ *
+ * Cache key includes the policy id so a published-id change auto-invalidates
+ * cached entries — operators who roll their MTA-STS policy don't have to wait
+ * for a TTL race. Negative results (no TXT record / no policy file / parse
+ * failure) are cached briefly under a separate key to avoid hammering DoH.
+ *
+ * Issue: #165 (carve-out from #156, item 2).
+ */
+
+/**
+ * Parsed `{mode, mx, maxAge, id}` extracted from the MTA-STS pair (TXT record
+ * + policy file). All fields nullable: an absent TXT record, a missing policy
+ * file, a non-200 fetch, or a malformed policy all surface the same all-null
+ * sentinel so the dashboard can render one "unavailable" affordance.
+ */
+export interface MtaStsPosture {
+	mode: "enforce" | "testing" | "none" | null;
+	mx: readonly string[] | null;
+	maxAge: number | null;
+	id: string | null;
+}
+
+/** Sentinel returned when posture is unavailable for any reason. */
+export function emptyMtaStsPosture(): MtaStsPosture {
+	return { mode: null, mx: null, maxAge: null, id: null };
+}
+
+const KV_PREFIX = "mta-sts:v1:";
+/** Long TTL on positive cache entries — they're keyed by policy id, so a
+ * fresh `id` produces a fresh cache key. 24h is well under the typical
+ * `max_age` operators publish (1 week+). */
+const KV_TTL_POSITIVE_S = 24 * 60 * 60;
+/** Short TTL on negative entries — when an operator publishes for the first
+ * time we want to discover it within minutes, not days. */
+const KV_TTL_NEGATIVE_S = 5 * 60;
+/** DoH resolver host. Hostname-based mock matching is required by repo CLAUDE.md. */
+const DOH_HOST = "cloudflare-dns.com";
+const DOH_URL = `https://${DOH_HOST}/dns-query`;
+/** Hard cap per upstream call — same budget as `workers/dmarc/txt.ts` so a
+ * slow MTA-STS server can't block the dashboard. Worst-case total is two
+ * sequential calls (TXT + HTTPS); the route wraps this in `Promise.allSettled`
+ * so even the worst case degrades to "unavailable" rather than a 5xx. */
+const UPSTREAM_TIMEOUT_MS = 1500;
+/** Cap policy-file size at 64 KiB. RFC 8461 §3.2 doesn't specify a limit but
+ * real policies are well under 1 KiB; this defends against a misconfigured
+ * server returning an HTML error page or an attacker pointing the policy URL
+ * at a large payload. */
+const POLICY_MAX_BYTES = 64 * 1024;
+
+/** Minimal `KVNamespace` view we depend on; lets tests pass a fake. */
+export interface MtaStsKv {
+	get(key: string, type: "json"): Promise<unknown>;
+	put(
+		key: string,
+		value: string,
+		options?: { expirationTtl?: number },
+	): Promise<void>;
+}
+
+/** Minimal `fetch` view we depend on; lets tests inject a stub. */
+export type MtaStsFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Parse a `_mta-sts.<domain>` TXT-record string into `{id}`. Only records
+ * starting with `v=STSv1` are considered. Tags are `;`-separated `name=value`
+ * pairs per RFC 8461 §3.1. Returns `null` when the record isn't a valid
+ * STS marker or when the `id` tag is missing.
+ *
+ * Tag names are case-insensitive; `id` values are not (the spec says they're
+ * arbitrary 1-32 char tokens, A-Za-z0-9).
+ */
+export function parseMtaStsTxt(record: string): { id: string } | null {
+	if (typeof record !== "string") return null;
+	const trimmed = record.trim();
+	if (!trimmed) return null;
+	const tags = new Map<string, string>();
+	for (const part of trimmed.split(";")) {
+		const eq = part.indexOf("=");
+		if (eq < 0) continue;
+		const name = part.slice(0, eq).trim().toLowerCase();
+		const value = part.slice(eq + 1).trim();
+		if (!name) continue;
+		// First-wins, mirroring the DMARC parser. A record with duplicate `id`
+		// is malformed; first-wins gives a deterministic answer rather than
+		// silently switching on tag-order in the upstream.
+		if (!tags.has(name)) tags.set(name, value);
+	}
+	if (tags.get("v") !== "STSv1") return null;
+	const id = tags.get("id");
+	// Per RFC 8461 §3.1 the id is 1-32 chars, A-Za-z0-9. Be defensive and
+	// reject empty / over-length / non-alphanumeric ids — a bogus id would
+	// still cache-bust correctly but it's likely a misconfiguration we'd
+	// rather surface as "unavailable" than as a phantom posture.
+	if (!id || id.length === 0 || id.length > 32) return null;
+	if (!/^[A-Za-z0-9]+$/.test(id)) return null;
+	return { id };
+}
+
+/**
+ * Pick the STSv1 policy record from a list of TXT strings published at
+ * `_mta-sts.<domain>`. Multiple TXT entries at that label are common (e.g. an
+ * old STS marker left next to a new one); RFC 8461 §3.1 says only the
+ * `v=STSv1`-prefixed record is authoritative. Returns null when none match.
+ */
+export function selectMtaStsTxtRecord(records: readonly string[]): string | null {
+	for (const r of records) {
+		if (typeof r !== "string") continue;
+		const t = r.trim();
+		if (/^v\s*=\s*STSv1\b/i.test(t)) return t;
+	}
+	return null;
+}
+
+/**
+ * Strip surrounding quotes and concatenate multi-string TXT-record fragments
+ * DoH returns. Same logic as `workers/dmarc/txt.ts:normalizeDohTxtData` —
+ * duplicated here rather than re-exported to keep `mta-sts/posture.ts`
+ * decoupled from the DMARC module's API surface.
+ */
+export function normalizeDohTxtData(data: string): string {
+	if (typeof data !== "string") return "";
+	const matches = [...data.matchAll(/"((?:[^"\\]|\\.)*)"/g)];
+	if (matches.length === 0) {
+		return data.replace(/^"|"$/g, "");
+	}
+	return matches.map((m) => m[1]).join("");
+}
+
+/**
+ * Parse the MTA-STS policy file body (RFC 8461 §3.2). Format is
+ * `key: value` per line, separated by `\r\n` per spec but we tolerate `\n`
+ * since real-world servers vary. `mx` may repeat. Required keys are
+ * `version: STSv1`, `mode`, and `max_age`; missing required keys produce a
+ * null result. Unknown keys are ignored.
+ */
+export function parseMtaStsPolicy(body: string): {
+	mode: "enforce" | "testing" | "none";
+	mx: string[];
+	maxAge: number;
+} | null {
+	if (typeof body !== "string") return null;
+	let version: string | null = null;
+	let mode: string | null = null;
+	let maxAgeRaw: string | null = null;
+	const mx: string[] = [];
+	for (const rawLine of body.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (!line || line.startsWith("#")) continue;
+		const colon = line.indexOf(":");
+		if (colon < 0) continue;
+		const key = line.slice(0, colon).trim().toLowerCase();
+		const value = line.slice(colon + 1).trim();
+		if (!key) continue;
+		switch (key) {
+			case "version":
+				version ??= value;
+				break;
+			case "mode":
+				mode ??= value.toLowerCase();
+				break;
+			case "max_age":
+				maxAgeRaw ??= value;
+				break;
+			case "mx":
+				if (value) mx.push(value.toLowerCase());
+				break;
+		}
+	}
+	if (version !== "STSv1") return null;
+	if (mode !== "enforce" && mode !== "testing" && mode !== "none") return null;
+	if (maxAgeRaw === null) return null;
+	const maxAge = Number.parseInt(maxAgeRaw, 10);
+	if (!Number.isFinite(maxAge) || maxAge < 0) return null;
+	return { mode, mx, maxAge };
+}
+
+/**
+ * Fetch and parse the MTA-STS posture for `<domain>`, with KV caching.
+ *
+ * Each upstream call (TXT + HTTPS) is hard-capped at `UPSTREAM_TIMEOUT_MS`
+ * and any failure (timeout, non-200, malformed JSON, missing record, parse
+ * failure) degrades to the all-null sentinel. Cache key includes the policy
+ * `id` so a published-id change auto-invalidates without a TTL race.
+ *
+ * The HTTPS policy fetch uses `redirect: "manual"` per the global CLAUDE.md
+ * rule — MTA-STS clients must not follow redirects when fetching the policy
+ * file (RFC 8461 §3.3 implies the well-known URI is the authoritative source
+ * and following a redirect could let an attacker substitute a permissive
+ * policy from a domain they control).
+ */
+export async function fetchMtaStsPosture(
+	domain: string,
+	options: {
+		kv?: MtaStsKv | null;
+		fetchImpl?: MtaStsFetch;
+	} = {},
+): Promise<MtaStsPosture> {
+	if (!domain || typeof domain !== "string") return emptyMtaStsPosture();
+	const fetchImpl = options.fetchImpl ?? (globalThis.fetch as MtaStsFetch);
+	const kv = options.kv ?? null;
+
+	const txtId = await resolveMtaStsTxtId(domain, fetchImpl);
+
+	if (!txtId) {
+		// Cache the negative under a distinct key so we don't re-resolve on
+		// every dashboard hit. Short TTL — when the operator publishes for
+		// the first time, surface it within minutes.
+		const negKey = `${KV_PREFIX}${domain}:none`;
+		if (kv) {
+			try {
+				const cached = await kv.get(negKey, "json");
+				if (cached && typeof cached === "object") {
+					return coerceMtaStsPosture(cached);
+				}
+			} catch {
+				// KV read failure is non-fatal — fall through to the empty
+				// sentinel below.
+			}
+			void kv
+				.put(negKey, JSON.stringify(emptyMtaStsPosture()), {
+					expirationTtl: KV_TTL_NEGATIVE_S,
+				})
+				.catch(() => {});
+		}
+		return emptyMtaStsPosture();
+	}
+
+	const cacheKey = `${KV_PREFIX}${domain}:${txtId}`;
+
+	if (kv) {
+		try {
+			const cached = await kv.get(cacheKey, "json");
+			if (cached && typeof cached === "object") {
+				return coerceMtaStsPosture(cached);
+			}
+		} catch {
+			// KV read failure is non-fatal; fall through to a fresh fetch.
+		}
+	}
+
+	const policy = await fetchAndParseMtaStsPolicy(domain, fetchImpl);
+	const posture: MtaStsPosture = policy
+		? { mode: policy.mode, mx: policy.mx, maxAge: policy.maxAge, id: txtId }
+		: { mode: null, mx: null, maxAge: null, id: txtId };
+
+	if (kv) {
+		// Write the resolved posture under the id-keyed cache. Long TTL is
+		// safe because publishing a new policy bumps the id and lands on a
+		// different cache key.
+		void kv
+			.put(cacheKey, JSON.stringify(posture), {
+				expirationTtl: KV_TTL_POSITIVE_S,
+			})
+			.catch(() => {});
+	}
+
+	return posture;
+}
+
+async function resolveMtaStsTxtId(
+	domain: string,
+	fetchImpl: MtaStsFetch,
+): Promise<string | null> {
+	const name = `_mta-sts.${domain}`;
+	let res: Response;
+	try {
+		res = await fetchImpl(
+			`${DOH_URL}?name=${encodeURIComponent(name)}&type=TXT`,
+			{
+				headers: { accept: "application/dns-json" },
+				signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+			},
+		);
+	} catch {
+		return null;
+	}
+	if (!res.ok) return null;
+	let body: unknown;
+	try {
+		body = await res.json();
+	} catch {
+		return null;
+	}
+	const answer = (body as { Answer?: Array<{ type?: number; data?: unknown }> })
+		.Answer;
+	if (!Array.isArray(answer)) return null;
+	const txts: string[] = [];
+	for (const a of answer) {
+		// TXT records are type=16 in DoH JSON.
+		if (a.type !== 16) continue;
+		if (typeof a.data !== "string") continue;
+		txts.push(normalizeDohTxtData(a.data));
+	}
+	const record = selectMtaStsTxtRecord(txts);
+	if (!record) return null;
+	const parsed = parseMtaStsTxt(record);
+	return parsed?.id ?? null;
+}
+
+async function fetchAndParseMtaStsPolicy(
+	domain: string,
+	fetchImpl: MtaStsFetch,
+): Promise<{
+	mode: "enforce" | "testing" | "none";
+	mx: string[];
+	maxAge: number;
+} | null> {
+	const url = `https://mta-sts.${domain}/.well-known/mta-sts.txt`;
+	let res: Response;
+	try {
+		res = await fetchImpl(url, {
+			// MTA-STS clients must not follow redirects — RFC 8461 §3.3 makes
+			// the well-known URI authoritative; a redirect would let an
+			// attacker substitute a permissive policy from a domain they
+			// control. (Global CLAUDE.md: MTA-STS fetches use redirect: manual.)
+			redirect: "manual",
+			signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+		});
+	} catch {
+		return null;
+	}
+	if (!res.ok) return null;
+	let text: string;
+	try {
+		// Defend against oversized responses by reading bytes and truncating.
+		const buf = await res.arrayBuffer();
+		if (buf.byteLength > POLICY_MAX_BYTES) return null;
+		text = new TextDecoder().decode(buf);
+	} catch {
+		return null;
+	}
+	return parseMtaStsPolicy(text);
+}
+
+function coerceMtaStsPosture(value: unknown): MtaStsPosture {
+	if (!value || typeof value !== "object") return emptyMtaStsPosture();
+	const v = value as {
+		mode?: unknown;
+		mx?: unknown;
+		maxAge?: unknown;
+		id?: unknown;
+	};
+	const validMode =
+		v.mode === "enforce" || v.mode === "testing" || v.mode === "none"
+			? v.mode
+			: null;
+	const mx = Array.isArray(v.mx)
+		? v.mx.filter((s): s is string => typeof s === "string")
+		: null;
+	const maxAge = typeof v.maxAge === "number" ? v.maxAge : null;
+	const id = typeof v.id === "string" ? v.id : null;
+	return { mode: validMode, mx, maxAge, id };
+}


### PR DESCRIPTION
## Summary

- Adds `workers/mta-sts/posture.ts` (`fetchMtaStsPosture`) — DoH for `_mta-sts.<domain>` TXT + HTTPS fetch of `mta-sts.<domain>/.well-known/mta-sts.txt`. 1500ms hard cap per call mirrors `workers/dmarc/txt.ts`.
- Cache key is `mta-sts:v1:<domain>:<policy-id>` so a published-`id` roll auto-invalidates; negative results land under `mta-sts:v1:<domain>:none` with a short TTL.
- Threads `mtaStsPosture: MtaStsPostureView` through `aggregateDomainStats` and renders a card on `/domains/:domain` next to the DMARC posture card.
- Policy HTTPS fetch uses `redirect: "manual"` per global CLAUDE.md (RFC 8461 §3.3 — well-known URI is authoritative; following a redirect would let an attacker substitute a permissive policy).
- Test mocks parse URLs (`new URL(url).hostname`); never substring (CodeQL `js/incomplete-url-substring-sanitization`).

Closes #165.

## Test plan

- [x] `npm test` — 419 passing, 0 failing across worker/lib tests; 20 pre-existing jsdom-not-installed errors in `tests/frontend/*` (same as on `main`).
- [x] `npm run typecheck` clean for all touched files; the only `error TS` lines are the same pre-existing `tests/frontend/*` errors that exist on `main` (missing `@testing-library/*` and jest-dom matchers).
- [x] New tests cover: enforce / testing / none / no-TXT / TXT-but-no-policy-file / oversized policy / timeout / malformed policy / KV cache hit by id / id rotation invalidates / negative cache. Plus the wiring tests in `tests/lib/domain-aggregation.test.ts` for the `aggregateDomainStats` thread-through.
- [x] README "Security" section gained a "Domain posture surfaces" subsection mentioning MTA-STS visibility.

## Acceptance items shipped

- [x] `workers/mta-sts/posture.ts` resolves TXT + fetches policy file + parses `mode`/`mx`/`max_age`.
- [x] Result cached in KV keyed on policy `id`; negative result cached briefly to avoid hammering DoH.
- [x] `/domains/:domain` renders an MTA-STS tile with mode (or empty-state when unavailable).
- [x] Tests cover enforce / testing / none / no-TXT / TXT-but-no-policy-file / timeout / malformed policy file. Mocks use `new URL(...).hostname` matching.
- [x] README.md Security section mentions MTA-STS visibility.

## Out of scope (not implemented, per the issue's explicit Out-of-scope list)

- Acting on MTA-STS (sending mail with TLS-required) — receiver-side surface only.
- Operator publishing flow — that's #16/#32 territory.
- TLS-RPT (#168 covers the posture half; #169 the inbound-ingestion half).

## Deferred follow-ups

- `SECURITY_SPEC.md` Rule 5 narrowing for MTA-STS-specific timeout-vs-parse-fail semantics is **not** edited from this PR (per the repo CLAUDE.md "don't race a SECURITY_SPEC.md update against a parallel doc PR" rule). If a narrowing is wanted, it should land as a separate `docs:` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)