### PR TITLE
feat(ui): mailbox-switcher popover in sidebar org card

### DIFF
--- a/app/components/phishsoc/MailboxSwitcher.tsx
+++ b/app/components/phishsoc/MailboxSwitcher.tsx
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { Menu } from "@base-ui/react/menu";
+import { CaretUpDownIcon, CheckIcon } from "@phosphor-icons/react";
+import { useNavigate } from "react-router";
+import type { Mailbox } from "~/types";
+
+// Sidebar mailbox-switcher (#188). Replaces the old "Select mailbox" card
+// that previously routed to "/" on click — a no-op from the org root and a
+// dishonest affordance everywhere else, since the chevron promised a
+// switcher.
+//
+// Sourced from `useMailboxes()` already loaded by Shell, so this component
+// stays presentational: it consumes the mailbox list and the active id, and
+// hands the picked id back as a navigation. base-ui Menu provides the
+// keyboard model (arrow keys, Enter, Escape), focus management, and the
+// `aria-haspopup` / `aria-expanded` wiring.
+
+interface MailboxSwitcherProps {
+	/** Active mailbox id, or undefined at the org root. Used to mark the
+	 * currently-selected entry in the menu and to no-op the trigger label. */
+	activeMailboxId: string | undefined;
+	/** Active mailbox object, sourced from `useMailbox(activeId)` in Shell.
+	 * Drives the trigger label; the menu items render from `mailboxes`.
+	 * Loosely typed because the Shell signature already widens to nullable
+	 * fields and this component just consumes them. */
+	mailbox: { name?: string | null; email?: string | null } | undefined;
+	/** Full mailbox list for the current org. Empty array renders the
+	 * "No mailboxes yet" state. */
+	mailboxes: Mailbox[] | undefined;
+	/** Total mailbox count surfaced under the trigger label. */
+	mailboxCount: number;
+	/** Closes the mobile drawer when the menu opens or an item is picked.
+	 * On desktop this is a no-op. The `[location.pathname]` effect in Shell
+	 * also catches route changes, but selecting the *currently active*
+	 * mailbox doesn't change pathname, so the explicit close is still needed
+	 * on mobile. */
+	onClose: () => void;
+}
+
+export default function MailboxSwitcher({
+	activeMailboxId,
+	mailbox,
+	mailboxes,
+	mailboxCount,
+	onClose,
+}: MailboxSwitcherProps) {
+	const navigate = useNavigate();
+	const orgDomain = mailbox?.email?.split("@")[1] ?? "—";
+	const orgInitial = (mailbox?.name || mailbox?.email || "?")[0]?.toUpperCase();
+	const list = mailboxes ?? [];
+
+	const handlePick = (id: string) => {
+		onClose();
+		if (id === activeMailboxId) return;
+		navigate(`/mailbox/${encodeURIComponent(id)}/dashboard`);
+	};
+
+	return (
+		<Menu.Root
+			// Sidebar dropdown — not a modal. Default `modal: true` would lock
+			// page scroll and disable outside interaction, which is heavier
+			// than a popover should be. base-ui still wires Escape and
+			// outside-click dismissal in non-modal mode.
+			modal={false}
+		>
+			<Menu.Trigger
+				className="mx-3 flex items-center gap-2.5 rounded-md border border-line bg-paper px-2.5 py-2 text-left hover:border-line-strong transition-colors"
+			>
+				<span className="flex h-7 w-7 items-center justify-center rounded-md bg-accent-tint text-accent-ink pp-serif text-[15px]">
+					{orgInitial}
+				</span>
+				<span className="flex-1 min-w-0">
+					<span className="block truncate text-[12.5px] font-medium text-ink">
+						{mailbox?.name || "Select mailbox"}
+					</span>
+					<span className="block truncate text-[10.5px] text-ink-3">
+						{orgDomain} · {mailboxCount} mailbox{mailboxCount === 1 ? "" : "es"}
+					</span>
+				</span>
+				<CaretUpDownIcon size={12} className="text-ink-3 shrink-0" />
+			</Menu.Trigger>
+			<Menu.Portal>
+				<Menu.Positioner sideOffset={4} align="start" className="z-50">
+					<Menu.Popup
+						aria-label="Switch mailbox"
+						className="min-w-[220px] max-w-[320px] rounded-md border border-line bg-paper py-1 shadow-lg outline-none"
+					>
+						{list.length === 0 ? (
+							// Empty state. Not a `MenuItem` — that would make it
+							// selectable; this is a static blurb plus a nav link the
+							// user can reach via Tab.
+							<div className="px-3 py-2 text-[12px] text-ink-2">
+								<div className="font-medium text-ink">No mailboxes yet</div>
+								<div className="mt-0.5 text-ink-3">
+									<a
+										href="/mailboxes"
+										onClick={(e) => {
+											e.preventDefault();
+											onClose();
+											navigate("/mailboxes");
+										}}
+										className="text-accent hover:underline"
+									>
+										Provision a mailbox
+									</a>
+								</div>
+							</div>
+						) : (
+							list.map((mb) => {
+								const isActive = mb.id === activeMailboxId;
+								return (
+									<Menu.Item
+										key={mb.id}
+										onClick={() => handlePick(mb.id)}
+										className={`mx-1 flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-[12.5px] outline-none data-[highlighted]:bg-paper-2 ${
+											isActive ? "text-ink" : "text-ink-2"
+										}`}
+									>
+										<span className="flex-1 min-w-0">
+											<span className="block truncate font-medium">
+												{mb.name || mb.email || mb.id}
+											</span>
+											{mb.email && mb.name && (
+												<span className="block truncate text-[10.5px] text-ink-3">
+													{mb.email}
+												</span>
+											)}
+										</span>
+										{isActive && (
+											<CheckIcon
+												size={12}
+												weight="bold"
+												aria-label="Active mailbox"
+												className="text-accent shrink-0"
+											/>
+										)}
+									</Menu.Item>
+								);
+							})
+						)}
+					</Menu.Popup>
+				</Menu.Positioner>
+			</Menu.Portal>
+		</Menu.Root>
+	);
+}

--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -1,7 +1,6 @@
 import {
 	BriefcaseIcon,
 	BuildingsIcon,
-	CaretRightIcon,
 	EnvelopeIcon,
 	GaugeIcon,
 	GearSixIcon,
@@ -21,10 +20,11 @@ import { useUIStore } from "~/hooks/useUIStore";
 import { useDashboardSummary } from "~/queries/dashboard";
 import { useDomainStats } from "~/queries/domains";
 import { useMailbox, useMailboxes } from "~/queries/mailboxes";
-import type { DomainMailboxRef } from "~/types";
+import type { DomainMailboxRef, Mailbox } from "~/types";
 import AgentPanelSlot from "./AgentPanelSlot";
 import Breadcrumb from "./Breadcrumb";
 import Logo from "./Logo";
+import MailboxSwitcher from "./MailboxSwitcher";
 import NotificationsBell from "./NotificationsBell";
 
 type PipelineTone = "safe" | "suspect" | "danger" | "muted";
@@ -114,11 +114,12 @@ function SectionLabel({ children }: { children: ReactNode }) {
 interface NavContentsProps {
 	mailboxId: string | undefined;
 	mailbox: { name?: string | null; email?: string | null } | undefined;
+	mailboxes: Mailbox[] | undefined;
 	mailboxCount: number;
 	pipelineState: PipelineState;
 	theme: "light" | "dark";
 	onToggleTheme: () => void;
-	onSwitchOrg: () => void;
+	onCloseSidebar: () => void;
 	onPipelineClick: () => void;
 	/**
 	 * When the current route is `/domains/:domain`, the active domain plus
@@ -138,17 +139,16 @@ interface NavContentsProps {
 function NavContents({
 	mailboxId,
 	mailbox,
+	mailboxes,
 	mailboxCount,
 	pipelineState,
 	theme,
 	onToggleTheme,
-	onSwitchOrg,
+	onCloseSidebar,
 	onPipelineClick,
 	domain,
 	domainMailboxes,
 }: NavContentsProps) {
-	const orgDomain = mailbox?.email?.split("@")[1] ?? "—";
-	const orgInitial = (mailbox?.name || mailbox?.email || "?")[0]?.toUpperCase();
 	const base = mailboxId ? `/mailbox/${encodeURIComponent(mailboxId)}` : "";
 
 	return (
@@ -157,26 +157,18 @@ function NavContents({
 				<Logo />
 			</div>
 
-			{/* Org switcher card — clicking it would open a tenant switcher;
-			    in POC it just routes to the home picker. */}
-			<button
-				type="button"
-				onClick={onSwitchOrg}
-				className="mx-3 flex items-center gap-2.5 rounded-md border border-line bg-paper px-2.5 py-2 text-left hover:border-line-strong transition-colors"
-			>
-				<span className="flex h-7 w-7 items-center justify-center rounded-md bg-accent-tint text-accent-ink pp-serif text-[15px]">
-					{orgInitial}
-				</span>
-				<span className="flex-1 min-w-0">
-					<span className="block truncate text-[12.5px] font-medium text-ink">
-						{mailbox?.name || "Select mailbox"}
-					</span>
-					<span className="block truncate text-[10.5px] text-ink-3">
-						{orgDomain} · {mailboxCount} mailbox{mailboxCount === 1 ? "" : "es"}
-					</span>
-				</span>
-				<CaretRightIcon size={12} className="text-ink-3 shrink-0" />
-			</button>
+			{/* Mailbox switcher (#188). Replaces the old "Select mailbox" card,
+			    which was wired to `navigate("/")` and therefore a no-op at the
+			    org root. The new card opens a base-ui Menu listing every
+			    mailbox the user has access to; selecting one navigates to the
+			    per-mailbox dashboard. */}
+			<MailboxSwitcher
+				activeMailboxId={mailboxId}
+				mailbox={mailbox}
+				mailboxes={mailboxes}
+				mailboxCount={mailboxCount}
+				onClose={onCloseSidebar}
+			/>
 
 			<nav className="mt-3 px-3 flex-1 overflow-y-auto">
 				{/* Org-scoped entries are always visible. They route to / and
@@ -397,14 +389,12 @@ export default function Shell({ children, rightPanel }: ShellProps) {
 		<NavContents
 			mailboxId={mailboxId}
 			mailbox={mailbox}
+			mailboxes={mailboxes}
 			mailboxCount={mailboxCount}
 			pipelineState={pipelineState}
 			theme={theme}
 			onToggleTheme={toggleTheme}
-			onSwitchOrg={() => {
-				closeSidebar();
-				navigate("/");
-			}}
+			onCloseSidebar={closeSidebar}
 			onPipelineClick={() => {
 				if (!mailboxId) return;
 				closeSidebar();

--- a/tests/frontend/shell-mailbox-switcher.test.tsx
+++ b/tests/frontend/shell-mailbox-switcher.test.tsx
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+// Sidebar mailbox-switcher (#188). The card at the top of the sidebar used
+// to be wired to `navigate("/")` — a no-op at the org root and a misleading
+// affordance everywhere else (it sported a chevron and a "Select mailbox"
+// placeholder). Path (a) of the issue: replace with a base-ui Menu that
+// lists the mailboxes the user has access to and navigates on selection.
+
+import { fireEvent, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes, useLocation } from "react-router";
+
+interface MailboxFixture {
+	id: string;
+	email: string;
+	name: string;
+}
+
+let mailboxFixture: MailboxFixture | undefined = undefined;
+let mailboxesFixture: MailboxFixture[] = [];
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({ data: mailboxFixture }),
+	useMailboxes: () => ({ data: mailboxesFixture }),
+}));
+
+vi.mock("~/queries/domains", () => ({
+	useDomainStats: () => ({
+		data: undefined,
+		isLoading: false,
+		isError: false,
+	}),
+}));
+
+vi.mock("~/queries/dashboard", () => ({
+	useDashboardSummary: () => ({
+		data: undefined,
+		isLoading: false,
+		isError: false,
+	}),
+}));
+
+import Shell from "~/components/phishsoc/Shell";
+import { renderWithProviders } from "./test-utils";
+
+function LocationReporter() {
+	const loc = useLocation();
+	return <div data-testid="location">{loc.pathname}</div>;
+}
+
+function renderShellAt(initialEntries: string[]) {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/"
+				element={
+					<Shell>
+						<LocationReporter />
+					</Shell>
+				}
+			/>
+			<Route
+				path="/mailboxes"
+				element={
+					<Shell>
+						<LocationReporter />
+					</Shell>
+				}
+			/>
+			<Route
+				path="/mailbox/:mailboxId/*"
+				element={
+					<Shell>
+						<LocationReporter />
+					</Shell>
+				}
+			/>
+		</Routes>,
+		{ initialEntries },
+	);
+}
+
+// base-ui Menu's trigger opens on `mousedown`, not `click` (the trigger
+// passes `event: 'mousedown'` to floating-ui's `useClick`). In a real
+// browser `userEvent.click` fires `pointerdown -> mousedown -> ...` and that
+// drives the trigger fine, but under jsdom that path doesn't reliably toggle
+// the open state — `fireEvent.mouseDown` does, and after a microtask the
+// open-transition settles so testing-library can find the popup.
+//
+// We keep this helper local to the test file rather than reaching for
+// `userEvent.pointer({ keys: '[MouseLeft]', target })` because the simpler
+// fireEvent path is closer to what the trigger actually subscribes to and
+// avoids userEvent's pointer-state bookkeeping interacting with base-ui's
+// focus guards.
+async function openMenu(trigger: HTMLElement) {
+	fireEvent.mouseDown(trigger);
+	// Yield for base-ui's mount/transition raf cycle. Without this the popup
+	// is in the DOM but still has `data-closed=""` + `hidden=""`.
+	await new Promise((r) => setTimeout(r, 50));
+}
+
+describe("Shell mailbox switcher (#188)", () => {
+	beforeEach(() => {
+		mailboxFixture = undefined;
+		mailboxesFixture = [];
+	});
+
+	it("trigger has aria-haspopup=menu and aria-expanded toggles on open", async () => {
+		mailboxesFixture = [
+			{ id: "m1", email: "alice@acme.com", name: "Alice" },
+			{ id: "m2", email: "bob@acme.com", name: "Bob" },
+		];
+		renderShellAt(["/"]);
+
+		// Trigger label reads "Select mailbox" at the org root because no
+		// mailbox is active — same string the old card displayed, just now
+		// backed by a real picker.
+		const trigger = screen.getByRole("button", { name: /select mailbox/i });
+		expect(trigger).toHaveAttribute("aria-haspopup", "menu");
+		expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+		await openMenu(trigger);
+
+		const menu = await screen.findByRole("menu");
+		expect(menu).toBeInTheDocument();
+		expect(trigger).toHaveAttribute("aria-expanded", "true");
+	});
+
+	it("opens from / and selecting a mailbox navigates to its dashboard", async () => {
+		mailboxesFixture = [
+			{ id: "m1", email: "alice@acme.com", name: "Alice" },
+			{ id: "m2", email: "bob@acme.com", name: "Bob" },
+		];
+		const user = userEvent.setup();
+		renderShellAt(["/"]);
+
+		expect(screen.getByTestId("location")).toHaveTextContent("/");
+
+		const trigger = screen.getByRole("button", { name: /select mailbox/i });
+		await openMenu(trigger);
+
+		const menu = await screen.findByRole("menu");
+		const bobItem = within(menu).getByRole("menuitem", { name: /bob/i });
+		await user.click(bobItem);
+
+		// Navigated to the per-mailbox landing route. The :mailboxId in the
+		// URL is encoded — fixture ids are URL-safe so they round-trip
+		// unchanged.
+		expect(screen.getByTestId("location")).toHaveTextContent(
+			"/mailbox/m2/dashboard",
+		);
+	});
+
+	it("marks the active mailbox in the menu list", async () => {
+		mailboxFixture = { id: "m1", email: "alice@acme.com", name: "Alice" };
+		mailboxesFixture = [
+			mailboxFixture,
+			{ id: "m2", email: "bob@acme.com", name: "Bob" },
+		];
+		renderShellAt(["/mailbox/m1/dashboard"]);
+
+		// On the per-mailbox route the trigger label switches to the active
+		// mailbox name.
+		const trigger = screen.getByRole("button", { name: /alice/i });
+		await openMenu(trigger);
+
+		const menu = await screen.findByRole("menu");
+		// The active row carries the "Active mailbox" check glyph; the
+		// inactive row does not.
+		expect(within(menu).getByLabelText(/active mailbox/i)).toBeInTheDocument();
+		// Sanity: there's exactly one active marker, not one per row.
+		expect(within(menu).getAllByLabelText(/active mailbox/i)).toHaveLength(1);
+	});
+
+	it("with zero mailboxes shows the empty state with a link to /mailboxes", async () => {
+		mailboxesFixture = [];
+		const user = userEvent.setup();
+		renderShellAt(["/"]);
+
+		const trigger = screen.getByRole("button", { name: /select mailbox/i });
+		await openMenu(trigger);
+
+		const menu = await screen.findByRole("menu");
+		// No selectable mailbox rows.
+		expect(within(menu).queryAllByRole("menuitem")).toHaveLength(0);
+		expect(within(menu).getByText(/no mailboxes yet/i)).toBeInTheDocument();
+
+		const link = within(menu).getByRole("link", { name: /provision a mailbox/i });
+		expect(link).toHaveAttribute("href", "/mailboxes");
+
+		await user.click(link);
+		expect(screen.getByTestId("location")).toHaveTextContent("/mailboxes");
+	});
+
+	it("Escape closes the menu", async () => {
+		mailboxesFixture = [{ id: "m1", email: "alice@acme.com", name: "Alice" }];
+		const user = userEvent.setup();
+		renderShellAt(["/"]);
+
+		const trigger = screen.getByRole("button", { name: /select mailbox/i });
+		await openMenu(trigger);
+		await screen.findByRole("menu");
+
+		await user.keyboard("{Escape}");
+		// `findByRole` w/ a polling negative would be ideal but RTL doesn't
+		// expose one; wait briefly for base-ui's close transition to detach
+		// the popup, then assert. The visible menu is gone — that's the
+		// observable Escape behavior the issue calls out. (`aria-expanded`
+		// on the trigger lags by a render under jsdom because the open-state
+		// store updates on a focus-cycle that the headless test environment
+		// doesn't fully run; checking the popup itself is the more honest
+		// assertion here.)
+		await new Promise((r) => setTimeout(r, 50));
+		expect(screen.queryByRole("menu")).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

- Replaces the sidebar "Select mailbox" card (which navigated to `/` — a no-op at the org root and a dishonest affordance everywhere else) with a real base-ui Menu popover that lists every mailbox in the org and navigates to `/mailbox/:id/dashboard` on selection.
- **Path (a)** from the issue: switcher popover. The data was already loaded in `Shell.tsx` via `useMailboxes()`, so the implementation is a presentational `MailboxSwitcher` component that consumes the existing list — no new query, no new infra, no new dependency (base-ui is already in the tree for the agent panel).
- Empty state: "No mailboxes yet" with a link to `/mailboxes` to provision. Active mailbox is marked with a check glyph. `modal={false}` so the popover doesn't lock page scroll like a dialog while still wiring Escape and outside-click dismissal via base-ui.

Closes #188
Part of #191

## Test plan

- [x] `npm test` — 602 passing, 0 failing (5 new tests in `tests/frontend/shell-mailbox-switcher.test.tsx`)
- [x] `npm run typecheck` — no errors
- [x] New tests cover the issue's two stated cases (open from `/`, select a mailbox, assert navigation; open with zero mailboxes shows the empty state) plus three more (ARIA wiring on the trigger, active-mailbox marker, Escape closes the popup)

## Implementation notes

- `aria-haspopup="menu"` and `aria-expanded` come from `Menu.Trigger` directly. `Menu.Item` provides arrow-key / Enter / Escape handling and focus management out of the box, matching the keyboard expectations from the issue.
- The active-mailbox check is rendered with `aria-label="Active mailbox"` so the test can assert presence without coupling to the icon name.
- Selecting the *currently active* mailbox is treated as a no-op (no extra navigate), but the sidebar drawer still closes — the route-pathname effect in Shell wouldn't fire in that case, so the explicit `onClose()` matters on mobile.
- A small fireEvent + RAF helper in the test (`openMenu`) is needed because `userEvent.click` doesn't reliably toggle base-ui Menu under jsdom — the trigger subscribes to `mousedown`. The production code path is unchanged and uses the standard `Menu.Trigger`.

## Out of scope (per issue)

- Multi-org / tenant switching.
- Search filter inside the popover (Acceptance explicitly says "not required for v1 if N is small").
- Mailbox provisioning UI changes (#181).