### PR TITLE
fix(ui): wire manual case dialog to backend

### DIFF
--- a/app/components/CreateCaseModal.tsx
+++ b/app/components/CreateCaseModal.tsx
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Manual case creation dialog (issue #190).
+ *
+ * The "+ Manual case" button on `/mailbox/:mailboxId/cases` opens this
+ * dialog. Submitting POSTs to the existing endpoint
+ *   `POST /api/v1/mailboxes/:mailboxId/cases`
+ * which validates against `CreateCaseBody` (workers/routes/cases.ts:29):
+ *
+ *   { title (req), notes?, emailId?, observables?, score? }
+ *
+ * v1 surfaces only `title`, `notes`, and `emailId`. `observables` and
+ * `score` are intentionally deferred — the worker accepts them, but the
+ * UI for repeating observable kind/value pairs is its own design problem
+ * and `score` is auto-derived from the originating email's verdict on
+ * the report-phish path. New manual cases land at status `"open"` —
+ * that's hardcoded in the DO's `createCase` impl, not exposed on the
+ * schema, so we don't render a status `<select>`.
+ *
+ * Validation errors are surfaced field-by-field from the worker's
+ * `parsed.error.flatten().fieldErrors` shape. Network / 500-class
+ * failures fall back to a generic toast via `useFeedback`.
+ */
+
+import { Button, Dialog, Input, Text } from "@cloudflare/kumo";
+import { type FormEvent, useCallback, useEffect, useState } from "react";
+import { useFeedback } from "~/lib/feedback";
+
+export interface CreateCaseModalProps {
+	open: boolean;
+	mailboxId: string | undefined;
+	onOpenChange: (open: boolean) => void;
+	/**
+	 * Called after a successful POST. The cases list page uses this to
+	 * bump a `refreshKey` so its `useEffect` re-fetches, and to flip the
+	 * visible tab to "open" so the new case is visible (it's hardcoded
+	 * to "open" by the worker). No id is passed: the list refetch is the
+	 * source of truth for what showed up.
+	 */
+	onCreated: () => void;
+}
+
+type FieldErrors = Partial<Record<"title" | "notes" | "emailId", string>>;
+
+export default function CreateCaseModal({
+	open,
+	mailboxId,
+	onOpenChange,
+	onCreated,
+}: CreateCaseModalProps) {
+	const feedback = useFeedback();
+	const [title, setTitle] = useState("");
+	const [notes, setNotes] = useState("");
+	const [emailId, setEmailId] = useState("");
+	const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+	const [submitting, setSubmitting] = useState(false);
+
+	const reset = useCallback(() => {
+		setTitle("");
+		setNotes("");
+		setEmailId("");
+		setFieldErrors({});
+		setSubmitting(false);
+	}, []);
+
+	const handleOpenChange = useCallback(
+		(next: boolean) => {
+			if (!next) reset();
+			onOpenChange(next);
+		},
+		[onOpenChange, reset],
+	);
+
+	// External `open=false` (e.g. parent closed it) should also reset.
+	useEffect(() => {
+		if (!open) reset();
+		// `reset` is stable; dep on `open` only.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [open]);
+
+	const handleSubmit = async (e: FormEvent) => {
+		e.preventDefault();
+		if (!mailboxId || submitting) return;
+		setFieldErrors({});
+
+		const body: Record<string, unknown> = { title: title.trim() };
+		const trimmedNotes = notes.trim();
+		if (trimmedNotes) body.notes = trimmedNotes;
+		const trimmedEmailId = emailId.trim();
+		if (trimmedEmailId) body.emailId = trimmedEmailId;
+
+		setSubmitting(true);
+		try {
+			const res = await fetch(
+				`/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/cases`,
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(body),
+				},
+			);
+			if (res.status === 400) {
+				// Zod safeParse failure → render field-by-field, NOT a
+				// generic toast (acceptance criterion).
+				const errBody = (await res
+					.json()
+					.catch(() => null)) as
+					| { error?: { fieldErrors?: Record<string, string[]> } }
+					| null;
+				const fe = errBody?.error?.fieldErrors ?? {};
+				setFieldErrors({
+					title: fe.title?.[0],
+					notes: fe.notes?.[0],
+					emailId: fe.emailId?.[0],
+				});
+				setSubmitting(false);
+				return;
+			}
+			if (!res.ok) {
+				feedback.error("Failed to create case");
+				setSubmitting(false);
+				return;
+			}
+			// Drain the body so the response is consumed cleanly.
+			await res.json().catch(() => null);
+			feedback.success("Case created");
+			reset();
+			onOpenChange(false);
+			onCreated();
+		} catch {
+			feedback.error("Failed to create case");
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<Dialog.Root open={open} onOpenChange={handleOpenChange}>
+			<Dialog size="sm" className="p-6">
+				<Dialog.Title className="text-base font-semibold mb-1">
+					Create manual case
+				</Dialog.Title>
+				<Dialog.Description className="text-ink-3 text-sm mb-5">
+					Open a case unattached to a specific email. New cases start
+					with status <strong className="text-ink">open</strong>.
+				</Dialog.Description>
+				<form onSubmit={handleSubmit} className="space-y-4">
+					<div>
+						<Input
+							label="Title"
+							placeholder="e.g. Reported wire-transfer phish from finance@..."
+							size="sm"
+							value={title}
+							onChange={(e) => setTitle(e.target.value)}
+							required
+							maxLength={500}
+							aria-invalid={fieldErrors.title ? true : undefined}
+						/>
+						{fieldErrors.title ? (
+							<Text variant="error" size="sm">
+								{fieldErrors.title}
+							</Text>
+						) : null}
+					</div>
+					<div>
+						<span className="text-sm font-medium text-ink mb-1.5 block">
+							Notes (optional)
+						</span>
+						<textarea
+							aria-label="Notes"
+							placeholder="Context, links, what you've already done…"
+							rows={4}
+							className="w-full rounded-md border border-line bg-paper px-3 py-2 text-[13px] text-ink placeholder:text-ink-3 focus:outline-none focus:border-line-strong"
+							value={notes}
+							onChange={(e) => setNotes(e.target.value)}
+						/>
+						{fieldErrors.notes ? (
+							<Text variant="error" size="sm">
+								{fieldErrors.notes}
+							</Text>
+						) : null}
+					</div>
+					<div>
+						<Input
+							label="Linked email ID (optional)"
+							placeholder="email_…"
+							size="sm"
+							value={emailId}
+							onChange={(e) => setEmailId(e.target.value)}
+							aria-invalid={fieldErrors.emailId ? true : undefined}
+						/>
+						{fieldErrors.emailId ? (
+							<Text variant="error" size="sm">
+								{fieldErrors.emailId}
+							</Text>
+						) : null}
+					</div>
+					<div className="flex justify-end gap-2 pt-2">
+						<Dialog.Close
+							render={(props) => (
+								<Button
+									{...props}
+									variant="secondary"
+									size="sm"
+									type="button"
+								>
+									Cancel
+								</Button>
+							)}
+						/>
+						<Button
+							type="submit"
+							variant="primary"
+							size="sm"
+							loading={submitting}
+							disabled={!title.trim() || !mailboxId}
+						>
+							Create case
+						</Button>
+					</div>
+				</form>
+			</Dialog>
+		</Dialog.Root>
+	);
+}

--- a/app/routes/cases.tsx
+++ b/app/routes/cases.tsx
@@ -3,8 +3,9 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 import { CaretRightIcon, PlusIcon } from "@phosphor-icons/react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "react-router";
+import CreateCaseModal from "~/components/CreateCaseModal";
 import VerdictPill from "~/components/phishsoc/VerdictPill";
 import { statusLabel, statusTone } from "~/components/phishsoc/verdict";
 
@@ -43,6 +44,10 @@ export default function CasesRoute() {
 	const [cases, setCases] = useState<CaseRow[] | null>(null);
 	const [tab, setTab] = useState<string>("open");
 	const [error, setError] = useState<string | null>(null);
+	const [createOpen, setCreateOpen] = useState(false);
+	// Bumped on successful manual-case create so both fetch effects re-run
+	// without a route-level refactor to react-query (issue #190 — UI-only).
+	const [refreshKey, setRefreshKey] = useState(0);
 
 	useEffect(() => {
 		if (!mailboxId) return;
@@ -59,7 +64,7 @@ export default function CasesRoute() {
 				setError("Failed to load cases");
 				setCases([]);
 			});
-	}, [mailboxId, tab]);
+	}, [mailboxId, tab, refreshKey]);
 
 	// Counts for the tab strip — derived from a separate fetch of the full list
 	// so the counts don't drop to zero when the user filters.
@@ -71,6 +76,15 @@ export default function CasesRoute() {
 			.then((r) => setAllCases(r.cases))
 			.catch(() => setAllCases([]));
 	}, [mailboxId, cases]);
+
+	const handleCreated = useCallback(() => {
+		// New cases land at status "open" (DO hardcodes it). Flip the
+		// active tab so the just-created case is visible no matter which
+		// tab the user was on, then bump the refresh key so the list and
+		// counts effects both re-run.
+		setTab("open");
+		setRefreshKey((k) => k + 1);
+	}, []);
 
 	const counts = useMemo(() => {
 		const out: Record<string, number> = { open: 0, "closed-tp": 0, "closed-fp": 0, all: allCases.length };
@@ -94,12 +108,20 @@ export default function CasesRoute() {
 				</div>
 				<button
 					type="button"
+					onClick={() => setCreateOpen(true)}
 					className="inline-flex items-center gap-1.5 rounded-md bg-paper border border-line px-3 py-1.5 text-[13px] text-ink hover:bg-paper-2 transition-colors"
 				>
 					<PlusIcon size={14} />
 					Manual case
 				</button>
 			</div>
+
+			<CreateCaseModal
+				open={createOpen}
+				mailboxId={mailboxId}
+				onOpenChange={setCreateOpen}
+				onCreated={handleCreated}
+			/>
 
 			{/* Filter bar — segmented status tabs. */}
 			<div className="flex items-center gap-1 mb-5 border-b border-line">

--- a/tests/frontend/cases-create-modal.test.tsx
+++ b/tests/frontend/cases-create-modal.test.tsx
@@ -1,0 +1,301 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Frontend tests for the manual-case create dialog (issue #190).
+ *
+ * Covers the acceptance criteria:
+ *   - Clicking "+ Manual case" opens the dialog.
+ *   - Submit a valid case → POST hits the worker endpoint, dialog
+ *     closes, the cases list re-fetches, and the new case appears.
+ *   - Submit an invalid case → field-level error renders inline,
+ *     dialog stays open.
+ *
+ * Mock fetch dispatcher matches by parsed URL (`new URL(url).hostname`)
+ * per the repo CLAUDE.md "URL host checks in test mocks must parse, not
+ * substring" rule that gates CodeQL.
+ */
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+
+import CasesRoute from "~/routes/cases";
+import { renderWithProviders } from "./test-utils";
+
+interface CaseRow {
+	id: string;
+	created_at: string;
+	updated_at: string;
+	status: string;
+	title: string;
+	shared_to_hub: number;
+}
+
+const baseCase = (over: Partial<CaseRow> = {}): CaseRow => ({
+	id: "case_initial",
+	created_at: "2026-04-29T11:00:00Z",
+	updated_at: "2026-04-29T11:30:00Z",
+	status: "open",
+	title: "Initial open case",
+	shared_to_hub: 0,
+	...over,
+});
+
+/**
+ * Build a fetch mock keyed on the request's parsed URL + method. Tests
+ * mutate `state.cases` and `state.lastPostBody` via the returned helpers.
+ *
+ * jsdom requires absolute URLs for `new URL(...)`; the route fetches
+ * relative paths, so we construct against `window.location.origin`.
+ */
+function installFetchMock() {
+	const state: {
+		cases: CaseRow[];
+		lastPostBody: unknown;
+		nextPostResponse:
+			| { kind: "ok"; id: string }
+			| { kind: "validation"; fieldErrors: Record<string, string[]> }
+			| { kind: "server-error" };
+	} = {
+		cases: [baseCase()],
+		lastPostBody: null,
+		nextPostResponse: { kind: "ok", id: "case_new" },
+	};
+
+	const fetchMock = vi.fn(
+		async (input: string | URL | Request, init?: RequestInit) => {
+			const rawUrl =
+				typeof input === "string"
+					? input
+					: input instanceof URL
+						? input.href
+						: input.url;
+			// Resolve relative URLs against the test origin so URL.parse works.
+			const origin =
+				typeof window !== "undefined" && window.location
+					? window.location.origin
+					: "http://localhost";
+			const u = new URL(rawUrl, origin);
+			const method = (init?.method ?? "GET").toUpperCase();
+
+			// Only the local app origin is in play; assert it matches so a
+			// mistakenly-absolute URL doesn't slip past the dispatcher.
+			if (u.hostname !== new URL(origin).hostname) {
+				throw new Error(`unexpected hostname: ${u.hostname}`);
+			}
+
+			// `GET /api/v1/mailboxes/:id/cases[?status=…]`
+			if (
+				method === "GET" &&
+				u.pathname.startsWith("/api/v1/mailboxes/") &&
+				u.pathname.endsWith("/cases")
+			) {
+				const status = u.searchParams.get("status");
+				const filtered = status
+					? state.cases.filter((c) => c.status === status)
+					: state.cases;
+				return new Response(JSON.stringify({ cases: filtered }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+
+			// `POST /api/v1/mailboxes/:id/cases`
+			if (
+				method === "POST" &&
+				u.pathname.startsWith("/api/v1/mailboxes/") &&
+				u.pathname.endsWith("/cases")
+			) {
+				state.lastPostBody = init?.body
+					? JSON.parse(init.body as string)
+					: null;
+				const next = state.nextPostResponse;
+				if (next.kind === "ok") {
+					// Insert the new case so the post-create refetch surfaces it.
+					state.cases = [
+						{
+							id: next.id,
+							created_at: "2026-05-03T12:00:00Z",
+							updated_at: "2026-05-03T12:00:00Z",
+							status: "open",
+							title:
+								(state.lastPostBody as { title?: string } | null)?.title ??
+								"(no title)",
+							shared_to_hub: 0,
+						},
+						...state.cases,
+					];
+					return new Response(JSON.stringify({ id: next.id }), {
+						status: 201,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				if (next.kind === "validation") {
+					return new Response(
+						JSON.stringify({
+							error: {
+								formErrors: [],
+								fieldErrors: next.fieldErrors,
+							},
+						}),
+						{
+							status: 400,
+							headers: { "Content-Type": "application/json" },
+						},
+					);
+				}
+				return new Response(JSON.stringify({ error: "boom" }), {
+					status: 500,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+
+			throw new Error(`unhandled fetch: ${method} ${u.pathname}`);
+		},
+	);
+
+	vi.stubGlobal("fetch", fetchMock);
+	return { state, fetchMock };
+}
+
+function renderCases() {
+	return renderWithProviders(
+		<Routes>
+			<Route path="/mailbox/:mailboxId/cases" element={<CasesRoute />} />
+		</Routes>,
+		{ initialEntries: ["/mailbox/m1/cases"] },
+	);
+}
+
+describe("CasesRoute manual-case dialog (issue #190)", () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
+
+	it("clicking '+ Manual case' opens the dialog with title/notes/email-id fields", async () => {
+		installFetchMock();
+		renderCases();
+
+		// Initial list rendered. The route renders desktop + mobile lists
+		// simultaneously, so the title appears twice — assert on the
+		// count rather than `findByText`.
+		const initial = await screen.findAllByText(/Initial open case/i);
+		expect(initial.length).toBeGreaterThan(0);
+
+		// Dialog not yet in the DOM. Match by the modal's unique title;
+		// kumo's <Toasty> region also has role="dialog", so a generic
+		// role query is too broad here.
+		expect(screen.queryByText(/create manual case/i)).toBeNull();
+
+		await userEvent.click(
+			screen.getByRole("button", { name: /manual case/i }),
+		);
+
+		// Dialog open with the schema-derived fields.
+		expect(
+			await screen.findByText(/create manual case/i),
+		).toBeInTheDocument();
+		expect(screen.getByLabelText(/^title$/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/^notes$/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/linked email id/i)).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /^create case$/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /^cancel$/i }),
+		).toBeInTheDocument();
+	});
+
+	it("submitting a valid case POSTs, closes the dialog, and the new case shows in the list", async () => {
+		const { state } = installFetchMock();
+		renderCases();
+
+		// Wait for initial render.
+		await screen.findAllByText(/Initial open case/i);
+
+		// Open dialog.
+		await userEvent.click(
+			screen.getByRole("button", { name: /manual case/i }),
+		);
+		await screen.findByText(/create manual case/i);
+
+		// Fill and submit.
+		await userEvent.type(
+			screen.getByLabelText(/^title$/i),
+			"Suspicious gift-card scam",
+		);
+		await userEvent.type(
+			screen.getByLabelText(/^notes$/i),
+			"Forwarded by user@example.com",
+		);
+		await userEvent.click(
+			screen.getByRole("button", { name: /^create case$/i }),
+		);
+
+		// Worker received the right body. `notes` populated; `emailId`
+		// omitted because it was blank.
+		await waitFor(() => {
+			expect(state.lastPostBody).toEqual({
+				title: "Suspicious gift-card scam",
+				notes: "Forwarded by user@example.com",
+			});
+		});
+
+		// Dialog closed. Note: kumo's <Toasty> renders each toast inside a
+		// `role="dialog"` element, so we can't query the modal generically
+		// — we check for the modal's title text instead, which is unique
+		// to the manual-case dialog.
+		await waitFor(() => {
+			expect(screen.queryByText(/create manual case/i)).toBeNull();
+		});
+
+		// List refetched and the new case appears (desktop + mobile copies).
+		const matches = await screen.findAllByText(/Suspicious gift-card scam/i);
+		expect(matches.length).toBeGreaterThan(0);
+	});
+
+	it("400 with field errors renders inline error text and keeps the dialog open", async () => {
+		const { state } = installFetchMock();
+		state.nextPostResponse = {
+			kind: "validation",
+			fieldErrors: {
+				title: ["String must contain at most 500 character(s)"],
+			},
+		};
+		renderCases();
+
+		await screen.findAllByText(/Initial open case/i);
+		await userEvent.click(
+			screen.getByRole("button", { name: /manual case/i }),
+		);
+		await screen.findByText(/create manual case/i);
+
+		// Type something that the client allows through but the worker
+		// rejects (mocked above as a max-length error). The point of this
+		// test is the error-rendering path, not the client-side guards.
+		await userEvent.type(
+			screen.getByLabelText(/^title$/i),
+			"a too-long title (mocked rejection)",
+		);
+		await userEvent.click(
+			screen.getByRole("button", { name: /^create case$/i }),
+		);
+
+		// Inline error rendered (NOT a generic toast).
+		expect(
+			await screen.findByText(/at most 500 character/i),
+		).toBeInTheDocument();
+
+		// Dialog still open — user can correct and retry. The "Create
+		// case" submit button only exists inside the modal, so its
+		// presence is a stronger signal than just the title text.
+		expect(
+			screen.getByRole("button", { name: /^create case$/i }),
+		).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary

- Wire the "+ Manual case" button on `/mailbox/:mailboxId/cases` (previously had no `onClick`) to a new kumo `Dialog`. The dialog POSTs to the existing `POST /api/v1/mailboxes/:id/cases` endpoint, surfaces field-level validation errors from the worker's `safeParse` failure (NOT a generic toast), and refetches the cases list on success — flipping the active tab to "open" so the just-created case is visible no matter which tab the user was on.
- v1 collects `title` (required), `notes`, and `emailId` — the required + most-useful optional fields from `CreateCaseBody`. `observables` and `score` are intentionally deferred (their UI shapes are their own design problem; `report-phish` auto-derives `score`). Tracked in #194.
- Tests in `tests/frontend/cases-create-modal.test.tsx` cover the three acceptance scenarios (open, valid submit + refetch + close, invalid submit + inline error). Mock `fetch` dispatcher parses URLs (`new URL(url).hostname` / `.pathname`) per the repo CLAUDE.md "URL host checks must parse, not substring" rule that gates CodeQL.

Closes #190
Part of #191

## Test plan

- [x] `npm test` — 600 passing, 0 failing (3 new tests added)
- [x] `npm run typecheck` — exit 0
- [x] Schema source-of-truth: required field is `title`; v1 surfaces `title` + the two optional inputs most useful for a manual create (`notes`, `emailId`). New cases land at `status: "open"` (DO hardcodes it; not in `CreateCaseBody`).
- [x] Validation errors from the worker render field-by-field (not a toast), per acceptance.
- [x] Esc-to-close, focus trap, Cancel — inherited from kumo's `Dialog.Root` + explicit `Dialog.Close` Cancel button.
- [x] CodeQL gate: mock dispatcher uses parsed-URL host/path checks.

## Deferred follow-ups

- #194 — manual case dialog: add observables editor + score override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)