### PR TITLE
fix(ui): remove dead 'SOC analyst' placeholder from sidebar

### DIFF
--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -292,14 +292,7 @@ function NavContents({
 				</button>
 			)}
 
-			<div className="border-t border-line px-3 py-2.5 flex items-center gap-2">
-				<div className="flex h-7 w-7 items-center justify-center rounded-full bg-accent-tint text-accent-ink text-[11px] font-medium">
-					SA
-				</div>
-				<div className="flex-1 min-w-0">
-					<div className="text-[12px] text-ink truncate">SOC analyst</div>
-					<div className="text-[10.5px] text-ink-3 truncate">Preview</div>
-				</div>
+			<div className="border-t border-line px-3 py-2.5 flex items-center justify-end">
 				<button
 					type="button"
 					onClick={onToggleTheme}

--- a/tests/frontend/shell-sidebar-footer.test.tsx
+++ b/tests/frontend/shell-sidebar-footer.test.tsx
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+import type { DashboardSummary } from "~/types";
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({
+		data: { id: "m1", email: "alice@acme.com", name: "Alice" },
+	}),
+	useMailboxes: () => ({
+		data: [{ id: "m1", email: "alice@acme.com", name: "Alice" }],
+	}),
+}));
+
+const queryState: {
+	data: DashboardSummary | undefined;
+	isLoading: boolean;
+	isError: boolean;
+} = {
+	data: {
+		now: "2026-04-30T12:00:00Z",
+		threatsBlocked: 0,
+		openCases: 0,
+		hubContributions: 0,
+		corroboration: null,
+		pipelineSuccess: 0.98,
+		p95Ms: null,
+		threatPressure: [],
+		recentCases: [],
+	},
+	isLoading: false,
+	isError: false,
+};
+
+vi.mock("~/queries/dashboard", () => ({
+	useDashboardSummary: () => queryState,
+}));
+
+import Shell from "~/components/phishsoc/Shell";
+import { renderWithProviders } from "./test-utils";
+
+function renderShell() {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/mailbox/:mailboxId/*"
+				element={
+					<Shell>
+						<div />
+					</Shell>
+				}
+			/>
+		</Routes>,
+		{ initialEntries: ["/mailbox/m1/dashboard"] },
+	);
+}
+
+describe("Shell sidebar footer (#189)", () => {
+	it("does not render the hardcoded 'SOC analyst' placeholder", () => {
+		renderShell();
+		expect(screen.queryByText(/SOC analyst/i)).not.toBeInTheDocument();
+	});
+
+	it("does not render the hardcoded 'Preview' placeholder text", () => {
+		renderShell();
+		// Scope: the dead avatar slot's "Preview" caption must be gone. There
+		// should be no element whose text content is exactly "Preview".
+		const previewNodes = screen
+			.queryAllByText(/^Preview$/i)
+			// Filter out anything that's part of a larger phrase rendered elsewhere
+			// (defensive — there is no such usage today).
+			.filter((node) => node.textContent?.trim() === "Preview");
+		expect(previewNodes).toHaveLength(0);
+	});
+
+	it("does not render the 'SA' avatar circle", () => {
+		renderShell();
+		// The dead avatar was a div containing only the literal "SA".
+		const saNodes = screen
+			.queryAllByText(/^SA$/)
+			.filter((node) => node.textContent?.trim() === "SA");
+		expect(saNodes).toHaveLength(0);
+	});
+
+	it("still renders the theme toggle in the sidebar footer", () => {
+		renderShell();
+		// The toggle's aria-label flips with theme; either label proves it's
+		// still mounted.
+		const toggle = screen.queryByRole("button", {
+			name: /Switch to (light|dark) mode/i,
+		});
+		expect(toggle).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary

- Took **path (b)** (relabel/fallback) from #189: removed the hardcoded "SA" avatar circle and "SOC analyst / Preview" text rows from `app/components/phishsoc/Shell.tsx`. The footer slot now contains only the (working) theme toggle, right-aligned to preserve sidebar balance.
- Path (a) — wiring an auth-aware account menu — is **explicitly deferred**; the surface no longer promises an account menu that does not exist.
- Real account menu tracked as #204.

Closes #189
Part of #191
Follow-up: #204

## Test plan

- [x] `npm test` — 601 passed, 0 failing across 53 files (includes 4 new assertions in `tests/frontend/shell-sidebar-footer.test.tsx`).
- [x] `npm run typecheck` — clean (`tsc -b` after `cf-typegen` + `react-router typegen`).
- [x] New tests assert: hardcoded "SOC analyst" gone, "Preview" caption gone, "SA" avatar gone, theme toggle still rendered with correct aria-label.