### PR TITLE
feat(posture): BIMI posture lookup for /domains/:domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,11 @@ The [`hub/`](hub/) subdirectory is a MISP-compatible community threat-intel hub 
 
 ### Domain posture surfaces
 
-The per-domain page (`/domains/:domain`) surfaces published email-auth posture alongside threat verdicts. Today it shows DMARC apex policy + alignment rate and **MTA-STS** mode/mx/max_age (`_mta-sts.<domain>` TXT + `https://mta-sts.<domain>/.well-known/mta-sts.txt`, cached in KV by policy `id` so a roll auto-invalidates).
+The per-domain page (`/domains/:domain`) surfaces published email-auth posture alongside threat verdicts. Today it shows:
+
+- DMARC apex policy + alignment rate.
+- **MTA-STS** mode/mx/max_age (`_mta-sts.<domain>` TXT + `https://mta-sts.<domain>/.well-known/mta-sts.txt`, cached in KV by policy `id` so a roll auto-invalidates).
+- **BIMI** record presence (`default._bimi.<domain>` TXT — surfaces "configured / configured-with-VMC / not configured / unavailable"; does NOT fetch the SVG logo or VMC certificate).
 
 ## Architecture
 

--- a/app/routes/domain-detail.tsx
+++ b/app/routes/domain-detail.tsx
@@ -99,6 +99,7 @@ function DomainBody({ data }: { data: DomainStats }) {
 			</div>
 			<div className="grid gap-4 lg:grid-cols-3">
 				<MtaStsPostureCard posture={data.mtaStsPosture} />
+				<BimiPostureCard posture={data.bimiPosture} />
 			</div>
 			<MailboxList mailboxes={data.mailboxes} />
 			{data.recentCases.length > 0 && <RecentCasesList cases={data.recentCases} />}
@@ -279,6 +280,43 @@ function MtaStsPostureCard({
 						value={posture.maxAge === null ? "—" : `${posture.maxAge}s`}
 					/>
 					<PostureRow label="id" value={posture.id ?? "—"} />
+				</dl>
+			)}
+		</div>
+	);
+}
+
+function BimiPostureCard({
+	posture,
+}: { posture: DomainStats["bimiPosture"] }) {
+	const unavailable = posture.configured === null;
+	return (
+		<div className="pp-card p-5">
+			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-3 flex items-center gap-1.5">
+				<ShieldCheckIcon size={12} />
+				BIMI posture
+			</div>
+			{unavailable ? (
+				<p className="text-[12.5px] text-ink-3">
+					BIMI lookup unavailable. The dashboard re-tries on the next domain
+					stats refresh.
+				</p>
+			) : posture.configured === false ? (
+				<p className="text-[12.5px] text-ink-3">
+					Not configured — no `default._bimi` TXT record published for this
+					domain.
+				</p>
+			) : (
+				<dl className="space-y-1.5 text-[12.5px]">
+					<PostureRow label="record" value="v=BIMI1 published" />
+					<PostureRow
+						label="logo"
+						value={posture.hasLogo ? "configured (l=)" : "—"}
+					/>
+					<PostureRow
+						label="VMC"
+						value={posture.hasVmc ? "configured (a=)" : "—"}
+					/>
 				</dl>
 			)}
 		</div>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -258,6 +258,15 @@ export interface MtaStsPosture {
 	id: string | null;
 }
 
+/** BIMI posture (#166). All fields nullable; `configured: true` + null
+ * `hasLogo`/`hasVmc` is impossible (the resolver always sets all three when
+ * a record exists). `configured: false` is "no `v=BIMI1` record published". */
+export interface BimiPosture {
+	configured: boolean | null;
+	hasLogo: boolean | null;
+	hasVmc: boolean | null;
+}
+
 /** One row in the `/api/v1/domains` list. */
 export interface DomainListEntry {
 	domain: string;
@@ -285,6 +294,7 @@ export interface DomainStats {
 	verdictMix: OrgVerdictMix;
 	dmarcPosture: DmarcPosture;
 	mtaStsPosture: MtaStsPosture;
+	bimiPosture: BimiPosture;
 	recentCases: DashboardCase[];
 }
 

--- a/tests/bimi/posture.test.ts
+++ b/tests/bimi/posture.test.ts
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, expect, it } from "vitest";
+import {
+	emptyBimiPosture,
+	fetchBimiPosture,
+	normalizeDohTxtData,
+	parseBimiTxt,
+	selectBimiRecord,
+	type BimiKv,
+} from "../../workers/bimi/posture";
+
+describe("parseBimiTxt", () => {
+	it("parses a record with both logo and VMC URLs", () => {
+		const r = parseBimiTxt(
+			"v=BIMI1; l=https://example.com/logo.svg; a=https://example.com/vmc.pem",
+		);
+		expect(r).toEqual({ configured: true, hasLogo: true, hasVmc: true });
+	});
+
+	it("parses a record with only a logo (no VMC)", () => {
+		const r = parseBimiTxt("v=BIMI1; l=https://example.com/logo.svg");
+		expect(r).toEqual({ configured: true, hasLogo: true, hasVmc: false });
+	});
+
+	it("treats empty l= as 'not present' (indicator-not-supported intent)", () => {
+		const r = parseBimiTxt("v=BIMI1; l=");
+		expect(r).toEqual({ configured: true, hasLogo: false, hasVmc: false });
+	});
+
+	it("returns null for non-BIMI1 records", () => {
+		expect(parseBimiTxt("v=spf1 -all")).toBeNull();
+		expect(parseBimiTxt("not even a tag list")).toBeNull();
+		expect(parseBimiTxt("")).toBeNull();
+	});
+
+	it("is case-insensitive on tag names but not on values", () => {
+		const r = parseBimiTxt("V=BIMI1; L=https://example.com/Logo.SVG");
+		expect(r?.hasLogo).toBe(true);
+	});
+
+	it("ignores duplicate tags after the first occurrence", () => {
+		const r = parseBimiTxt(
+			"v=BIMI1; l=https://first.example/logo.svg; l=https://second.example/logo.svg",
+		);
+		expect(r?.hasLogo).toBe(true);
+	});
+});
+
+describe("selectBimiRecord", () => {
+	it("picks the v=BIMI1-prefixed record", () => {
+		const r = selectBimiRecord([
+			"google-site-verification=abc",
+			"v=BIMI1; l=https://example.com/logo.svg",
+			"v=spf1 -all",
+		]);
+		expect(r).toBe("v=BIMI1; l=https://example.com/logo.svg");
+	});
+
+	it("returns null when no BIMI1 record present", () => {
+		expect(selectBimiRecord(["v=spf1 -all"])).toBeNull();
+	});
+
+	it("matches case-insensitively and tolerates whitespace around v=", () => {
+		expect(selectBimiRecord(["V = BIMI1; l=https://x"])).toMatch(/BIMI1/);
+	});
+});
+
+describe("normalizeDohTxtData", () => {
+	it("concatenates multi-string TXT-record fragments without inserting whitespace", () => {
+		expect(normalizeDohTxtData('"v=BIMI1; " "l=https://example.com/logo.svg"')).toBe(
+			"v=BIMI1; l=https://example.com/logo.svg",
+		);
+	});
+
+	it("strips surrounding quotes from a single-fragment string", () => {
+		expect(normalizeDohTxtData('"v=BIMI1; l=https://x"')).toBe(
+			"v=BIMI1; l=https://x",
+		);
+	});
+});
+
+// ── DoH integration tests ──────────────────────────────────────────────
+
+function fakeKv(initial: Record<string, unknown> = {}): BimiKv & {
+	store: Map<string, string>;
+} {
+	const store = new Map<string, string>();
+	for (const [k, v] of Object.entries(initial)) {
+		store.set(k, JSON.stringify(v));
+	}
+	return {
+		store,
+		async get(key: string, _type: "json") {
+			const raw = store.get(key);
+			return raw ? (JSON.parse(raw) as unknown) : null;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+	};
+}
+
+function dohTxtResponse(records: string[]): Response {
+	return new Response(
+		JSON.stringify({
+			Status: 0,
+			Answer: records.map((data) => ({
+				name: "default._bimi.acme.com",
+				type: 16,
+				data,
+			})),
+		}),
+		{ status: 200, headers: { "content-type": "application/dns-json" } },
+	);
+}
+
+describe("fetchBimiPosture", () => {
+	it("resolves a record with logo + VMC over DoH", async () => {
+		const fetchImpl = async (url: string) => {
+			// Hostname-based dispatch — substring matching on URLs is a CodeQL
+			// `js/incomplete-url-substring-sanitization` trip wire (repo CLAUDE.md).
+			expect(new URL(url).hostname).toBe("cloudflare-dns.com");
+			return dohTxtResponse([
+				'"v=BIMI1; l=https://example.com/logo.svg; a=https://example.com/vmc.pem"',
+			]);
+		};
+		const r = await fetchBimiPosture("acme.com", { fetchImpl });
+		expect(r).toEqual({ configured: true, hasLogo: true, hasVmc: true });
+	});
+
+	it("distinguishes 'no record' (configured=false) from 'unavailable' (configured=null)", async () => {
+		const fetchImpl = async () =>
+			new Response(JSON.stringify({ Status: 0, Answer: [] }), { status: 200 });
+		const r = await fetchBimiPosture("acme.com", { fetchImpl });
+		expect(r).toEqual({ configured: false, hasLogo: false, hasVmc: false });
+	});
+
+	it("returns the empty sentinel when DoH returns non-200", async () => {
+		const fetchImpl = async () => new Response("nope", { status: 500 });
+		const r = await fetchBimiPosture("acme.com", { fetchImpl });
+		expect(r).toEqual(emptyBimiPosture());
+	});
+
+	it("returns the empty sentinel when fetch rejects (timeout / network)", async () => {
+		const fetchImpl = async () => {
+			throw new Error("network");
+		};
+		const r = await fetchBimiPosture("acme.com", { fetchImpl });
+		expect(r).toEqual(emptyBimiPosture());
+	});
+
+	it("returns the empty sentinel when DoH returns malformed JSON", async () => {
+		const fetchImpl = async () => new Response("<html>", { status: 200 });
+		const r = await fetchBimiPosture("acme.com", { fetchImpl });
+		expect(r).toEqual(emptyBimiPosture());
+	});
+
+	it("returns the empty sentinel when TXT data isn't parseable as v=BIMI1", async () => {
+		// Malformed `v=BIMI1` tag — the record exists but isn't a valid BIMI1.
+		const fetchImpl = async () => dohTxtResponse(['"not a bimi record"']);
+		const r = await fetchBimiPosture("acme.com", { fetchImpl });
+		// `configured: false` — we did get a TXT response with no v=BIMI1 in it.
+		expect(r).toEqual({ configured: false, hasLogo: false, hasVmc: false });
+	});
+
+	it("queries the default._bimi.<domain> label", async () => {
+		let captured = "";
+		const fetchImpl = async (url: string) => {
+			captured = url;
+			return dohTxtResponse(['"v=BIMI1; l=https://example.com/logo.svg"']);
+		};
+		await fetchBimiPosture("acme.com", { fetchImpl });
+		const u = new URL(captured);
+		expect(u.hostname).toBe("cloudflare-dns.com");
+		expect(u.pathname).toBe("/dns-query");
+		expect(u.searchParams.get("name")).toBe("default._bimi.acme.com");
+		expect(u.searchParams.get("type")).toBe("TXT");
+	});
+
+	it("reads from KV cache when a parsed posture is stored", async () => {
+		const kv = fakeKv({
+			"bimi:v1:acme.com": {
+				configured: true,
+				hasLogo: true,
+				hasVmc: false,
+			},
+		});
+		let calls = 0;
+		const fetchImpl = async () => {
+			calls += 1;
+			return dohTxtResponse(['"v=BIMI1; l=https://example.com/logo.svg"']);
+		};
+		const r = await fetchBimiPosture("acme.com", { fetchImpl, kv });
+		expect(calls).toBe(0);
+		expect(r).toEqual({ configured: true, hasLogo: true, hasVmc: false });
+	});
+
+	it("writes the resolved posture (including null sentinels) to KV", async () => {
+		const kv = fakeKv();
+		const fetchImpl = async () =>
+			new Response(JSON.stringify({ Status: 0, Answer: [] }), { status: 200 });
+		await fetchBimiPosture("acme.com", { fetchImpl, kv });
+		await new Promise((r) => setTimeout(r, 0));
+		const cached = kv.store.get("bimi:v1:acme.com");
+		expect(cached).toBeDefined();
+		// `configured: false` is what we store for "no record" (NOT the empty
+		// sentinel) — it's a real, durable answer to the lookup.
+		expect(JSON.parse(cached!)).toEqual({
+			configured: false,
+			hasLogo: false,
+			hasVmc: false,
+		});
+	});
+});

--- a/tests/frontend/domain-detail.test.tsx
+++ b/tests/frontend/domain-detail.test.tsx
@@ -74,6 +74,11 @@ const populated: DomainStats = {
 		maxAge: null,
 		id: null,
 	},
+	bimiPosture: {
+		configured: null,
+		hasLogo: null,
+		hasVmc: null,
+	},
 	recentCases: [
 		{
 			id: "C1",

--- a/tests/frontend/shell-domain-nav.test.tsx
+++ b/tests/frontend/shell-domain-nav.test.tsx
@@ -68,6 +68,11 @@ const populated: DomainStats = {
 		maxAge: null,
 		id: null,
 	},
+	bimiPosture: {
+		configured: null,
+		hasLogo: null,
+		hasVmc: null,
+	},
 	recentCases: [],
 };
 

--- a/tests/lib/domain-aggregation.test.ts
+++ b/tests/lib/domain-aggregation.test.ts
@@ -328,6 +328,43 @@ describe("aggregateDomainStats", () => {
 		});
 	});
 
+	it("falls back to the all-null BIMI posture when the handler doesn't supply one (#166)", () => {
+		const result = aggregateDomainStats({
+			domain: "acme.com",
+			mailboxes: [
+				{ id: "alice@acme.com", email: "alice@acme.com", name: "Alice" },
+			],
+			summaries: [domainSummary()],
+			now: NOW.toISOString(),
+		});
+		expect(result!.bimiPosture).toEqual({
+			configured: null,
+			hasLogo: null,
+			hasVmc: null,
+		});
+	});
+
+	it("threads a real BIMI posture through unchanged when supplied (#166)", () => {
+		const result = aggregateDomainStats({
+			domain: "acme.com",
+			mailboxes: [
+				{ id: "alice@acme.com", email: "alice@acme.com", name: "Alice" },
+			],
+			summaries: [domainSummary()],
+			now: NOW.toISOString(),
+			bimiPosture: {
+				configured: true,
+				hasLogo: true,
+				hasVmc: true,
+			},
+		});
+		expect(result!.bimiPosture).toEqual({
+			configured: true,
+			hasLogo: true,
+			hasVmc: true,
+		});
+	});
+
 	it("tolerates null (failed) summaries as zero contributions", () => {
 		const result = aggregateDomainStats({
 			domain: "acme.com",

--- a/workers/bimi/posture.ts
+++ b/workers/bimi/posture.ts
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * BIMI (Brand Indicators for Message Identification) posture lookup.
+ *
+ * Resolves `default._bimi.<domain>` TXT and surfaces whether the domain
+ * publishes a BIMI record, whether a logo URL (`l=`) is present, and
+ * whether a Verified Mark Certificate URL (`a=`) is present. Posture-only
+ * — we deliberately do NOT fetch the SVG logo or the VMC certificate; the
+ * dashboard surfaces only "configured / configured-with-vmc / not configured /
+ * unavailable".
+ *
+ * Mirrors the DoH + KV + 1500ms-cap pattern from `workers/dmarc/txt.ts`.
+ *
+ * Issue: #166 (carve-out from #156, item 4).
+ */
+
+/** Parsed `{configured, hasLogo, hasVmc}` from `default._bimi.<domain>`.
+ * `null` fields signal "unavailable" — same affordance as the DMARC posture
+ * sentinel, so a timeout / DNS error / NXDOMAIN all surface the same UI. */
+export interface BimiPosture {
+	configured: boolean | null;
+	hasLogo: boolean | null;
+	hasVmc: boolean | null;
+}
+
+/** Sentinel for "unavailable / lookup failed / no record". */
+export function emptyBimiPosture(): BimiPosture {
+	return { configured: null, hasLogo: null, hasVmc: null };
+}
+
+const KV_PREFIX = "bimi:v1:";
+/** Short TTL — BIMI records change infrequently but there's no cache buster
+ * (unlike MTA-STS's policy `id`), so we re-resolve every hour. Negative cache
+ * uses the same TTL since BIMI publishing is uncommon and a longer negative
+ * cache would slow first-publish discovery. */
+const KV_TTL_S = 60 * 60;
+/** DoH resolver host. Hostname-based mock matching is required by repo CLAUDE.md. */
+const DOH_HOST = "cloudflare-dns.com";
+const DOH_URL = `https://${DOH_HOST}/dns-query`;
+/** Hard cap matches `workers/dmarc/txt.ts`. */
+const DOH_TIMEOUT_MS = 1500;
+
+/** Minimal `KVNamespace` view we depend on; lets tests pass a fake. */
+export interface BimiKv {
+	get(key: string, type: "json"): Promise<unknown>;
+	put(
+		key: string,
+		value: string,
+		options?: { expirationTtl?: number },
+	): Promise<void>;
+}
+
+/** Minimal `fetch` view we depend on; lets tests inject a stub. */
+export type BimiFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Parse a `default._bimi.<domain>` TXT-record string into `{configured,
+ * hasLogo, hasVmc}`. Only records starting with `v=BIMI1` are considered.
+ * Tags are `;`-separated `name=value` pairs; we look for `l=` (logo URL)
+ * and `a=` (VMC URL).
+ *
+ * BIMI Group's published spec calls these tags `l` (location) and `a`
+ * (authority). An empty value (`l=`) is treated as "not present" — the
+ * spec allows the operator to publish an "indicator-not-supported" record
+ * with empty `l`, which is intent to NOT show a brand indicator.
+ */
+export function parseBimiTxt(record: string): BimiPosture | null {
+	if (typeof record !== "string") return null;
+	const trimmed = record.trim();
+	if (!trimmed) return null;
+	const tags = new Map<string, string>();
+	for (const part of trimmed.split(";")) {
+		const eq = part.indexOf("=");
+		if (eq < 0) continue;
+		const name = part.slice(0, eq).trim().toLowerCase();
+		const value = part.slice(eq + 1).trim();
+		if (!name) continue;
+		// First-wins, mirroring the DMARC and MTA-STS parsers.
+		if (!tags.has(name)) tags.set(name, value);
+	}
+	if (tags.get("v") !== "BIMI1") return null;
+	const lRaw = tags.get("l");
+	const aRaw = tags.get("a");
+	const hasLogo = typeof lRaw === "string" && lRaw.length > 0;
+	const hasVmc = typeof aRaw === "string" && aRaw.length > 0;
+	return { configured: true, hasLogo, hasVmc };
+}
+
+/**
+ * Pick the BIMI policy record from a list of TXT strings published at
+ * `default._bimi.<domain>`. Returns null when no `v=BIMI1` record exists.
+ */
+export function selectBimiRecord(records: readonly string[]): string | null {
+	for (const r of records) {
+		if (typeof r !== "string") continue;
+		const t = r.trim();
+		if (/^v\s*=\s*BIMI1\b/i.test(t)) return t;
+	}
+	return null;
+}
+
+/**
+ * Strip surrounding quotes and concatenate multi-string TXT-record fragments
+ * DoH returns. Same logic as `workers/dmarc/txt.ts:normalizeDohTxtData` —
+ * duplicated to keep the BIMI module decoupled from the DMARC API surface.
+ */
+export function normalizeDohTxtData(data: string): string {
+	if (typeof data !== "string") return "";
+	const matches = [...data.matchAll(/"((?:[^"\\]|\\.)*)"/g)];
+	if (matches.length === 0) {
+		return data.replace(/^"|"$/g, "");
+	}
+	return matches.map((m) => m[1]).join("");
+}
+
+/**
+ * Fetch and parse the BIMI posture for `<domain>`, with KV caching.
+ *
+ * Cache holds positive and negative results under the same key with the same
+ * short TTL — there's no published cache buster like MTA-STS's `id`, so we
+ * rely on the TTL alone. A failed upstream (timeout, non-200, malformed JSON,
+ * no `v=BIMI1` record) degrades to the all-null sentinel; the caller should
+ * treat this as best-effort and not fail the surrounding request.
+ */
+export async function fetchBimiPosture(
+	domain: string,
+	options: {
+		kv?: BimiKv | null;
+		fetchImpl?: BimiFetch;
+	} = {},
+): Promise<BimiPosture> {
+	if (!domain || typeof domain !== "string") return emptyBimiPosture();
+	const fetchImpl = options.fetchImpl ?? (globalThis.fetch as BimiFetch);
+	const kv = options.kv ?? null;
+	const cacheKey = `${KV_PREFIX}${domain}`;
+
+	if (kv) {
+		try {
+			const cached = await kv.get(cacheKey, "json");
+			if (cached && typeof cached === "object") {
+				return coerceBimiPosture(cached);
+			}
+		} catch {
+			// KV read failure is non-fatal; fall through to a fresh DoH lookup.
+		}
+	}
+
+	const posture = await resolveBimiTxt(domain, fetchImpl);
+
+	if (kv) {
+		void kv
+			.put(cacheKey, JSON.stringify(posture), { expirationTtl: KV_TTL_S })
+			.catch(() => {});
+	}
+
+	return posture;
+}
+
+async function resolveBimiTxt(
+	domain: string,
+	fetchImpl: BimiFetch,
+): Promise<BimiPosture> {
+	const name = `default._bimi.${domain}`;
+	let res: Response;
+	try {
+		res = await fetchImpl(
+			`${DOH_URL}?name=${encodeURIComponent(name)}&type=TXT`,
+			{
+				headers: { accept: "application/dns-json" },
+				signal: AbortSignal.timeout(DOH_TIMEOUT_MS),
+			},
+		);
+	} catch {
+		return emptyBimiPosture();
+	}
+	if (!res.ok) return emptyBimiPosture();
+	let body: unknown;
+	try {
+		body = await res.json();
+	} catch {
+		return emptyBimiPosture();
+	}
+	const answer = (body as { Answer?: Array<{ type?: number; data?: unknown }> })
+		.Answer;
+	if (!Array.isArray(answer)) return emptyBimiPosture();
+	const txts: string[] = [];
+	for (const a of answer) {
+		// TXT records are type=16 in DoH JSON.
+		if (a.type !== 16) continue;
+		if (typeof a.data !== "string") continue;
+		txts.push(normalizeDohTxtData(a.data));
+	}
+	const record = selectBimiRecord(txts);
+	if (!record) {
+		// Distinguish "no record" (configured=false) from "lookup unavailable"
+		// (configured=null). The all-null sentinel is for the latter.
+		return { configured: false, hasLogo: false, hasVmc: false };
+	}
+	const parsed = parseBimiTxt(record);
+	return parsed ?? emptyBimiPosture();
+}
+
+function coerceBimiPosture(value: unknown): BimiPosture {
+	if (!value || typeof value !== "object") return emptyBimiPosture();
+	const v = value as { configured?: unknown; hasLogo?: unknown; hasVmc?: unknown };
+	return {
+		configured: typeof v.configured === "boolean" ? v.configured : null,
+		hasLogo: typeof v.hasLogo === "boolean" ? v.hasLogo : null,
+		hasVmc: typeof v.hasVmc === "boolean" ? v.hasVmc : null,
+	};
+}

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -55,6 +55,7 @@ import {
 } from "./lib/dashboard-aggregation";
 import { emptyDmarcTxtPosture, fetchDmarcTxtPosture } from "./dmarc/txt";
 import { emptyMtaStsPosture, fetchMtaStsPosture } from "./mta-sts/posture";
+import { emptyBimiPosture, fetchBimiPosture } from "./bimi/posture";
 import { listTextModels } from "./lib/text-models";
 import { fetchHubCorroborationCount } from "./intel/hub-corroboration";
 import { loadHubCredentials } from "./lib/hub-config";
@@ -309,14 +310,23 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 	const mtaStsPromise = fetchMtaStsPosture(domain, {
 		kv: c.env.BLOOM_KV ?? null,
 	});
+	const bimiPromise = fetchBimiPosture(domain, {
+		kv: c.env.BLOOM_KV ?? null,
+	});
 
-	const [settledSummaries, settledAlignments, settledTxt, settledMtaSts] =
-		await Promise.all([
-			Promise.allSettled(summaryPromises),
-			Promise.allSettled(alignmentPromises),
-			Promise.allSettled([txtPromise]),
-			Promise.allSettled([mtaStsPromise]),
-		]);
+	const [
+		settledSummaries,
+		settledAlignments,
+		settledTxt,
+		settledMtaSts,
+		settledBimi,
+	] = await Promise.all([
+		Promise.allSettled(summaryPromises),
+		Promise.allSettled(alignmentPromises),
+		Promise.allSettled([txtPromise]),
+		Promise.allSettled([mtaStsPromise]),
+		Promise.allSettled([bimiPromise]),
+	]);
 
 	const summaries: Array<DomainMailboxSummary | null> = settledSummaries.map((r) => {
 		if (r.status !== "fulfilled") {
@@ -355,6 +365,11 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 			? settledMtaSts[0].value
 			: emptyMtaStsPosture();
 
+	const bimiPosture =
+		settledBimi[0].status === "fulfilled"
+			? settledBimi[0].value
+			: emptyBimiPosture();
+
 	const mailboxRefs: DomainMailboxRef[] = scoped.map((m) => ({
 		id: m.id,
 		email: m.email,
@@ -367,6 +382,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		summaries,
 		dmarcPosture,
 		mtaStsPosture,
+		bimiPosture,
 	});
 	// `aggregateDomainStats` only returns null when `mailboxes.length === 0`,
 	// which we already guarded above with the 404 — but narrow the type

--- a/workers/lib/dashboard-aggregation.ts
+++ b/workers/lib/dashboard-aggregation.ts
@@ -433,6 +433,15 @@ export interface MtaStsPostureView {
 	id: string | null;
 }
 
+/** BIMI posture (#166). `configured=null` is "lookup unavailable",
+ * `configured=false` is "no `v=BIMI1` record exists". `hasLogo`/`hasVmc`
+ * track whether the `l=` / `a=` tags carry non-empty URLs. */
+export interface BimiPostureView {
+	configured: boolean | null;
+	hasLogo: boolean | null;
+	hasVmc: boolean | null;
+}
+
 export interface DomainListEntry {
 	domain: string;
 	mailboxesCount: number;
@@ -459,6 +468,9 @@ export interface DomainStats {
 	/** MTA-STS posture (#165). All-null when the upstream lookup failed or
 	 * the domain doesn't publish a policy. */
 	mtaStsPosture: MtaStsPostureView;
+	/** BIMI posture (#166). All-null when the upstream lookup failed; a
+	 * `configured: false` posture means "no `v=BIMI1` record published". */
+	bimiPosture: BimiPostureView;
 	recentCases: DomainRecentCase[];
 }
 
@@ -501,6 +513,12 @@ export function emptyDmarcPosture(): DmarcPosture {
  * "not configured / unavailable" (same affordance as DMARC). */
 export function emptyMtaStsPostureView(): MtaStsPostureView {
 	return { mode: null, mx: null, maxAge: null, id: null };
+}
+
+/** Empty BIMI posture sentinel — `configured=null` distinguishes "lookup
+ * unavailable" from a `configured=false` "no record published" result. */
+export function emptyBimiPostureView(): BimiPostureView {
+	return { configured: null, hasLogo: null, hasVmc: null };
 }
 
 /** Per-mailbox alignment totals harvested from `dmarc_records` by the DO.
@@ -627,6 +645,11 @@ interface AggregateDomainStatsInput {
 	 * the published policy file. Omitted defaults to the all-null sentinel.
 	 */
 	mtaStsPosture?: MtaStsPostureView;
+	/**
+	 * BIMI posture (#166) from the `default._bimi.<domain>` DoH lookup.
+	 * Omitted defaults to the all-null sentinel.
+	 */
+	bimiPosture?: BimiPostureView;
 }
 
 /**
@@ -685,6 +708,7 @@ export function aggregateDomainStats(
 		verdictMix,
 		dmarcPosture: input.dmarcPosture ?? emptyDmarcPosture(),
 		mtaStsPosture: input.mtaStsPosture ?? emptyMtaStsPostureView(),
+		bimiPosture: input.bimiPosture ?? emptyBimiPostureView(),
 		recentCases: recentCases.slice(0, 5),
 	};
 }


### PR DESCRIPTION
## Summary

- Adds `workers/bimi/posture.ts` (`fetchBimiPosture`) — DoH lookup for `default._bimi.<domain>` TXT. 1500ms hard cap; KV cache key `bimi:v1:<domain>` with 1h TTL.
- Posture-only: surfaces `configured` / `hasLogo` / `hasVmc` from the `v=BIMI1`, `l=`, `a=` tags. Does NOT fetch the SVG logo or VMC certificate.
- Threads `bimiPosture: BimiPostureView` through `aggregateDomainStats` and renders a card on `/domains/:domain`.
- `configured: false` (no record) and `configured: null` (lookup unavailable) get distinct affordances on the domain detail page.
- Test mocks parse URLs (`new URL(url).hostname`); never substring (CodeQL `js/incomplete-url-substring-sanitization`).

Closes #166.

## Test plan

- [x] `npm test` — 409 passing, 0 failing across worker/lib tests; 20 pre-existing jsdom-not-installed errors in `tests/frontend/*` (same as on `main`).
- [x] `npm run typecheck` clean for all touched files; the only `error TS` lines are the same pre-existing `tests/frontend/*` errors that exist on `main`.
- [x] New tests cover: BIMI1 with logo+VMC / logo-only / empty `l=` / non-BIMI / no-record (`configured: false`) / DoH 5xx / DoH timeout / DoH non-JSON / case-insensitive tags / multi-string TXT / KV cache hit / KV write-on-miss.

## Acceptance items shipped

- [x] `workers/bimi/posture.ts` resolves `default._bimi.<domain>` and parses `v`, `l`, `a` tags.
- [x] Result cached in KV with short TTL; negative-cache too (the same key holds either positive or `configured: false` results).
- [x] `/domains/:domain` renders a BIMI tile with one of: "configured", "configured (with VMC)", "not configured", "unavailable".
- [x] Tests cover: `v=BIMI1; l=...; a=...`, `v=BIMI1; l=...` (no VMC), missing record, malformed tag, timeout. Mocks use `new URL(...).hostname` matching.
- [x] README.md Security section mentions BIMI visibility.

## Out of scope (per issue)

- Rendering the SVG logo (inbox UI concern).
- Validating the VMC certificate chain.
- BIMI-3 (VMC-required) enforcement signal.

## Stacking note

This is independent of PR #178 (MTA-STS posture, #165). Both extend the `aggregateDomainStats` input and add a posture card to the same `<div className="grid gap-4 lg:grid-cols-3">` layout block on `domain-detail.tsx`. There may be a small textual conflict in `dashboard-aggregation.ts` and `domain-detail.tsx` if both land — the second to merge needs a quick rebase. Both branches are stacked on `main`, not on each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)