### PR TITLE
feat(ui): manual case dialog — observables editor + score override

### DIFF
--- a/app/components/CreateCaseModal.tsx
+++ b/app/components/CreateCaseModal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
 
 /**
- * Manual case creation dialog (issue #190).
+ * Manual case creation dialog (issue #190, extended in #194).
  *
  * The "+ Manual case" button on `/mailbox/:mailboxId/cases` opens this
  * dialog. Submitting POSTs to the existing endpoint
@@ -10,21 +10,45 @@
  *
  *   { title (req), notes?, emailId?, observables?, score? }
  *
- * v1 surfaces only `title`, `notes`, and `emailId`. `observables` and
- * `score` are intentionally deferred — the worker accepts them, but the
- * UI for repeating observable kind/value pairs is its own design problem
- * and `score` is auto-derived from the originating email's verdict on
- * the report-phish path. New manual cases land at status `"open"` —
- * that's hardcoded in the DO's `createCase` impl, not exposed on the
- * schema, so we don't render a status `<select>`.
+ * Surfaces:
+ *   - title (required), notes, emailId — the v1 surface (#190).
+ *   - observables — repeating editor: `kind` dropdown +
+ *     `value` input. Add/remove rows. Empty rows are silently
+ *     dropped before POST. When the array would be empty post-drop,
+ *     we omit `observables` from the body entirely (the schema
+ *     marks it `.optional()`).
+ *   - score — optional integer 0-100. Empty by default. When empty
+ *     on submit, we OMIT `score` from the body (do NOT send `null`).
+ *     `report-phish` is the path that derives a verdict score
+ *     automatically; manual creates leave it null on purpose, and
+ *     omitting lets the worker default it. Invalid input
+ *     (non-integer / out-of-range) shows an inline message and
+ *     blocks submit.
+ *
+ * Status is hardcoded to `"open"` by the DO's `createCase` impl —
+ * not exposed on the schema, so we don't render a status `<select>`.
  *
  * Validation errors are surfaced field-by-field from the worker's
  * `parsed.error.flatten().fieldErrors` shape. Network / 500-class
  * failures fall back to a generic toast via `useFeedback`.
+ *
+ * Per-row observable errors: zod's `flatten()` collapses nested
+ * issues into `formErrors`, so the worker's current response can
+ * only carry an `observables` top-level error (e.g. "Required").
+ * We surface that above the editor. If the response ever grows
+ * `observables.<i>.<field>` keys (e.g. via a richer error
+ * serializer), `observableRowErrors` below maps them to the
+ * matching row inline.
  */
 
 import { Button, Dialog, Input, Text } from "@cloudflare/kumo";
-import { type FormEvent, useCallback, useEffect, useState } from "react";
+import {
+	type FormEvent,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+} from "react";
 import { useFeedback } from "~/lib/feedback";
 
 export interface CreateCaseModalProps {
@@ -41,7 +65,61 @@ export interface CreateCaseModalProps {
 	onCreated: () => void;
 }
 
-type FieldErrors = Partial<Record<"title" | "notes" | "emailId", string>>;
+/**
+ * Set of `kind` values rendered by the case-detail observable list
+ * (`OBSERVABLE_TONE` at app/routes/case-detail.tsx:37). Keep these in
+ * sync — a `kind` not in that map renders muted on case-detail.
+ */
+const OBSERVABLE_KINDS = ["email", "url", "domain", "ipv4", "ipv6"] as const;
+type ObservableKind = (typeof OBSERVABLE_KINDS)[number];
+
+interface ObservableRow {
+	/** Stable key for React. Not sent to the worker. */
+	key: string;
+	kind: ObservableKind;
+	value: string;
+}
+
+type FieldErrors = Partial<
+	Record<"title" | "notes" | "emailId" | "observables" | "score", string>
+>;
+
+/**
+ * Per-row error map keyed by observable row index. Only populated when
+ * the worker's 400 response includes nested keys like
+ * `observables.0.value` — current `flatten()` output won't carry these,
+ * but the surface is wired so a future richer error response renders
+ * inline next to the offending row.
+ */
+type ObservableRowErrors = Record<number, { kind?: string; value?: string }>;
+
+let _rowKeySeq = 0;
+function nextRowKey(): string {
+	_rowKeySeq += 1;
+	return `obs-${_rowKeySeq}`;
+}
+
+function emptyRow(): ObservableRow {
+	return { key: nextRowKey(), kind: "email", value: "" };
+}
+
+/**
+ * Validate score input. Returns `{ value: number }` for a parseable
+ * integer in [0, 100], `{ value: null }` for empty/whitespace (omit
+ * from body), or `{ error }` for invalid input (block submit).
+ */
+function parseScore(raw: string): { value: number | null } | { error: string } {
+	const trimmed = raw.trim();
+	if (trimmed === "") return { value: null };
+	if (!/^-?\d+$/.test(trimmed)) {
+		return { error: "Score must be a whole number between 0 and 100." };
+	}
+	const n = Number(trimmed);
+	if (!Number.isInteger(n) || n < 0 || n > 100) {
+		return { error: "Score must be a whole number between 0 and 100." };
+	}
+	return { value: n };
+}
 
 export default function CreateCaseModal({
 	open,
@@ -53,14 +131,23 @@ export default function CreateCaseModal({
 	const [title, setTitle] = useState("");
 	const [notes, setNotes] = useState("");
 	const [emailId, setEmailId] = useState("");
+	const [observables, setObservables] = useState<ObservableRow[]>(() => [
+		emptyRow(),
+	]);
+	const [score, setScore] = useState("");
 	const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+	const [observableRowErrors, setObservableRowErrors] =
+		useState<ObservableRowErrors>({});
 	const [submitting, setSubmitting] = useState(false);
 
 	const reset = useCallback(() => {
 		setTitle("");
 		setNotes("");
 		setEmailId("");
+		setObservables([emptyRow()]);
+		setScore("");
 		setFieldErrors({});
+		setObservableRowErrors({});
 		setSubmitting(false);
 	}, []);
 
@@ -79,16 +166,69 @@ export default function CreateCaseModal({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [open]);
 
+	// Live-validate score as the user types so the inline error is in
+	// sync with the disabled-submit state. Empty string is valid (=> omit).
+	const scoreValidation = useMemo(() => parseScore(score), [score]);
+	const scoreError =
+		"error" in scoreValidation ? scoreValidation.error : undefined;
+
+	const addObservableRow = () => {
+		setObservables((rows) => [...rows, emptyRow()]);
+	};
+
+	const removeObservableRow = (key: string) => {
+		setObservables((rows) => {
+			const next = rows.filter((r) => r.key !== key);
+			// Always keep at least one row in the editor — adds back an
+			// empty row if the user removes the last populated one. The
+			// row is dropped at submit time if still empty.
+			return next.length > 0 ? next : [emptyRow()];
+		});
+		// Drop any stale row error for the removed row's index. The
+		// reindex isn't perfect (errors stick to the old indices), but
+		// any new submit clears them anyway.
+		setObservableRowErrors({});
+	};
+
+	const updateObservableRow = (
+		key: string,
+		patch: Partial<Pick<ObservableRow, "kind" | "value">>,
+	) => {
+		setObservables((rows) =>
+			rows.map((r) => (r.key === key ? { ...r, ...patch } : r)),
+		);
+	};
+
 	const handleSubmit = async (e: FormEvent) => {
 		e.preventDefault();
 		if (!mailboxId || submitting) return;
+		// Block submit on a client-side score error.
+		if (scoreError) return;
 		setFieldErrors({});
+		setObservableRowErrors({});
 
 		const body: Record<string, unknown> = { title: title.trim() };
 		const trimmedNotes = notes.trim();
 		if (trimmedNotes) body.notes = trimmedNotes;
 		const trimmedEmailId = emailId.trim();
 		if (trimmedEmailId) body.emailId = trimmedEmailId;
+
+		// Drop empty rows. A row is "empty" when its value is blank
+		// after trim — kind always has a default, so an unset kind
+		// isn't possible here.
+		const populatedObservables = observables
+			.map((r) => ({ kind: r.kind, value: r.value.trim() }))
+			.filter((r) => r.value.length > 0);
+		if (populatedObservables.length > 0) {
+			body.observables = populatedObservables;
+		}
+
+		// Score: only attach when set (validated above). When empty,
+		// omit entirely — the worker defaults it. Per #194 acceptance:
+		// do NOT send `null`.
+		if ("value" in scoreValidation && scoreValidation.value !== null) {
+			body.score = scoreValidation.value;
+		}
 
 		setSubmitting(true);
 		try {
@@ -103,9 +243,7 @@ export default function CreateCaseModal({
 			if (res.status === 400) {
 				// Zod safeParse failure → render field-by-field, NOT a
 				// generic toast (acceptance criterion).
-				const errBody = (await res
-					.json()
-					.catch(() => null)) as
+				const errBody = (await res.json().catch(() => null)) as
 					| { error?: { fieldErrors?: Record<string, string[]> } }
 					| null;
 				const fe = errBody?.error?.fieldErrors ?? {};
@@ -113,7 +251,23 @@ export default function CreateCaseModal({
 					title: fe.title?.[0],
 					notes: fe.notes?.[0],
 					emailId: fe.emailId?.[0],
+					observables: fe.observables?.[0],
+					score: fe.score?.[0],
 				});
+				// Map any nested-key errors to the matching row index.
+				// Pattern: `observables.<i>.<field>`. Stock zod
+				// `flatten()` won't emit these, but the surface is
+				// wired so a richer serializer renders inline.
+				const rowErrors: ObservableRowErrors = {};
+				for (const [k, msgs] of Object.entries(fe)) {
+					const m = /^observables\.(\d+)\.(kind|value)$/.exec(k);
+					if (m && msgs && msgs.length > 0) {
+						const idx = Number(m[1]);
+						const field = m[2] as "kind" | "value";
+						rowErrors[idx] = { ...rowErrors[idx], [field]: msgs[0] };
+					}
+				}
+				setObservableRowErrors(rowErrors);
 				setSubmitting(false);
 				return;
 			}
@@ -133,6 +287,9 @@ export default function CreateCaseModal({
 			setSubmitting(false);
 		}
 	};
+
+	const submitDisabled =
+		!title.trim() || !mailboxId || Boolean(scoreError);
 
 	return (
 		<Dialog.Root open={open} onOpenChange={handleOpenChange}>
@@ -195,6 +352,113 @@ export default function CreateCaseModal({
 							</Text>
 						) : null}
 					</div>
+
+					{/* Observables editor (#194). */}
+					<div>
+						<span className="text-sm font-medium text-ink mb-1.5 block">
+							Observables (optional)
+						</span>
+						<div className="space-y-2">
+							{observables.map((row, idx) => {
+								const rowErr = observableRowErrors[idx];
+								return (
+									<div key={row.key}>
+										<div className="flex gap-2 items-start">
+											<select
+												aria-label={`Observable kind ${idx + 1}`}
+												value={row.kind}
+												onChange={(e) =>
+													updateObservableRow(row.key, {
+														kind: e.target.value as ObservableKind,
+													})
+												}
+												className="rounded-md border border-line bg-paper px-2 py-1.5 text-[13px] text-ink focus:outline-none focus:border-line-strong"
+											>
+												{OBSERVABLE_KINDS.map((k) => (
+													<option key={k} value={k}>
+														{k}
+													</option>
+												))}
+											</select>
+											<input
+												type="text"
+												aria-label={`Observable value ${idx + 1}`}
+												placeholder="value"
+												value={row.value}
+												onChange={(e) =>
+													updateObservableRow(row.key, {
+														value: e.target.value,
+													})
+												}
+												maxLength={500}
+												className="flex-1 rounded-md border border-line bg-paper px-3 py-1.5 text-[13px] text-ink placeholder:text-ink-3 focus:outline-none focus:border-line-strong"
+												aria-invalid={rowErr?.value ? true : undefined}
+											/>
+											<Button
+												type="button"
+												variant="secondary"
+												size="sm"
+												onClick={() => removeObservableRow(row.key)}
+												aria-label={`Remove observable ${idx + 1}`}
+											>
+												Remove
+											</Button>
+										</div>
+										{rowErr?.kind ? (
+											<Text variant="error" size="sm">
+												{rowErr.kind}
+											</Text>
+										) : null}
+										{rowErr?.value ? (
+											<Text variant="error" size="sm">
+												{rowErr.value}
+											</Text>
+										) : null}
+									</div>
+								);
+							})}
+						</div>
+						<div className="mt-2">
+							<Button
+								type="button"
+								variant="secondary"
+								size="sm"
+								onClick={addObservableRow}
+							>
+								Add observable
+							</Button>
+						</div>
+						{fieldErrors.observables ? (
+							<Text variant="error" size="sm">
+								{fieldErrors.observables}
+							</Text>
+						) : null}
+					</div>
+
+					{/* Score override (#194). */}
+					<div>
+						<Input
+							label="Score override (optional, 0-100)"
+							placeholder="leave blank for none"
+							size="sm"
+							inputMode="numeric"
+							value={score}
+							onChange={(e) => setScore(e.target.value)}
+							aria-invalid={
+								scoreError || fieldErrors.score ? true : undefined
+							}
+						/>
+						{scoreError ? (
+							<Text variant="error" size="sm">
+								{scoreError}
+							</Text>
+						) : fieldErrors.score ? (
+							<Text variant="error" size="sm">
+								{fieldErrors.score}
+							</Text>
+						) : null}
+					</div>
+
 					<div className="flex justify-end gap-2 pt-2">
 						<Dialog.Close
 							render={(props) => (
@@ -213,7 +477,7 @@ export default function CreateCaseModal({
 							variant="primary"
 							size="sm"
 							loading={submitting}
-							disabled={!title.trim() || !mailboxId}
+							disabled={submitDisabled}
 						>
 							Create case
 						</Button>

--- a/tests/frontend/cases-create-modal.test.tsx
+++ b/tests/frontend/cases-create-modal.test.tsx
@@ -259,6 +259,167 @@ describe("CasesRoute manual-case dialog (issue #190)", () => {
 		expect(matches.length).toBeGreaterThan(0);
 	});
 
+	it("submit with two observables + a score POSTs the right body (issue #194)", async () => {
+		const { state } = installFetchMock();
+		renderCases();
+		await screen.findAllByText(/Initial open case/i);
+		await userEvent.click(
+			screen.getByRole("button", { name: /manual case/i }),
+		);
+		await screen.findByText(/create manual case/i);
+
+		await userEvent.type(
+			screen.getByLabelText(/^title$/i),
+			"Two observables + score",
+		);
+
+		// Add a second observable row, fill both. The first row defaults
+		// to kind=email (matches OBSERVABLE_TONE in case-detail.tsx).
+		await userEvent.type(
+			screen.getByLabelText(/^observable value 1$/i),
+			"finance@evil.example",
+		);
+		await userEvent.click(
+			screen.getByRole("button", { name: /^add observable$/i }),
+		);
+		await userEvent.selectOptions(
+			screen.getByLabelText(/^observable kind 2$/i),
+			"url",
+		);
+		await userEvent.type(
+			screen.getByLabelText(/^observable value 2$/i),
+			"https://evil.example/login",
+		);
+
+		// Set a score in range.
+		await userEvent.type(
+			screen.getByLabelText(/score override/i),
+			"77",
+		);
+
+		await userEvent.click(
+			screen.getByRole("button", { name: /^create case$/i }),
+		);
+
+		await waitFor(() => {
+			expect(state.lastPostBody).toEqual({
+				title: "Two observables + score",
+				observables: [
+					{ kind: "email", value: "finance@evil.example" },
+					{ kind: "url", value: "https://evil.example/login" },
+				],
+				score: 77,
+			});
+		});
+	});
+
+	it("clearing the score before submit drops `score` from the body (issue #194)", async () => {
+		const { state } = installFetchMock();
+		renderCases();
+		await screen.findAllByText(/Initial open case/i);
+		await userEvent.click(
+			screen.getByRole("button", { name: /manual case/i }),
+		);
+		await screen.findByText(/create manual case/i);
+
+		await userEvent.type(
+			screen.getByLabelText(/^title$/i),
+			"Cleared-score case",
+		);
+
+		const scoreInput = screen.getByLabelText(/score override/i);
+		await userEvent.type(scoreInput, "42");
+		await userEvent.clear(scoreInput);
+
+		await userEvent.click(
+			screen.getByRole("button", { name: /^create case$/i }),
+		);
+
+		// `score` must NOT appear in the body — empty input means "let
+		// the worker default it", per #194 acceptance.
+		await waitFor(() => {
+			expect(state.lastPostBody).toEqual({
+				title: "Cleared-score case",
+			});
+		});
+		expect(state.lastPostBody as Record<string, unknown>).not.toHaveProperty(
+			"score",
+		);
+	});
+
+	it("empty observable rows are dropped pre-POST (issue #194)", async () => {
+		const { state } = installFetchMock();
+		renderCases();
+		await screen.findAllByText(/Initial open case/i);
+		await userEvent.click(
+			screen.getByRole("button", { name: /manual case/i }),
+		);
+		await screen.findByText(/create manual case/i);
+
+		await userEvent.type(
+			screen.getByLabelText(/^title$/i),
+			"Drops empty observables",
+		);
+
+		// Row 1 stays empty (default state). Add row 2 and leave it empty
+		// too. Add row 3 and populate it.
+		await userEvent.click(
+			screen.getByRole("button", { name: /^add observable$/i }),
+		);
+		await userEvent.click(
+			screen.getByRole("button", { name: /^add observable$/i }),
+		);
+		await userEvent.selectOptions(
+			screen.getByLabelText(/^observable kind 3$/i),
+			"domain",
+		);
+		await userEvent.type(
+			screen.getByLabelText(/^observable value 3$/i),
+			"evil.example",
+		);
+
+		await userEvent.click(
+			screen.getByRole("button", { name: /^create case$/i }),
+		);
+
+		await waitFor(() => {
+			expect(state.lastPostBody).toEqual({
+				title: "Drops empty observables",
+				observables: [{ kind: "domain", value: "evil.example" }],
+			});
+		});
+	});
+
+	it("invalid score input shows inline error and blocks submit (issue #194)", async () => {
+		const { state } = installFetchMock();
+		renderCases();
+		await screen.findAllByText(/Initial open case/i);
+		await userEvent.click(
+			screen.getByRole("button", { name: /manual case/i }),
+		);
+		await screen.findByText(/create manual case/i);
+
+		await userEvent.type(
+			screen.getByLabelText(/^title$/i),
+			"Invalid score",
+		);
+		await userEvent.type(
+			screen.getByLabelText(/score override/i),
+			"150",
+		);
+
+		// Inline message rendered, submit button disabled.
+		expect(
+			await screen.findByText(/whole number between 0 and 100/i),
+		).toBeInTheDocument();
+		const submitBtn = screen.getByRole("button", { name: /^create case$/i });
+		expect(submitBtn).toBeDisabled();
+
+		// Even a forced click does not POST.
+		await userEvent.click(submitBtn);
+		expect(state.lastPostBody).toBeNull();
+	});
+
 	it("400 with field errors renders inline error text and keeps the dialog open", async () => {
 		const { state } = installFetchMock();
 		state.nextPostResponse = {


### PR DESCRIPTION
## Summary

Extends the manual-case dialog (#190) to post the full `CreateCaseBody` shape per #194:

- **Observables editor**: repeating rows with a `kind` dropdown (`email | url | domain | ipv4 | ipv6` — matches `OBSERVABLE_TONE` in `app/routes/case-detail.tsx:37`) and a value input. Add / remove rows. Empty rows are silently dropped pre-POST; `observables` is omitted entirely when no rows are populated.
- **Score override**: optional integer 0-100. Empty by default. Invalid input (non-integer / out-of-range) shows an inline message and disables submit. When the field is empty on submit, the body OMITS `score` (does not send `null`) — the worker defaults it. `report-phish` is the path that derives a verdict score automatically.
- **Per-row error surface** wired for nested `observables.<i>.<field>` keys. Current zod `flatten()` won't emit them, so today only top-level `observables` errors show; the surface is ready when the worker's error serializer grows.

Closes #194

## Test plan

- [x] `npm test` — 674 passing, 0 failing across 58 files.
- [x] `npm run typecheck` — no new errors in `app/components/CreateCaseModal.tsx`. Pre-existing `@testing-library/react` typings noise in `tests/frontend/*` is unchanged from baseline.
- [x] New test: valid submit with two observables + score POSTs `{title, observables: [...], score: 77}`.
- [x] New test: clearing the score before submit drops `score` from the body (`null` is NOT sent).
- [x] New test: empty observable rows are dropped — only the populated row reaches the worker.
- [x] New test: invalid score (e.g. `150`) shows inline message and disables the submit button.
- [x] Existing v1 paths still pass (open dialog, POST title+notes, render server fieldErrors inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)