### PR TITLE
fix(ui): disable "Ask co-pilot" on org-level routes

### DIFF
--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -488,13 +488,34 @@ export default function Shell({ children, rightPanel }: ShellProps) {
 						>
 							<BellIcon size={16} />
 						</button>
+						{/* The agent panel only mounts inside `/mailbox/:mailboxId/*`
+						    routes (mailbox.tsx is the only caller passing
+						    `rightPanel={<AgentSidebar />}`). On org-level routes
+						    (`/`, `/settings`, `/mailboxes`, `/domains`,
+						    `/domains/:domain`) clicking the button toggled
+						    internal state but nothing visible happened — silent
+						    no-op (#186). Until an org-scope co-pilot ships
+						    (follow-up #198), gate the trigger on `mailboxId` so
+						    the button only fires where it can do work. We render
+						    `disabled` with a `title` tooltip rather than hiding
+						    so the affordance stays discoverable and the topbar
+						    layout doesn't shift when entering a mailbox. */}
 						<button
 							type="button"
 							onClick={() => toggleAgentPanel()}
-							aria-expanded={isAgentPanelOpen}
+							disabled={!mailboxId}
+							aria-disabled={!mailboxId}
+							title={
+								mailboxId
+									? undefined
+									: "Pick a mailbox to chat with the agent"
+							}
+							aria-expanded={mailboxId ? isAgentPanelOpen : undefined}
 							aria-controls="agent-panel"
 							className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[12px] font-medium transition-colors ${
-								isAgentPanelOpen
+								!mailboxId
+									? "bg-paper-2 text-ink-3 border-line cursor-not-allowed opacity-60"
+									: isAgentPanelOpen
 									? "bg-accent text-paper border-accent hover:bg-[color-mix(in_oklch,var(--accent)_85%,black)]"
 									: "bg-accent-tint text-accent border-[color-mix(in_oklch,var(--accent)_25%,transparent)] hover:bg-[color-mix(in_oklch,var(--accent-tint)_70%,var(--paper))]"
 							}`}
@@ -502,7 +523,13 @@ export default function Shell({ children, rightPanel }: ShellProps) {
 							<SparkleIcon
 								size={13}
 								weight="fill"
-								className={isAgentPanelOpen ? "text-paper" : "text-accent"}
+								className={
+									!mailboxId
+										? "text-ink-3"
+										: isAgentPanelOpen
+										? "text-paper"
+										: "text-accent"
+								}
 							/>
 							Ask co-pilot
 						</button>

--- a/tests/frontend/shell-agent-panel-org-routes.test.tsx
+++ b/tests/frontend/shell-agent-panel-org-routes.test.tsx
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+//
+// Regression test for #186 — "Ask co-pilot" no-op on org-level routes.
+//
+// The Shell topbar's "Ask co-pilot" button used to render unconditionally on
+// every page, but the agent panel only mounts inside `/mailbox/:mailboxId/*`
+// routes (mailbox.tsx is the only caller passing `rightPanel={<AgentSidebar
+// />}`). Clicking the button on `/`, `/settings`, `/mailboxes`, `/domains`,
+// or `/domains/:domain` toggled internal state but produced no visible change.
+//
+// Until an org-scope co-pilot ships, the trigger must be `disabled` (with a
+// tooltip explaining why) when the current route has no `mailboxId`. The
+// per-mailbox route still opens the panel.
+
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({
+		data: { id: "m1", email: "alice@acme.com", name: "Alice" },
+	}),
+	useMailboxes: () => ({
+		data: [{ id: "m1", email: "alice@acme.com", name: "Alice" }],
+	}),
+}));
+
+vi.mock("~/queries/dashboard", () => ({
+	useDashboardSummary: () => ({
+		data: undefined,
+		isLoading: false,
+		isError: false,
+	}),
+}));
+
+vi.mock("~/queries/domains", () => ({
+	useDomainStats: () => ({
+		data: undefined,
+		isLoading: false,
+		isError: false,
+	}),
+}));
+
+import Shell from "~/components/phishsoc/Shell";
+import { useUIStore } from "~/hooks/useUIStore";
+import { renderWithProviders } from "./test-utils";
+
+const RIGHT_PANEL_TEST_ID = "agent-panel-content";
+
+function RightPanelStub() {
+	return <div data-testid={RIGHT_PANEL_TEST_ID}>agent panel content</div>;
+}
+
+// Renders Shell mounted at the route patterns the app actually uses, so
+// `useParams<{ mailboxId }>()` resolves the same way it does in production.
+// Org-level routes pass no `rightPanel`; mailbox-level routes do.
+function renderAtRoute(initialEntry: string) {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/"
+				element={
+					<Shell>
+						<div data-testid="main-content">main</div>
+					</Shell>
+				}
+			/>
+			<Route
+				path="/settings"
+				element={
+					<Shell>
+						<div data-testid="main-content">main</div>
+					</Shell>
+				}
+			/>
+			<Route
+				path="/mailboxes"
+				element={
+					<Shell>
+						<div data-testid="main-content">main</div>
+					</Shell>
+				}
+			/>
+			<Route
+				path="/domains"
+				element={
+					<Shell>
+						<div data-testid="main-content">main</div>
+					</Shell>
+				}
+			/>
+			<Route
+				path="/domains/:domain"
+				element={
+					<Shell>
+						<div data-testid="main-content">main</div>
+					</Shell>
+				}
+			/>
+			<Route
+				path="/mailbox/:mailboxId/*"
+				element={
+					<Shell rightPanel={<RightPanelStub />}>
+						<div data-testid="main-content">main</div>
+					</Shell>
+				}
+			/>
+		</Routes>,
+		{ initialEntries: [initialEntry] },
+	);
+}
+
+beforeEach(() => {
+	useUIStore.setState({ isAgentPanelOpen: false });
+	window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+		matches: false,
+		media: query,
+		onchange: null,
+		addListener: vi.fn(),
+		removeListener: vi.fn(),
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
+		dispatchEvent: vi.fn(),
+	}));
+});
+
+afterEach(() => {
+	useUIStore.setState({ isAgentPanelOpen: false });
+});
+
+describe("Shell 'Ask co-pilot' button — org-level routes (#186)", () => {
+	const orgRoutes: Array<[label: string, path: string]> = [
+		["org overview /", "/"],
+		["org settings /settings", "/settings"],
+		["mailboxes list /mailboxes", "/mailboxes"],
+		["domains list /domains", "/domains"],
+		["domain detail /domains/:domain", "/domains/example.com"],
+	];
+
+	for (const [label, path] of orgRoutes) {
+		it(`is disabled with a 'pick a mailbox' tooltip on ${label}`, () => {
+			renderAtRoute(path);
+			const trigger = screen.getByRole("button", {
+				name: /ask co-?pilot/i,
+			});
+			expect(trigger).toBeDisabled();
+			expect(trigger).toHaveAttribute(
+				"title",
+				"Pick a mailbox to chat with the agent",
+			);
+			// Without a mailbox, aria-expanded shouldn't advertise an
+			// open/closed panel state — the panel can't open here at all.
+			expect(trigger).not.toHaveAttribute("aria-expanded");
+		});
+
+		it(`clicking it on ${label} does not toggle the agent panel state`, async () => {
+			const user = userEvent.setup();
+			renderAtRoute(path);
+			const trigger = screen.getByRole("button", {
+				name: /ask co-?pilot/i,
+			});
+			expect(useUIStore.getState().isAgentPanelOpen).toBe(false);
+			// userEvent.click respects `disabled` and skips the click,
+			// so the store stays untouched — exactly the behavior we want.
+			await user.click(trigger);
+			expect(useUIStore.getState().isAgentPanelOpen).toBe(false);
+			expect(screen.queryByTestId(RIGHT_PANEL_TEST_ID)).not.toBeInTheDocument();
+		});
+	}
+});
+
+describe("Shell 'Ask co-pilot' button — mailbox-level route still works", () => {
+	it("is enabled on /mailbox/:mailboxId/* and opens the panel on click", async () => {
+		const user = userEvent.setup();
+		renderAtRoute("/mailbox/m1/dashboard");
+		const trigger = screen.getByRole("button", { name: /ask co-?pilot/i });
+		expect(trigger).not.toBeDisabled();
+		expect(trigger).not.toHaveAttribute("title");
+		expect(trigger).toHaveAttribute("aria-expanded", "false");
+		await user.click(trigger);
+		expect(useUIStore.getState().isAgentPanelOpen).toBe(true);
+		expect(screen.getByTestId(RIGHT_PANEL_TEST_ID)).toBeInTheDocument();
+		expect(trigger).toHaveAttribute("aria-expanded", "true");
+	});
+});


### PR DESCRIPTION
## Summary

- Fixes the silent no-op where Shell's "Ask co-pilot" button toggled internal state but rendered nothing on `/`, `/settings`, `/mailboxes`, `/domains`, `/domains/:domain` (the agent panel only mounts inside `/mailbox/:mailboxId/*` — `app/routes/mailbox.tsx:71` is the only caller that passes `rightPanel={<AgentSidebar />}`).
- Path chosen: **(b) hide/disable**, not (a) wire-up. Path (a) needs new product infra (an org-scope agent surface, cross-mailbox tools, or multi-tenant agent routing) that issue #186 explicitly excludes under "Out of scope" ("Adding cross-mailbox tools to the existing per-mailbox `EmailAgent`" / "Authentication / multi-tenant agent routing"). Path (b) is the safe fallback the issue lists; the org-scope work is filed as #198.
- Implementation: render the button as `disabled` with `title="Pick a mailbox to chat with the agent"` when `useParams().mailboxId` is `undefined`. Preferred over hiding because the affordance stays discoverable and the topbar layout doesn't shift when entering a mailbox.

Closes #186
Part of #191
Follow-up filed: #198 (Org-scope co-pilot — wire 'Ask co-pilot' across org-level routes)

## Test plan

- [x] `npm test` — 608 passing, 0 failing (added `tests/frontend/shell-agent-panel-org-routes.test.tsx`: 5 org routes × 2 assertions disabled+inert + 1 mailbox-route still-works regression).
- [x] `npm run typecheck` — clean (exit 0).
- [ ] Click through `/`, `/settings`, `/mailboxes`, `/domains`, `/domains/:domain` — button is disabled with the tooltip; click does nothing.
- [ ] Navigate into `/mailbox/:mailboxId/*` — button enables, click opens panel as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)