### PR TITLE
feat(ui): wire Shell topbar notifications bell to a popover

### DIFF
--- a/app/components/phishsoc/NotificationsBell.tsx
+++ b/app/components/phishsoc/NotificationsBell.tsx
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { Popover } from "@base-ui/react/popover";
+import { BellIcon } from "@phosphor-icons/react";
+import { Link } from "react-router";
+import { useDashboardSummary } from "~/queries/dashboard";
+
+// Minimal notifications popover (#185). v1 has no notifications subsystem
+// behind it — the bell would otherwise be a dead affordance — so we surface
+// a single derived signal from data already on the wire: the number of open
+// cases on the active mailbox (`useDashboardSummary().openCases`). When the
+// bell is rendered outside a mailbox (org routes have `mailboxId === undefined`)
+// the dashboard query is gated off and the popover renders the empty state.
+//
+// The aria-haspopup / aria-expanded / Escape-to-close / focus-management
+// contract is owned by base-ui's Popover.Trigger + Popover.Popup — see
+// `node_modules/@base-ui/react/popover/trigger/PopoverTrigger.d.ts`. We don't
+// hand-roll any of it.
+//
+// Out of scope (per the issue): push/web notifications, persistent unread
+// state, agent-error feed, incoming hub-invitation feed. A follow-up under
+// the org-shell sweep (#191) tracks expanding the surface once those data
+// sources exist.
+
+interface NotificationItem {
+	key: string;
+	label: string;
+	to: string;
+}
+
+interface NotificationsBellProps {
+	mailboxId: string | undefined;
+}
+
+export default function NotificationsBell({ mailboxId }: NotificationsBellProps) {
+	// `useDashboardSummary` is `enabled: !!mailboxId` internally, so passing
+	// `undefined` off-mailbox doesn't trigger a fetch — the popover just
+	// renders the empty state.
+	const { data: summary } = useDashboardSummary(mailboxId);
+	const openCases = summary?.openCases ?? 0;
+
+	const items: NotificationItem[] = [];
+	if (mailboxId && openCases > 0) {
+		items.push({
+			key: "open-cases",
+			label: `${openCases} open case${openCases === 1 ? "" : "s"}`,
+			to: `/mailbox/${encodeURIComponent(mailboxId)}/cases`,
+		});
+	}
+
+	const hasItems = items.length > 0;
+
+	return (
+		<Popover.Root>
+			<Popover.Trigger
+				aria-label="Notifications"
+				className="relative flex h-8 w-8 items-center justify-center rounded-md text-ink-3 hover:bg-paper-2 hover:text-ink transition-colors"
+			>
+				<BellIcon size={16} />
+				{hasItems && (
+					<span
+						aria-hidden
+						data-testid="notifications-badge"
+						className="absolute top-1 right-1 h-2 w-2 rounded-full bg-accent ring-2 ring-paper"
+					/>
+				)}
+			</Popover.Trigger>
+			<Popover.Portal>
+				<Popover.Positioner sideOffset={6} align="end">
+					<Popover.Popup
+						aria-label="Notifications"
+						className="min-w-[260px] max-w-[320px] rounded-md border border-line bg-paper text-ink shadow-lg outline-none p-1"
+					>
+						{hasItems ? (
+							<ul className="flex flex-col">
+								{items.map((item) => (
+									<li key={item.key}>
+										<Link
+											to={item.to}
+											className="block rounded-md px-2.5 py-1.5 text-[13px] text-ink hover:bg-paper-2 hover:text-ink"
+										>
+											{item.label}
+										</Link>
+									</li>
+								))}
+							</ul>
+						) : (
+							<div className="px-2.5 py-2 text-[12px] text-ink-3">
+								No notifications
+							</div>
+						)}
+					</Popover.Popup>
+				</Popover.Positioner>
+			</Popover.Portal>
+		</Popover.Root>
+	);
+}

--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -1,5 +1,4 @@
 import {
-	BellIcon,
 	BriefcaseIcon,
 	BuildingsIcon,
 	CaretRightIcon,
@@ -26,6 +25,7 @@ import type { DomainMailboxRef } from "~/types";
 import AgentPanelSlot from "./AgentPanelSlot";
 import Breadcrumb from "./Breadcrumb";
 import Logo from "./Logo";
+import NotificationsBell from "./NotificationsBell";
 
 type PipelineTone = "safe" | "suspect" | "danger" | "muted";
 
@@ -500,13 +500,7 @@ export default function Shell({ children, rightPanel }: ShellProps) {
 						/>
 					</form>
 					<div className="ml-auto flex items-center gap-1.5 shrink-0">
-						<button
-							type="button"
-							className="flex h-8 w-8 items-center justify-center rounded-md text-ink-3 hover:bg-paper-2 hover:text-ink transition-colors"
-							aria-label="Notifications"
-						>
-							<BellIcon size={16} />
-						</button>
+						<NotificationsBell mailboxId={mailboxId} />
 						{/* The agent panel only mounts inside `/mailbox/:mailboxId/*`
 						    routes (mailbox.tsx is the only caller passing
 						    `rightPanel={<AgentSidebar />}`). On org-level routes

--- a/tests/frontend/shell-notifications.test.tsx
+++ b/tests/frontend/shell-notifications.test.tsx
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+//
+// Tests for the Shell topbar notifications popover (#185). Verifies:
+//  - bell is reachable as a button with aria-label="Notifications"
+//  - clicking the bell opens a popover
+//  - popover shows "No notifications" when there's nothing to surface
+//  - popover surfaces an "{N} open cases" item linking to `/mailbox/:id/cases`
+//    when the dashboard summary reports `openCases > 0`
+//  - bell shows a dot/badge iff there's at least one item
+//  - aria-haspopup, aria-expanded, and Escape-to-close all work
+//
+// These tests don't mock fetch — `useDashboardSummary` is mocked at the
+// module boundary — so URL substring rules don't apply here.
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({
+		data: { id: "m1", email: "alice@acme.com", name: "Alice" },
+	}),
+	useMailboxes: () => ({
+		data: [{ id: "m1", email: "alice@acme.com", name: "Alice" }],
+	}),
+}));
+
+vi.mock("~/queries/domains", () => ({
+	useDomainStats: () => ({
+		data: undefined,
+		isLoading: false,
+		isError: false,
+	}),
+}));
+
+// `useDashboardSummary` is reassigned per-test via `setSummary`; the mock
+// closure reads from a mutable ref so we don't have to re-import the module
+// or restore mocks between cases.
+let dashboardSummary: { openCases: number } | undefined = undefined;
+function setSummary(next: { openCases: number } | undefined) {
+	dashboardSummary = next;
+}
+
+vi.mock("~/queries/dashboard", () => ({
+	useDashboardSummary: () => ({
+		data: dashboardSummary,
+		isLoading: false,
+		isError: false,
+	}),
+}));
+
+import Shell from "~/components/phishsoc/Shell";
+import { useUIStore } from "~/hooks/useUIStore";
+import { renderWithProviders } from "./test-utils";
+
+function renderShell(initialEntries: string[] = ["/mailbox/m1/dashboard"]) {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/mailbox/:mailboxId/*"
+				element={
+					<Shell>
+						<div data-testid="main-content">main</div>
+					</Shell>
+				}
+			/>
+			{/* Org-route variant — Shell still renders, just with mailboxId
+			    undefined. Mirrors what `/`, `/mailboxes`, `/domains` do at
+			    runtime so we can exercise the no-mailbox notifications path. */}
+			<Route
+				path="*"
+				element={
+					<Shell>
+						<div data-testid="main-content">main</div>
+					</Shell>
+				}
+			/>
+		</Routes>,
+		{ initialEntries },
+	);
+}
+
+beforeEach(() => {
+	useUIStore.setState({ isAgentPanelOpen: false, isSidebarOpen: false });
+	setSummary(undefined);
+});
+
+afterEach(() => {
+	setSummary(undefined);
+});
+
+describe("Shell notifications bell — closed state", () => {
+	it("renders a button labeled 'Notifications' with popover affordances", () => {
+		renderShell();
+		const bell = screen.getByRole("button", { name: /notifications/i });
+		// base-ui Popover.Trigger wires aria-haspopup + aria-expanded for free.
+		expect(bell).toHaveAttribute("aria-haspopup");
+		expect(bell).toHaveAttribute("aria-expanded", "false");
+	});
+
+	it("does not render the popover content before the bell is clicked", () => {
+		renderShell();
+		// Empty-state copy is the canary — it only mounts inside the popup.
+		expect(screen.queryByText(/no notifications/i)).not.toBeInTheDocument();
+	});
+
+	it("does not show the badge when there are zero open cases", () => {
+		setSummary({ openCases: 0 });
+		renderShell();
+		expect(screen.queryByTestId("notifications-badge")).not.toBeInTheDocument();
+	});
+});
+
+describe("Shell notifications bell — empty state", () => {
+	it("shows 'No notifications' when openCases is 0", async () => {
+		setSummary({ openCases: 0 });
+		const user = userEvent.setup();
+		renderShell();
+		const bell = screen.getByRole("button", { name: /notifications/i });
+		await user.click(bell);
+		expect(bell).toHaveAttribute("aria-expanded", "true");
+		expect(await screen.findByText(/no notifications/i)).toBeInTheDocument();
+	});
+
+	it("shows 'No notifications' when summary is undefined (org / loading)", async () => {
+		setSummary(undefined);
+		const user = userEvent.setup();
+		renderShell(["/"]);
+		const bell = screen.getByRole("button", { name: /notifications/i });
+		await user.click(bell);
+		expect(await screen.findByText(/no notifications/i)).toBeInTheDocument();
+	});
+});
+
+describe("Shell notifications bell — populated state", () => {
+	it("shows '{N} open cases' linking to /mailbox/:id/cases when openCases > 0", async () => {
+		setSummary({ openCases: 3 });
+		const user = userEvent.setup();
+		renderShell();
+		const bell = screen.getByRole("button", { name: /notifications/i });
+		// Badge dot is visible before opening.
+		expect(screen.getByTestId("notifications-badge")).toBeInTheDocument();
+		await user.click(bell);
+		const link = await screen.findByRole("link", { name: /3 open cases/i });
+		expect(link).toHaveAttribute("href", "/mailbox/m1/cases");
+	});
+
+	it("singularizes the label when openCases === 1", async () => {
+		setSummary({ openCases: 1 });
+		const user = userEvent.setup();
+		renderShell();
+		await user.click(screen.getByRole("button", { name: /notifications/i }));
+		const link = await screen.findByRole("link", { name: /^1 open case$/i });
+		expect(link).toHaveAttribute("href", "/mailbox/m1/cases");
+	});
+
+	it("does not render the empty-state copy when items exist", async () => {
+		setSummary({ openCases: 2 });
+		const user = userEvent.setup();
+		renderShell();
+		await user.click(screen.getByRole("button", { name: /notifications/i }));
+		await screen.findByRole("link", { name: /open cases/i });
+		expect(screen.queryByText(/no notifications/i)).not.toBeInTheDocument();
+	});
+});
+
+describe("Shell notifications bell — keyboard / a11y", () => {
+	it("Escape closes the popover", async () => {
+		setSummary({ openCases: 2 });
+		const user = userEvent.setup();
+		renderShell();
+		const bell = screen.getByRole("button", { name: /notifications/i });
+		await user.click(bell);
+		await screen.findByRole("link", { name: /open cases/i });
+		await user.keyboard("{Escape}");
+		// The popup unmounts on close; aria-expanded flips back to "false".
+		await waitFor(() => {
+			expect(bell).toHaveAttribute("aria-expanded", "false");
+		});
+		expect(screen.queryByRole("link", { name: /open cases/i })).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary

- **Path chosen: (a) minimal-popover wire-up.** The data source for v1 — open cases on the active mailbox — is already accessible via `useDashboardSummary` (which Shell already imports and every Shell-rendering test already mocks). No new server endpoint required.
- Replaces the dead `<button aria-label="Notifications">` at `Shell.tsx:484-490` with a new `NotificationsBell` component that wraps `@base-ui/react/popover`. The popover surfaces a single item — `"{N} open case(s)" → /mailbox/:id/cases` — when `summary.openCases > 0`, and "No notifications" otherwise. A dot badge appears iff there's at least one item.
- `aria-haspopup`, `aria-expanded`, focus management, and Escape-to-close are owned by base-ui's `Popover.Trigger` / `Popover.Popup` — not hand-rolled. The primitive matches `AgentPanelSlot`'s existing use of `@base-ui/react/dialog`.

## Why path (a) over path (b)

The Acceptance only requires "derive the count from existing queries (`useDashboardSummary`, `useOrgOverview`, etc.)". `useDashboardSummary` is already in Shell, already mocked by `shell-mocks.ts` consumers, and gated to `!!mailboxId` — so org routes naturally fall through to the empty state. Adding `useOrgOverview` (no `enabled` gate) would force patching every Shell-rendering test and isn't needed to satisfy the contract.

## Acceptance — shipped vs deferred

Shipped (path (a)):
- [x] Clicking the bell opens a popover (base-ui `Popover`, matches `Dialog` primitive used by `AgentPanelSlot`).
- [x] "No notifications" empty state when `openCases === 0` or `summary` is undefined.
- [x] "{N} open case(s)" item linking to `/mailbox/:id/cases` when `openCases > 0`.
- [x] Bell shows dot/badge iff there's ≥1 item.
- [x] `aria-haspopup`, `aria-expanded`, focus management, and Escape-to-close all work (base-ui owns these).
- [x] No new server-side endpoint; count derived from `useDashboardSummary`.

Deferred (out of scope per issue, or no client data source today):
- Agent-error feed: no client-side agent-error query exists yet. The issue's "e.g." list is illustrative — open cases alone satisfy "list of items linking to source." A follow-up under #191 should expand the surface once an agent-errors feed lands.
- Incoming hub-invitations: only an outbound `useCreateHubInvite` mutation exists; no inbound-pending-invitations query.
- Push/web notifications, persistent unread state, per-user preferences (explicitly out-of-scope).

## Test plan

- [x] `npm test` — **606 passing, 0 failing** (was 597 before; 9 new tests in `tests/frontend/shell-notifications.test.tsx`).
- [x] `npm run typecheck` — exit 0.
- [x] New test file covers: closed state aria attributes, popover content not pre-rendered, badge gated on item count, empty state on `openCases === 0` and on undefined summary, `"{N} open cases"` label + `/mailbox/m1/cases` href, singular/plural label, Escape-to-close.

Closes #185
Part of #191