### PR TITLE
fix(ui): wrap routes/org-settings.tsx in <Shell> so /settings mounts the org co-pilot (closes #211)

### DIFF
--- a/app/routes/org-settings.tsx
+++ b/app/routes/org-settings.tsx
@@ -13,6 +13,7 @@ import {
 	validateHubConfig,
 	type HubFieldErrors,
 } from "~/components/HubSettingsPanel";
+import Shell from "~/components/phishsoc/Shell";
 import type { HubConfigSettings, SecuritySettings } from "~/types";
 import {
 	DEFAULT_CLASSIFIER_MODEL,
@@ -149,15 +150,18 @@ export default function OrgSettingsRoute() {
 
 	if (isLoading) {
 		return (
-			<div className="flex justify-center py-20">
-				<Loader size="lg" />
-			</div>
+			<Shell>
+				<div className="flex justify-center py-20">
+					<Loader size="lg" />
+				</div>
+			</Shell>
 		);
 	}
 
 	const isCustomPrompt = agentPrompt.trim().length > 0;
 
 	return (
+		<Shell>
 		<div className="max-w-2xl px-4 py-4 md:px-8 md:py-6 h-full overflow-y-auto">
 			<h1 className="pp-serif text-ink mb-2">Organization settings</h1>
 			<p className="text-xs text-ink-3 mb-6 max-w-xl">
@@ -332,5 +336,6 @@ export default function OrgSettingsRoute() {
 				</div>
 			</div>
 		</div>
+		</Shell>
 	);
 }

--- a/tests/frontend/org-settings-shell.test.tsx
+++ b/tests/frontend/org-settings-shell.test.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+//
+// #211: `OrgSettingsRoute` previously returned its body without `<Shell>`,
+// so production navigation to `/settings` dropped the user out of the
+// topbar/sidebar/breadcrumb chrome and lost the org-scope "Ask co-pilot"
+// button mounted by the Shell-level fallback added in #198.
+//
+// This smoke test mounts the actual route component at `/settings` and
+// asserts the topbar "Ask co-pilot" button is present — i.e. Shell is
+// wrapping the route.
+
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+
+vi.mock("~/queries/org-settings", () => ({
+	useOrgSettings: () => ({ data: { settings: {} }, isLoading: false }),
+	useUpdateOrgSettings: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("~/queries/text-models", () => ({
+	useTextModels: () => ({ models: ["@cf/meta/llama-3.3-70b-instruct-fp8-fast"] }),
+}));
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({ data: undefined }),
+	useMailboxes: () => ({ data: [] }),
+}));
+
+vi.mock("~/queries/dashboard", () => ({
+	useDashboardSummary: () => ({ data: undefined, isLoading: false, isError: false }),
+}));
+
+vi.mock("~/queries/domains", () => ({
+	useDomainStats: () => ({ data: undefined, isLoading: false, isError: false }),
+}));
+
+vi.mock("~/queries/org", () => ({
+	useOrgOverview: () => ({ data: undefined, isLoading: false, isError: false }),
+}));
+
+import OrgSettingsRoute from "~/routes/org-settings";
+import { renderWithProviders } from "./test-utils";
+
+describe("OrgSettingsRoute (#211)", () => {
+	it("mounts inside <Shell> so /settings exposes the org-scope co-pilot trigger", () => {
+		renderWithProviders(
+			<Routes>
+				<Route path="/settings" element={<OrgSettingsRoute />} />
+			</Routes>,
+			{ initialEntries: ["/settings"] },
+		);
+
+		// Shell topbar's "Ask co-pilot" button is the marker that Shell wraps
+		// the route. Without #211's fix, the route rendered raw and this
+		// button did not exist on /settings.
+		const trigger = screen.getByRole("button", { name: /ask co-?pilot/i });
+		expect(trigger).not.toBeDisabled();
+	});
+});


### PR DESCRIPTION
## Summary

- `OrgSettingsRoute` returned a bare `<div>` rather than nesting in `<Shell>`, so production navigation to `/settings` dropped the user out of the topbar / sidebar / breadcrumb chrome and lost the org-scope \"Ask co-pilot\" button mounted by the Shell-level fallback added in #198.
- Wrap both the loading branch and the main branch of the route in `<Shell>`, mirroring `app/routes/home.tsx` and every other top-level route.
- New `tests/frontend/org-settings-shell.test.tsx` mounts the actual `OrgSettingsRoute` at `/settings` (rather than mounting `<Shell>` directly inside a `<Routes>` harness) and asserts the topbar trigger is present — the existing #198 harness was the reason this regression slipped through.

Closes #211.

## Test plan

- [x] `npm test` — 709 passing, 0 failing (62 files)
- [x] `npm run typecheck` — exit 0
- [x] New smoke test asserts \"Ask co-pilot\" trigger exists when `/settings` is rendered through the actual route component