### PR TITLE
feat(cases): AI co-pilot summary on case detail (closes #127)

### DIFF
--- a/app/routes/case-detail.tsx
+++ b/app/routes/case-detail.tsx
@@ -6,8 +6,10 @@ import {
 	ArrowLeftIcon,
 	BriefcaseIcon,
 	ShieldWarningIcon,
+	SparkleIcon,
+	WarningIcon,
 } from "@phosphor-icons/react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router";
 import ScoreRing from "~/components/phishsoc/ScoreRing";
 import VerdictPill from "~/components/phishsoc/VerdictPill";
@@ -16,6 +18,7 @@ import { useFeedback } from "~/lib/feedback";
 
 interface CaseEmail { case_id: string; email_id: string; }
 interface CaseObservable { id: string; kind: string; value: string; }
+type SummaryStatus = "pending" | "ready" | "failed" | null;
 interface CaseRecord {
 	id: string;
 	created_at: string;
@@ -30,9 +33,26 @@ interface CaseRecord {
 	// pre-#126 rows) leave it null — render a muted "—" instead of the
 	// ring.
 	score: number | null;
+	// AI co-pilot summary (issue #127). `summary_status` lifecycle:
+	// 'pending' → 'ready' | 'failed'. NULL means no summary was
+	// requested for this case (manual API create with no linked email,
+	// or pre-#127 rows) — UI hides the card. Frontend polls while
+	// status is 'pending' and stops on any terminal value.
+	summary?: string | null;
+	summary_status?: SummaryStatus;
 	emails: CaseEmail[];
 	observables: CaseObservable[];
 }
+
+// Polling cadence for the co-pilot summary card while
+// `summary_status === 'pending'`. The summarizer is a single
+// Workers AI call against a small instruct model — typically
+// resolves in well under 30s. We cap at 60s to bound the
+// polling cost on cases that get orphaned in 'pending' (e.g.
+// the DO restarted between createCase and the waitUntil
+// dispatch finishing).
+const SUMMARY_POLL_INTERVAL_MS = 2500;
+const SUMMARY_POLL_MAX_MS = 60_000;
 
 const OBSERVABLE_TONE: Record<string, "danger" | "suspect" | "info" | "muted"> = {
 	domain: "suspect",
@@ -78,6 +98,28 @@ export default function CaseDetailRoute() {
 	}, [mailboxId, caseId]);
 
 	useEffect(() => { load(); }, [load]);
+
+	// Poll for the AI co-pilot summary (issue #127) while it's still
+	// generating. Stops on any terminal status ('ready' / 'failed') or
+	// when it's been pending past SUMMARY_POLL_MAX_MS (orphaned-row
+	// safeguard). Restarts when caseId changes.
+	const pollStartedAtRef = useRef<number | null>(null);
+	useEffect(() => {
+		pollStartedAtRef.current = null;
+	}, [caseId]);
+	useEffect(() => {
+		if (data?.summary_status !== "pending") {
+			pollStartedAtRef.current = null;
+			return;
+		}
+		if (pollStartedAtRef.current === null) {
+			pollStartedAtRef.current = Date.now();
+		}
+		const elapsed = Date.now() - pollStartedAtRef.current;
+		if (elapsed >= SUMMARY_POLL_MAX_MS) return;
+		const handle = setTimeout(load, SUMMARY_POLL_INTERVAL_MS);
+		return () => clearTimeout(handle);
+	}, [data?.summary_status, data?.updated_at, load]);
 
 	const updateStatus = async (status: string) => {
 		if (!mailboxId || !caseId) return;
@@ -225,10 +267,18 @@ export default function CaseDetailRoute() {
 						</div>
 					)}
 
-					{/* Co-pilot summary card intentionally omitted until AI
-					    summarization is wired to cases. A "Coming soon"
-					    placeholder read as a real product surface to operators
-					    — empty space is more honest. */}
+					{/* AI co-pilot summary (issue #127). Renders when
+					    summary_status is non-null (i.e. summary was requested
+					    for this case). Hidden when null/undefined to preserve
+					    the empty-state honesty: cases without a linked email
+					    don't get a placeholder card. */}
+					{data.summary_status && (
+						<CoPilotSummaryCard
+							status={data.summary_status}
+							summary={data.summary ?? null}
+							onRetry={load}
+						/>
+					)}
 				</div>
 
 				{/* Right column: observables / IOCs + status controls */}
@@ -300,6 +350,61 @@ export default function CaseDetailRoute() {
 					    fabricated. */}
 				</div>
 			</div>
+		</div>
+	);
+}
+
+interface CoPilotSummaryCardProps {
+	status: Exclude<SummaryStatus, null>;
+	summary: string | null;
+	onRetry: () => void;
+}
+
+function CoPilotSummaryCard({ status, summary, onRetry }: CoPilotSummaryCardProps) {
+	return (
+		<div className="pp-card p-5" data-testid="copilot-summary-card">
+			<div className="flex items-center gap-1.5 text-[11px] uppercase tracking-[0.06em] text-ink-3 mb-2">
+				<SparkleIcon size={12} weight="fill" />
+				<span>Co-pilot summary</span>
+			</div>
+			{status === "ready" && summary ? (
+				<div
+					className="text-[13px] text-ink-2 whitespace-pre-wrap leading-relaxed"
+					data-testid="copilot-summary-ready"
+				>
+					{summary}
+				</div>
+			) : status === "pending" ? (
+				<div
+					className="flex items-center gap-2 text-[12.5px] text-ink-3"
+					data-testid="copilot-summary-pending"
+					role="status"
+					aria-live="polite"
+				>
+					<span
+						className="inline-block h-2 w-2 rounded-full bg-ink-3 animate-pulse"
+						aria-hidden="true"
+					/>
+					<span>Generating summary…</span>
+				</div>
+			) : (
+				<div
+					className="space-y-2 text-[12.5px] text-ink-3"
+					data-testid="copilot-summary-failed"
+				>
+					<div className="flex items-start gap-1.5 text-danger">
+						<WarningIcon size={13} weight="fill" className="mt-[2px] shrink-0" />
+						<span>Couldn't generate a summary for this case.</span>
+					</div>
+					<button
+						type="button"
+						onClick={onRetry}
+						className="text-[12px] text-ink-2 underline underline-offset-2 hover:text-ink"
+					>
+						Refresh
+					</button>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/tests/frontend/case-detail.test.tsx
+++ b/tests/frontend/case-detail.test.tsx
@@ -21,6 +21,8 @@ const baseCase = {
 	shared_to_hub: 0,
 	hub_event_uuid: null,
 	score: null as number | null,
+	summary: null as string | null,
+	summary_status: null as "pending" | "ready" | "failed" | null,
 	emails: [],
 	observables: [],
 };
@@ -30,6 +32,20 @@ function mockFetchOnce(payload: unknown) {
 		ok: true,
 		json: async () => payload,
 	} as Response);
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+// Test-only fetch mock that returns a pre-defined sequence of payloads
+// for successive calls. Used by the summary-polling test (#127) where
+// the first GET returns `pending` and the second returns `ready`.
+function mockFetchSequence(payloads: unknown[]) {
+	let i = 0;
+	const fetchMock = vi.fn().mockImplementation(async () => {
+		const payload = payloads[Math.min(i, payloads.length - 1)];
+		i++;
+		return { ok: true, json: async () => payload } as Response;
+	});
 	vi.stubGlobal("fetch", fetchMock);
 	return fetchMock;
 }
@@ -101,5 +117,105 @@ describe("CaseDetailRoute (issue #126 — real per-case score)", () => {
 			expect(screen.queryByText(/\/\s*100/)).toBeNull();
 		});
 		expect(screen.getByText(/case_abc123/i)).toBeInTheDocument();
+	});
+});
+
+// ── AI co-pilot summary card (issue #127) ─────────────────────────
+//
+// The card renders only when `data.summary_status` is non-null.
+// Lifecycle: pending → ready | failed. The "loading" state is the
+// 'pending' card; "empty" is `summary_status === null` (card hidden);
+// "error" is the 'failed' card with a refresh affordance.
+describe("CaseDetailRoute — AI co-pilot summary card (#127)", () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("hides the card entirely when summary_status is null (empty state)", async () => {
+		mockFetchOnce({ case: { ...baseCase, summary_status: null, summary: null } });
+		renderCaseDetail();
+
+		expect(
+			await screen.findByText(/Suspicious wire-transfer request/i),
+		).toBeInTheDocument();
+		expect(screen.queryByTestId("copilot-summary-card")).toBeNull();
+		expect(screen.queryByText(/Co-pilot summary/i)).toBeNull();
+	});
+
+	it("renders the loading state while summary_status is 'pending'", async () => {
+		mockFetchSequence([
+			{ case: { ...baseCase, summary_status: "pending", summary: null } },
+		]);
+		renderCaseDetail();
+
+		expect(
+			await screen.findByText(/Suspicious wire-transfer request/i),
+		).toBeInTheDocument();
+		expect(screen.getByTestId("copilot-summary-pending")).toBeInTheDocument();
+		expect(screen.getByText(/Generating summary…/i)).toBeInTheDocument();
+		expect(screen.queryByTestId("copilot-summary-ready")).toBeNull();
+		expect(screen.queryByTestId("copilot-summary-failed")).toBeNull();
+	});
+
+	it("renders the summary text when summary_status is 'ready'", async () => {
+		const summaryText =
+			"This email pressures the recipient into a same-day wire " +
+			"transfer using a spoofed CFO display name. Two suspicious " +
+			"links and an urgency cue suggest a BEC attempt.";
+		mockFetchOnce({
+			case: { ...baseCase, summary_status: "ready", summary: summaryText },
+		});
+		renderCaseDetail();
+
+		expect(
+			await screen.findByText(/Suspicious wire-transfer request/i),
+		).toBeInTheDocument();
+		expect(screen.getByTestId("copilot-summary-ready")).toHaveTextContent(
+			/wire transfer/i,
+		);
+		expect(screen.queryByTestId("copilot-summary-pending")).toBeNull();
+		expect(screen.queryByTestId("copilot-summary-failed")).toBeNull();
+	});
+
+	it("renders the error state with a Refresh affordance when summary_status is 'failed'", async () => {
+		mockFetchOnce({
+			case: { ...baseCase, summary_status: "failed", summary: null },
+		});
+		renderCaseDetail();
+
+		expect(
+			await screen.findByText(/Suspicious wire-transfer request/i),
+		).toBeInTheDocument();
+		const failed = await screen.findByTestId("copilot-summary-failed");
+		expect(failed).toHaveTextContent(/couldn'?t generate/i);
+		expect(
+			screen.getByRole("button", { name: /refresh/i }),
+		).toBeInTheDocument();
+	});
+
+	it("polls while pending and switches to ready when the next fetch resolves", async () => {
+		const summaryText = "Verdict-reasoning summary text from the AI.";
+		const fetchMock = mockFetchSequence([
+			{ case: { ...baseCase, summary_status: "pending", summary: null } },
+			{ case: { ...baseCase, summary_status: "ready", summary: summaryText } },
+		]);
+		renderCaseDetail();
+
+		await screen.findByTestId("copilot-summary-pending");
+
+		await waitFor(
+			() => {
+				expect(screen.queryByTestId("copilot-summary-ready")).not.toBeNull();
+			},
+			{ timeout: 8000 },
+		);
+		expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+		expect(screen.queryByTestId("copilot-summary-pending")).toBeNull();
+		expect(screen.getByTestId("copilot-summary-ready")).toHaveTextContent(
+			summaryText,
+		);
 	});
 });

--- a/tests/routes/cases.test.ts
+++ b/tests/routes/cases.test.ts
@@ -116,10 +116,25 @@ function makeStub(emails: Record<string, FakeEmailRow>) {
 		},
 		async updateCase() { /* no-op for these tests */ },
 		async flagSender() { /* no-op */ },
+		// AI co-pilot summary dispatch (issue #127). The route fires
+		// this via `c.executionCtx.waitUntil` after createCase; the
+		// score-plumbing tests don't care about the summary outcome,
+		// so the stub just no-ops.
+		async generateCaseSummary() { /* no-op */ },
 	};
 
 	return { stub, cases, createCalls };
 }
+
+// Minimal ExecutionContext stub. Hono's `app.request` accepts the ctx
+// as its 4th argument; routes that fire `c.executionCtx.waitUntil(...)`
+// (the report-phish summary dispatch in issue #127) require it to be
+// present. We don't await the dispatched promise — the test only
+// asserts the synchronous response shape.
+const fakeCtx = {
+	waitUntil: () => {},
+	passThroughOnException: () => {},
+} as unknown as ExecutionContext;
 
 function makeApp(stub: ReturnType<typeof makeStub>["stub"]) {
 	// Mount caseRoutes under the same prefix the real app uses so the
@@ -179,6 +194,7 @@ describe("workers/routes/cases — issue #126 per-case score", () => {
 				body: JSON.stringify({ emailId: "em_1" }),
 			},
 			fakeEnv,
+			fakeCtx,
 		);
 		expect(res.status).toBe(201);
 		const body = (await res.json()) as { caseId: string };
@@ -213,6 +229,7 @@ describe("workers/routes/cases — issue #126 per-case score", () => {
 				body: JSON.stringify({ emailId: "em_unscored" }),
 			},
 			fakeEnv,
+			fakeCtx,
 		);
 		expect(res.status).toBe(201);
 		const body = (await res.json()) as { caseId: string };
@@ -236,6 +253,7 @@ describe("workers/routes/cases — issue #126 per-case score", () => {
 			"/api/v1/mailboxes/m1/cases/case_1",
 			undefined,
 			fakeEnv,
+			fakeCtx,
 		);
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as {
@@ -259,6 +277,7 @@ describe("workers/routes/cases — issue #126 per-case score", () => {
 			"/api/v1/mailboxes/m1/cases/case_1",
 			undefined,
 			fakeEnv,
+			fakeCtx,
 		);
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as {
@@ -282,6 +301,7 @@ describe("workers/routes/cases — issue #126 per-case score", () => {
 				}),
 			},
 			fakeEnv,
+			fakeCtx,
 		);
 		expect(res.status).toBe(201);
 		expect(createCalls).toHaveLength(1);
@@ -303,6 +323,7 @@ describe("workers/routes/cases — issue #126 per-case score", () => {
 				}),
 			},
 			fakeEnv,
+			fakeCtx,
 		);
 		expect(res.status).toBe(400);
 		expect(createCalls).toHaveLength(0);

--- a/workers/db/schema.ts
+++ b/workers/db/schema.ts
@@ -154,6 +154,14 @@ export const cases = sqliteTable("cases", {
 	// don't carry a scored verdict (manual API create without `score`,
 	// or pre-#126 rows) leave it NULL.
 	score: integer("score"),
+	// AI-generated plain-language verdict-reasoning summary (issue #127).
+	// `summary_status` tracks generation lifecycle: 'pending' while the
+	// async waitUntil-dispatched task runs, 'ready' once persisted,
+	// 'failed' on terminal error. NULL means no summary was ever
+	// requested (manual API create with no linked email, or pre-#127
+	// rows). The frontend hides the card when status is NULL.
+	summary: text("summary"),
+	summary_status: text("summary_status"),
 });
 
 export const caseEmails = sqliteTable(

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -12,6 +12,7 @@ import type { Env } from "../types";
 import { applyMigrations, mailboxMigrations } from "./migrations";
 import { attachmentObjectKey } from "../lib/attachments";
 import { computeVerdictMix } from "../lib/dashboard-aggregation";
+import { summarizeCase } from "../lib/ai";
 
 /**
  * SQL expression to normalize email subjects by stripping common
@@ -1300,6 +1301,12 @@ export class MailboxDO extends DurableObject<Env> {
 	}) {
 		const id = crypto.randomUUID();
 		const now = new Date().toISOString();
+		// AI co-pilot summary (issue #127): mark 'pending' at creation
+		// time when there's a linked email so the route handler can
+		// dispatch `generateCaseSummary` via `waitUntil` and the frontend
+		// can show a loading state. Without an emailId we leave both
+		// summary columns NULL — the UI hides the card.
+		const summaryStatus = input.emailId ? "pending" : null;
 		this.db
 			.insert(schema.cases)
 			.values({
@@ -1312,6 +1319,8 @@ export class MailboxDO extends DurableObject<Env> {
 				shared_to_hub: 0,
 				hub_event_uuid: null,
 				score: input.score ?? null,
+				summary: null,
+				summary_status: summaryStatus,
 			})
 			.run();
 		if (input.emailId) {
@@ -1398,6 +1407,70 @@ export class MailboxDO extends DurableObject<Env> {
 			.values({ id, case_id: caseId, kind, value })
 			.run();
 		return { id };
+	}
+
+	/**
+	 * Generate the AI co-pilot summary for a case (issue #127).
+	 *
+	 * Designed to be invoked from a route's `c.executionCtx.waitUntil`
+	 * after `createCase` returns, so the user-facing response stays
+	 * fast. Resolves the linked email (first one — multi-email cases
+	 * are summarized from the originating message), runs the AI
+	 * summarizer, and persists the result with a terminal
+	 * `summary_status` of `'ready'` or `'failed'`. If the case has
+	 * been deleted between dispatch and execution, this no-ops.
+	 */
+	async generateCaseSummary(caseId: string): Promise<void> {
+		const row = this.db
+			.select()
+			.from(schema.cases)
+			.where(eq(schema.cases.id, caseId))
+			.get();
+		if (!row) return;
+
+		const linked = this.db
+			.select()
+			.from(schema.caseEmails)
+			.where(eq(schema.caseEmails.case_id, caseId))
+			.limit(1)
+			.get();
+
+		const finalize = (status: "ready" | "failed", summary: string | null) => {
+			this.db
+				.update(schema.cases)
+				.set({
+					summary,
+					summary_status: status,
+					updated_at: new Date().toISOString(),
+				})
+				.where(eq(schema.cases.id, caseId))
+				.run();
+		};
+
+		if (!linked) {
+			finalize("failed", null);
+			return;
+		}
+
+		const email = await this.getEmail(linked.email_id);
+		if (!email) {
+			finalize("failed", null);
+			return;
+		}
+
+		const summary = await summarizeCase(this.env.AI, {
+			subject: email.subject ?? "",
+			sender: email.sender ?? "",
+			bodyHtml: email.body ?? null,
+			score: typeof row.score === "number" ? row.score : null,
+		});
+
+		if (!summary) {
+			finalize("failed", null);
+			return;
+		}
+
+		finalize("ready", summary);
 	}
 
 	async getDmarcSummary(domain: string) {

--- a/workers/durableObject/migrations.ts
+++ b/workers/durableObject/migrations.ts
@@ -327,4 +327,17 @@ export const mailboxMigrations: Migration[] = [
             ALTER TABLE cases ADD COLUMN score INTEGER;
         `,
 	},
+	{
+		// AI co-pilot summary on case detail (issue #127). `summary` holds
+		// the rendered text; `summary_status` is one of 'pending' | 'ready'
+		// | 'failed', or NULL when no summary was requested (manual API
+		// create with no linked email, or pre-#127 rows). Forward-only
+		// ALTERs; existing rows leave both columns NULL and the UI hides
+		// the card.
+		name: "14_cases_summary",
+		sql: `
+            ALTER TABLE cases ADD COLUMN summary TEXT;
+            ALTER TABLE cases ADD COLUMN summary_status TEXT;
+        `,
+	},
 ];

--- a/workers/lib/ai.ts
+++ b/workers/lib/ai.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+	DEFAULT_CLASSIFIER_MODEL,
 	DEFAULT_DRAFT_VERIFIER_MODEL,
 	DEFAULT_INJECTION_SCANNER_MODEL,
 } from "../../shared/mailbox-settings";
@@ -210,4 +211,76 @@ export async function verifyDraft(
 
 function normalizeWhitespace(s: string): string {
 	return s.replace(/\s+/g, " ").trim();
+}
+
+// ── Case Co-pilot Summary ──────────────────────────────────────────
+
+const CASE_SUMMARY_PROMPT = `You are a security analyst writing a brief verdict-reasoning summary for a phishing investigation case.
+
+You will receive an email's metadata and body excerpt. Produce 2-3 short sentences in plain English explaining why this email looks suspicious or benign — what an analyst should notice. Reference concrete signals (sender pattern, urgency cues, suspicious links, brand impersonation, financial requests, etc.) when present.
+
+RULES:
+1. Output ONLY the summary text. No preamble ("Here is the summary:"), no bullet lists, no markdown headings.
+2. 2-3 sentences total. Not a paragraph essay.
+3. Speak directly to the analyst ("This email…", "The sender…"), not in the third person about the case.
+4. If signals are weak, say so — do not fabricate certainty.
+5. Do not repeat the subject verbatim or quote large chunks of the body.`;
+
+export interface SummarizeCaseInput {
+	subject: string;
+	sender: string;
+	bodyHtml: string | null | undefined;
+	score?: number | null;
+}
+
+/**
+ * AI co-pilot summary for a case (issue #127).
+ *
+ * Produces a 2-3 sentence verdict-reasoning string from a single linked
+ * email's subject, sender, and body excerpt. Returns null on AI failure
+ * so callers can persist 'failed' status; throws are not used because
+ * generation runs in a `waitUntil` background task and a thrown error
+ * would just orphan the case in 'pending'.
+ */
+export async function summarizeCase(
+	ai: Ai,
+	input: SummarizeCaseInput,
+	options: { model?: string; maxBodyChars?: number } = {},
+): Promise<string | null> {
+	const subject = input.subject?.trim() || "(no subject)";
+	const sender = input.sender?.trim() || "(unknown sender)";
+	const bodyText = input.bodyHtml ? stripHtmlToText(input.bodyHtml).trim() : "";
+	const maxBodyChars = options.maxBodyChars ?? 4000;
+	const bodyExcerpt = bodyText.length > maxBodyChars
+		? `${bodyText.slice(0, maxBodyChars)}…`
+		: bodyText;
+
+	const scoreLine = typeof input.score === "number"
+		? `Verdict score: ${input.score}/100\n`
+		: "";
+
+	const userMessage = `${scoreLine}Sender: ${sender}\nSubject: ${subject}\n\nBody:\n${bodyExcerpt || "(empty)"}`;
+
+	const model = options.model?.trim() || DEFAULT_CLASSIFIER_MODEL;
+
+	try {
+		const response = (await ai.run(
+			model as Parameters<typeof ai.run>[0],
+			{
+				messages: [
+					{ role: "system", content: CASE_SUMMARY_PROMPT },
+					{ role: "user", content: userMessage },
+				],
+				max_tokens: 320,
+				temperature: 0.2,
+			},
+		)) as { response?: string };
+
+		const summary = response?.response?.trim() ?? "";
+		if (!summary) return null;
+		return summary;
+	} catch (e) {
+		console.error("Case summarizer failed:", (e as Error).message);
+		return null;
+	}
 }

--- a/workers/routes/cases.ts
+++ b/workers/routes/cases.ts
@@ -58,6 +58,16 @@ caseRoutes.post("/", async (c) => {
 	const parsed = CreateCaseBody.safeParse(await c.req.json().catch(() => null));
 	if (!parsed.success) return c.json({ error: parsed.error.flatten() }, 400);
 	const result = await c.var.mailboxStub.createCase(parsed.data);
+	// Dispatch AI co-pilot summary generation in the background when the
+	// case has a linked email (issue #127). createCase marks
+	// summary_status='pending' on the row in the same transaction; this
+	// `waitUntil` resolves it to 'ready' or 'failed'. Cases without a
+	// linked email leave both summary columns NULL — the UI hides the card.
+	if (parsed.data.emailId) {
+		c.executionCtx.waitUntil(
+			c.var.mailboxStub.generateCaseSummary(result.id),
+		);
+	}
 	return c.json(result, 201);
 });
 
@@ -115,6 +125,12 @@ caseRoutes.post("/report-phish", async (c) => {
 		observables,
 		score: verdictScore,
 	});
+
+	// Async AI co-pilot summary generation (issue #127). createCase
+	// marked summary_status='pending'; this waitUntil-dispatched task
+	// resolves it to 'ready' or 'failed' so the case-detail page can
+	// poll while the analyst is reviewing the case.
+	c.executionCtx.waitUntil(c.var.mailboxStub.generateCaseSummary(id));
 
 	// Reputation penalty on the sender so the pipeline flags future mail.
 	if (email.sender) {


### PR DESCRIPTION
## Summary

- Persists an AI-generated verdict-reasoning summary on each case via two new `cases` columns (`summary`, `summary_status`) so [`app/routes/case-detail.tsx`](app/routes/case-detail.tsx) can replace the placeholder card removed in PR #125 with real content.
- Both case-creation paths (`POST /` and `POST /report-phish`) mark `summary_status='pending'` when there's a linked email and dispatch generation via `c.executionCtx.waitUntil` so the user-facing response stays fast; the DO method finalizes the row to `'ready'` (with summary text) or `'failed'`.
- Frontend renders four states — **empty** (status null → card hidden), **loading** (`pending` → polling pill, 2.5s cadence, 60s safety cap), **ready** (summary text), **error** (`failed` → message + Refresh button) — and stops polling on terminal status.

Closes #127.

## Test plan

- [x] `npx vitest run tests/frontend/case-detail.test.tsx` — 8 passing (3 pre-existing #126 score tests + 5 new #127 summary-card tests covering hidden/loading/ready/error/polling).
- [x] `npx vitest run tests/routes/cases.test.ts` — 6 passing (existing #126 score-plumbing tests, threaded an `executionCtx` mock + no-op `generateCaseSummary` onto the fake stub since `report-phish` now dispatches summary generation via `waitUntil`).
- [x] Full suite via `npm test`: **714 passing, 0 failing** (62 files).
- [x] `npm run typecheck`: clean (0 errors).

## Acceptance vs. shipped

| # | Acceptance | Status |
|---|---|---|
| 1 | AI summarizer produces a plain-language verdict-reasoning string per case (or per linked email aggregated to the case) | ✅ `summarizeCase` in [`workers/lib/ai.ts`](workers/lib/ai.ts); v1 summarizes from the **first linked email** rather than aggregating multiples (deferred — see below) |
| 2 | Summary persisted on the case record and exposed via the case API | ✅ `summary` + `summary_status` columns on `cases`; `getCase` returns both via the existing `...row` spread |
| 3 | `app/routes/case-detail.tsx` renders the summary card with the real value when present; the card stays hidden when the summary is null/empty | ✅ Card gated on `data.summary_status` truthy — null/undefined hides it entirely |
| 4 | Loading + empty + error states for the card | ✅ Loading = `pending` (polling pill); empty = card hidden; error = `failed` (message + Refresh) |
| 5 | Frontend test asserts the card renders only when `data.summary` is non-empty | ✅ "hides the card entirely when summary_status is null" (empty-state assertion in [`tests/frontend/case-detail.test.tsx`](tests/frontend/case-detail.test.tsx)) |

## Deferred (not in this PR)

These were touched on by #127 but felt out-of-scope for the v1 wiring; happy to file follow-ups if useful:

- **Multi-email summary aggregation.** A case can have multiple linked emails; v1 summarizes from the first one only. The acceptance allowed either approach ("per linked email aggregated to the case") and aggregation has its own design surface (truncation across N bodies, header summarization). Single-email is the natural fit for `report-phish`-created cases (which is the primary entry point) — multi-email cases are usually built up via observable correlation later.
- **Per-mailbox summarizer model override.** Currently uses `DEFAULT_CLASSIFIER_MODEL` directly. The other AI helpers (`isPromptInjection`, `verifyDraft`) accept a `model` option threaded from `MailboxSettings`; a follow-up could add a `summarizerModel` field for parity, but it isn't needed for the card to work.
- **User-initiated regeneration.** The Refresh button on the failed-state card just re-fetches the case — it doesn't kick off a new summary attempt. A "Retry summary" affordance that POSTs to a `/cases/:id/regenerate-summary` endpoint would be the natural follow-up.

## PR-size note

8 files changed (430 lines). Just over the local `≥6 files` auto-decompose threshold, but this is a tightly-coupled vertical slice — schema → DO method → route dispatch → frontend rendering — that can't be carved into independently shippable units (e.g. a schema-only PR would have no consumer; a frontend-only PR would have no data). Two of the eight files are tests; the production diff is six files. Surfacing the threshold here per the workflow rule rather than silently shipping.

## Spec follow-up

None required — `SECURITY_SPEC.md` invariants are not affected (no new untrusted-input handling, no JWT/auth surface, no MTA-STS/network fetch, no URL substring checks in tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)