### PR TITLE
feat(posture): TLS-RPT posture lookup for /domains/:domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The per-domain page (`/domains/:domain`) surfaces published email-auth posture a
 - **MTA-STS** mode/mx/max_age (`_mta-sts.<domain>` TXT + `https://mta-sts.<domain>/.well-known/mta-sts.txt`, cached in KV by policy `id` so a roll auto-invalidates).
 - **BIMI** record presence (`default._bimi.<domain>` TXT — surfaces "configured / configured-with-VMC / not configured / unavailable"; does NOT fetch the SVG logo or VMC certificate).
 - **SPF** posture (`<domain>` TXT for `v=spf1 …` — surfaces mechanism count, `all` qualifier, include count, and a bounded include-chain resolver that flags records exceeding RFC 7208 §4.6.4's 10-DNS-lookup ceiling).
+- **TLS-RPT** posture (`_smtp._tls.<domain>` TXT for `v=TLSRPTv1` — surfaces "TLS reporting configured: yes / no" plus the parsed `rua=` endpoint URLs; posture-only, does NOT ingest inbound TLS-RPT reports here).
 
 ## Architecture
 

--- a/app/routes/domain-detail.tsx
+++ b/app/routes/domain-detail.tsx
@@ -102,6 +102,9 @@ function DomainBody({ data }: { data: DomainStats }) {
 				<BimiPostureCard posture={data.bimiPosture} />
 				<SpfPostureCard posture={data.spfPosture} />
 			</div>
+			<div className="grid gap-4 lg:grid-cols-3">
+				<TlsRptPostureCard posture={data.tlsRptPosture} />
+			</div>
 			<MailboxList mailboxes={data.mailboxes} />
 			{data.recentCases.length > 0 && <RecentCasesList cases={data.recentCases} />}
 		</>
@@ -368,6 +371,59 @@ function SpfPostureCard({
 						}
 					/>
 				</dl>
+			)}
+		</div>
+	);
+}
+
+function TlsRptPostureCard({
+	posture,
+}: { posture: DomainStats["tlsRptPosture"] }) {
+	// Per #168 constraint: "Unavailable" (configured=null) and "genuinely
+	// missing" (configured=false) render the SAME empty-state affordance.
+	// Operators don't need to distinguish "lookup blip" from "no record" at
+	// the tile level — both cases mean the same actionable thing: "publish
+	// a TLS-RPT record". The KV layer still distinguishes the two so a
+	// transient blip doesn't poison the cache for an hour.
+	const notConfigured = posture.configured !== true;
+	const endpoints = posture.endpoints ?? [];
+	return (
+		<div className="pp-card p-5">
+			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-3 flex items-center gap-1.5">
+				<ShieldCheckIcon size={12} />
+				TLS-RPT posture
+			</div>
+			{notConfigured ? (
+				<p className="text-[12.5px] text-ink-3">
+					TLS reporting not configured for this domain (or the lookup was
+					unavailable). Operators publish a `_smtp._tls.&lt;domain&gt;` TXT
+					record like `v=TLSRPTv1; rua=mailto:tlsrpt@&lt;domain&gt;` to enable
+					it.
+				</p>
+			) : (
+				<>
+					<dl className="space-y-1.5 text-[12.5px]">
+						<PostureRow label="reporting" value="configured (v=TLSRPTv1)" />
+						<PostureRow
+							label="endpoints"
+							value={endpoints.length === 0 ? "—" : String(endpoints.length)}
+						/>
+					</dl>
+					{endpoints.length > 0 ? (
+						// Keep the URI list outside the `<dl>` — `<dl>` can only contain
+						// `<dt>`/`<dd>` pairs, and we want the URLs as a flat list.
+						<ul className="space-y-1 mt-2">
+							{endpoints.map((ep) => (
+								<li
+									key={ep}
+									className="pp-mono text-[11px] text-ink-2 break-all"
+								>
+									{ep}
+								</li>
+							))}
+						</ul>
+					) : null}
+				</>
 			)}
 		</div>
 	);

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -278,6 +278,15 @@ export interface SpfPosture {
 	exceedsLimit: boolean | null;
 }
 
+/** TLS-RPT posture (#168). `configured=null` is "lookup unavailable",
+ * `configured=false` is "no `v=TLSRPTv1` record at `_smtp._tls.<domain>`".
+ * `endpoints` is the parsed `rua=` URI list (mailto: / https:); empty list
+ * when the record exists but carries no endpoint. */
+export interface TlsRptPosture {
+	configured: boolean | null;
+	endpoints: readonly string[] | null;
+}
+
 /** One row in the `/api/v1/domains` list. */
 export interface DomainListEntry {
 	domain: string;
@@ -307,6 +316,7 @@ export interface DomainStats {
 	mtaStsPosture: MtaStsPosture;
 	bimiPosture: BimiPosture;
 	spfPosture: SpfPosture;
+	tlsRptPosture: TlsRptPosture;
 	recentCases: DashboardCase[];
 }
 

--- a/tests/frontend/domain-detail.test.tsx
+++ b/tests/frontend/domain-detail.test.tsx
@@ -87,6 +87,10 @@ const populated: DomainStats = {
 		totalLookups: null,
 		exceedsLimit: null,
 	},
+	tlsRptPosture: {
+		configured: null,
+		endpoints: null,
+	},
 	recentCases: [
 		{
 			id: "C1",

--- a/tests/frontend/shell-domain-nav.test.tsx
+++ b/tests/frontend/shell-domain-nav.test.tsx
@@ -81,6 +81,10 @@ const populated: DomainStats = {
 		totalLookups: null,
 		exceedsLimit: null,
 	},
+	tlsRptPosture: {
+		configured: null,
+		endpoints: null,
+	},
 	recentCases: [],
 };
 

--- a/tests/lib/domain-aggregation.test.ts
+++ b/tests/lib/domain-aggregation.test.ts
@@ -405,6 +405,46 @@ describe("aggregateDomainStats", () => {
 		expect(result!.spfPosture.exceedsLimit).toBe(false);
 	});
 
+	it("falls back to the all-null TLS-RPT posture when the handler doesn't supply one (#168)", () => {
+		const result = aggregateDomainStats({
+			domain: "acme.com",
+			mailboxes: [
+				{ id: "alice@acme.com", email: "alice@acme.com", name: "Alice" },
+			],
+			summaries: [domainSummary()],
+			now: NOW.toISOString(),
+		});
+		expect(result!.tlsRptPosture).toEqual({
+			configured: null,
+			endpoints: null,
+		});
+	});
+
+	it("threads a real TLS-RPT posture through unchanged when supplied (#168)", () => {
+		const result = aggregateDomainStats({
+			domain: "acme.com",
+			mailboxes: [
+				{ id: "alice@acme.com", email: "alice@acme.com", name: "Alice" },
+			],
+			summaries: [domainSummary()],
+			now: NOW.toISOString(),
+			tlsRptPosture: {
+				configured: true,
+				endpoints: [
+					"mailto:tlsrpt@acme.com",
+					"https://reports.acme.com/tlsrpt",
+				],
+			},
+		});
+		expect(result!.tlsRptPosture).toEqual({
+			configured: true,
+			endpoints: [
+				"mailto:tlsrpt@acme.com",
+				"https://reports.acme.com/tlsrpt",
+			],
+		});
+	});
+
 	it("tolerates null (failed) summaries as zero contributions", () => {
 		const result = aggregateDomainStats({
 			domain: "acme.com",

--- a/tests/tlsrpt/posture.test.ts
+++ b/tests/tlsrpt/posture.test.ts
@@ -1,0 +1,337 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, expect, it } from "vitest";
+import {
+	emptyTlsRptPosture,
+	fetchTlsRptPosture,
+	normalizeDohTxtData,
+	parseRuaList,
+	parseTlsRptTxt,
+	selectTlsRptRecord,
+	type TlsRptKv,
+} from "../../workers/tlsrpt/posture";
+
+describe("parseTlsRptTxt", () => {
+	it("parses a record with a single mailto rua endpoint", () => {
+		const r = parseTlsRptTxt("v=TLSRPTv1; rua=mailto:tlsrpt@example.com");
+		expect(r).toEqual({
+			configured: true,
+			endpoints: ["mailto:tlsrpt@example.com"],
+		});
+	});
+
+	it("parses a record with a single https rua endpoint", () => {
+		const r = parseTlsRptTxt(
+			"v=TLSRPTv1; rua=https://reports.example.com/tlsrpt",
+		);
+		expect(r).toEqual({
+			configured: true,
+			endpoints: ["https://reports.example.com/tlsrpt"],
+		});
+	});
+
+	it("parses a record with multiple comma-separated rua endpoints", () => {
+		const r = parseTlsRptTxt(
+			"v=TLSRPTv1; rua=mailto:tlsrpt@example.com,https://reports.example.com/tlsrpt",
+		);
+		expect(r).toEqual({
+			configured: true,
+			endpoints: [
+				"mailto:tlsrpt@example.com",
+				"https://reports.example.com/tlsrpt",
+			],
+		});
+	});
+
+	it("treats an empty rua= as 'configured but no endpoint published'", () => {
+		const r = parseTlsRptTxt("v=TLSRPTv1; rua=");
+		expect(r).toEqual({ configured: true, endpoints: [] });
+	});
+
+	it("treats a missing rua tag as configured-but-empty (defensive — not RFC compliant)", () => {
+		// RFC 8460 §3 requires `rua=` on a TLSRPTv1 record, but we don't
+		// gatekeep on that — surfacing "configured: true, endpoints: []"
+		// matches what the operator actually published and lets the UI flag
+		// the misconfig rather than swallowing it.
+		const r = parseTlsRptTxt("v=TLSRPTv1");
+		expect(r).toEqual({ configured: true, endpoints: [] });
+	});
+
+	it("returns null for non-TLSRPTv1 records", () => {
+		expect(parseTlsRptTxt("v=spf1 -all")).toBeNull();
+		expect(parseTlsRptTxt("not even a tag list")).toBeNull();
+		expect(parseTlsRptTxt("")).toBeNull();
+	});
+
+	it("is case-insensitive on tag names", () => {
+		const r = parseTlsRptTxt("V=TLSRPTv1; RUA=mailto:tlsrpt@example.com");
+		expect(r?.endpoints).toEqual(["mailto:tlsrpt@example.com"]);
+	});
+
+	it("ignores duplicate rua tags after the first occurrence", () => {
+		const r = parseTlsRptTxt(
+			"v=TLSRPTv1; rua=mailto:first@example.com; rua=mailto:second@example.com",
+		);
+		expect(r?.endpoints).toEqual(["mailto:first@example.com"]);
+	});
+
+	it("trims whitespace around comma-separated endpoint URIs", () => {
+		const r = parseTlsRptTxt(
+			"v=TLSRPTv1; rua=mailto:tlsrpt@example.com , https://reports.example.com/tlsrpt",
+		);
+		expect(r?.endpoints).toEqual([
+			"mailto:tlsrpt@example.com",
+			"https://reports.example.com/tlsrpt",
+		]);
+	});
+});
+
+describe("parseRuaList", () => {
+	it("returns [] for undefined / empty inputs", () => {
+		expect(parseRuaList(undefined)).toEqual([]);
+		expect(parseRuaList("")).toEqual([]);
+		expect(parseRuaList("   ")).toEqual([]);
+	});
+
+	it("splits on commas and trims whitespace", () => {
+		expect(parseRuaList("mailto:a@x, mailto:b@x  ,  https://r.example/t")).toEqual([
+			"mailto:a@x",
+			"mailto:b@x",
+			"https://r.example/t",
+		]);
+	});
+
+	it("drops empty items produced by trailing commas", () => {
+		expect(parseRuaList("mailto:a@x,,mailto:b@x,")).toEqual([
+			"mailto:a@x",
+			"mailto:b@x",
+		]);
+	});
+});
+
+describe("selectTlsRptRecord", () => {
+	it("picks the v=TLSRPTv1-prefixed record", () => {
+		const r = selectTlsRptRecord([
+			"google-site-verification=abc",
+			"v=TLSRPTv1; rua=mailto:tlsrpt@example.com",
+			"v=spf1 -all",
+		]);
+		expect(r).toBe("v=TLSRPTv1; rua=mailto:tlsrpt@example.com");
+	});
+
+	it("returns null when no TLSRPTv1 record present", () => {
+		expect(selectTlsRptRecord(["v=spf1 -all"])).toBeNull();
+		expect(selectTlsRptRecord([])).toBeNull();
+	});
+
+	it("matches case-insensitively and tolerates whitespace around v=", () => {
+		expect(
+			selectTlsRptRecord(["V = TLSRPTv1; rua=mailto:t@x"]),
+		).toMatch(/TLSRPTv1/);
+	});
+});
+
+describe("normalizeDohTxtData", () => {
+	it("concatenates multi-string TXT-record fragments without inserting whitespace", () => {
+		expect(
+			normalizeDohTxtData(
+				'"v=TLSRPTv1; " "rua=mailto:tlsrpt@example.com"',
+			),
+		).toBe("v=TLSRPTv1; rua=mailto:tlsrpt@example.com");
+	});
+
+	it("strips surrounding quotes from a single-fragment string", () => {
+		expect(normalizeDohTxtData('"v=TLSRPTv1; rua=mailto:t@x"')).toBe(
+			"v=TLSRPTv1; rua=mailto:t@x",
+		);
+	});
+});
+
+// ── DoH integration tests ──────────────────────────────────────────────
+
+function fakeKv(initial: Record<string, unknown> = {}): TlsRptKv & {
+	store: Map<string, string>;
+} {
+	const store = new Map<string, string>();
+	for (const [k, v] of Object.entries(initial)) {
+		store.set(k, JSON.stringify(v));
+	}
+	return {
+		store,
+		async get(key: string, _type: "json") {
+			const raw = store.get(key);
+			return raw ? (JSON.parse(raw) as unknown) : null;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+	};
+}
+
+function dohTxtResponse(records: string[]): Response {
+	return new Response(
+		JSON.stringify({
+			Status: 0,
+			Answer: records.map((data) => ({
+				name: "_smtp._tls.acme.com",
+				type: 16,
+				data,
+			})),
+		}),
+		{ status: 200, headers: { "content-type": "application/dns-json" } },
+	);
+}
+
+describe("fetchTlsRptPosture", () => {
+	it("resolves a configured record over DoH and returns the parsed endpoints", async () => {
+		const fetchImpl = async (url: string) => {
+			// Hostname-based dispatch — substring matching on URLs is a CodeQL
+			// `js/incomplete-url-substring-sanitization` trip wire (repo CLAUDE.md).
+			expect(new URL(url).hostname).toBe("cloudflare-dns.com");
+			return dohTxtResponse([
+				'"v=TLSRPTv1; rua=mailto:tlsrpt@example.com,https://reports.example.com/tlsrpt"',
+			]);
+		};
+		const r = await fetchTlsRptPosture("acme.com", { fetchImpl });
+		expect(r).toEqual({
+			configured: true,
+			endpoints: [
+				"mailto:tlsrpt@example.com",
+				"https://reports.example.com/tlsrpt",
+			],
+		});
+	});
+
+	it("distinguishes 'no record' (configured=false) from 'unavailable' (configured=null)", async () => {
+		// Empty Answer array — durable "no TLSRPTv1 record at this label".
+		const fetchImpl = async () =>
+			new Response(JSON.stringify({ Status: 0, Answer: [] }), { status: 200 });
+		const r = await fetchTlsRptPosture("acme.com", { fetchImpl });
+		expect(r).toEqual({ configured: false, endpoints: [] });
+	});
+
+	it("treats a TXT label with non-TLSRPT entries as 'no record'", async () => {
+		const fetchImpl = async () =>
+			dohTxtResponse(['"some other txt"', '"google-site-verification=abc"']);
+		const r = await fetchTlsRptPosture("acme.com", { fetchImpl });
+		expect(r).toEqual({ configured: false, endpoints: [] });
+	});
+
+	it("returns the empty sentinel when DoH returns non-200", async () => {
+		const fetchImpl = async () => new Response("nope", { status: 500 });
+		const r = await fetchTlsRptPosture("acme.com", { fetchImpl });
+		expect(r).toEqual(emptyTlsRptPosture());
+	});
+
+	it("returns the empty sentinel when fetch rejects (timeout / network)", async () => {
+		// `AbortSignal.timeout(1500)` hits this branch when the upstream is
+		// slow — the caller doesn't differentiate "timed out" from "refused
+		// connection"; both surface as the unavailable sentinel.
+		const fetchImpl = async () => {
+			throw new Error("network");
+		};
+		const r = await fetchTlsRptPosture("acme.com", { fetchImpl });
+		expect(r).toEqual(emptyTlsRptPosture());
+	});
+
+	it("returns the empty sentinel when DoH returns malformed JSON", async () => {
+		const fetchImpl = async () => new Response("<html>", { status: 200 });
+		const r = await fetchTlsRptPosture("acme.com", { fetchImpl });
+		expect(r).toEqual(emptyTlsRptPosture());
+	});
+
+	it("queries the _smtp._tls.<domain> label", async () => {
+		let captured = "";
+		const fetchImpl = async (url: string) => {
+			captured = url;
+			return dohTxtResponse(['"v=TLSRPTv1; rua=mailto:tlsrpt@example.com"']);
+		};
+		await fetchTlsRptPosture("acme.com", { fetchImpl });
+		const u = new URL(captured);
+		expect(u.hostname).toBe("cloudflare-dns.com");
+		expect(u.pathname).toBe("/dns-query");
+		expect(u.searchParams.get("name")).toBe("_smtp._tls.acme.com");
+		expect(u.searchParams.get("type")).toBe("TXT");
+	});
+
+	it("reads from KV cache when a parsed posture is stored", async () => {
+		const kv = fakeKv({
+			"tlsrpt-txt:v1:acme.com": {
+				configured: true,
+				endpoints: ["mailto:tlsrpt@example.com"],
+			},
+		});
+		let calls = 0;
+		const fetchImpl = async () => {
+			calls += 1;
+			return dohTxtResponse(['"v=TLSRPTv1; rua=mailto:other@example.com"']);
+		};
+		const r = await fetchTlsRptPosture("acme.com", { fetchImpl, kv });
+		expect(calls).toBe(0);
+		expect(r).toEqual({
+			configured: true,
+			endpoints: ["mailto:tlsrpt@example.com"],
+		});
+	});
+
+	it("writes the durable-negative posture (configured=false) to KV", async () => {
+		const kv = fakeKv();
+		const fetchImpl = async () =>
+			new Response(JSON.stringify({ Status: 0, Answer: [] }), { status: 200 });
+		await fetchTlsRptPosture("acme.com", { fetchImpl, kv });
+		await new Promise((r) => setTimeout(r, 0));
+		const cached = kv.store.get("tlsrpt-txt:v1:acme.com");
+		expect(cached).toBeDefined();
+		expect(JSON.parse(cached!)).toEqual({
+			configured: false,
+			endpoints: [],
+		});
+	});
+
+	it("does NOT cache the unavailable sentinel (transient errors mustn't poison the cache)", async () => {
+		const kv = fakeKv();
+		const fetchImpl = async () => {
+			throw new Error("network");
+		};
+		const r = await fetchTlsRptPosture("acme.com", { fetchImpl, kv });
+		await new Promise((r) => setTimeout(r, 0));
+		expect(r).toEqual(emptyTlsRptPosture());
+		// A `configured: null` result is transient — caching it for an hour
+		// would mean a one-off DoH blip locks the dashboard into "unavailable"
+		// for every subsequent load. Verify the cache is empty after the call.
+		expect(kv.store.has("tlsrpt-txt:v1:acme.com")).toBe(false);
+	});
+
+	it("writes the resolved posture to KV when configured=true", async () => {
+		const kv = fakeKv();
+		const fetchImpl = async () =>
+			dohTxtResponse(['"v=TLSRPTv1; rua=mailto:tlsrpt@example.com"']);
+		await fetchTlsRptPosture("acme.com", { fetchImpl, kv });
+		await new Promise((r) => setTimeout(r, 0));
+		const cached = kv.store.get("tlsrpt-txt:v1:acme.com");
+		expect(cached).toBeDefined();
+		expect(JSON.parse(cached!)).toEqual({
+			configured: true,
+			endpoints: ["mailto:tlsrpt@example.com"],
+		});
+	});
+
+	it("coerces a malformed cached value back to the empty sentinel", async () => {
+		// A cache poisoning would be cheap to recover from — the posture is
+		// best-effort and re-fetched on KV miss — but coerce shape defensively.
+		const kv = fakeKv({
+			"tlsrpt-txt:v1:acme.com": { configured: "not-a-bool", endpoints: 42 },
+		});
+		let calls = 0;
+		const fetchImpl = async () => {
+			calls += 1;
+			return dohTxtResponse(['"v=TLSRPTv1; rua=mailto:tlsrpt@example.com"']);
+		};
+		const r = await fetchTlsRptPosture("acme.com", { fetchImpl, kv });
+		// Coerced — `configured: null`, `endpoints: null` because the cached
+		// shape was wrong. We do NOT re-fetch in this branch (the cache is
+		// authoritative for "this domain has been resolved recently").
+		expect(calls).toBe(0);
+		expect(r).toEqual({ configured: null, endpoints: null });
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -57,6 +57,7 @@ import { emptyDmarcTxtPosture, fetchDmarcTxtPosture } from "./dmarc/txt";
 import { emptyMtaStsPosture, fetchMtaStsPosture } from "./mta-sts/posture";
 import { emptyBimiPosture, fetchBimiPosture } from "./bimi/posture";
 import { emptySpfPosture, fetchSpfPosture } from "./spf/posture";
+import { emptyTlsRptPosture, fetchTlsRptPosture } from "./tlsrpt/posture";
 import { listTextModels } from "./lib/text-models";
 import { fetchHubCorroborationCount } from "./intel/hub-corroboration";
 import { loadHubCredentials } from "./lib/hub-config";
@@ -317,6 +318,9 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 	const spfPromise = fetchSpfPosture(domain, {
 		kv: c.env.BLOOM_KV ?? null,
 	});
+	const tlsRptPromise = fetchTlsRptPosture(domain, {
+		kv: c.env.BLOOM_KV ?? null,
+	});
 
 	const [
 		settledSummaries,
@@ -325,6 +329,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		settledMtaSts,
 		settledBimi,
 		settledSpf,
+		settledTlsRpt,
 	] = await Promise.all([
 		Promise.allSettled(summaryPromises),
 		Promise.allSettled(alignmentPromises),
@@ -332,6 +337,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		Promise.allSettled([mtaStsPromise]),
 		Promise.allSettled([bimiPromise]),
 		Promise.allSettled([spfPromise]),
+		Promise.allSettled([tlsRptPromise]),
 	]);
 
 	const summaries: Array<DomainMailboxSummary | null> = settledSummaries.map((r) => {
@@ -381,6 +387,11 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 			? settledSpf[0].value
 			: emptySpfPosture();
 
+	const tlsRptPosture =
+		settledTlsRpt[0].status === "fulfilled"
+			? settledTlsRpt[0].value
+			: emptyTlsRptPosture();
+
 	const mailboxRefs: DomainMailboxRef[] = scoped.map((m) => ({
 		id: m.id,
 		email: m.email,
@@ -395,6 +406,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		mtaStsPosture,
 		bimiPosture,
 		spfPosture,
+		tlsRptPosture,
 	});
 	// `aggregateDomainStats` only returns null when `mailboxes.length === 0`,
 	// which we already guarded above with the 404 — but narrow the type

--- a/workers/lib/dashboard-aggregation.ts
+++ b/workers/lib/dashboard-aggregation.ts
@@ -455,6 +455,15 @@ export interface SpfPostureView {
 	exceedsLimit: boolean | null;
 }
 
+/** TLS-RPT posture (#168). `configured=null` is "lookup unavailable",
+ * `configured=false` is "no `v=TLSRPTv1` record at `_smtp._tls.<domain>`".
+ * `endpoints` is the parsed `rua=` URI list (mailto: / https:); empty list
+ * when the record exists but carries no endpoint. */
+export interface TlsRptPostureView {
+	configured: boolean | null;
+	endpoints: readonly string[] | null;
+}
+
 export interface DomainListEntry {
 	domain: string;
 	mailboxesCount: number;
@@ -487,6 +496,9 @@ export interface DomainStats {
 	/** SPF posture (#167). All-null when the upstream lookup failed; the
 	 * bounded include-chain resolver caps DoH calls at MAX_LOOKUPS. */
 	spfPosture: SpfPostureView;
+	/** TLS-RPT posture (#168). `configured: null` when the upstream lookup
+	 * failed; `configured: false` when no `v=TLSRPTv1` record is published. */
+	tlsRptPosture: TlsRptPostureView;
 	recentCases: DomainRecentCase[];
 }
 
@@ -547,6 +559,13 @@ export function emptySpfPostureView(): SpfPostureView {
 		totalLookups: null,
 		exceedsLimit: null,
 	};
+}
+
+/** Empty TLS-RPT posture sentinel — `configured=null` distinguishes
+ * "lookup unavailable" from a `configured=false` "no record published"
+ * result. Mirrors the BIMI sentinel shape. */
+export function emptyTlsRptPostureView(): TlsRptPostureView {
+	return { configured: null, endpoints: null };
 }
 
 /** Per-mailbox alignment totals harvested from `dmarc_records` by the DO.
@@ -683,6 +702,11 @@ interface AggregateDomainStatsInput {
 	 * include-chain resolver. Omitted defaults to the all-null sentinel.
 	 */
 	spfPosture?: SpfPostureView;
+	/**
+	 * TLS-RPT posture (#168) from the `_smtp._tls.<domain>` DoH lookup.
+	 * Omitted defaults to the all-null sentinel.
+	 */
+	tlsRptPosture?: TlsRptPostureView;
 }
 
 /**
@@ -743,6 +767,7 @@ export function aggregateDomainStats(
 		mtaStsPosture: input.mtaStsPosture ?? emptyMtaStsPostureView(),
 		bimiPosture: input.bimiPosture ?? emptyBimiPostureView(),
 		spfPosture: input.spfPosture ?? emptySpfPostureView(),
+		tlsRptPosture: input.tlsRptPosture ?? emptyTlsRptPostureView(),
 		recentCases: recentCases.slice(0, 5),
 	};
 }

--- a/workers/tlsrpt/posture.ts
+++ b/workers/tlsrpt/posture.ts
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * TLS-RPT (RFC 8460) posture lookup.
+ *
+ * Resolves `_smtp._tls.<domain>` TXT and surfaces whether the domain
+ * publishes a `v=TLSRPTv1` record advertising a TLS-RPT collector. The
+ * dashboard renders "TLS reporting configured: yes / no" plus the parsed
+ * `rua=` endpoint list when present.
+ *
+ * Posture-only — we deliberately do NOT POST anything to the published
+ * collector and we do NOT ingest inbound TLS-RPT reports here. Inbound
+ * ingestion is a separate sub-issue from #156.
+ *
+ * Mirrors the DoH + KV + 1500ms-cap pattern from `workers/dmarc/txt.ts`.
+ *
+ * Issue: #168 (carve-out from #156, item 1, posture half).
+ */
+
+/** Parsed `{configured, endpoints}` from `_smtp._tls.<domain>`.
+ *
+ * `configured: null` is the "unavailable / lookup failed" sentinel — same
+ * affordance the rest of the posture cards use for transient DoH errors.
+ * `configured: false` is the durable "no `v=TLSRPTv1` record published"
+ * answer; we cache that under the same TTL as positive results so a
+ * domain that hasn't published TLS-RPT doesn't re-hit DoH on every load.
+ *
+ * `endpoints` is the parsed `rua=` URI list — `mailto:tlsrpt@…` and/or
+ * `https://…` collectors. Empty list (`[]`) when the record exists but
+ * carried no `rua=` value; null when the lookup is unavailable. */
+export interface TlsRptPosture {
+	configured: boolean | null;
+	endpoints: readonly string[] | null;
+}
+
+/** Sentinel for "unavailable / lookup failed". `configured: false` (a
+ * durable "no record" answer) is a separate state and is NOT this sentinel. */
+export function emptyTlsRptPosture(): TlsRptPosture {
+	return { configured: null, endpoints: null };
+}
+
+const KV_PREFIX = "tlsrpt-txt:v1:";
+/** Short TTL — TLS-RPT records change infrequently but operators do roll
+ * collector endpoints. 1h matches the DMARC / BIMI cadence; negative cache
+ * uses the same TTL so first-publish discovery isn't gated on a long miss. */
+const KV_TTL_S = 60 * 60;
+/** DoH resolver host. Hostname-based mock matching is required by repo CLAUDE.md. */
+const DOH_HOST = "cloudflare-dns.com";
+const DOH_URL = `https://${DOH_HOST}/dns-query`;
+/** Hard cap matches `workers/dmarc/txt.ts`. */
+const DOH_TIMEOUT_MS = 1500;
+
+/** Minimal `KVNamespace` view we depend on; lets tests pass a fake. */
+export interface TlsRptKv {
+	get(key: string, type: "json"): Promise<unknown>;
+	put(
+		key: string,
+		value: string,
+		options?: { expirationTtl?: number },
+	): Promise<void>;
+}
+
+/** Minimal `fetch` view we depend on; lets tests inject a stub. */
+export type TlsRptFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Parse a `_smtp._tls.<domain>` TXT-record string into `{configured,
+ * endpoints}`. Only records starting with `v=TLSRPTv1` are considered.
+ * Tags are `;`-separated `name=value` pairs per RFC 8460 §3.
+ *
+ * The `rua=` value is a comma-separated list of generic URIs. RFC 8460 §3
+ * defines exactly two schemes today (`mailto:` and `https:`); we surface
+ * the parsed URI list to the UI without filtering by scheme — operators
+ * occasionally publish vendor-specific schemes and we'd rather show the
+ * literal text than silently swallow it. Empty / missing `rua=` yields
+ * `endpoints: []` — the record exists but no collector is published.
+ *
+ * Returns null when the record isn't a `v=TLSRPTv1` record at all, so the
+ * caller can distinguish "malformed" from "configured-but-empty".
+ */
+export function parseTlsRptTxt(record: string): TlsRptPosture | null {
+	if (typeof record !== "string") return null;
+	const trimmed = record.trim();
+	if (!trimmed) return null;
+	const tags = new Map<string, string>();
+	for (const part of trimmed.split(";")) {
+		const eq = part.indexOf("=");
+		if (eq < 0) continue;
+		const name = part.slice(0, eq).trim().toLowerCase();
+		const value = part.slice(eq + 1).trim();
+		if (!name) continue;
+		// First-wins, mirroring the DMARC and BIMI parsers — `v=TLSRPTv1;
+		// rua=mailto:a@x; rua=mailto:b@x` reports the first endpoint rather
+		// than silently overwriting it.
+		if (!tags.has(name)) tags.set(name, value);
+	}
+	if (tags.get("v") !== "TLSRPTv1") return null;
+	const ruaRaw = tags.get("rua");
+	const endpoints = parseRuaList(ruaRaw);
+	return { configured: true, endpoints };
+}
+
+/** Parse a comma-separated `rua=` URI list. Whitespace around items is
+ * trimmed. An undefined / empty input yields `[]` (the record exists but
+ * publishes no endpoint — valid per RFC 8460, just degenerate).
+ *
+ * Exported for tests; the production parser routes through `parseTlsRptTxt`. */
+export function parseRuaList(raw: string | undefined): string[] {
+	if (typeof raw !== "string") return [];
+	const trimmed = raw.trim();
+	if (!trimmed) return [];
+	return trimmed
+		.split(",")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+}
+
+/**
+ * Pick the TLS-RPT policy record from a list of TXT strings published at
+ * `_smtp._tls.<domain>`. Returns null when no `v=TLSRPTv1` record exists.
+ */
+export function selectTlsRptRecord(records: readonly string[]): string | null {
+	for (const r of records) {
+		if (typeof r !== "string") continue;
+		const t = r.trim();
+		if (/^v\s*=\s*TLSRPTv1\b/i.test(t)) return t;
+	}
+	return null;
+}
+
+/**
+ * Strip surrounding quotes and concatenate multi-string TXT-record fragments
+ * DoH returns. Same logic as `workers/dmarc/txt.ts:normalizeDohTxtData` —
+ * duplicated to keep the TLS-RPT module decoupled from the DMARC API surface.
+ */
+export function normalizeDohTxtData(data: string): string {
+	if (typeof data !== "string") return "";
+	const matches = [...data.matchAll(/"((?:[^"\\]|\\.)*)"/g)];
+	if (matches.length === 0) {
+		return data.replace(/^"|"$/g, "");
+	}
+	return matches.map((m) => m[1]).join("");
+}
+
+/**
+ * Fetch and parse the TLS-RPT posture for `<domain>`, with KV caching.
+ *
+ * Cache holds positive (`configured: true`) and durable-negative
+ * (`configured: false`) results under the same key with the same short TTL.
+ * The `configured: null` sentinel is NEVER cached — a transient DoH error
+ * shouldn't poison the cache for an hour.
+ *
+ * A failed upstream (timeout, non-200, malformed JSON) degrades to the
+ * empty sentinel; the caller should treat this as best-effort and not fail
+ * the surrounding request.
+ */
+export async function fetchTlsRptPosture(
+	domain: string,
+	options: {
+		kv?: TlsRptKv | null;
+		fetchImpl?: TlsRptFetch;
+	} = {},
+): Promise<TlsRptPosture> {
+	if (!domain || typeof domain !== "string") return emptyTlsRptPosture();
+	const fetchImpl = options.fetchImpl ?? (globalThis.fetch as TlsRptFetch);
+	const kv = options.kv ?? null;
+	const cacheKey = `${KV_PREFIX}${domain}`;
+
+	if (kv) {
+		try {
+			const cached = await kv.get(cacheKey, "json");
+			if (cached && typeof cached === "object") {
+				return coerceTlsRptPosture(cached);
+			}
+		} catch {
+			// KV read failure is non-fatal; fall through to a fresh DoH lookup.
+		}
+	}
+
+	const posture = await resolveTlsRptTxt(domain, fetchImpl);
+
+	// Only cache durable answers — `configured: null` is a transient signal
+	// (DoH timed out, returned non-200, or the JSON didn't parse). Caching it
+	// would mean an hour of unavailability after a single blip.
+	if (kv && posture.configured !== null) {
+		void kv
+			.put(cacheKey, JSON.stringify(posture), { expirationTtl: KV_TTL_S })
+			.catch(() => {});
+	}
+
+	return posture;
+}
+
+async function resolveTlsRptTxt(
+	domain: string,
+	fetchImpl: TlsRptFetch,
+): Promise<TlsRptPosture> {
+	const name = `_smtp._tls.${domain}`;
+	let res: Response;
+	try {
+		res = await fetchImpl(
+			`${DOH_URL}?name=${encodeURIComponent(name)}&type=TXT`,
+			{
+				headers: { accept: "application/dns-json" },
+				signal: AbortSignal.timeout(DOH_TIMEOUT_MS),
+			},
+		);
+	} catch {
+		return emptyTlsRptPosture();
+	}
+	if (!res.ok) return emptyTlsRptPosture();
+	let body: unknown;
+	try {
+		body = await res.json();
+	} catch {
+		return emptyTlsRptPosture();
+	}
+	const answer = (body as { Answer?: Array<{ type?: number; data?: unknown }> })
+		.Answer;
+	// `Answer` absent is NOT the same as `Answer: []` — a missing field means
+	// the resolver didn't even return the field shape we expect, which we treat
+	// as a transient unavailability rather than a durable "no record".
+	if (!Array.isArray(answer)) return emptyTlsRptPosture();
+	const txts: string[] = [];
+	for (const a of answer) {
+		// TXT records are type=16 in DoH JSON.
+		if (a.type !== 16) continue;
+		if (typeof a.data !== "string") continue;
+		txts.push(normalizeDohTxtData(a.data));
+	}
+	const record = selectTlsRptRecord(txts);
+	if (!record) {
+		// Distinguish "no TLSRPTv1 record" (durable answer, configured=false)
+		// from "lookup unavailable" (configured=null). Empty Answer or non-TLSRPT
+		// TXT entries land here.
+		return { configured: false, endpoints: [] };
+	}
+	const parsed = parseTlsRptTxt(record);
+	// `parseTlsRptTxt` returns null only when the record doesn't start with
+	// `v=TLSRPTv1` — but we already filtered for that in `selectTlsRptRecord`,
+	// so this branch is defensive. Treat a parse miss as "configured but
+	// malformed", durable-negative for cache purposes.
+	return parsed ?? { configured: false, endpoints: [] };
+}
+
+function coerceTlsRptPosture(value: unknown): TlsRptPosture {
+	if (!value || typeof value !== "object") return emptyTlsRptPosture();
+	const v = value as { configured?: unknown; endpoints?: unknown };
+	const configured =
+		typeof v.configured === "boolean" ? v.configured : null;
+	let endpoints: readonly string[] | null = null;
+	if (Array.isArray(v.endpoints)) {
+		endpoints = v.endpoints.filter(
+			(e): e is string => typeof e === "string",
+		);
+	}
+	return { configured, endpoints };
+}


### PR DESCRIPTION
## Summary

- New `workers/tlsrpt/posture.ts` resolves `_smtp._tls.<domain>` over DoH (1500ms cap) and parses `v=TLSRPTv1; rua=...` into `{configured, endpoints}`. KV-cached under `tlsrpt-txt:v1:<domain>` (1h TTL); durable-negative answers cached, transient unavailable sentinel deliberately not (a one-off DoH blip mustn't lock the dashboard into "unavailable" for an hour).
- `/domains/:domain` renders a TLS-RPT tile. Per the issue's constraint, "unavailable" and "no record" collapse to one empty-state affordance; the configured branch lists the parsed `rua=` endpoints.
- Wired into `aggregateDomainStats` + the domain-stats fan-out alongside the existing DMARC / MTA-STS / BIMI / SPF posture lookups.

Closes #168
4/7 of #156

## Test plan

- [x] `npm test` — 511 passing, 0 failing (was 480 baseline; +29 TLS-RPT unit + DoH integration tests, +2 aggregator threading tests). 20 frontend test errors are pre-existing (`jsdom` not installed in `node_modules`); unaffected by this change.
- [x] `npm run typecheck` — 205 errors, identical to baseline (all pre-existing `@testing-library/react` / `toBeInTheDocument` resolution misses in `tests/frontend/**`); no new errors introduced.
- [x] Tests cover: configured (mailto / https / multi-endpoint), missing record, malformed (non-TLSRPTv1 TXT, malformed JSON), timeout / network reject, KV read/write, do-NOT-cache-unavailable invariant. All mocks match by `new URL(url).hostname`.
- [x] Re-walked Acceptance + Constraints from #168 line by line: parser handles real records (single mailto, single https, comma-separated mixed list, empty `rua=`, missing `rua=` defensive), KV positive + negative caching, tile renders configured / not-configured with the URL list, README Security section updated, mocks parse URLs.

## Out of scope / deferred follow-ups

- Inbound TLS-RPT report ingestion is tracked as #169 (already filed) — pairs with this PR.
- No `wrangler.jsonc` changes; no `cf-typegen` regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)