### PR TITLE
feat(ui): org-scope co-pilot on org-level routes (closes #198)

### DIFF
--- a/app/components/phishsoc/OrgAgentPanel.tsx
+++ b/app/components/phishsoc/OrgAgentPanel.tsx
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+//
+// Org-scope co-pilot (#198). Sibling to `~/components/AgentPanel.tsx`. The
+// per-mailbox agent is a real durable-object backed chat with tools that
+// operate on a single mailbox's emails; this panel is intentionally a much
+// thinner thing — a chat-shaped UI that synthesizes answers client-side
+// from data already loaded by `useOrgOverview`. v1 has no backing agent,
+// no streaming, no tools. The badge/header is deliberately distinct so
+// users know they're in cross-mailbox context.
+//
+// v2 (out of scope here, tracked separately): a real org-scope DO with
+// cross-mailbox tools, once the per-mailbox `EmailAgent` story stabilizes.
+
+import { Badge, Button, Tooltip } from "@cloudflare/kumo";
+import {
+	ArrowUpIcon,
+	BuildingsIcon,
+	TrashIcon,
+	UserIcon,
+} from "@phosphor-icons/react";
+import { useEffect, useRef, useState } from "react";
+import { useOrgOverview } from "~/queries/org";
+import type { OrgOverview } from "~/types";
+
+interface ChatMessage {
+	id: string;
+	role: "user" | "assistant";
+	text: string;
+}
+
+const SUGGESTED_PROMPTS = [
+	"How is the pipeline doing?",
+	"What's the verdict mix today?",
+	"What are the top threats?",
+	"How many threats blocked in the last 24h?",
+] as const;
+
+// Format a verdict-mix object as a short summary line. Zero totals get a
+// dedicated "no traffic" answer rather than rendering "0 safe, 0 phishing…".
+function formatVerdictMix(label: string, mix: OrgOverview["verdictMix"]): string {
+	const total = mix.safe + mix.suspicious + mix.phishing + mix.spam + mix.bec;
+	if (total === 0) return `${label}: no traffic recorded.`;
+	const parts: string[] = [];
+	if (mix.safe) parts.push(`${mix.safe} safe`);
+	if (mix.suspicious) parts.push(`${mix.suspicious} suspicious`);
+	if (mix.phishing) parts.push(`${mix.phishing} phishing`);
+	if (mix.spam) parts.push(`${mix.spam} spam`);
+	if (mix.bec) parts.push(`${mix.bec} BEC`);
+	return `${label} (${total} total): ${parts.join(", ")}.`;
+}
+
+function formatPipeline(health: OrgOverview["pipelineHealth"]): string {
+	if (health.runs24h === 0) return "Pipeline: no runs in the last 24h.";
+	const successPct = health.successRate24h == null
+		? "unknown success rate"
+		: `${Math.round(health.successRate24h * 100)}% success`;
+	const p95 = health.p95Ms == null ? "p95 unavailable" : `${health.p95Ms}ms p95`;
+	return `Pipeline (24h): ${health.runs24h} runs, ${successPct}, ${p95}.`;
+}
+
+function formatTopThreats(threats: OrgOverview["topThreats"]): string {
+	if (threats.length === 0) return "No threat categories recorded yet.";
+	const top = threats.slice(0, 5);
+	const lines = top.map((t) => `• ${t.category} — ${t.count}`);
+	return `Top threats:\n${lines.join("\n")}`;
+}
+
+// Tiny deterministic router. Maps the user's prompt to a pre-formatted answer
+// over `useOrgOverview` data. No LLM, no fetch — by design. v2 swaps this
+// out for a real backing agent.
+function answerForPrompt(prompt: string, data: OrgOverview | undefined): string {
+	if (!data) {
+		return "I don't have the org overview loaded yet. Try again in a moment.";
+	}
+	const q = prompt.toLowerCase();
+	if (q.includes("pipeline") || q.includes("health") || q.includes("latency")) {
+		return formatPipeline(data.pipelineHealth);
+	}
+	if (q.includes("verdict") || q.includes("mix")) {
+		const today = formatVerdictMix("Verdict mix (24h)", data.verdictMix);
+		const week = formatVerdictMix("Verdict mix (7d)", data.verdictMix7d);
+		return `${today}\n\n${week}`;
+	}
+	if (q.includes("threat") || q.includes("phishing") || q.includes("attack")) {
+		const blocked = `Threats blocked: ${data.threatsBlocked24h} (24h), ${data.threatsBlocked7d} (7d).`;
+		return `${blocked}\n\n${formatTopThreats(data.topThreats)}`;
+	}
+	if (q.includes("blocked")) {
+		return `Threats blocked: ${data.threatsBlocked24h} in the last 24h, ${data.threatsBlocked7d} in the last 7 days.`;
+	}
+	if (q.includes("case")) {
+		return `Open cases across the org: ${data.openCasesTotal}.`;
+	}
+	if (q.includes("mailbox") || q.includes("domain")) {
+		return `${data.mailboxesCount} mailbox${data.mailboxesCount === 1 ? "" : "es"} across ${data.domainsCount} domain${data.domainsCount === 1 ? "" : "s"}.`;
+	}
+	if (q.includes("hub") || q.includes("contribution")) {
+		return `Hub contributions in the last 24h: ${data.hubContributions24h}.`;
+	}
+	// Fallback: render an at-a-glance summary so the user still gets something
+	// grounded rather than a "I don't know" message.
+	return [
+		`Here's what I can see across the org:`,
+		`• ${data.mailboxesCount} mailbox${data.mailboxesCount === 1 ? "" : "es"} across ${data.domainsCount} domain${data.domainsCount === 1 ? "" : "s"}`,
+		`• ${data.threatsBlocked24h} threats blocked in the last 24h`,
+		`• ${data.openCasesTotal} open case${data.openCasesTotal === 1 ? "" : "s"}`,
+		"",
+		`Try asking about pipeline health, verdict mix, or top threats.`,
+	].join("\n");
+}
+
+let nextId = 0;
+function makeId(prefix: string): string {
+	nextId += 1;
+	return `${prefix}-${nextId}`;
+}
+
+export default function OrgAgentPanel() {
+	const { data } = useOrgOverview();
+	const [messages, setMessages] = useState<ChatMessage[]>([]);
+	const [input, setInput] = useState("");
+	const scrollRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		// Pin the scroll to the bottom whenever a new message arrives — same
+		// behavior as the per-mailbox AgentPanel.
+		if (scrollRef.current) {
+			scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+		}
+	}, [messages.length]);
+
+	function ask(prompt: string) {
+		const trimmed = prompt.trim();
+		if (!trimmed) return;
+		const userMsg: ChatMessage = { id: makeId("u"), role: "user", text: trimmed };
+		const reply: ChatMessage = {
+			id: makeId("a"),
+			role: "assistant",
+			text: answerForPrompt(trimmed, data),
+		};
+		setMessages((prev) => [...prev, userMsg, reply]);
+		setInput("");
+	}
+
+	function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+		e.preventDefault();
+		ask(input);
+	}
+
+	return (
+		<div data-testid="org-agent-panel" className="flex flex-col h-full">
+			{/* Header — deliberately distinct from AgentPanel's "AI · Email Agent"
+			    badge so users know this is org-scope (cross-mailbox) and there
+			    are no per-mailbox tools available here. */}
+			<div className="flex items-center justify-between px-3 py-1.5 border-b border-line shrink-0">
+				<div className="flex items-center gap-2">
+					<Badge variant="primary">Org</Badge>
+					<span className="text-xs text-ink-3">Org Co-pilot</span>
+				</div>
+				<div className="flex items-center gap-1">
+					{messages.length > 0 && (
+						<Tooltip content="Clear chat" asChild>
+							<Button
+								variant="ghost"
+								shape="square"
+								size="sm"
+								icon={<TrashIcon size={14} />}
+								onClick={() => setMessages([])}
+								aria-label="Clear chat"
+							/>
+						</Tooltip>
+					)}
+				</div>
+			</div>
+
+			{/* Messages */}
+			<div ref={scrollRef} className="flex-1 overflow-y-auto px-3 py-4">
+				{messages.length === 0 ? (
+					<div className="flex flex-col items-center justify-center h-full gap-4">
+						<div className="flex h-12 w-12 items-center justify-center rounded-xl bg-accent/10">
+							<BuildingsIcon
+								size={24}
+								weight="duotone"
+								className="text-accent"
+							/>
+						</div>
+						<p className="text-xs text-ink-3 text-center leading-relaxed px-4">
+							I answer org-wide questions from data already loaded on
+							this page — verdict mix, top threats, pipeline health.
+							Per-mailbox actions live in the mailbox co-pilot.
+						</p>
+						<div className="flex flex-col gap-1.5 w-full">
+							{SUGGESTED_PROMPTS.map((prompt) => (
+								<button
+									key={prompt}
+									type="button"
+									onClick={() => ask(prompt)}
+									className="text-left px-3 py-2 rounded-lg border border-line text-xs text-ink hover:bg-paper-2 hover:border-line-strong transition-colors cursor-pointer bg-transparent"
+								>
+									{prompt}
+								</button>
+							))}
+						</div>
+					</div>
+				) : (
+					<div className="flex flex-col gap-3">
+						{messages.map((msg) => (
+							<MessageBubble key={msg.id} message={msg} />
+						))}
+					</div>
+				)}
+			</div>
+
+			{/* Composer */}
+			<div className="border-t border-line p-3 shrink-0">
+				<form onSubmit={handleSubmit} className="flex items-end gap-2">
+					<textarea
+						value={input}
+						onChange={(e) => setInput(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter" && !e.shiftKey) {
+								e.preventDefault();
+								ask(input);
+							}
+						}}
+						placeholder="Ask about pipeline, verdicts, threats…"
+						rows={1}
+						aria-label="Ask the org co-pilot"
+						className="flex-1 resize-none rounded-lg border border-line bg-paper-2 px-3 py-2 text-xs text-ink placeholder:text-ink-3 focus:outline-none focus:ring-1 focus:ring-accent min-h-[36px] max-h-[100px]"
+					/>
+					<Button
+						type="submit"
+						variant="primary"
+						size="sm"
+						shape="square"
+						icon={<ArrowUpIcon size={14} weight="bold" />}
+						disabled={!input.trim()}
+						aria-label="Send"
+					/>
+				</form>
+			</div>
+		</div>
+	);
+}
+
+function MessageBubble({ message }: { message: ChatMessage }) {
+	const isUser = message.role === "user";
+	return (
+		<div className={`flex gap-2 ${isUser ? "flex-row-reverse" : ""}`}>
+			<div
+				className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full ${
+					isUser ? "bg-accent text-paper" : "bg-paper-3 text-ink"
+				}`}
+			>
+				{isUser ? (
+					<UserIcon size={12} weight="bold" />
+				) : (
+					<BuildingsIcon size={12} weight="bold" />
+				)}
+			</div>
+			<div
+				className={`flex-1 min-w-0 rounded-lg px-3 py-2 text-xs leading-relaxed whitespace-pre-wrap ${
+					isUser
+						? "bg-accent/10 text-ink"
+						: "bg-paper-2 text-ink"
+				}`}
+			>
+				{message.text}
+			</div>
+		</div>
+	);
+}

--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -28,6 +28,7 @@ import Breadcrumb from "./Breadcrumb";
 import Logo from "./Logo";
 import MailboxSwitcher from "./MailboxSwitcher";
 import NotificationsBell from "./NotificationsBell";
+import OrgAgentPanel from "./OrgAgentPanel";
 
 type PipelineTone = "safe" | "suspect" | "danger" | "muted";
 
@@ -502,34 +503,19 @@ export default function Shell({ children, rightPanel }: ShellProps) {
 					</form>
 					<div className="ml-auto flex items-center gap-1.5 shrink-0">
 						<NotificationsBell mailboxId={mailboxId} />
-						{/* The agent panel only mounts inside `/mailbox/:mailboxId/*`
-						    routes (mailbox.tsx is the only caller passing
-						    `rightPanel={<AgentSidebar />}`). On org-level routes
-						    (`/`, `/settings`, `/mailboxes`, `/domains`,
-						    `/domains/:domain`) clicking the button toggled
-						    internal state but nothing visible happened — silent
-						    no-op (#186). Until an org-scope co-pilot ships
-						    (follow-up #198), gate the trigger on `mailboxId` so
-						    the button only fires where it can do work. We render
-						    `disabled` with a `title` tooltip rather than hiding
-						    so the affordance stays discoverable and the topbar
-						    layout doesn't shift when entering a mailbox. */}
+						{/* Mailbox routes pass `rightPanel={<AgentSidebar />}` (the
+						    per-mailbox `EmailAgent`-backed chat). Org-level routes
+						    pass no `rightPanel` and fall back to the org-scope
+						    co-pilot mounted below (#198). Either way the button
+						    opens a working panel — the disabled branch from #186
+						    is gone. */}
 						<button
 							type="button"
 							onClick={() => toggleAgentPanel()}
-							disabled={!mailboxId}
-							aria-disabled={!mailboxId}
-							title={
-								mailboxId
-									? undefined
-									: "Pick a mailbox to chat with the agent"
-							}
-							aria-expanded={mailboxId ? isAgentPanelOpen : undefined}
+							aria-expanded={isAgentPanelOpen}
 							aria-controls="agent-panel"
 							className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[12px] font-medium transition-colors ${
-								!mailboxId
-									? "bg-paper-2 text-ink-3 border-line cursor-not-allowed opacity-60"
-									: isAgentPanelOpen
+								isAgentPanelOpen
 									? "bg-accent text-paper border-accent hover:bg-[color-mix(in_oklch,var(--accent)_85%,black)]"
 									: "bg-accent-tint text-accent border-[color-mix(in_oklch,var(--accent)_25%,transparent)] hover:bg-[color-mix(in_oklch,var(--accent-tint)_70%,var(--paper))]"
 							}`}
@@ -537,13 +523,7 @@ export default function Shell({ children, rightPanel }: ShellProps) {
 							<SparkleIcon
 								size={13}
 								weight="fill"
-								className={
-									!mailboxId
-										? "text-ink-3"
-										: isAgentPanelOpen
-										? "text-paper"
-										: "text-accent"
-								}
+								className={isAgentPanelOpen ? "text-paper" : "text-accent"}
 							/>
 							Ask co-pilot
 						</button>
@@ -561,7 +541,15 @@ export default function Shell({ children, rightPanel }: ShellProps) {
 						<Breadcrumb />
 						<div className="flex-1 min-h-0">{children}</div>
 					</main>
-					{rightPanel && <AgentPanelSlot rightPanel={rightPanel} />}
+					{rightPanel ? (
+						<AgentPanelSlot rightPanel={rightPanel} />
+					) : !mailboxId ? (
+						// Org-scope fallback (#198). Mailbox routes always pass
+						// `rightPanel`; if a future Shell caller on a mailbox
+						// route forgets to, we don't accidentally mount the
+						// org panel against per-mailbox context.
+						<AgentPanelSlot rightPanel={<OrgAgentPanel />} />
+					) : null}
 				</div>
 			</div>
 		</div>

--- a/tests/frontend/shell-agent-panel-org-routes.test.tsx
+++ b/tests/frontend/shell-agent-panel-org-routes.test.tsx
@@ -1,16 +1,16 @@
 // Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
 //
-// Regression test for #186 — "Ask co-pilot" no-op on org-level routes.
+// Coverage for the org-scope co-pilot wiring (#198), which replaces the
+// disabled-state fallback added in #186.
 //
-// The Shell topbar's "Ask co-pilot" button used to render unconditionally on
-// every page, but the agent panel only mounts inside `/mailbox/:mailboxId/*`
-// routes (mailbox.tsx is the only caller passing `rightPanel={<AgentSidebar
-// />}`). Clicking the button on `/`, `/settings`, `/mailboxes`, `/domains`,
-// or `/domains/:domain` toggled internal state but produced no visible change.
-//
-// Until an org-scope co-pilot ships, the trigger must be `disabled` (with a
-// tooltip explaining why) when the current route has no `mailboxId`. The
-// per-mailbox route still opens the panel.
+// Before #198: the Shell topbar's "Ask co-pilot" button was `disabled` on
+// every org-level route (`/`, `/settings`, `/mailboxes`, `/domains`,
+// `/domains/:domain`) because the panel only mounted inside
+// `/mailbox/:mailboxId/*` (mailbox.tsx was the only caller passing
+// `rightPanel`). #198 wires Shell to mount a sibling `OrgAgentPanel`
+// whenever no `rightPanel` is supplied AND there's no `mailboxId`, so the
+// button opens a working org-scope panel on those routes. The per-mailbox
+// route is unchanged.
 
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -42,11 +42,32 @@ vi.mock("~/queries/domains", () => ({
 	}),
 }));
 
+vi.mock("~/queries/org", () => ({
+	useOrgOverview: () => ({
+		data: {
+			now: "2026-05-03T00:00:00Z",
+			threatsBlocked24h: 12,
+			threatsBlocked7d: 84,
+			openCasesTotal: 3,
+			mailboxesCount: 4,
+			domainsCount: 2,
+			verdictMix: { safe: 100, suspicious: 5, phishing: 2, spam: 8, bec: 0 },
+			verdictMix7d: { safe: 700, suspicious: 30, phishing: 12, spam: 50, bec: 1 },
+			topThreats: [{ category: "phishing", count: 7 }],
+			pipelineHealth: { successRate24h: 0.99, p95Ms: 1200, runs24h: 250 },
+			hubContributions24h: 5,
+		},
+		isLoading: false,
+		isError: false,
+	}),
+}));
+
 import Shell from "~/components/phishsoc/Shell";
 import { useUIStore } from "~/hooks/useUIStore";
 import { renderWithProviders } from "./test-utils";
 
 const RIGHT_PANEL_TEST_ID = "agent-panel-content";
+const ORG_PANEL_TEST_ID = "org-agent-panel";
 
 function RightPanelStub() {
 	return <div data-testid={RIGHT_PANEL_TEST_ID}>agent panel content</div>;
@@ -54,7 +75,8 @@ function RightPanelStub() {
 
 // Renders Shell mounted at the route patterns the app actually uses, so
 // `useParams<{ mailboxId }>()` resolves the same way it does in production.
-// Org-level routes pass no `rightPanel`; mailbox-level routes do.
+// Org-level routes pass no `rightPanel` (Shell falls back to OrgAgentPanel);
+// mailbox-level routes pass the per-mailbox AgentSidebar stub.
 function renderAtRoute(initialEntry: string) {
 	return renderWithProviders(
 		<Routes>
@@ -99,6 +121,14 @@ function renderAtRoute(initialEntry: string) {
 				}
 			/>
 			<Route
+				path="/domains/:domain/settings"
+				element={
+					<Shell>
+						<div data-testid="main-content">main</div>
+					</Shell>
+				}
+			/>
+			<Route
 				path="/mailbox/:mailboxId/*"
 				element={
 					<Shell rightPanel={<RightPanelStub />}>
@@ -113,8 +143,10 @@ function renderAtRoute(initialEntry: string) {
 
 beforeEach(() => {
 	useUIStore.setState({ isAgentPanelOpen: false });
+	// xl+ in-flow render — keeps the slot a plain `<aside>` rather than a
+	// base-ui Dialog portal, which simplifies queries.
 	window.matchMedia = vi.fn().mockImplementation((query: string) => ({
-		matches: false,
+		matches: query === "(min-width: 1280px)",
 		media: query,
 		onchange: null,
 		addListener: vi.fn(),
@@ -129,49 +161,65 @@ afterEach(() => {
 	useUIStore.setState({ isAgentPanelOpen: false });
 });
 
-describe("Shell 'Ask co-pilot' button — org-level routes (#186)", () => {
+describe("Shell 'Ask co-pilot' button — org-level routes (#198)", () => {
 	const orgRoutes: Array<[label: string, path: string]> = [
 		["org overview /", "/"],
 		["org settings /settings", "/settings"],
 		["mailboxes list /mailboxes", "/mailboxes"],
 		["domains list /domains", "/domains"],
 		["domain detail /domains/:domain", "/domains/example.com"],
+		[
+			"domain settings /domains/:domain/settings",
+			"/domains/example.com/settings",
+		],
 	];
 
 	for (const [label, path] of orgRoutes) {
-		it(`is disabled with a 'pick a mailbox' tooltip on ${label}`, () => {
+		it(`is enabled and advertises panel state on ${label}`, () => {
 			renderAtRoute(path);
 			const trigger = screen.getByRole("button", {
 				name: /ask co-?pilot/i,
 			});
-			expect(trigger).toBeDisabled();
-			expect(trigger).toHaveAttribute(
-				"title",
-				"Pick a mailbox to chat with the agent",
-			);
-			// Without a mailbox, aria-expanded shouldn't advertise an
-			// open/closed panel state — the panel can't open here at all.
-			expect(trigger).not.toHaveAttribute("aria-expanded");
+			expect(trigger).not.toBeDisabled();
+			expect(trigger).not.toHaveAttribute("title");
+			// Closed-but-enabled — aria-expanded should be advertised so AT
+			// announces the state once the panel can actually open.
+			expect(trigger).toHaveAttribute("aria-expanded", "false");
 		});
 
-		it(`clicking it on ${label} does not toggle the agent panel state`, async () => {
+		it(`clicking it on ${label} mounts the org-scope co-pilot`, async () => {
 			const user = userEvent.setup();
 			renderAtRoute(path);
 			const trigger = screen.getByRole("button", {
 				name: /ask co-?pilot/i,
 			});
 			expect(useUIStore.getState().isAgentPanelOpen).toBe(false);
-			// userEvent.click respects `disabled` and skips the click,
-			// so the store stays untouched — exactly the behavior we want.
+			expect(screen.queryByTestId(ORG_PANEL_TEST_ID)).not.toBeInTheDocument();
 			await user.click(trigger);
-			expect(useUIStore.getState().isAgentPanelOpen).toBe(false);
-			expect(screen.queryByTestId(RIGHT_PANEL_TEST_ID)).not.toBeInTheDocument();
+			expect(useUIStore.getState().isAgentPanelOpen).toBe(true);
+			expect(screen.getByTestId(ORG_PANEL_TEST_ID)).toBeInTheDocument();
+			// The per-mailbox panel must NOT be mounted on org routes.
+			expect(
+				screen.queryByTestId(RIGHT_PANEL_TEST_ID),
+			).not.toBeInTheDocument();
+			expect(trigger).toHaveAttribute("aria-expanded", "true");
 		});
 	}
+
+	it("the org-scope panel header is visibly distinct from the per-mailbox agent's", async () => {
+		const user = userEvent.setup();
+		renderAtRoute("/");
+		await user.click(screen.getByRole("button", { name: /ask co-?pilot/i }));
+		const panel = screen.getByTestId(ORG_PANEL_TEST_ID);
+		// Org badge + "Org Co-pilot" label, not the per-mailbox "AI" / "Email Agent".
+		expect(panel).toHaveTextContent(/Org/);
+		expect(panel).toHaveTextContent(/Org Co-pilot/);
+		expect(panel).not.toHaveTextContent(/Email Agent/);
+	});
 });
 
 describe("Shell 'Ask co-pilot' button — mailbox-level route still works", () => {
-	it("is enabled on /mailbox/:mailboxId/* and opens the panel on click", async () => {
+	it("is enabled on /mailbox/:mailboxId/* and opens the per-mailbox panel on click", async () => {
 		const user = userEvent.setup();
 		renderAtRoute("/mailbox/m1/dashboard");
 		const trigger = screen.getByRole("button", { name: /ask co-?pilot/i });
@@ -180,7 +228,9 @@ describe("Shell 'Ask co-pilot' button — mailbox-level route still works", () =
 		expect(trigger).toHaveAttribute("aria-expanded", "false");
 		await user.click(trigger);
 		expect(useUIStore.getState().isAgentPanelOpen).toBe(true);
+		// Per-mailbox stub mounts; org-scope panel does NOT.
 		expect(screen.getByTestId(RIGHT_PANEL_TEST_ID)).toBeInTheDocument();
+		expect(screen.queryByTestId(ORG_PANEL_TEST_ID)).not.toBeInTheDocument();
 		expect(trigger).toHaveAttribute("aria-expanded", "true");
 	});
 });


### PR DESCRIPTION
## Summary

- Replaces the #186 disabled-state fallback with a working client-side co-pilot on every org-level route (`/`, `/settings`, `/mailboxes`, `/domains`, `/domains/:domain`, `/domains/:domain/settings`).
- New `app/components/phishsoc/OrgAgentPanel.tsx` is a sibling to `AgentPanel.tsx` — same `AgentPanelSlot` (in-flow at xl+, slide-over below xl), but the badge ("Org") and header ("Org Co-pilot" with `BuildingsIcon`) are deliberately distinct from the per-mailbox agent's "AI · Email Agent" so users know it's cross-mailbox scope with no per-mailbox tools.
- v1 answers come from a tiny deterministic prompt → answer router over `useOrgOverview` data (verdict mix 24h/7d, top threats, pipeline health, threats blocked, open cases, mailbox/domain counts, hub contributions). No new DO, no LLM call, no `useChat`. v2 (real backing agent) is tracked separately and called out below.

Closes #198

## Implementation notes

- Shell-level fallback gate is `!rightPanel && !mailboxId`. A future Shell caller on `/mailbox/:mailboxId/*` that forgets to pass `rightPanel` won't accidentally mount the org panel against per-mailbox context.
- All five touch-points on the topbar button flipped (`disabled`, `aria-disabled`, `title`, `aria-expanded`, className branch). The button now unconditionally toggles, and `aria-expanded` is always advertised.
- `mailbox.tsx` is unchanged — it still passes its own `<AgentSidebar />` so the per-mailbox `EmailAgent` flow is untouched.
- Existing `tests/frontend/shell-agent-panel-org-routes.test.tsx` rewritten to assert the new opens-on-org-routes behavior plus header distinctness; the per-mailbox case still asserts the original stub mounts. Added `/domains/:domain/settings` to the iterated org-route list (it was in Acceptance but missing from the prior test file).

## Test plan

- [x] `npm test` — 702 passing, 0 failing
- [x] `npm run typecheck` — clean
- [x] Per-mailbox `/mailbox/:mailboxId/*` route still mounts the per-mailbox `AgentSidebar` (regression-locked in test).
- [x] Org-route test asserts org-scope panel mounts and header reads "Org" / "Org Co-pilot", not "Email Agent".
- [ ] Manual: confirm in-flow vs slide-over breakpoint feels right at xl boundary on org routes.

## Deferred follow-ups

- #211 — `fix(ui): wrap routes/org-settings.tsx in <Shell>`. `org-settings.tsx` does not currently render Shell at all (verified during research). The Shell-level fallback added here will activate once that route is wrapped, but the wrap itself is pre-existing inconsistency, separately tracked.
- #212 — `feat(agent): v2 — back the org co-pilot with a real DO + cross-mailbox tools`. Explicitly out of scope per the issue; v2 once the per-mailbox `EmailAgent` story stabilizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)