### PR TITLE
fix(ui): disable topbar search on org-level routes (#187)

### DIFF
--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -469,14 +469,33 @@ export default function Shell({ children, rightPanel }: ShellProps) {
 						onSubmit={handleSearchSubmit}
 						className="flex items-center gap-2 flex-1 max-w-xl"
 					>
-						<MagnifyingGlassIcon size={14} className="text-ink-3 shrink-0" />
+						<MagnifyingGlassIcon
+							size={14}
+							className={`shrink-0 ${mailboxId ? "text-ink-3" : "text-ink-4"}`}
+						/>
+						{/*
+						 * Search today is mailbox-scoped: the only registered route is
+						 * `/mailbox/:mailboxId/search`, and the submit handler bails when
+						 * `mailboxId` is missing. On org-level routes (`/`, `/settings`,
+						 * `/mailboxes`, `/domains`, `/domains/:domain`) we surface a
+						 * disabled input with explanatory placeholder so cmd+K + Enter
+						 * doesn't appear to silently swallow the query (#187). Org-scope
+						 * search across every mailbox the user can see is tracked
+						 * separately.
+						 */}
 						<input
 							ref={searchInputRef}
 							type="search"
 							value={searchQuery}
 							onChange={(e) => setSearchQuery(e.target.value)}
-							className="flex-1 bg-transparent border-0 outline-none text-[13px] text-ink placeholder:text-ink-4"
-							placeholder="Search emails…  ⌘K"
+							disabled={!mailboxId}
+							aria-disabled={!mailboxId}
+							className="flex-1 bg-transparent border-0 outline-none text-[13px] text-ink placeholder:text-ink-4 disabled:cursor-not-allowed"
+							placeholder={
+								mailboxId
+									? "Search emails…  ⌘K"
+									: "Pick a mailbox to search emails"
+							}
 							aria-label="Search"
 						/>
 					</form>

--- a/tests/frontend/shell-search.test.tsx
+++ b/tests/frontend/shell-search.test.tsx
@@ -43,6 +43,57 @@ function renderShell(initialEntries: string[] = ["/mailbox/m1/dashboard"]) {
 	);
 }
 
+// Render the shell with org-level routes only (no `:mailboxId`). Mirrors the
+// real route table for `/`, `/settings`, `/mailboxes`, `/domains`, and
+// `/domains/:domain` — none of which carry a mailbox in the URL.
+function renderOrgShell(initialEntries: string[]) {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/"
+				element={
+					<Shell>
+						<LocationReporter />
+					</Shell>
+				}
+			/>
+			<Route
+				path="/settings"
+				element={
+					<Shell>
+						<LocationReporter />
+					</Shell>
+				}
+			/>
+			<Route
+				path="/mailboxes"
+				element={
+					<Shell>
+						<LocationReporter />
+					</Shell>
+				}
+			/>
+			<Route
+				path="/domains"
+				element={
+					<Shell>
+						<LocationReporter />
+					</Shell>
+				}
+			/>
+			<Route
+				path="/domains/:domain"
+				element={
+					<Shell>
+						<LocationReporter />
+					</Shell>
+				}
+			/>
+		</Routes>,
+		{ initialEntries },
+	);
+}
+
 describe("Shell search", () => {
 	it("typing + Enter navigates to /mailbox/:id/search?q=…", async () => {
 		const user = userEvent.setup();
@@ -107,5 +158,62 @@ describe("Shell search", () => {
 		expect(placeholder).not.toMatch(/indicator/i);
 		expect(placeholder).not.toMatch(/case/i);
 		expect(placeholder).toMatch(/email|message|search/i);
+	});
+});
+
+// Path-(b) fix for #187: on org-level routes (no `:mailboxId` in URL) the
+// search submit handler used to silently no-op. We now render the input as
+// `disabled` with explanatory placeholder so cmd+K + Enter can't appear to
+// swallow a query without feedback. Org-scope search is tracked separately.
+describe("Shell search on org-level routes (no mailboxId)", () => {
+	it.each([
+		["/"],
+		["/settings"],
+		["/mailboxes"],
+		["/domains"],
+		["/domains/example.com"],
+	])("disables the search input on %s", (path) => {
+		renderOrgShell([path]);
+		const input = screen.getByRole("searchbox", { name: /search/i });
+		expect(input).toBeDisabled();
+		expect(input.getAttribute("placeholder")).toBe(
+			"Pick a mailbox to search emails",
+		);
+	});
+
+	it("cmd+K does not focus the disabled input on org routes", async () => {
+		const user = userEvent.setup();
+		renderOrgShell(["/"]);
+		const input = screen.getByRole("searchbox", { name: /search/i });
+		expect(input).toBeDisabled();
+		expect(document.activeElement).not.toBe(input);
+		await user.keyboard("{Meta>}k{/Meta}");
+		// A `disabled` input cannot receive focus, so cmd+K is effectively a
+		// no-op on org routes — exactly what the acceptance criterion asks for.
+		expect(document.activeElement).not.toBe(input);
+	});
+
+	it("submitting the form on org routes does not navigate", async () => {
+		const user = userEvent.setup();
+		renderOrgShell(["/"]);
+		expect(screen.getByTestId("location")).toHaveTextContent("/");
+		const form = screen
+			.getByRole("searchbox", { name: /search/i })
+			.closest("form");
+		expect(form).not.toBeNull();
+		// Even if a programmatic submit fires (e.g. user found a way to bypass
+		// the disabled input), the handler still bails when `mailboxId` is
+		// missing — belt-and-suspenders verification.
+		form?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		// Yield to microtasks / react-router's effect queue.
+		await user.keyboard("{Tab}");
+		expect(screen.getByTestId("location")).toHaveTextContent("/");
+	});
+
+	it("re-enables the input once a mailbox-scoped route is mounted", () => {
+		renderShell(["/mailbox/m1/dashboard"]);
+		const input = screen.getByRole("searchbox", { name: /search/i });
+		expect(input).not.toBeDisabled();
+		expect(input.getAttribute("placeholder")).toMatch(/⌘K/);
 	});
 });


### PR DESCRIPTION
## Summary

- Path (b) of the two paths in #187: hide / disable the search input on routes without a `mailboxId`. Path (a) (org-scope route + endpoint) requires meaningful infra (new server-side handler / `?scope=org` parameter); the fallback is a clean fix that removes the user-facing footgun today.
- On `/`, `/settings`, `/mailboxes`, `/domains`, `/domains/:domain` the topbar input now renders `disabled` with placeholder "Pick a mailbox to search emails". cmd+K can't focus a `disabled` input, so the shortcut is effectively a no-op on org routes (exactly what the acceptance criterion allows).
- Per-mailbox routes are unaffected: cmd+K still focuses, typing + Enter still navigates to `/mailbox/:id/search?q=...`.

Closes #187
Part of #191
Follow-up: #197 (org-scope search across all accessible mailboxes)

## Test plan

- [x] `npm test` — 605 passed (52 files), 0 failing
- [x] `npm run typecheck` — clean
- [x] New tests in `tests/frontend/shell-search.test.tsx` cover:
  - input is `disabled` with the right placeholder on `/`, `/settings`, `/mailboxes`, `/domains`, `/domains/:domain`
  - cmd+K does not focus the disabled input on org routes
  - programmatic form submit on org routes does not navigate
  - input re-enables once a mailbox-scoped route is mounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)