### PR TITLE
feat(ui+worker): org-scope search across mailboxes (closes #197)

### DIFF
--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -389,10 +389,17 @@ export default function Shell({ children, rightPanel }: ShellProps) {
 	const handleSearchSubmit = (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		const q = searchQuery.trim();
-		if (!q || !mailboxId) return;
-		navigate(
-			`/mailbox/${encodeURIComponent(mailboxId)}/search?q=${encodeURIComponent(q)}`,
-		);
+		if (!q) return;
+		// On a mailbox-scoped route, scope the search to that mailbox. On every
+		// other route (org-level: `/`, `/settings`, `/mailboxes`, `/domains`,
+		// `/domains/:domain`) fall back to the org-scope search route (#197).
+		if (mailboxId) {
+			navigate(
+				`/mailbox/${encodeURIComponent(mailboxId)}/search?q=${encodeURIComponent(q)}`,
+			);
+		} else {
+			navigate(`/search?q=${encodeURIComponent(q)}`);
+		}
 	};
 
 	const navContents = (
@@ -470,33 +477,14 @@ export default function Shell({ children, rightPanel }: ShellProps) {
 						onSubmit={handleSearchSubmit}
 						className="flex items-center gap-2 flex-1 max-w-xl"
 					>
-						<MagnifyingGlassIcon
-							size={14}
-							className={`shrink-0 ${mailboxId ? "text-ink-3" : "text-ink-4"}`}
-						/>
-						{/*
-						 * Search today is mailbox-scoped: the only registered route is
-						 * `/mailbox/:mailboxId/search`, and the submit handler bails when
-						 * `mailboxId` is missing. On org-level routes (`/`, `/settings`,
-						 * `/mailboxes`, `/domains`, `/domains/:domain`) we surface a
-						 * disabled input with explanatory placeholder so cmd+K + Enter
-						 * doesn't appear to silently swallow the query (#187). Org-scope
-						 * search across every mailbox the user can see is tracked
-						 * separately.
-						 */}
+						<MagnifyingGlassIcon size={14} className="shrink-0 text-ink-3" />
 						<input
 							ref={searchInputRef}
 							type="search"
 							value={searchQuery}
 							onChange={(e) => setSearchQuery(e.target.value)}
-							disabled={!mailboxId}
-							aria-disabled={!mailboxId}
-							className="flex-1 bg-transparent border-0 outline-none text-[13px] text-ink placeholder:text-ink-4 disabled:cursor-not-allowed"
-							placeholder={
-								mailboxId
-									? "Search emails…  ⌘K"
-									: "Pick a mailbox to search emails"
-							}
+							className="flex-1 bg-transparent border-0 outline-none text-[13px] text-ink placeholder:text-ink-4"
+							placeholder="Search emails…  ⌘K"
 							aria-label="Search"
 						/>
 					</form>

--- a/app/queries/keys.ts
+++ b/app/queries/keys.ts
@@ -22,6 +22,8 @@ export const queryKeys = {
 	search: {
 		results: (mailboxId: string, query: string, page: number) =>
 			["search", mailboxId, query, page] as const,
+		orgResults: (query: string, page: number) =>
+			["search", "_org", query, page] as const,
 	},
 	dashboard: (mailboxId: string) => ["dashboard", mailboxId] as const,
 	org: {

--- a/app/queries/search.ts
+++ b/app/queries/search.ts
@@ -58,3 +58,48 @@ export function useSearchEmails(
 		enabled: !!mailboxId && !!query,
 	});
 }
+
+/**
+ * Org-scope variant of {@link useSearchEmails} (#197). Hits the cross-mailbox
+ * search endpoint and exposes results tagged with the originating mailbox so
+ * the org page can render a per-row mailbox chip.
+ */
+export type OrgSearchResultRow = Email & {
+	mailbox_id: string;
+	mailbox_email: string;
+};
+
+export function useOrgSearchEmails(query: string, page: number) {
+	return useQuery<{ results: OrgSearchResultRow[]; totalCount: number }>({
+		queryKey: query
+			? queryKeys.search.orgResults(query, page)
+			: ["search", "_org_disabled"],
+		queryFn: async () => {
+			const parsed = parseSearchQuery(query);
+			const params: Record<string, string> = {
+				page: String(page),
+				limit: String(SEARCH_PAGE_SIZE),
+			};
+			if (parsed.query) params.query = parsed.query;
+			if (parsed.from) params.from = parsed.from;
+			if (parsed.to) params.to = parsed.to;
+			if (parsed.subject) params.subject = parsed.subject;
+			if (parsed.folder) params.folder = parsed.folder;
+			if (parsed.date_start) params.date_start = parsed.date_start;
+			if (parsed.date_end) params.date_end = parsed.date_end;
+			if (parsed.is_read !== undefined) params.is_read = String(parsed.is_read);
+			if (parsed.is_starred !== undefined) params.is_starred = String(parsed.is_starred);
+			if (parsed.has_attachment) params.has_attachment = "true";
+
+			const data = await api.searchOrgEmails(params) as {
+				emails: OrgSearchResultRow[];
+				totalCount: number;
+			};
+			return {
+				results: data?.emails ?? [],
+				totalCount: data?.totalCount ?? 0,
+			};
+		},
+		enabled: !!query,
+	});
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -15,6 +15,7 @@ export default [
 	route("domains", "routes/domains-list.tsx"),
 	route("domains/:domain", "routes/domain-detail.tsx"),
 	route("domains/:domain/settings", "routes/domain-settings.tsx"),
+	route("search", "routes/search-results-org.tsx"),
 	route("mailbox/:mailboxId", "routes/mailbox.tsx", [
 		index("routes/mailbox-index.tsx"),
 		route("dashboard", "routes/dashboard.tsx"),

--- a/app/routes/search-results-org.tsx
+++ b/app/routes/search-results-org.tsx
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { Badge, Button, Pagination, Tooltip } from "@cloudflare/kumo";
+import { ArrowLeftIcon } from "@phosphor-icons/react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import Shell from "~/components/phishsoc/Shell";
+import { useFeedback } from "~/lib/feedback";
+import { formatListDate, getSnippetText } from "~/lib/utils";
+import { useOrgSearchEmails, SEARCH_PAGE_SIZE, type OrgSearchResultRow } from "~/queries/search";
+import { highlightTerms, SearchEmptyState } from "./search-shared";
+
+export default function SearchResultsOrgRoute() {
+	const [searchParams] = useSearchParams();
+	const navigate = useNavigate();
+	const urlQuery = searchParams.get("q") || "";
+	const [page, setPage] = useState(1);
+	const searchKey = useMemo(() => `_org::${urlQuery}`, [urlQuery]);
+	const prevSearchKeyRef = useRef(searchKey);
+	const searchChanged = prevSearchKeyRef.current !== searchKey;
+	const currentPage = searchChanged ? 1 : page;
+
+	useEffect(() => {
+		if (!searchChanged) return;
+		prevSearchKeyRef.current = searchKey;
+		setPage(1);
+	}, [searchChanged, searchKey]);
+
+	const { data: searchData, isLoading, isError } = useOrgSearchEmails(urlQuery, currentPage);
+	const results = searchData?.results ?? [];
+	const totalCount = searchData?.totalCount ?? 0;
+
+	const feedback = useFeedback();
+	useEffect(() => {
+		if (isError) feedback.error("Search failed. Try again.");
+	}, [isError, feedback]);
+
+	// Org-scope rows can't open an in-page panel — selection state lives in
+	// per-mailbox UI stores. Drop the user into the originating mailbox's
+	// search page (same query) so they can interact with the email there.
+	const handleRowClick = (email: OrgSearchResultRow) => {
+		navigate(
+			`/mailbox/${encodeURIComponent(email.mailbox_id)}/search?q=${encodeURIComponent(urlQuery)}`,
+		);
+	};
+
+	const folderDisplayName = (name: string | null | undefined): string => {
+		if (!name) return "";
+		const map: Record<string, string> = { inbox: "Inbox", sent: "Sent", draft: "Drafts", archive: "Archive", trash: "Trash", quarantine: "Quarantine" };
+		return map[name.toLowerCase()] || name;
+	};
+
+	return (
+		<Shell>
+			<div className="flex flex-col h-full">
+				<div className="flex items-center gap-2 px-4 py-3.5 border-b border-line shrink-0 md:px-5">
+					<Tooltip content="Back" side="bottom" asChild><Button variant="ghost" shape="square" size="sm" icon={<ArrowLeftIcon size={18} />} onClick={() => navigate("/")} aria-label="Back" /></Tooltip>
+					<div className="min-w-0 flex-1">
+						<h1 className="pp-serif text-ink truncate">Search Results</h1>
+						{!isLoading && (
+							<span className="text-sm text-ink-3">
+								{totalCount} result{totalCount !== 1 ? "s" : ""} across all mailboxes{urlQuery ? ` for "${urlQuery}"` : ""}
+							</span>
+						)}
+					</div>
+				</div>
+				<div className="flex-1 overflow-y-auto">
+					{isLoading ? (
+						<div className="divide-y divide-line">
+							{Array.from({ length: 5 }).map((_, i) => (
+								<div key={i} className="flex items-center gap-3 px-4 py-2.5 md:px-5 md:py-3 animate-pulse">
+									<div className="w-2.5 shrink-0" />
+									<div className="flex-1 min-w-0">
+										<div className="flex items-center gap-2">
+											<div className="h-3 w-24 rounded bg-paper-3" />
+											<div className="h-3 flex-1 rounded bg-paper-3" />
+											<div className="h-3 w-12 rounded bg-paper-3 ml-auto" />
+										</div>
+										<div className="h-2.5 w-3/4 rounded bg-paper-3 mt-2" />
+									</div>
+								</div>
+							))}
+						</div>
+					) : results.length === 0 ? (
+						<SearchEmptyState query={urlQuery} />
+					) : (
+						<div>{results.map((email) => {
+							const snippet = getSnippetText(email.snippet, 120);
+							const folderName = (email as OrgSearchResultRow & { folder_name?: string }).folder_name;
+							return (
+								<div key={`${email.mailbox_id}:${email.id}`} role="button" tabIndex={0} onClick={() => handleRowClick(email)} onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleRowClick(email); } }} className="group flex items-center gap-3 w-full text-left cursor-pointer transition-colors border-b border-line px-4 py-2.5 md:px-5 md:py-3 hover:bg-paper-2">
+									<div className="w-2.5 shrink-0 flex justify-center">{!email.read && <div className="h-2 w-2 rounded-full bg-accent" />}</div>
+									<div className="min-w-0 flex-1">
+										<div className="flex items-center gap-2">
+											<span className={`truncate text-sm ${!email.read ? "font-semibold text-ink" : "text-ink"}`}>{highlightTerms(email.sender.split("@")[0], urlQuery)}</span>
+											<Badge variant="outline">{email.mailbox_email}</Badge>
+											{folderName && <Badge variant="outline">{folderDisplayName(folderName)}</Badge>}
+											<span className="text-sm text-ink-3 shrink-0 ml-auto">{formatListDate(email.date)}</span>
+										</div>
+										<div className={`truncate text-sm mt-0.5 ${!email.read ? "font-medium text-ink" : "text-ink-3"}`}>{highlightTerms(email.subject, urlQuery)}</div>
+										{snippet && <div className="truncate text-xs text-ink-3 mt-0.5">{highlightTerms(snippet, urlQuery)}</div>}
+									</div>
+								</div>
+							);
+						})}</div>
+					)}
+				</div>
+				{totalCount > SEARCH_PAGE_SIZE && <div className="flex justify-center py-3 border-t border-line shrink-0"><Pagination page={currentPage} setPage={setPage} perPage={SEARCH_PAGE_SIZE} totalCount={totalCount} /></div>}
+			</div>
+		</Shell>
+	);
+}

--- a/app/routes/search-results.tsx
+++ b/app/routes/search-results.tsx
@@ -3,7 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 import { Badge, Button, Pagination, Tooltip } from "@cloudflare/kumo";
-import { ArrowLeftIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { ArrowLeftIcon } from "@phosphor-icons/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 import MailboxSplitView from "~/components/MailboxSplitView";
@@ -13,22 +13,7 @@ import { useUpdateEmail } from "~/queries/emails";
 import { useSearchEmails, SEARCH_PAGE_SIZE } from "~/queries/search";
 import { useUIStore } from "~/hooks/useUIStore";
 import type { Email } from "~/types";
-
-function highlightTerms(text: string, query: string): React.ReactNode {
-	if (!query || !text) return text;
-	const freeText = query.replace(/\b(?:from|to|subject|in|is|has|before|after):"[^"]*"/gi, "").replace(/\b(?:from|to|subject|in|is|has|before|after):\S+/gi, "").trim();
-	if (!freeText) return text;
-	try {
-		const escaped = freeText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-		const regex = new RegExp(`(${escaped})`, "gi");
-		const parts = text.split(regex);
-		if (parts.length === 1) return text;
-		// Use case-insensitive string comparison instead of regex.test() with g flag,
-		// which has stateful lastIndex causing alternating true/false results.
-		const lowerEscaped = escaped.toLowerCase();
-		return parts.map((part, i) => part.toLowerCase() === lowerEscaped ? <mark key={i} className="bg-accent-tint text-accent-ink rounded-sm px-0.5">{part}</mark> : part);
-	} catch { return text; }
-}
+import { highlightTerms, SearchEmptyState } from "./search-shared";
 
 export default function SearchResultsRoute() {
 	const { mailboxId } = useParams<{ mailboxId: string }>();
@@ -109,12 +94,7 @@ export default function SearchResultsRoute() {
 							))}
 						</div>
 					) : results.length === 0 ? (
-						<div className="flex flex-col items-center justify-center py-24 px-6 text-center">
-							<div className="mb-4"><MagnifyingGlassIcon size={48} weight="thin" className="text-ink-3" /></div>
-							<h3 className="text-base font-semibold text-ink mb-1.5">No results found</h3>
-							<p className="text-sm text-ink-3 max-w-xs">{urlQuery ? `Nothing matched "${urlQuery}". Try different keywords or check your spelling.` : "Enter a search term to find emails by subject, sender, or content."}</p>
-							{urlQuery && <p className="text-xs text-ink-3 mt-3 max-w-sm">Tip: Use operators like <code className="bg-paper-3 px-1 rounded pp-mono">from:name</code>, <code className="bg-paper-3 px-1 rounded pp-mono">is:unread</code>, <code className="bg-paper-3 px-1 rounded pp-mono">has:attachment</code>, <code className="bg-paper-3 px-1 rounded pp-mono">before:2025-01-01</code></p>}
-						</div>
+						<SearchEmptyState query={urlQuery} />
 					) : (
 						<div>{results.map((email) => {
 							const isSelected = selectedEmailId === email.id;

--- a/app/routes/search-shared.tsx
+++ b/app/routes/search-shared.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Shared search-results helpers used by both the per-mailbox and org-scope
+ * search pages so the empty/no-results affordance + query highlighting stay
+ * identical across the two surfaces (#197).
+ */
+
+import { MagnifyingGlassIcon } from "@phosphor-icons/react";
+
+export function highlightTerms(text: string, query: string): React.ReactNode {
+	if (!query || !text) return text;
+	const freeText = query
+		.replace(/\b(?:from|to|subject|in|is|has|before|after):"[^"]*"/gi, "")
+		.replace(/\b(?:from|to|subject|in|is|has|before|after):\S+/gi, "")
+		.trim();
+	if (!freeText) return text;
+	try {
+		const escaped = freeText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		const regex = new RegExp(`(${escaped})`, "gi");
+		const parts = text.split(regex);
+		if (parts.length === 1) return text;
+		// Avoid `regex.test()` with the `g` flag — its stateful `lastIndex`
+		// produces alternating true/false results across iterations.
+		const lowerEscaped = escaped.toLowerCase();
+		return parts.map((part, i) =>
+			part.toLowerCase() === lowerEscaped ? (
+				<mark key={i} className="bg-accent-tint text-accent-ink rounded-sm px-0.5">{part}</mark>
+			) : (
+				part
+			),
+		);
+	} catch {
+		return text;
+	}
+}
+
+export function SearchEmptyState({ query }: { query: string }) {
+	return (
+		<div className="flex flex-col items-center justify-center py-24 px-6 text-center">
+			<div className="mb-4">
+				<MagnifyingGlassIcon size={48} weight="thin" className="text-ink-3" />
+			</div>
+			<h3 className="text-base font-semibold text-ink mb-1.5">No results found</h3>
+			<p className="text-sm text-ink-3 max-w-xs">
+				{query
+					? `Nothing matched "${query}". Try different keywords or check your spelling.`
+					: "Enter a search term to find emails by subject, sender, or content."}
+			</p>
+			{query && (
+				<p className="text-xs text-ink-3 mt-3 max-w-sm">
+					Tip: Use operators like{" "}
+					<code className="bg-paper-3 px-1 rounded pp-mono">from:name</code>,{" "}
+					<code className="bg-paper-3 px-1 rounded pp-mono">is:unread</code>,{" "}
+					<code className="bg-paper-3 px-1 rounded pp-mono">has:attachment</code>,{" "}
+					<code className="bg-paper-3 px-1 rounded pp-mono">before:2025-01-01</code>
+				</p>
+			)}
+		</div>
+	);
+}

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -204,6 +204,10 @@ const api = {
 	searchEmails: (mailboxId: string, params: Record<string, string>) =>
 		get<EmailListResponse | Email[]>(`/api/v1/mailboxes/${mailboxId}/search`, { params }),
 
+	// Org-scope search across every mailbox the caller can see (#197).
+	searchOrgEmails: (params: Record<string, string>) =>
+		get<EmailListResponse>("/api/v1/org/search", { params }),
+
 	// Dashboard
 	getDashboardSummary: (mailboxId: string, opts?: { signal?: AbortSignal }) =>
 		get<DashboardSummary>(`/api/v1/mailboxes/${mailboxId}/dashboard`, { signal: opts?.signal }),

--- a/tests/frontend/shell-search.test.tsx
+++ b/tests/frontend/shell-search.test.tsx
@@ -89,6 +89,14 @@ function renderOrgShell(initialEntries: string[]) {
 					</Shell>
 				}
 			/>
+			<Route
+				path="/search"
+				element={
+					<Shell>
+						<LocationReporter />
+					</Shell>
+				}
+			/>
 		</Routes>,
 		{ initialEntries },
 	);
@@ -161,10 +169,10 @@ describe("Shell search", () => {
 	});
 });
 
-// Path-(b) fix for #187: on org-level routes (no `:mailboxId` in URL) the
-// search submit handler used to silently no-op. We now render the input as
-// `disabled` with explanatory placeholder so cmd+K + Enter can't appear to
-// swallow a query without feedback. Org-scope search is tracked separately.
+// Org-scope search (#197): on org-level routes (no `:mailboxId` in URL), a
+// submit must navigate to the top-level `/search?q=…` route that fans out
+// across every mailbox the caller can see. The previous disabled-input
+// fallback (#187) is gone — operators get an actual cross-mailbox surface.
 describe("Shell search on org-level routes (no mailboxId)", () => {
 	it.each([
 		["/"],
@@ -172,48 +180,44 @@ describe("Shell search on org-level routes (no mailboxId)", () => {
 		["/mailboxes"],
 		["/domains"],
 		["/domains/example.com"],
-	])("disables the search input on %s", (path) => {
+	])("submitting on %s navigates to /search?q=…", async (path) => {
+		const user = userEvent.setup();
 		renderOrgShell([path]);
 		const input = screen.getByRole("searchbox", { name: /search/i });
-		expect(input).toBeDisabled();
-		expect(input.getAttribute("placeholder")).toBe(
-			"Pick a mailbox to search emails",
+		expect(input).not.toBeDisabled();
+		await user.click(input);
+		await user.keyboard("invoice");
+		await user.keyboard("{Enter}");
+		expect(screen.getByTestId("location")).toHaveTextContent(
+			"/search?q=invoice",
 		);
 	});
 
-	it("cmd+K does not focus the disabled input on org routes", async () => {
+	it("URL-encodes special characters in org-scope queries", async () => {
 		const user = userEvent.setup();
 		renderOrgShell(["/"]);
 		const input = screen.getByRole("searchbox", { name: /search/i });
-		expect(input).toBeDisabled();
-		expect(document.activeElement).not.toBe(input);
-		await user.keyboard("{Meta>}k{/Meta}");
-		// A `disabled` input cannot receive focus, so cmd+K is effectively a
-		// no-op on org routes — exactly what the acceptance criterion asks for.
-		expect(document.activeElement).not.toBe(input);
+		await user.click(input);
+		await user.type(input, "from:bob & jane");
+		await user.keyboard("{Enter}");
+		const location = screen.getByTestId("location").textContent ?? "";
+		expect(location).toContain("/search?q=");
+		expect(location).toContain("%26");
+		expect(location).toContain("from%3Abob");
 	});
 
-	it("submitting the form on org routes does not navigate", async () => {
+	it("cmd+K focuses the search input on org routes too", async () => {
 		const user = userEvent.setup();
 		renderOrgShell(["/"]);
-		expect(screen.getByTestId("location")).toHaveTextContent("/");
-		const form = screen
-			.getByRole("searchbox", { name: /search/i })
-			.closest("form");
-		expect(form).not.toBeNull();
-		// Even if a programmatic submit fires (e.g. user found a way to bypass
-		// the disabled input), the handler still bails when `mailboxId` is
-		// missing — belt-and-suspenders verification.
-		form?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
-		// Yield to microtasks / react-router's effect queue.
-		await user.keyboard("{Tab}");
-		expect(screen.getByTestId("location")).toHaveTextContent("/");
-	});
-
-	it("re-enables the input once a mailbox-scoped route is mounted", () => {
-		renderShell(["/mailbox/m1/dashboard"]);
 		const input = screen.getByRole("searchbox", { name: /search/i });
 		expect(input).not.toBeDisabled();
+		await user.keyboard("{Meta>}k{/Meta}");
+		expect(document.activeElement).toBe(input);
+	});
+
+	it("placeholder copy matches the mailbox-scoped surface", () => {
+		renderOrgShell(["/"]);
+		const input = screen.getByRole("searchbox", { name: /search/i });
 		expect(input.getAttribute("placeholder")).toMatch(/⌘K/);
 	});
 });

--- a/tests/lib/org-search.test.ts
+++ b/tests/lib/org-search.test.ts
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, expect, it } from "vitest";
+import {
+	aggregateOrgSearch,
+	type PerMailboxSearchResult,
+} from "../../workers/lib/org-search";
+
+function row(id: string, date: string | null, extra: Record<string, unknown> = {}) {
+	return { id, date, ...extra };
+}
+
+describe("aggregateOrgSearch", () => {
+	it("merges + tags rows from each mailbox with mailbox metadata", () => {
+		const perMailbox: PerMailboxSearchResult[] = [
+			{
+				mailboxId: "alice@acme.com",
+				mailboxEmail: "alice@acme.com",
+				count: 1,
+				emails: [row("e1", "2026-05-01T00:00:00Z", { sender: "x" })],
+			},
+			{
+				mailboxId: "bob@acme.com",
+				mailboxEmail: "bob@acme.com",
+				count: 1,
+				emails: [row("e2", "2026-05-02T00:00:00Z", { sender: "y" })],
+			},
+		];
+		const out = aggregateOrgSearch(perMailbox, 1, 25);
+		expect(out.totalCount).toBe(2);
+		expect(out.emails).toHaveLength(2);
+		// Tagged with mailbox provenance so the UI can render a per-row chip.
+		expect(out.emails[0]).toMatchObject({
+			id: "e2",
+			mailbox_id: "bob@acme.com",
+			mailbox_email: "bob@acme.com",
+		});
+		expect(out.emails[1]).toMatchObject({
+			id: "e1",
+			mailbox_id: "alice@acme.com",
+		});
+	});
+
+	it("orders merged rows by date DESC across mailboxes", () => {
+		const perMailbox: PerMailboxSearchResult[] = [
+			{
+				mailboxId: "a",
+				mailboxEmail: "a",
+				count: 2,
+				emails: [
+					row("a-old", "2026-01-01T00:00:00Z"),
+					row("a-new", "2026-04-01T00:00:00Z"),
+				],
+			},
+			{
+				mailboxId: "b",
+				mailboxEmail: "b",
+				count: 2,
+				emails: [
+					row("b-mid", "2026-03-01T00:00:00Z"),
+					row("b-newest", "2026-05-01T00:00:00Z"),
+				],
+			},
+		];
+		const out = aggregateOrgSearch(perMailbox, 1, 25);
+		expect(out.emails.map((e) => e.id)).toEqual([
+			"b-newest",
+			"a-new",
+			"b-mid",
+			"a-old",
+		]);
+	});
+
+	it("paginates the merged result set, totalCount stays absolute", () => {
+		const emails = Array.from({ length: 30 }, (_, i) =>
+			row(`e${i}`, `2026-04-${String(i + 1).padStart(2, "0")}T00:00:00Z`),
+		);
+		const perMailbox: PerMailboxSearchResult[] = [
+			{ mailboxId: "a", mailboxEmail: "a", count: 30, emails },
+		];
+		const page1 = aggregateOrgSearch(perMailbox, 1, 10);
+		const page2 = aggregateOrgSearch(perMailbox, 2, 10);
+		const page4 = aggregateOrgSearch(perMailbox, 4, 10);
+		expect(page1.emails).toHaveLength(10);
+		expect(page2.emails).toHaveLength(10);
+		expect(page4.emails).toHaveLength(0); // past the end
+		// Both pages report the same total.
+		expect(page1.totalCount).toBe(30);
+		expect(page2.totalCount).toBe(30);
+		expect(page4.totalCount).toBe(30);
+		// Pages don't overlap.
+		const page1Ids = new Set(page1.emails.map((e) => e.id));
+		expect(page2.emails.every((e) => !page1Ids.has(e.id))).toBe(true);
+	});
+
+	it("sums counts across mailboxes (totalCount tracks the underlying DB total, not the page)", () => {
+		// Common case: each mailbox has many matches but only a slice of each
+		// mailbox's matches makes it into the merged page. totalCount is what
+		// pagination uses and must reflect the org-wide match total.
+		const perMailbox: PerMailboxSearchResult[] = [
+			{ mailboxId: "a", mailboxEmail: "a", count: 142, emails: [row("a1", "2026-05-01")] },
+			{ mailboxId: "b", mailboxEmail: "b", count: 7, emails: [row("b1", "2026-04-01")] },
+			{ mailboxId: "c", mailboxEmail: "c", count: 0, emails: [] },
+		];
+		const out = aggregateOrgSearch(perMailbox, 1, 25);
+		expect(out.totalCount).toBe(149);
+		expect(out.emails.map((e) => e.id)).toEqual(["a1", "b1"]);
+	});
+
+	it("handles missing dates by sorting them to the end", () => {
+		const perMailbox: PerMailboxSearchResult[] = [
+			{
+				mailboxId: "a",
+				mailboxEmail: "a",
+				count: 3,
+				emails: [
+					row("dated", "2026-04-01"),
+					row("undated-1", null),
+					row("undated-2", null),
+				],
+			},
+		];
+		const out = aggregateOrgSearch(perMailbox, 1, 25);
+		expect(out.emails[0].id).toBe("dated");
+		// The two undated rows trail; their relative order is unspecified.
+		expect(out.emails.slice(1).map((e) => e.id).sort()).toEqual([
+			"undated-1",
+			"undated-2",
+		]);
+	});
+
+	it("returns an empty response when no mailboxes match", () => {
+		const out = aggregateOrgSearch([], 1, 25);
+		expect(out).toEqual({ emails: [], totalCount: 0 });
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -61,6 +61,7 @@ import { emptyTlsRptPosture, fetchTlsRptPosture } from "./tlsrpt/posture";
 import { listTextModels } from "./lib/text-models";
 import { fetchHubCorroborationCount } from "./intel/hub-corroboration";
 import { loadHubCredentials } from "./lib/hub-config";
+import { aggregateOrgSearch, type PerMailboxSearchResult } from "./lib/org-search";
 
 type AppContext = Context<MailboxContext>;
 
@@ -233,6 +234,56 @@ app.get("/api/v1/org/overview", async (c) => {
 	}
 
 	return c.json(overview);
+});
+
+// -- Org-scope search (#197) ----------------------------------------
+
+/** Per-mailbox cap for org-search fan-out. We pull at most this many rows
+ * from each mailbox to bound the merged-page sort + response size. The org
+ * page slices the merged ordering to the requested page; common operator
+ * queries fit well below the cap. */
+const ORG_SEARCH_PER_MAILBOX_CAP = 200;
+
+app.get("/api/v1/org/search", async (c) => {
+	const searchOpts = {
+		query: c.req.query("query") || "",
+		folder: c.req.query("folder"),
+		from: c.req.query("from"),
+		to: c.req.query("to"),
+		subject: c.req.query("subject"),
+		date_start: c.req.query("date_start"),
+		date_end: c.req.query("date_end"),
+		is_read: boolQuery(c, "is_read"),
+		is_starred: boolQuery(c, "is_starred"),
+		has_attachment: boolQuery(c, "has_attachment"),
+	};
+	const page = Math.max(1, intQuery(c, "page") ?? 1);
+	const limit = Math.min(Math.max(intQuery(c, "limit") ?? 25, 1), 100);
+
+	const mailboxes = await listMailboxes(c.env.BUCKET);
+	const settled = await Promise.allSettled(
+		mailboxes.map(async (m) => {
+			const stub = c.env.MAILBOX.get(c.env.MAILBOX.idFromName(m.id)) as any;
+			const [emails, count] = await Promise.all([
+				stub.searchEmails({
+					...searchOpts,
+					page: 1,
+					limit: ORG_SEARCH_PER_MAILBOX_CAP,
+				}),
+				stub.countSearchResults(searchOpts),
+			]);
+			return { mailboxId: m.id, mailboxEmail: m.email, emails, count };
+		}),
+	);
+	const perMailbox: PerMailboxSearchResult[] = [];
+	for (const r of settled) {
+		if (r.status !== "fulfilled") {
+			console.error("org-search: mailbox search failed:", (r.reason as Error)?.message);
+			continue;
+		}
+		perMailbox.push(r.value);
+	}
+	return c.json(aggregateOrgSearch(perMailbox, page, limit));
 });
 
 // -- Per-domain stats + drill-down (#85) ----------------------------

--- a/workers/lib/org-search.ts
+++ b/workers/lib/org-search.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Pure aggregator for the org-scope search endpoint (#197).
+ *
+ * The endpoint fans out across every mailbox the caller can see (today: every
+ * mailbox in the org, since #27 isn't closed yet), collects per-mailbox
+ * `searchEmails` + `countSearchResults` results, then merges them into a
+ * single date-ordered, page-sliced response. Keeping the merge as a pure
+ * function lets us unit-test ordering, pagination, and per-mailbox tagging
+ * without having to mock R2 + every Durable Object stub.
+ */
+
+export type OrgSearchEmailRow = {
+	id: string;
+	date: string | null;
+	[k: string]: unknown;
+};
+
+export type PerMailboxSearchResult = {
+	mailboxId: string;
+	mailboxEmail: string;
+	emails: OrgSearchEmailRow[];
+	count: number;
+};
+
+export type OrgSearchResponseRow = OrgSearchEmailRow & {
+	mailbox_id: string;
+	mailbox_email: string;
+};
+
+export type OrgSearchResponse = {
+	emails: OrgSearchResponseRow[];
+	totalCount: number;
+};
+
+/**
+ * Merge per-mailbox search results into a single page-sliced response.
+ *
+ * Ordering matches per-mailbox search: `date DESC`, with `null`/missing dates
+ * sorted to the end so they don't displace dated rows.
+ */
+export function aggregateOrgSearch(
+	perMailbox: PerMailboxSearchResult[],
+	page: number,
+	limit: number,
+): OrgSearchResponse {
+	const rows: OrgSearchResponseRow[] = [];
+	let totalCount = 0;
+	for (const r of perMailbox) {
+		totalCount += r.count;
+		for (const e of r.emails) {
+			rows.push({
+				...e,
+				mailbox_id: r.mailboxId,
+				mailbox_email: r.mailboxEmail,
+			});
+		}
+	}
+	rows.sort((a, b) => {
+		const da = a.date ?? "";
+		const db = b.date ?? "";
+		if (!da && !db) return 0;
+		if (!da) return 1;
+		if (!db) return -1;
+		return db.localeCompare(da);
+	});
+	const start = Math.max(0, (page - 1) * limit);
+	const slice = rows.slice(start, start + limit);
+	return { emails: slice, totalCount };
+}


### PR DESCRIPTION
## Summary

- Adds top-level `/search?q=...` route + `GET /api/v1/org/search` worker endpoint that fans out across every mailbox the caller can see and returns date-ordered, paginated, mailbox-tagged results.
- Removes the disabled-input fallback from #187: cmd+K now focuses the search input on every route (org and mailbox), the placeholder is the canonical `Search emails… ⌘K` everywhere, and submitting from `/`, `/settings`, `/mailboxes`, `/domains`, `/domains/:domain` lands on `/search?q=...`.
- Mailbox-scoped routes continue to navigate to `/mailbox/:id/search` — existing affordance preserved. Per-row clicks on the org page open the per-mailbox search page so the user can interact with the email in its native mailbox context.

Closes #197.

## Implementation notes

- `workers/lib/org-search.ts` is a pure aggregator (`aggregateOrgSearch(perMailboxResults, page, limit)`) so the merge + sort + pagination logic is unit-testable in `tests/lib/org-search.test.ts` without spinning up DO stubs. Endpoint in `workers/index.ts` is a thin shim that fans out via `listMailboxes` + `Promise.allSettled` (mirrors the `org/overview` pattern).
- `ORG_SEARCH_PER_MAILBOX_CAP = 200` bounds per-mailbox fetch size so the merged-page sort + JSON response stay reasonable. Common-case operator queries fit well under that. The acceptance criterion's "profile first" performance guidance applies if the cap proves limiting.
- Empty/no-results state and `highlightTerms` are extracted to `app/routes/search-shared.tsx` so the per-mailbox and org pages render the same affordance — matches the issue's "must match" constraint.
- Frontend test split: `Shell search` (mailbox-scoped, unchanged); `Shell search on org-level routes` rewritten to assert navigation to `/search?q=…` from each org route.

## Test plan

- [x] `npm test` — 705 passing, 0 failing
- [x] `npm run typecheck` — 0 errors
- [x] No CodeQL `js/incomplete-url-substring-sanitization` exposure (the new worker / tests do not parse URLs by substring)
- [x] `SECURITY_SPEC.md` not edited from this PR

## Out of scope / follow-ups

- Faceted / typeahead / suggestion UX changes.
- Cross-tenant search beyond what `listMailboxes` returns (gated by #27 today).
- Server-side performance tuning beyond the per-mailbox cap (deferred per the issue's "profile first" guidance).