### PR TITLE
chore(domains): add q-r.contact and donthype.me to DOMAINS

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,7 @@
 		// Production deploys must also define POLICY_AUD and TEAM_DOMAIN.
 		// TEAM_DOMAIN may be the base Access URL or the full /cdn-cgi/access/certs URL.
 		// The worker now fails closed outside local development if Access is not configured.
-		"DOMAINS": "cortech.online,dmarc.mx",
+		"DOMAINS": "cortech.online,dmarc.mx,q-r.contact,donthype.me",
 		"EMAIL_ADDRESSES": []
 	},
 	"send_email": [


### PR DESCRIPTION
## Summary
- Adds `q-r.contact` and `donthype.me` to the worker's `DOMAINS` var in [wrangler.jsonc:16](../blob/main/wrangler.jsonc#L16) so mailboxes on those domains are accepted.

## Follow-up still required per domain
Per the [README two-domain test](../blob/main/README.md#two-domain-end-to-end-test), the new domains also need:
1. Email Routing enabled with a catch-all forwarding to this Worker.
2. Domain (or specific MAIL FROM addresses) verified under **Email → Email Service** so `send_email` can send from it.
3. A mailbox created in the app.

## Test plan
- [ ] `wrangler deploy` picks up the new `DOMAINS` value
- [ ] Create a mailbox on each new domain after Email Routing + Email Service are configured
- [ ] Inbound test message lands in the new mailbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)