### PR TITLE
feat(ui): mailbox-switcher search filter when count > 8

### DIFF
--- a/app/components/phishsoc/MailboxSwitcher.tsx
+++ b/app/components/phishsoc/MailboxSwitcher.tsx
@@ -4,6 +4,7 @@
 
 import { Menu } from "@base-ui/react/menu";
 import { CaretUpDownIcon, CheckIcon } from "@phosphor-icons/react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import type { Mailbox } from "~/types";
 
@@ -40,6 +41,11 @@ interface MailboxSwitcherProps {
 	onClose: () => void;
 }
 
+// Threshold above which a search filter is rendered inside the popover.
+// Below this, the flat scroll is fine; above it, finding a mailbox by
+// scanning the list becomes the bottleneck (#203).
+const MAILBOX_SEARCH_THRESHOLD = 8;
+
 export default function MailboxSwitcher({
 	activeMailboxId,
 	mailbox,
@@ -51,11 +57,66 @@ export default function MailboxSwitcher({
 	const orgDomain = mailbox?.email?.split("@")[1] ?? "—";
 	const orgInitial = (mailbox?.name || mailbox?.email || "?")[0]?.toUpperCase();
 	const list = mailboxes ?? [];
+	const showSearch = list.length > MAILBOX_SEARCH_THRESHOLD;
+
+	const [query, setQuery] = useState("");
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	const popupRef = useRef<HTMLDivElement | null>(null);
+
+	// Reset the filter every time the menu closes so the next open starts
+	// clean — without this, reopening the popover would surface the previous
+	// query and confuse the affordance.
+	const handleOpenChange = (open: boolean) => {
+		if (!open) setQuery("");
+	};
+
+	// Focus the search input on open. base-ui's FloatingFocusManager runs
+	// `initialFocus: true` for a top-level menu, which targets the first
+	// tabbable element — that's the input now, but our items also become
+	// tabbable via roving focus. An explicit focus() inside a microtask is
+	// the most reliable way to land focus on the input regardless of the
+	// composite's roving-focus race.
+	useEffect(() => {
+		if (!showSearch) return;
+		// Wait one tick for the popup to mount before focusing.
+		const id = window.setTimeout(() => {
+			inputRef.current?.focus();
+		}, 0);
+		return () => window.clearTimeout(id);
+		// Re-run when the popup mounts (popupRef changes via callback ref) —
+		// but useEffect on render is enough here because the popup mounts as
+		// part of the same render cycle that sets `showSearch`.
+	}, [showSearch]);
+
+	const filtered = useMemo(() => {
+		const q = query.trim().toLowerCase();
+		if (!q) return list;
+		return list.filter((mb) => {
+			const name = (mb.name ?? "").toLowerCase();
+			const email = (mb.email ?? "").toLowerCase();
+			return name.includes(q) || email.includes(q);
+		});
+	}, [list, query]);
 
 	const handlePick = (id: string) => {
 		onClose();
 		if (id === activeMailboxId) return;
 		navigate(`/mailbox/${encodeURIComponent(id)}/dashboard`);
+	};
+
+	// ↓ from the input should land on the first matching menuitem. The input
+	// is intentionally NOT a Menu.Item (so it never shows up in roving focus
+	// and never gets selected by Enter from another row), so we wire the
+	// arrow manually. Querying the popup for `role="menuitem"` keeps us
+	// agnostic to base-ui's internal composite store.
+	const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+		if (event.key !== "ArrowDown") return;
+		const popup = popupRef.current;
+		if (!popup) return;
+		const firstItem = popup.querySelector<HTMLElement>('[role="menuitem"]');
+		if (!firstItem) return;
+		event.preventDefault();
+		firstItem.focus();
 	};
 
 	return (
@@ -65,6 +126,7 @@ export default function MailboxSwitcher({
 			// than a popover should be. base-ui still wires Escape and
 			// outside-click dismissal in non-modal mode.
 			modal={false}
+			onOpenChange={handleOpenChange}
 		>
 			<Menu.Trigger
 				className="mx-3 flex items-center gap-2.5 rounded-md border border-line bg-paper px-2.5 py-2 text-left hover:border-line-strong transition-colors"
@@ -85,9 +147,28 @@ export default function MailboxSwitcher({
 			<Menu.Portal>
 				<Menu.Positioner sideOffset={4} align="start" className="z-50">
 					<Menu.Popup
+						ref={popupRef}
 						aria-label="Switch mailbox"
 						className="min-w-[220px] max-w-[320px] rounded-md border border-line bg-paper py-1 shadow-lg outline-none"
 					>
+						{showSearch && (
+							// Static input, not a Menu.Item — keeps it out of the
+							// composite's roving focus so arrow keys on the items
+							// don't cycle through it. Tabbing still reaches it
+							// because it's a focusable element in DOM order.
+							<div className="px-2 pb-1 pt-0.5">
+								<input
+									ref={inputRef}
+									type="text"
+									value={query}
+									onChange={(e) => setQuery(e.target.value)}
+									onKeyDown={handleInputKeyDown}
+									placeholder="Search mailboxes"
+									aria-label="Search mailboxes"
+									className="w-full rounded-sm border border-line bg-paper-2 px-2 py-1 text-[12px] text-ink placeholder:text-ink-3 outline-none focus:border-line-strong"
+								/>
+							</div>
+						)}
 						{list.length === 0 ? (
 							// Empty state. Not a `MenuItem` — that would make it
 							// selectable; this is a static blurb plus a nav link the
@@ -108,8 +189,14 @@ export default function MailboxSwitcher({
 									</a>
 								</div>
 							</div>
+						) : filtered.length === 0 ? (
+							// Search has filtered out every row. Not a Menu.Item so
+							// arrow keys don't try to highlight it.
+							<div className="px-3 py-2 text-[12px] text-ink-3">
+								No matches
+							</div>
 						) : (
-							list.map((mb) => {
+							filtered.map((mb) => {
 								const isActive = mb.id === activeMailboxId;
 								return (
 									<Menu.Item

--- a/tests/frontend/shell-mailbox-switcher.test.tsx
+++ b/tests/frontend/shell-mailbox-switcher.test.tsx
@@ -193,6 +193,107 @@ describe("Shell mailbox switcher (#188)", () => {
 		expect(screen.getByTestId("location")).toHaveTextContent("/mailboxes");
 	});
 
+	// #203: search filter when mailbox count exceeds the threshold (>8).
+	describe("search filter (#203)", () => {
+		function makeMailboxes(n: number): MailboxFixture[] {
+			return Array.from({ length: n }, (_, i) => ({
+				id: `m${i + 1}`,
+				email: `user${i + 1}@acme.com`,
+				name: `Person ${i + 1}`,
+			}));
+		}
+
+		it("does not render the search input when count <= 8", async () => {
+			mailboxesFixture = makeMailboxes(8);
+			renderShellAt(["/"]);
+
+			const trigger = screen.getByRole("button", { name: /select mailbox/i });
+			await openMenu(trigger);
+
+			const menu = await screen.findByRole("menu");
+			expect(
+				within(menu).queryByRole("textbox", { name: /search mailboxes/i }),
+			).toBeNull();
+			// All 8 rows should be present.
+			expect(within(menu).getAllByRole("menuitem")).toHaveLength(8);
+		});
+
+		it("renders the search input when count > 8 and filters by name substring", async () => {
+			mailboxesFixture = makeMailboxes(12);
+			// Give one mailbox a distinctive name so the substring search has
+			// something unambiguous to match.
+			mailboxesFixture[6] = {
+				id: "m7",
+				email: "needle@acme.com",
+				name: "Needle Person",
+			};
+			renderShellAt(["/"]);
+
+			const trigger = screen.getByRole("button", { name: /select mailbox/i });
+			await openMenu(trigger);
+
+			const menu = await screen.findByRole("menu");
+			const input = within(menu).getByRole("textbox", {
+				name: /search mailboxes/i,
+			});
+			expect(input).toBeInTheDocument();
+			// All 12 rows visible before filtering.
+			expect(within(menu).getAllByRole("menuitem")).toHaveLength(12);
+
+			fireEvent.change(input, { target: { value: "needle" } });
+
+			// Only the matching row remains.
+			const items = within(menu).getAllByRole("menuitem");
+			expect(items).toHaveLength(1);
+			expect(items[0]).toHaveTextContent(/needle/i);
+		});
+
+		it("filter is case-insensitive and matches email substring", async () => {
+			mailboxesFixture = makeMailboxes(12);
+			mailboxesFixture[3] = {
+				id: "m4",
+				email: "unique-handle@acme.com",
+				name: "Plain Name",
+			};
+			renderShellAt(["/"]);
+
+			const trigger = screen.getByRole("button", { name: /select mailbox/i });
+			await openMenu(trigger);
+
+			const menu = await screen.findByRole("menu");
+			const input = within(menu).getByRole("textbox", {
+				name: /search mailboxes/i,
+			});
+
+			fireEvent.change(input, { target: { value: "UNIQUE-HANDLE" } });
+
+			const items = within(menu).getAllByRole("menuitem");
+			expect(items).toHaveLength(1);
+			expect(items[0]).toHaveTextContent(/Plain Name/);
+		});
+
+		it('shows "No matches" when the filter empties the list, and clearing restores it', async () => {
+			mailboxesFixture = makeMailboxes(12);
+			renderShellAt(["/"]);
+
+			const trigger = screen.getByRole("button", { name: /select mailbox/i });
+			await openMenu(trigger);
+
+			const menu = await screen.findByRole("menu");
+			const input = within(menu).getByRole("textbox", {
+				name: /search mailboxes/i,
+			});
+
+			fireEvent.change(input, { target: { value: "zzznomatchzzz" } });
+			expect(within(menu).queryAllByRole("menuitem")).toHaveLength(0);
+			expect(within(menu).getByText(/no matches/i)).toBeInTheDocument();
+
+			fireEvent.change(input, { target: { value: "" } });
+			// Full list restored.
+			expect(within(menu).getAllByRole("menuitem")).toHaveLength(12);
+		});
+	});
+
 	it("Escape closes the menu", async () => {
 		mailboxesFixture = [{ id: "m1", email: "alice@acme.com", name: "Alice" }];
 		const user = userEvent.setup();


### PR DESCRIPTION
## Summary

- Adds a search input to the top of the sidebar mailbox-switcher popover (#188); it only renders once `mailboxes.length > 8` (`MAILBOX_SEARCH_THRESHOLD`), so small orgs see no UI change.
- Filter is case-insensitive substring match against `name` OR `email`. Empty filter shows the full list; "No matches" empty state when the filter rules everything out.
- Input is intentionally not a `Menu.Item` (so arrow keys on rows don't cycle through it). Focused on open; ArrowDown from the input forwards focus to the first matching menuitem.
- Filter resets on close so the next open starts clean.

Closes #203

## Test plan

- [x] `npm test` — 674 passing, 0 failing (9 in the mailbox-switcher file: 5 prior + 4 new).
- [x] `npm run typecheck` — clean.
- [x] New: with 12 mailboxes, typing a substring of one mailbox's name leaves only the matching row.
- [x] New: input is NOT rendered when count ≤ 8 (boundary tested at exactly 8).
- [x] New: case-insensitive email-substring match works.
- [x] New: "No matches" appears when the filter empties the list, and clearing restores all 12 rows.

## Out of scope

Per the issue: server-side search, fuzzy matching, and match highlighting are explicitly deferred.