### PR TITLE
feat(posture): DKIM published-record posture for /domains/:domain (closes #170)

### DIFF
--- a/app/routes/domain-detail.tsx
+++ b/app/routes/domain-detail.tsx
@@ -104,6 +104,7 @@ function DomainBody({ data }: { data: DomainStats }) {
 			</div>
 			<div className="grid gap-4 lg:grid-cols-3">
 				<TlsRptPostureCard posture={data.tlsRptPosture} />
+				<DkimPostureCard posture={data.dkimPosture} />
 			</div>
 			<MailboxList mailboxes={data.mailboxes} />
 			{data.recentCases.length > 0 && <RecentCasesList cases={data.recentCases} />}
@@ -424,6 +425,43 @@ function TlsRptPostureCard({
 						</ul>
 					) : null}
 				</>
+			)}
+		</div>
+	);
+}
+
+function DkimPostureCard({
+	posture,
+}: { posture: DomainStats["dkimPosture"] }) {
+	// Per #170 constraint: "Unavailable" (published=null) and "genuinely
+	// missing" (published=false) render the SAME affordance — the operator
+	// just sees "missing" and re-checks on the next refresh. The KV layer
+	// distinguishes the two so a transient blip doesn't poison the cache.
+	const selectors = posture.selectors;
+	return (
+		<div className="pp-card p-5">
+			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-3 flex items-center gap-1.5">
+				<ShieldCheckIcon size={12} />
+				DKIM posture
+			</div>
+			{selectors.length === 0 ? (
+				<p className="text-[12.5px] text-ink-3">
+					No DKIM selectors observed on inbound mail in the last 30 days.
+					Selectors are lifted from `Authentication-Results.dkim header.s=`
+					on inbound messages, then resolved at
+					`&lt;selector&gt;._domainkey.&lt;domain&gt;` to confirm the
+					record is still published.
+				</p>
+			) : (
+				<dl className="space-y-1.5 text-[12.5px]">
+					{selectors.map((s) => (
+						<PostureRow
+							key={s.selector}
+							label={s.selector}
+							value={s.published === true ? "published" : "missing"}
+						/>
+					))}
+				</dl>
 			)}
 		</div>
 	);

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -287,6 +287,21 @@ export interface TlsRptPosture {
 	endpoints: readonly string[] | null;
 }
 
+/** DKIM published-record posture (#170). Per-selector list of selectors
+ * observed over a 30-day inbound-mail window, each with current
+ * `<selector>._domainkey.<domain>` published-yes/no/unavailable status.
+ *
+ * Empty `selectors` is the natural state for a domain that's never sent
+ * inbound DKIM-signed mail. `published: null` is the transient "lookup
+ * unavailable" sentinel; the UI renders it identically to `false` (per
+ * #170 Constraints) but the cache layer keeps them separate. */
+export interface DkimPosture {
+	selectors: ReadonlyArray<{
+		selector: string;
+		published: boolean | null;
+	}>;
+}
+
 /** One row in the `/api/v1/domains` list. */
 export interface DomainListEntry {
 	domain: string;
@@ -317,6 +332,7 @@ export interface DomainStats {
 	bimiPosture: BimiPosture;
 	spfPosture: SpfPosture;
 	tlsRptPosture: TlsRptPosture;
+	dkimPosture: DkimPosture;
 	recentCases: DashboardCase[];
 }
 

--- a/tests/dkim/posture.test.ts
+++ b/tests/dkim/posture.test.ts
@@ -2,6 +2,8 @@
 
 import { describe, expect, it } from "vitest";
 import {
+	DKIM_OBSERVATION_WINDOW_DAYS,
+	dkimObservationCutoffIso,
 	emptyDkimPosture,
 	fetchDkimPosture,
 	isAnyPublished,
@@ -59,6 +61,79 @@ describe("isAnyPublished", () => {
 	it("returns false when no TXT entry is a valid DKIM record", () => {
 		expect(isAnyPublished(["v=spf1 -all", "x=y"])).toBe(false);
 		expect(isAnyPublished([])).toBe(false);
+	});
+});
+
+describe("dkimObservationCutoffIso (#170 — 30-day observation horizon)", () => {
+	it("defaults to a 30-day window matching the issue's stated horizon", () => {
+		expect(DKIM_OBSERVATION_WINDOW_DAYS).toBe(30);
+	});
+
+	it("computes the cutoff as nowIso - 30d", () => {
+		// 30 days = 2_592_000_000 ms. Cutoff falls exactly there relative to
+		// `nowIso` so the SQL filter `last_seen_iso >= cutoff` keeps rows
+		// observed within the last 30d (inclusive of the boundary).
+		const now = new Date("2026-05-04T12:00:00Z").toISOString();
+		const cutoff = dkimObservationCutoffIso(now);
+		expect(cutoff).toBe("2026-04-04T12:00:00.000Z");
+	});
+
+	it("a row at exactly the cutoff is still fresh (>= comparison, not strict >)", () => {
+		// Boundary semantics: an observation at `now - 30d` to the millisecond
+		// is the *oldest* row the read should still surface. The `>=` filter
+		// in `getDkimSelectorsObserved` makes that explicit; this test pins
+		// the cutoff math so the inclusive boundary stays inclusive.
+		const now = new Date("2026-05-04T12:00:00Z").toISOString();
+		const cutoff = dkimObservationCutoffIso(now);
+		// A row with last_seen_iso === cutoff is fresh (kept).
+		expect(cutoff >= cutoff).toBe(true);
+	});
+
+	it("rows older than the cutoff are stale (< cutoff = excluded by the SQL filter)", () => {
+		// At `now - 30d - 1ms` the row is past the horizon and the SQL
+		// `>= cutoff` filter excludes it. The lazy-GC pass on
+		// `recordDkimSelectorsObserved` deletes the same set with `< cutoff`,
+		// so reads and writes share the boundary.
+		const now = new Date("2026-05-04T12:00:00Z").toISOString();
+		const cutoff = dkimObservationCutoffIso(now);
+		const stale = new Date(
+			new Date(cutoff).getTime() - 1,
+		).toISOString();
+		expect(stale < cutoff).toBe(true);
+	});
+
+	it("rows newer than the cutoff are fresh (> cutoff = kept)", () => {
+		const now = new Date("2026-05-04T12:00:00Z").toISOString();
+		const cutoff = dkimObservationCutoffIso(now);
+		const fresh = new Date(
+			new Date(cutoff).getTime() + 1,
+		).toISOString();
+		expect(fresh > cutoff).toBe(true);
+	});
+
+	it("supports a custom window for callers that want a tighter horizon", () => {
+		const now = new Date("2026-05-04T12:00:00Z").toISOString();
+		expect(dkimObservationCutoffIso(now, 7)).toBe(
+			"2026-04-27T12:00:00.000Z",
+		);
+		expect(dkimObservationCutoffIso(now, 1)).toBe(
+			"2026-05-03T12:00:00.000Z",
+		);
+	});
+
+	it("falls back to 'now − window' against the runtime clock when nowIso is malformed", () => {
+		// Defensive: a NaN cutoff would make the SQL filter silently match
+		// nothing (or every row, depending on engine). The fallback keeps
+		// the read returning recent rows. We can't pin the exact value
+		// (depends on Date.now()) but we can pin the shape.
+		const before = Date.now();
+		const cutoff = dkimObservationCutoffIso("not-a-date");
+		const after = Date.now();
+		const cutoffMs = new Date(cutoff).getTime();
+		expect(Number.isFinite(cutoffMs)).toBe(true);
+		const windowMs = DKIM_OBSERVATION_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+		expect(cutoffMs).toBeGreaterThanOrEqual(before - windowMs);
+		expect(cutoffMs).toBeLessThanOrEqual(after - windowMs);
 	});
 });
 

--- a/tests/dkim/posture.test.ts
+++ b/tests/dkim/posture.test.ts
@@ -1,0 +1,314 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, expect, it } from "vitest";
+import {
+	emptyDkimPosture,
+	fetchDkimPosture,
+	isAnyPublished,
+	isPublishedDkimRecord,
+	normalizeDohTxtData,
+	type DkimPostureKv,
+} from "../../workers/dkim/posture";
+
+describe("isPublishedDkimRecord", () => {
+	it("treats a canonical v=DKIM1 record with non-empty p= as published", () => {
+		expect(
+			isPublishedDkimRecord("v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQ"),
+		).toBe(true);
+	});
+
+	it("treats v=DKIM1 with empty p= as 'revoked' — NOT published", () => {
+		// RFC 6376 §3.6.1 — `p=` empty signals the operator has retired the
+		// key. The label still resolves but the selector should be treated as
+		// gone; counting it as published would mislead the dashboard into
+		// claiming a retired selector is still in service.
+		expect(isPublishedDkimRecord("v=DKIM1; k=rsa; p=")).toBe(false);
+	});
+
+	it("treats v=DKIM1 with no p= tag as published (forgiving toward malformed-but-shaped records)", () => {
+		expect(isPublishedDkimRecord("v=DKIM1; k=rsa")).toBe(true);
+	});
+
+	it("treats a record without v=DKIM1 but with non-empty p= as published (legacy form)", () => {
+		expect(isPublishedDkimRecord("k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQ")).toBe(true);
+	});
+
+	it("rejects a non-DKIM TXT entry", () => {
+		expect(isPublishedDkimRecord("google-site-verification=abc")).toBe(false);
+		expect(isPublishedDkimRecord("v=spf1 -all")).toBe(false);
+		expect(isPublishedDkimRecord("")).toBe(false);
+	});
+
+	it("is case-insensitive on tag names and on v= value", () => {
+		expect(isPublishedDkimRecord("V=DKIM1; K=rsa; P=AAA")).toBe(true);
+		expect(isPublishedDkimRecord("v=dkim1; p=AAA")).toBe(true);
+	});
+});
+
+describe("isAnyPublished", () => {
+	it("returns true when at least one TXT entry is a valid DKIM record", () => {
+		expect(
+			isAnyPublished([
+				"google-site-verification=abc",
+				"v=DKIM1; k=rsa; p=AAA",
+				"some-other=tag",
+			]),
+		).toBe(true);
+	});
+
+	it("returns false when no TXT entry is a valid DKIM record", () => {
+		expect(isAnyPublished(["v=spf1 -all", "x=y"])).toBe(false);
+		expect(isAnyPublished([])).toBe(false);
+	});
+});
+
+describe("normalizeDohTxtData", () => {
+	it("concatenates multi-string TXT-record fragments", () => {
+		expect(
+			normalizeDohTxtData(
+				'"v=DKIM1; k=rsa; " "p=MIGfMA0GCSqGSIb3DQEBAQ"',
+			),
+		).toBe("v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQ");
+	});
+
+	it("strips surrounding quotes from a single-fragment string", () => {
+		expect(normalizeDohTxtData('"v=DKIM1; p=AAA"')).toBe("v=DKIM1; p=AAA");
+	});
+});
+
+// ── DoH integration tests ──────────────────────────────────────────────
+
+function fakeKv(initial: Record<string, unknown> = {}): DkimPostureKv & {
+	store: Map<string, string>;
+} {
+	const store = new Map<string, string>();
+	for (const [k, v] of Object.entries(initial)) {
+		store.set(k, JSON.stringify(v));
+	}
+	return {
+		store,
+		async get(key: string, _type: "json") {
+			const raw = store.get(key);
+			return raw ? (JSON.parse(raw) as unknown) : null;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+	};
+}
+
+function dohTxtResponse(records: string[], status = 0): Response {
+	return new Response(
+		JSON.stringify({
+			Status: status,
+			Answer: records.map((data) => ({ type: 16, data })),
+		}),
+		{ status: 200, headers: { "content-type": "application/dns-json" } },
+	);
+}
+
+function dohNxdomainResponse(): Response {
+	// Cloudflare's resolver returns Status:3 (NXDOMAIN) with no Answer field.
+	return new Response(JSON.stringify({ Status: 3 }), { status: 200 });
+}
+
+describe("fetchDkimPosture", () => {
+	it("returns the empty posture for a domain with zero observed selectors (no DoH calls)", async () => {
+		let calls = 0;
+		const fetchImpl = async () => {
+			calls += 1;
+			return dohTxtResponse([]);
+		};
+		const r = await fetchDkimPosture("acme.com", [], { fetchImpl });
+		expect(r).toEqual(emptyDkimPosture());
+		expect(calls).toBe(0);
+	});
+
+	it("resolves one selector with a passing TXT record as published=true", async () => {
+		const fetchImpl = async (url: string) => {
+			// Hostname-based dispatch — substring matching on URLs is a CodeQL
+			// `js/incomplete-url-substring-sanitization` trip wire (repo CLAUDE.md).
+			expect(new URL(url).hostname).toBe("cloudflare-dns.com");
+			expect(new URL(url).searchParams.get("name")).toBe(
+				"sel1._domainkey.acme.com",
+			);
+			return dohTxtResponse(['"v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQ"']);
+		};
+		const r = await fetchDkimPosture("acme.com", ["sel1"], { fetchImpl });
+		expect(r).toEqual({
+			selectors: [{ selector: "sel1", published: true }],
+		});
+	});
+
+	it("treats NXDOMAIN as a durable published=false", async () => {
+		const fetchImpl = async () => dohNxdomainResponse();
+		const r = await fetchDkimPosture("acme.com", ["missing"], { fetchImpl });
+		expect(r).toEqual({
+			selectors: [{ selector: "missing", published: false }],
+		});
+	});
+
+	it("treats NOERROR-no-data as a durable published=false", async () => {
+		const fetchImpl = async () =>
+			new Response(JSON.stringify({ Status: 0 }), { status: 200 });
+		const r = await fetchDkimPosture("acme.com", ["empty"], { fetchImpl });
+		expect(r).toEqual({
+			selectors: [{ selector: "empty", published: false }],
+		});
+	});
+
+	it("returns mixed published/missing posture across multiple selectors", async () => {
+		const fetchImpl = async (url: string) => {
+			const name = new URL(url).searchParams.get("name");
+			if (name === "good._domainkey.acme.com") {
+				return dohTxtResponse(['"v=DKIM1; k=rsa; p=AAA"']);
+			}
+			if (name === "gone._domainkey.acme.com") {
+				return dohNxdomainResponse();
+			}
+			throw new Error(`unexpected DoH name: ${name}`);
+		};
+		const r = await fetchDkimPosture("acme.com", ["good", "gone"], {
+			fetchImpl,
+		});
+		expect(r).toEqual({
+			selectors: [
+				{ selector: "gone", published: false },
+				{ selector: "good", published: true },
+			],
+		});
+	});
+
+	it("returns published=null on DoH non-200 (transient unavailability)", async () => {
+		const fetchImpl = async () => new Response("server error", { status: 500 });
+		const r = await fetchDkimPosture("acme.com", ["sel"], { fetchImpl });
+		expect(r).toEqual({
+			selectors: [{ selector: "sel", published: null }],
+		});
+	});
+
+	it("returns published=null when DoH fetch rejects (timeout / network)", async () => {
+		const fetchImpl = async () => {
+			throw new Error("network");
+		};
+		const r = await fetchDkimPosture("acme.com", ["sel"], { fetchImpl });
+		expect(r).toEqual({
+			selectors: [{ selector: "sel", published: null }],
+		});
+	});
+
+	it("returns published=null when DoH returns malformed JSON", async () => {
+		const fetchImpl = async () =>
+			new Response("<html>", { status: 200 });
+		const r = await fetchDkimPosture("acme.com", ["sel"], { fetchImpl });
+		expect(r).toEqual({
+			selectors: [{ selector: "sel", published: null }],
+		});
+	});
+
+	it("treats SERVFAIL (Status=2) as a transient null, not durable false", async () => {
+		const fetchImpl = async () =>
+			new Response(JSON.stringify({ Status: 2 }), { status: 200 });
+		const r = await fetchDkimPosture("acme.com", ["sel"], { fetchImpl });
+		expect(r).toEqual({
+			selectors: [{ selector: "sel", published: null }],
+		});
+	});
+
+	it("counts an empty p= record as published=false (revoked key)", async () => {
+		const fetchImpl = async () => dohTxtResponse(['"v=DKIM1; k=rsa; p="']);
+		const r = await fetchDkimPosture("acme.com", ["retired"], { fetchImpl });
+		expect(r).toEqual({
+			selectors: [{ selector: "retired", published: false }],
+		});
+	});
+
+	it("dedupes selector inputs case-insensitively", async () => {
+		const seen: string[] = [];
+		const fetchImpl = async (url: string) => {
+			const name = new URL(url).searchParams.get("name") ?? "";
+			seen.push(name);
+			return dohTxtResponse(['"v=DKIM1; p=AAA"']);
+		};
+		await fetchDkimPosture("acme.com", ["Sel1", "sel1", "SEL1"], { fetchImpl });
+		expect(seen).toEqual(["sel1._domainkey.acme.com"]);
+	});
+
+	it("reads from KV cache when a per-selector posture is stored", async () => {
+		const kv = fakeKv({
+			"dkim-published:v1:acme.com:sel1": { published: true },
+		});
+		let calls = 0;
+		const fetchImpl = async () => {
+			calls += 1;
+			return dohTxtResponse(['"v=DKIM1; p=BBB"']);
+		};
+		const r = await fetchDkimPosture("acme.com", ["sel1"], { fetchImpl, kv });
+		expect(calls).toBe(0);
+		expect(r).toEqual({
+			selectors: [{ selector: "sel1", published: true }],
+		});
+	});
+
+	it("writes the durable-positive posture to KV", async () => {
+		const kv = fakeKv();
+		const fetchImpl = async () =>
+			dohTxtResponse(['"v=DKIM1; p=AAA"']);
+		await fetchDkimPosture("acme.com", ["sel1"], { fetchImpl, kv });
+		await new Promise((r) => setTimeout(r, 0));
+		const cached = kv.store.get("dkim-published:v1:acme.com:sel1");
+		expect(cached).toBeDefined();
+		expect(JSON.parse(cached!)).toEqual({ published: true });
+	});
+
+	it("writes the durable-negative posture to KV (NXDOMAIN sticks for the TTL)", async () => {
+		const kv = fakeKv();
+		const fetchImpl = async () => dohNxdomainResponse();
+		await fetchDkimPosture("acme.com", ["gone"], { fetchImpl, kv });
+		await new Promise((r) => setTimeout(r, 0));
+		const cached = kv.store.get("dkim-published:v1:acme.com:gone");
+		expect(cached).toBeDefined();
+		expect(JSON.parse(cached!)).toEqual({ published: false });
+	});
+
+	it("does NOT cache the unavailable sentinel (transient errors mustn't poison the cache)", async () => {
+		const kv = fakeKv();
+		const fetchImpl = async () => {
+			throw new Error("network");
+		};
+		const r = await fetchDkimPosture("acme.com", ["sel"], { fetchImpl, kv });
+		await new Promise((r) => setTimeout(r, 0));
+		expect(r).toEqual({
+			selectors: [{ selector: "sel", published: null }],
+		});
+		expect(kv.store.has("dkim-published:v1:acme.com:sel")).toBe(false);
+	});
+
+	it("falls through KV miss to DoH and writes the result", async () => {
+		const kv = fakeKv();
+		let calls = 0;
+		const fetchImpl = async () => {
+			calls += 1;
+			return dohTxtResponse(['"v=DKIM1; p=AAA"']);
+		};
+		const r = await fetchDkimPosture("acme.com", ["sel1"], { fetchImpl, kv });
+		expect(calls).toBe(1);
+		expect(r).toEqual({
+			selectors: [{ selector: "sel1", published: true }],
+		});
+	});
+
+	it("queries the <selector>._domainkey.<domain> label with TXT", async () => {
+		let captured = "";
+		const fetchImpl = async (url: string) => {
+			captured = url;
+			return dohTxtResponse(['"v=DKIM1; p=AAA"']);
+		};
+		await fetchDkimPosture("acme.com", ["googleapis"], { fetchImpl });
+		const u = new URL(captured);
+		expect(u.hostname).toBe("cloudflare-dns.com");
+		expect(u.pathname).toBe("/dns-query");
+		expect(u.searchParams.get("name")).toBe("googleapis._domainkey.acme.com");
+		expect(u.searchParams.get("type")).toBe("TXT");
+	});
+});

--- a/tests/frontend/domain-detail.test.tsx
+++ b/tests/frontend/domain-detail.test.tsx
@@ -91,6 +91,9 @@ const populated: DomainStats = {
 		configured: null,
 		endpoints: null,
 	},
+	dkimPosture: {
+		selectors: [],
+	},
 	recentCases: [
 		{
 			id: "C1",
@@ -162,6 +165,47 @@ describe("DomainDetailRoute", () => {
 		// Recent cases panel.
 		expect(screen.getByText(/recent cases/i)).toBeInTheDocument();
 		expect(screen.getByText(/suspicious wire transfer/i)).toBeInTheDocument();
+	});
+
+	it("renders the DKIM tile empty-state when no selectors have been observed (#170)", () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderDomainDetail("acme.com");
+		const dkimCard = screen
+			.getByText(/dkim posture/i)
+			.closest(".pp-card") as HTMLElement;
+		expect(
+			within(dkimCard).getByText(/no dkim selectors observed on inbound mail/i),
+		).toBeInTheDocument();
+	});
+
+	it("renders observed DKIM selectors with published / missing affordances (#170)", () => {
+		queryState = {
+			data: {
+				...populated,
+				dkimPosture: {
+					selectors: [
+						{ selector: "google", published: true },
+						{ selector: "retired", published: false },
+						// `null` is the transient-unavailable sentinel; per the
+						// #170 Constraints it renders identically to `false`
+						// (the same "missing" affordance) so the operator
+						// re-checks on the next refresh rather than acting on a
+						// distinct "lookup failed" tier.
+						{ selector: "blip", published: null },
+					],
+				},
+			},
+			isLoading: false,
+			isError: false,
+		};
+		renderDomainDetail("acme.com");
+		const dkimCard = screen
+			.getByText(/dkim posture/i)
+			.closest(".pp-card") as HTMLElement;
+		expect(within(dkimCard).getByText("google")).toBeInTheDocument();
+		expect(within(dkimCard).getByText("published")).toBeInTheDocument();
+		// Two selectors render "missing": the durable-false and the transient-null.
+		expect(within(dkimCard).getAllByText("missing")).toHaveLength(2);
 	});
 
 	it("renders the DMARC fields when posture data is present (forward-compatible)", () => {

--- a/tests/frontend/shell-domain-nav.test.tsx
+++ b/tests/frontend/shell-domain-nav.test.tsx
@@ -85,6 +85,9 @@ const populated: DomainStats = {
 		configured: null,
 		endpoints: null,
 	},
+	dkimPosture: {
+		selectors: [],
+	},
 	recentCases: [],
 };
 

--- a/tests/lib/domain-aggregation.test.ts
+++ b/tests/lib/domain-aggregation.test.ts
@@ -445,6 +445,43 @@ describe("aggregateDomainStats", () => {
 		});
 	});
 
+	it("falls back to the empty DKIM posture when the handler doesn't supply one (#170)", () => {
+		const result = aggregateDomainStats({
+			domain: "acme.com",
+			mailboxes: [
+				{ id: "alice@acme.com", email: "alice@acme.com", name: "Alice" },
+			],
+			summaries: [domainSummary()],
+			now: NOW.toISOString(),
+		});
+		expect(result!.dkimPosture).toEqual({ selectors: [] });
+	});
+
+	it("threads a real DKIM posture through unchanged when supplied (#170)", () => {
+		const result = aggregateDomainStats({
+			domain: "acme.com",
+			mailboxes: [
+				{ id: "alice@acme.com", email: "alice@acme.com", name: "Alice" },
+			],
+			summaries: [domainSummary()],
+			now: NOW.toISOString(),
+			dkimPosture: {
+				selectors: [
+					{ selector: "google", published: true },
+					{ selector: "retired", published: false },
+					{ selector: "blip", published: null },
+				],
+			},
+		});
+		expect(result!.dkimPosture).toEqual({
+			selectors: [
+				{ selector: "google", published: true },
+				{ selector: "retired", published: false },
+				{ selector: "blip", published: null },
+			],
+		});
+	});
+
 	it("tolerates null (failed) summaries as zero contributions", () => {
 		const result = aggregateDomainStats({
 			domain: "acme.com",

--- a/tests/security/auth.test.ts
+++ b/tests/security/auth.test.ts
@@ -130,6 +130,152 @@ describe("parseAuthResults — authserv-id gating", () => {
 	});
 });
 
+describe("parseAuthResults — DKIM selector observations", () => {
+	it("returns an empty observations list when no Authentication-Results header is present", () => {
+		const v = parseAuthResults([header("From", "a@b.com")]);
+		expect(v.dkimObservations).toEqual([]);
+	});
+
+	it("extracts (domain, selector) on a dkim=pass with header.d= and header.s=", () => {
+		const v = parseAuthResults([
+			header(
+				"Authentication-Results",
+				"mx.google.com; spf=pass smtp.mailfrom=example.com; dkim=pass header.i=@example.com header.s=selector1 header.d=example.com header.b=abc; dmarc=pass",
+			),
+		]);
+		expect(v.dkimObservations).toEqual([
+			{ domain: "example.com", selector: "selector1" },
+		]);
+	});
+
+	it("extracts on dkim=fail too — failing signatures still carry an observed selector", () => {
+		const v = parseAuthResults([
+			header(
+				"Authentication-Results",
+				"srv1; dkim=fail header.d=example.com header.s=sel-fail header.b=xyz",
+			),
+		]);
+		expect(v.dkimObservations).toEqual([
+			{ domain: "example.com", selector: "sel-fail" },
+		]);
+	});
+
+	it("extracts every signature from a header with multiple dkim=pass segments", () => {
+		// Forwarders frequently re-sign and emit one Authentication-Results
+		// header that carries both the original and the forwarder signatures.
+		const v = parseAuthResults([
+			header(
+				"Authentication-Results",
+				"mx.google.com; dkim=pass header.d=example.com header.s=sel1 header.b=AAA; dkim=pass header.d=mailinglist.example header.s=fwd-sel header.b=BBB; dmarc=pass",
+			),
+		]);
+		expect(v.dkimObservations).toEqual([
+			{ domain: "example.com", selector: "sel1" },
+			{ domain: "mailinglist.example", selector: "fwd-sel" },
+		]);
+	});
+
+	it("dedupes a selector observed twice in the same header (case-insensitive)", () => {
+		const v = parseAuthResults([
+			header(
+				"Authentication-Results",
+				"srv; dkim=pass header.d=Example.com header.s=Sel1 header.b=AAA; dkim=pass header.d=example.com header.s=sel1 header.b=BBB",
+			),
+		]);
+		expect(v.dkimObservations).toEqual([
+			{ domain: "example.com", selector: "sel1" },
+		]);
+	});
+
+	it("ignores dkim=none / temperror / permerror — no verified selector to roll up", () => {
+		const v = parseAuthResults([
+			header(
+				"Authentication-Results",
+				"srv; dkim=none header.d=example.com header.s=ignored1; dkim=temperror header.d=example.com header.s=ignored2; dkim=permerror header.d=example.com header.s=ignored3",
+			),
+		]);
+		expect(v.dkimObservations).toEqual([]);
+	});
+
+	it("skips a dkim=pass segment missing header.d= or header.s=", () => {
+		const v = parseAuthResults([
+			header(
+				"Authentication-Results",
+				"srv; dkim=pass header.b=onlybody-no-domain-no-selector",
+			),
+		]);
+		expect(v.dkimObservations).toEqual([]);
+	});
+
+	it("does NOT cross method boundaries — header.d= on the SPF segment is not paired with the DKIM selector", () => {
+		// `;`-segment scoping prevents misattribution. Without it, an SPF segment
+		// carrying `header.d=other` followed by a DKIM segment with `header.s=sel`
+		// would emit `(other, sel)` — a wrong observation that would hit DoH for
+		// a selector that doesn't exist under that domain.
+		const v = parseAuthResults([
+			header(
+				"Authentication-Results",
+				"srv; spf=pass header.d=other.example; dkim=pass header.s=sel1 header.d=example.com",
+			),
+		]);
+		expect(v.dkimObservations).toEqual([
+			{ domain: "example.com", selector: "sel1" },
+		]);
+	});
+
+	it("handles quoted selectors and quoted domains", () => {
+		const v = parseAuthResults([
+			header(
+				"Authentication-Results",
+				'srv; dkim=pass header.d="example.com" header.s="sel quoted"',
+			),
+		]);
+		expect(v.dkimObservations).toEqual([
+			{ domain: "example.com", selector: "sel quoted" },
+		]);
+	});
+
+	it("does NOT record observations from headers whose authserv-id is untrusted", () => {
+		// Threat model: an attacker-controlled relay can inject an
+		// Authentication-Results header claiming `dkim=pass header.d=victim.com
+		// header.s=attacker-sel`. Recording that selector would make the
+		// dashboard advertise an attacker-chosen DKIM selector as "observed"
+		// for victim.com. The trusted-id gate prevents this.
+		const v = parseAuthResults(
+			[
+				header(
+					"Authentication-Results",
+					"attacker.example; dkim=pass header.d=victim.com header.s=attacker-sel",
+				),
+				header(
+					"Authentication-Results",
+					"mx.cloudflare.net; dkim=pass header.d=victim.com header.s=legit-sel",
+				),
+			],
+			{ trustedAuthservIds: ["mx.cloudflare.net"] },
+		);
+		expect(v.dkimObservations).toEqual([
+			{ domain: "victim.com", selector: "legit-sel" },
+		]);
+	});
+
+	it("dedupes selectors observed across multiple Authentication-Results headers", () => {
+		const v = parseAuthResults([
+			header(
+				"Authentication-Results",
+				"inner; dkim=pass header.d=example.com header.s=sel1",
+			),
+			header(
+				"Authentication-Results",
+				"outer; dkim=pass header.d=example.com header.s=sel1",
+			),
+		]);
+		expect(v.dkimObservations).toEqual([
+			{ domain: "example.com", selector: "sel1" },
+		]);
+	});
+});
+
 describe("scoreAuth", () => {
 	it("scores a clean pass as a net-negative (credit)", () => {
 		const { score } = scoreAuth({ spf: "pass", dkim: "pass", dmarc: "pass" });

--- a/workers/dkim/posture.ts
+++ b/workers/dkim/posture.ts
@@ -49,6 +49,39 @@ export function emptyDkimPosture(): DkimPosture {
 	return { selectors: [] };
 }
 
+/** Number of days an observed selector remains in the rollup before the
+ * DO's read filter (and lazy-GC pass on writes) drops it. The 30-day window
+ * is the issue's stated horizon (#170 Constraints). Exported so the DO and
+ * tests share the same source of truth — keeping the cutoff math in one
+ * place avoids the failure mode where one site reads the same data the
+ * other just deleted. */
+export const DKIM_OBSERVATION_WINDOW_DAYS = 30;
+
+/**
+ * Compute the inclusive ISO cutoff for the DKIM-selector observation window.
+ * Rows whose `last_seen_iso >= cutoff` are still fresh; rows older than the
+ * cutoff are eligible for GC and excluded from reads.
+ *
+ * Pure helper so the boundary semantics are unit-testable without standing
+ * up a DO. The codebase has no DO test harness, so the cutoff math is the
+ * one piece of the 30-day-window invariant we can exercise directly.
+ */
+export function dkimObservationCutoffIso(
+	nowIso: string,
+	windowDays: number = DKIM_OBSERVATION_WINDOW_DAYS,
+): string {
+	const nowMs = new Date(nowIso).getTime();
+	if (!Number.isFinite(nowMs)) {
+		// Defensive: a caller passing a malformed `nowIso` would otherwise
+		// produce a NaN cutoff and the SQL filter would silently match
+		// nothing. Fall back to "now − window" using the runtime clock so
+		// the read still returns recent rows.
+		const fallback = Date.now() - windowDays * 24 * 60 * 60 * 1000;
+		return new Date(fallback).toISOString();
+	}
+	return new Date(nowMs - windowDays * 24 * 60 * 60 * 1000).toISOString();
+}
+
 const KV_PREFIX = "dkim-published:v1:";
 /** 1h TTL: matches the DMARC / MTA-STS / BIMI / SPF / TLS-RPT cadence so
  * operators don't have to memorise a different per-surface refresh time. */

--- a/workers/dkim/posture.ts
+++ b/workers/dkim/posture.ts
@@ -1,0 +1,278 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * DKIM published-record posture lookup.
+ *
+ * Unlike the other posture surfaces (DMARC / MTA-STS / BIMI / SPF / TLS-RPT)
+ * which read a single well-known label, DKIM posture is per-selector — a
+ * domain may publish many selectors (`s1._domainkey.<domain>`,
+ * `s2._domainkey.<domain>`, ...) and we have no a-priori list. The selectors
+ * come from inbound `Authentication-Results.dkim header.s=` observations
+ * persisted per-mailbox-DO; the caller passes the deduplicated 30d set in.
+ *
+ * For each selector we resolve `<selector>._domainkey.<domain>` over DoH and
+ * answer one question: is a DKIM record still published at that label? A
+ * record exists when the resolver returns at least one TXT entry and one
+ * of those entries either starts with `v=DKIM1` or carries a non-empty `p=`
+ * tag (RFC 6376 §3.6.1 lets `v=` be absent — `p=` is the only required tag).
+ *
+ * Per-key cache shape lets one bad selector not invalidate the whole domain:
+ * a selector that resolves cleanly today stays cached for an hour even if a
+ * sibling lookup times out the next time around.
+ *
+ * Mirrors the DoH + KV + 1500ms-cap pattern from `workers/dmarc/txt.ts` and
+ * `workers/tlsrpt/posture.ts`. Issue: #170.
+ */
+
+/** Per-selector posture row.
+ *
+ * `published: null` is the "lookup unavailable" sentinel — DoH timed out,
+ * returned non-200, or returned malformed JSON. The dashboard renders this
+ * with the same affordance as `false` (per Constraints in #170) but the
+ * cache layer keeps them separate so a transient blip doesn't poison the
+ * cache for an hour. */
+export interface DkimSelectorPosture {
+	selector: string;
+	published: boolean | null;
+}
+
+/** Whole-domain DKIM posture surface — the list of observed selectors with
+ * each one's published-record status. Empty `selectors` means "no selectors
+ * observed in the 30d window"; the UI renders the appropriate empty state.
+ */
+export interface DkimPosture {
+	selectors: ReadonlyArray<DkimSelectorPosture>;
+}
+
+/** Sentinel for "no observations yet" — same shape as a degenerate result. */
+export function emptyDkimPosture(): DkimPosture {
+	return { selectors: [] };
+}
+
+const KV_PREFIX = "dkim-published:v1:";
+/** 1h TTL: matches the DMARC / MTA-STS / BIMI / SPF / TLS-RPT cadence so
+ * operators don't have to memorise a different per-surface refresh time. */
+const KV_TTL_S = 60 * 60;
+/** DoH resolver host. Hostname-based mock matching is required by repo CLAUDE.md. */
+const DOH_HOST = "cloudflare-dns.com";
+const DOH_URL = `https://${DOH_HOST}/dns-query`;
+/** Hard cap matches `workers/dmarc/txt.ts` and the rest of the posture set. */
+const DOH_TIMEOUT_MS = 1500;
+
+/** Minimal `KVNamespace` view we depend on; lets tests pass a fake. */
+export interface DkimPostureKv {
+	get(key: string, type: "json"): Promise<unknown>;
+	put(
+		key: string,
+		value: string,
+		options?: { expirationTtl?: number },
+	): Promise<void>;
+}
+
+/** Minimal `fetch` view we depend on; lets tests inject a stub. */
+export type DkimPostureFetch = (
+	input: string,
+	init?: RequestInit,
+) => Promise<Response>;
+
+/**
+ * Strip surrounding quotes and concatenate multi-string TXT-record fragments
+ * DoH returns. Same logic as `workers/tlsrpt/posture.ts:normalizeDohTxtData`
+ * — duplicated to keep the DKIM module decoupled.
+ */
+export function normalizeDohTxtData(data: string): string {
+	if (typeof data !== "string") return "";
+	const matches = [...data.matchAll(/"((?:[^"\\]|\\.)*)"/g)];
+	if (matches.length === 0) {
+		return data.replace(/^"|"$/g, "");
+	}
+	return matches.map((m) => m[1]).join("");
+}
+
+/**
+ * Decide whether a single TXT-record string represents a published DKIM
+ * key. Two acceptance forms:
+ *   - `v=DKIM1; ...` (canonical RFC 6376 form).
+ *   - any record carrying a non-empty `p=<base64>` tag (RFC 6376 §3.6.1
+ *     lets `v=` be absent for backwards-compat, and `p=` is the only
+ *     mandatory tag).
+ *
+ * A record with `p=` empty (`p=`) is the "key-revoked" sentinel per RFC
+ * 6376 §3.6.1 — the label still exists, but the record is publishing
+ * "this selector is intentionally retired". For posture purposes we count
+ * that as NOT published — the operator wants the selector treated as gone.
+ */
+export function isPublishedDkimRecord(record: string): boolean {
+	if (typeof record !== "string") return false;
+	const trimmed = record.trim();
+	if (!trimmed) return false;
+	const tags = new Map<string, string>();
+	for (const part of trimmed.split(";")) {
+		const eq = part.indexOf("=");
+		if (eq < 0) continue;
+		const name = part.slice(0, eq).trim().toLowerCase();
+		const value = part.slice(eq + 1).trim();
+		if (!name) continue;
+		// First-wins to mirror the rest of the parser family.
+		if (!tags.has(name)) tags.set(name, value);
+	}
+	const v = tags.get("v");
+	const p = tags.get("p");
+	if (v && /^DKIM1$/i.test(v)) {
+		// Canonical record. `p=` empty is "revoked" — count as not published.
+		if (p !== undefined) return p.length > 0;
+		// `v=DKIM1` with no `p=` is malformed but published-shape; treat as
+		// published rather than swallowing it (the operator did write a record).
+		return true;
+	}
+	// No `v=DKIM1` — fall back to "non-empty `p=` tag exists".
+	return typeof p === "string" && p.length > 0;
+}
+
+/**
+ * Pick whether any TXT entry at `<selector>._domainkey.<domain>` is a
+ * published DKIM record. A label may carry multiple TXT entries (vendor
+ * verifications, an old DKIM record left next to a new one); any one of
+ * them being a valid DKIM record means "published".
+ */
+export function isAnyPublished(records: readonly string[]): boolean {
+	for (const r of records) {
+		if (isPublishedDkimRecord(r)) return true;
+	}
+	return false;
+}
+
+/**
+ * Fetch the DKIM posture for `domain` over DoH, one selector at a time.
+ *
+ * The resolver is sequential — selector counts per domain are bounded by
+ * the 30d observation window (single-digit common case, low-double-digit
+ * worst case for forwarder-heavy domains). Sequential keeps the Worker
+ * from fan-firing 30+ concurrent DoH requests and tripping rate limits;
+ * each resolution is hard-capped at 1.5s so even 10 misses cap the call
+ * at 15s wall time before the surrounding handler's timeout takes over.
+ *
+ * Empty `selectors` short-circuits — we return `{ selectors: [] }` without
+ * touching DoH. The UI renders that as "no DKIM selectors observed".
+ *
+ * Per-selector results are cached in KV. The transient `published: null`
+ * sentinel is NEVER cached — same invariant as `tlsrpt/posture.ts`.
+ */
+export async function fetchDkimPosture(
+	domain: string,
+	selectors: readonly string[],
+	options: {
+		kv?: DkimPostureKv | null;
+		fetchImpl?: DkimPostureFetch;
+	} = {},
+): Promise<DkimPosture> {
+	if (!domain || typeof domain !== "string") return emptyDkimPosture();
+	if (selectors.length === 0) return emptyDkimPosture();
+	const fetchImpl = options.fetchImpl ?? (globalThis.fetch as DkimPostureFetch);
+	const kv = options.kv ?? null;
+
+	// Dedupe + lower-case at the entry — the DO already lower-cases on
+	// observation, but this guards against callers that union from elsewhere.
+	const uniq: string[] = [];
+	const seen = new Set<string>();
+	for (const sel of selectors) {
+		if (typeof sel !== "string") continue;
+		const key = sel.toLowerCase();
+		if (!key || seen.has(key)) continue;
+		seen.add(key);
+		uniq.push(key);
+	}
+
+	const out: DkimSelectorPosture[] = [];
+	for (const selector of uniq) {
+		const cacheKey = `${KV_PREFIX}${domain}:${selector}`;
+
+		let cached: boolean | null | undefined;
+		if (kv) {
+			try {
+				const v = await kv.get(cacheKey, "json");
+				if (v && typeof v === "object") {
+					const pub = (v as { published?: unknown }).published;
+					if (typeof pub === "boolean") cached = pub;
+				}
+			} catch {
+				// KV read failure is non-fatal — fall through to a fresh DoH lookup.
+			}
+		}
+
+		if (cached !== undefined) {
+			out.push({ selector, published: cached });
+			continue;
+		}
+
+		const published = await resolveOneSelector(domain, selector, fetchImpl);
+		out.push({ selector, published });
+
+		// Only cache durable answers — `published: null` is transient (DoH
+		// timed out or returned non-200). Caching it would mean an hour of
+		// "unavailable" after a single blip. Mirrors `tlsrpt/posture.ts`.
+		if (kv && published !== null) {
+			void kv
+				.put(
+					cacheKey,
+					JSON.stringify({ published }),
+					{ expirationTtl: KV_TTL_S },
+				)
+				.catch(() => {});
+		}
+	}
+
+	// Stable ordering keeps the UI tile layout deterministic across reloads.
+	out.sort((a, b) => a.selector.localeCompare(b.selector));
+
+	return { selectors: out };
+}
+
+async function resolveOneSelector(
+	domain: string,
+	selector: string,
+	fetchImpl: DkimPostureFetch,
+): Promise<boolean | null> {
+	const name = `${selector}._domainkey.${domain}`;
+	let res: Response;
+	try {
+		res = await fetchImpl(
+			`${DOH_URL}?name=${encodeURIComponent(name)}&type=TXT`,
+			{
+				headers: { accept: "application/dns-json" },
+				signal: AbortSignal.timeout(DOH_TIMEOUT_MS),
+			},
+		);
+	} catch {
+		return null;
+	}
+	if (!res.ok) return null;
+	let body: unknown;
+	try {
+		body = await res.json();
+	} catch {
+		return null;
+	}
+	const answer = (body as { Answer?: Array<{ type?: number; data?: unknown }> })
+		.Answer;
+	// Cloudflare's resolver returns NXDOMAIN as `Status: 3` with no `Answer`
+	// field — that's a durable "no record at this label", which for DKIM means
+	// the selector is not published. Distinguishing it from "lookup unavailable"
+	// matters for caching: a stable false stays cached, a transient null does
+	// not.
+	const status = (body as { Status?: unknown }).Status;
+	if (Array.isArray(answer)) {
+		const txts: string[] = [];
+		for (const a of answer) {
+			if (a.type !== 16) continue;
+			if (typeof a.data !== "string") continue;
+			txts.push(normalizeDohTxtData(a.data));
+		}
+		return isAnyPublished(txts);
+	}
+	// `Status: 3` is NXDOMAIN per RFC 8484 §4.2.1 / DoH JSON convention.
+	// `Status: 0` with no Answer is NOERROR-no-data — also durable "no record".
+	// Anything else (SERVFAIL=2, etc.) is treated as transient unavailability.
+	if (status === 0 || status === 3) return false;
+	return null;
+}

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -13,6 +13,7 @@ import { applyMigrations, mailboxMigrations } from "./migrations";
 import { attachmentObjectKey } from "../lib/attachments";
 import { computeVerdictMix } from "../lib/dashboard-aggregation";
 import { summarizeCase } from "../lib/ai";
+import { dkimObservationCutoffIso } from "../dkim/posture";
 
 /**
  * SQL expression to normalize email subjects by stripping common
@@ -1565,9 +1566,7 @@ export class MailboxDO extends DurableObject<Env> {
 	): Promise<void> {
 		if (observations.length === 0) return;
 		const nowIso = opts.now ?? new Date().toISOString();
-		const cutoffIso = new Date(
-			new Date(nowIso).getTime() - 30 * 24 * 60 * 60 * 1000,
-		).toISOString();
+		const cutoffIso = dkimObservationCutoffIso(nowIso);
 
 		const seen = new Set<string>();
 		for (const obs of observations) {
@@ -1605,9 +1604,7 @@ export class MailboxDO extends DurableObject<Env> {
 	): Promise<string[]> {
 		if (!domain || typeof domain !== "string") return [];
 		const nowIso = opts.now ?? new Date().toISOString();
-		const cutoffIso = new Date(
-			new Date(nowIso).getTime() - 30 * 24 * 60 * 60 * 1000,
-		).toISOString();
+		const cutoffIso = dkimObservationCutoffIso(nowIso);
 		const rows = [
 			...this.ctx.storage.sql.exec(
 				`SELECT selector FROM dkim_selectors_observed

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -1542,6 +1542,85 @@ export class MailboxDO extends DurableObject<Env> {
 	}
 
 	/**
+	 * Record `(domain, selector)` pairs observed on inbound DKIM=pass / =fail
+	 * evaluations into the `dkim_selectors_observed` rollup. Idempotent:
+	 * re-observing an existing pair updates `last_seen_iso`; the unique key
+	 * keeps cardinality bounded by `(distinct selectors per domain)`.
+	 *
+	 * Lazy GC: every write also prunes rows whose `last_seen_iso` is older
+	 * than `nowIso - 30d`, so the table size never exceeds the active
+	 * 30-day observation set. Reads (`getDkimSelectorsObserved`) apply the
+	 * same horizon as a defence in depth — the GC pass is opportunistic
+	 * (only fires on writes), so a domain that hasn't sent mail in months
+	 * could still carry stale rows until the next observation lands.
+	 *
+	 * Empty input is a no-op — the security pipeline calls this on every
+	 * inbound message regardless of whether DKIM headers were present.
+	 *
+	 * Issue: #170.
+	 */
+	async recordDkimSelectorsObserved(
+		observations: ReadonlyArray<{ domain: string; selector: string }>,
+		opts: { now?: string } = {},
+	): Promise<void> {
+		if (observations.length === 0) return;
+		const nowIso = opts.now ?? new Date().toISOString();
+		const cutoffIso = new Date(
+			new Date(nowIso).getTime() - 30 * 24 * 60 * 60 * 1000,
+		).toISOString();
+
+		const seen = new Set<string>();
+		for (const obs of observations) {
+			if (!obs?.domain || !obs?.selector) continue;
+			const domain = obs.domain.toLowerCase();
+			const selector = obs.selector.toLowerCase();
+			const key = `${domain}|${selector}`;
+			if (seen.has(key)) continue;
+			seen.add(key);
+			this.ctx.storage.sql.exec(
+				`INSERT INTO dkim_selectors_observed (domain, selector, last_seen_iso)
+				 VALUES (?1, ?2, ?3)
+				 ON CONFLICT(domain, selector) DO UPDATE SET last_seen_iso = ?3`,
+				domain,
+				selector,
+				nowIso,
+			);
+		}
+
+		this.ctx.storage.sql.exec(
+			`DELETE FROM dkim_selectors_observed WHERE last_seen_iso < ?1`,
+			cutoffIso,
+		);
+	}
+
+	/**
+	 * Read the `(selector)` set observed for `domain` over the last 30 days.
+	 * Lower-cased and de-duplicated on the way in, so the caller can
+	 * union across mailboxes without further normalisation. Returns an
+	 * empty array when no observations have landed in the window.
+	 */
+	async getDkimSelectorsObserved(
+		domain: string,
+		opts: { now?: string } = {},
+	): Promise<string[]> {
+		if (!domain || typeof domain !== "string") return [];
+		const nowIso = opts.now ?? new Date().toISOString();
+		const cutoffIso = new Date(
+			new Date(nowIso).getTime() - 30 * 24 * 60 * 60 * 1000,
+		).toISOString();
+		const rows = [
+			...this.ctx.storage.sql.exec(
+				`SELECT selector FROM dkim_selectors_observed
+				 WHERE domain = ?1 AND last_seen_iso >= ?2
+				 ORDER BY selector ASC`,
+				domain.toLowerCase(),
+				cutoffIso,
+			),
+		] as Array<{ selector: string }>;
+		return rows.map((r) => r.selector);
+	}
+
+	/**
 	 * Aggregate the operations dashboard payload in one round-trip from the
 	 * UI. Each card lives in its own indexed query — see
 	 * `migrations.ts/11_dashboard_indexes` and `12_pipeline_runs` for the

--- a/workers/durableObject/migrations.ts
+++ b/workers/durableObject/migrations.ts
@@ -340,4 +340,25 @@ export const mailboxMigrations: Migration[] = [
             ALTER TABLE cases ADD COLUMN summary_status TEXT;
         `,
 	},
+	{
+		// DKIM selectors observed from inbound mail's Authentication-Results
+		// (issue #170). One row per `(domain, selector)` pair seen on a
+		// trusted DKIM=pass / DKIM=fail evaluation; `last_seen_iso` updated
+		// on every re-observation. The 30d observation window is enforced
+		// by the read path, with a delete-on-write GC pruning older rows
+		// the next time observations land. Per-mailbox-DO scope keeps
+		// multi-tenant safety intact — selectors observed on mailbox A
+		// never leak into mailbox B's posture.
+		name: "15_dkim_selectors_observed",
+		sql: `
+            CREATE TABLE IF NOT EXISTS dkim_selectors_observed (
+                domain TEXT NOT NULL,
+                selector TEXT NOT NULL,
+                last_seen_iso TEXT NOT NULL,
+                PRIMARY KEY (domain, selector)
+            );
+            CREATE INDEX IF NOT EXISTS idx_dkim_selectors_observed_domain ON dkim_selectors_observed(domain);
+            CREATE INDEX IF NOT EXISTS idx_dkim_selectors_observed_last_seen ON dkim_selectors_observed(last_seen_iso);
+        `,
+	},
 ];

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -58,6 +58,7 @@ import { emptyMtaStsPosture, fetchMtaStsPosture } from "./mta-sts/posture";
 import { emptyBimiPosture, fetchBimiPosture } from "./bimi/posture";
 import { emptySpfPosture, fetchSpfPosture } from "./spf/posture";
 import { emptyTlsRptPosture, fetchTlsRptPosture } from "./tlsrpt/posture";
+import { emptyDkimPosture, fetchDkimPosture } from "./dkim/posture";
 import { listTextModels } from "./lib/text-models";
 import { fetchHubCorroborationCount } from "./intel/hub-corroboration";
 import { loadHubCredentials } from "./lib/hub-config";
@@ -383,6 +384,16 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 			.get(c.env.MAILBOX.idFromName(m.id))
 			.getDmarcAlignmentTotals(domain, alignmentSinceIso),
 	);
+	// Per-mailbox DKIM-selector fan-out (#170). Each mailbox observes its own
+	// selector set; we union here so the per-domain DKIM tile reflects every
+	// inbound DKIM signature seen for `domain` over the 30-day window. The
+	// per-mailbox-DO scoping is preserved — selectors observed on a mailbox
+	// of a different domain never enter this fan-out.
+	const dkimSelectorPromises = scoped.map((m) =>
+		c.env.MAILBOX
+			.get(c.env.MAILBOX.idFromName(m.id))
+			.getDkimSelectorsObserved(domain),
+	);
 	const txtPromise = fetchDmarcTxtPosture(domain, {
 		kv: c.env.BLOOM_KV ?? null,
 	});
@@ -402,6 +413,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 	const [
 		settledSummaries,
 		settledAlignments,
+		settledDkimSelectors,
 		settledTxt,
 		settledMtaSts,
 		settledBimi,
@@ -410,6 +422,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 	] = await Promise.all([
 		Promise.allSettled(summaryPromises),
 		Promise.allSettled(alignmentPromises),
+		Promise.allSettled(dkimSelectorPromises),
 		Promise.allSettled([txtPromise]),
 		Promise.allSettled([mtaStsPromise]),
 		Promise.allSettled([bimiPromise]),
@@ -469,6 +482,35 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 			? settledTlsRpt[0].value
 			: emptyTlsRptPosture();
 
+	// Union the per-mailbox selector lists. A failed DO call contributes
+	// nothing rather than blocking the whole DKIM tile — same degradation
+	// model as `getDmarcAlignmentTotals`.
+	const observedSelectors = new Set<string>();
+	for (const r of settledDkimSelectors) {
+		if (r.status !== "fulfilled") {
+			console.error(
+				"domain-stats: dkim-selectors failed:",
+				(r.reason as Error)?.message,
+			);
+			continue;
+		}
+		for (const sel of r.value) {
+			if (typeof sel === "string" && sel.length > 0) observedSelectors.add(sel);
+		}
+	}
+
+	const dkimPosture = observedSelectors.size === 0
+		? emptyDkimPosture()
+		: await fetchDkimPosture(domain, [...observedSelectors], {
+			kv: c.env.BLOOM_KV ?? null,
+		}).catch((e) => {
+			console.error(
+				"domain-stats: dkim posture lookup failed:",
+				(e as Error).message,
+			);
+			return emptyDkimPosture();
+		});
+
 	const mailboxRefs: DomainMailboxRef[] = scoped.map((m) => ({
 		id: m.id,
 		email: m.email,
@@ -484,6 +526,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		bimiPosture,
 		spfPosture,
 		tlsRptPosture,
+		dkimPosture,
 	});
 	// `aggregateDomainStats` only returns null when `mailboxes.length === 0`,
 	// which we already guarded above with the 404 — but narrow the type

--- a/workers/lib/dashboard-aggregation.ts
+++ b/workers/lib/dashboard-aggregation.ts
@@ -464,6 +464,27 @@ export interface TlsRptPostureView {
 	endpoints: readonly string[] | null;
 }
 
+/** DKIM published-record posture (#170). Per-selector list of selectors
+ * observed over the last 30 days on inbound mail to this domain, each with
+ * its current published-at-`<selector>._domainkey.<domain>` status.
+ *
+ * `published: true` — DoH returned a TXT entry that's a valid DKIM record.
+ * `published: false` — durable "no record" (NXDOMAIN, NOERROR-no-data, or
+ *   `p=` empty / "key revoked").
+ * `published: null` — transient "lookup unavailable" (DoH timed out, returned
+ *   non-200, or non-cacheable status). The UI renders this with the same
+ *   affordance as `false` per the #170 Constraints, but the cache layer
+ *   keeps them separate.
+ *
+ * Empty `selectors` is the natural state for a domain that's never sent
+ * inbound DKIM-signed mail; the UI shows the empty-state affordance. */
+export interface DkimPostureView {
+	selectors: ReadonlyArray<{
+		selector: string;
+		published: boolean | null;
+	}>;
+}
+
 export interface DomainListEntry {
 	domain: string;
 	mailboxesCount: number;
@@ -499,6 +520,10 @@ export interface DomainStats {
 	/** TLS-RPT posture (#168). `configured: null` when the upstream lookup
 	 * failed; `configured: false` when no `v=TLSRPTv1` record is published. */
 	tlsRptPosture: TlsRptPostureView;
+	/** DKIM published-record posture (#170). Per-selector list across the
+	 * 30-day inbound-mail observation window. Empty `selectors` is the natural
+	 * state for a domain that's never received DKIM-signed inbound mail. */
+	dkimPosture: DkimPostureView;
 	recentCases: DomainRecentCase[];
 }
 
@@ -566,6 +591,12 @@ export function emptySpfPostureView(): SpfPostureView {
  * result. Mirrors the BIMI sentinel shape. */
 export function emptyTlsRptPostureView(): TlsRptPostureView {
 	return { configured: null, endpoints: null };
+}
+
+/** Empty DKIM posture sentinel — empty selector list, rendered by the UI
+ * as "no DKIM selectors observed in the last 30 days". */
+export function emptyDkimPostureView(): DkimPostureView {
+	return { selectors: [] };
 }
 
 /** Per-mailbox alignment totals harvested from `dmarc_records` by the DO.
@@ -707,6 +738,13 @@ interface AggregateDomainStatsInput {
 	 * Omitted defaults to the all-null sentinel.
 	 */
 	tlsRptPosture?: TlsRptPostureView;
+	/**
+	 * DKIM posture (#170) from per-mailbox observed selectors fanned out
+	 * across the domain plus DoH lookups against
+	 * `<selector>._domainkey.<domain>`. Omitted defaults to the empty
+	 * sentinel (no selectors observed).
+	 */
+	dkimPosture?: DkimPostureView;
 }
 
 /**
@@ -768,6 +806,7 @@ export function aggregateDomainStats(
 		bimiPosture: input.bimiPosture ?? emptyBimiPostureView(),
 		spfPosture: input.spfPosture ?? emptySpfPostureView(),
 		tlsRptPosture: input.tlsRptPosture ?? emptyTlsRptPostureView(),
+		dkimPosture: input.dkimPosture ?? emptyDkimPostureView(),
 		recentCases: recentCases.slice(0, 5),
 	};
 }

--- a/workers/security/auth.ts
+++ b/workers/security/auth.ts
@@ -45,10 +45,23 @@ export interface AuthVerdict {
 	 * that as a strong suspicion signal.
 	 */
 	trusted?: boolean;
+	/**
+	 * `(domain, selector)` pairs observed on `dkim=pass` / `dkim=fail` results
+	 * with both `header.d=` and `header.s=` properties present. Subject to the
+	 * same trusted-authserv-id gate as the rest of the verdict — observations
+	 * from forged headers (untrusted authserv-id when gating is on) are never
+	 * surfaced. `dkim=none/temperror/permerror` results are excluded because
+	 * they don't carry a verified selector to roll up.
+	 *
+	 * Domain and selector are lower-cased at extraction so the per-mailbox-DO
+	 * `(domain, selector)` PRIMARY KEY de-dupes case variants without extra
+	 * normalisation in the storage path. Issue #170.
+	 */
+	dkimObservations: ReadonlyArray<{ domain: string; selector: string }>;
 }
 
 export function emptyVerdict(): AuthVerdict {
-	return { spf: "none", dkim: "none", dmarc: "none" };
+	return { spf: "none", dkim: "none", dmarc: "none", dkimObservations: [] };
 }
 
 /**
@@ -71,6 +84,19 @@ function findAuthHeaders(rawHeaders: unknown): string[] {
 }
 
 const RESULT_RE = /(spf|dkim|dmarc)\s*=\s*(pass|fail|neutral|none|softfail|temperror|permerror)/gi;
+
+/**
+ * Match `header.d=<value>` or `header.s=<value>` with either a quoted or bare
+ * value. Values run until the next whitespace or `;` (the method-segment
+ * delimiter). Quoted values let through `header.s="some selector"` which
+ * exists in the wild for selectors with unusual characters. Used to extract
+ * DKIM selector observations for the per-mailbox `dkim_selectors_observed`
+ * rollup (#170).
+ */
+const HEADER_PROP_RE = /header\.([ds])\s*=\s*(?:"([^"]*)"|([^\s;]+))/gi;
+/** Match `dkim=pass` or `dkim=fail` with a word boundary so `dkim=none`,
+ * `dkim=temperror`, etc. are excluded from selector observation. */
+const DKIM_PASS_OR_FAIL_RE = /\bdkim\s*=\s*(pass|fail)\b/i;
 
 function extractAuthservId(raw: string): string | undefined {
 	const firstToken = raw.split(";")[0]?.trim();
@@ -97,7 +123,18 @@ function matchesTrusted(authservId: string, trusted: readonly string[]): boolean
 }
 
 export function parseAuthResults(rawHeaders: unknown, options: ParseAuthOptions = {}): AuthVerdict {
-	const verdict = emptyVerdict();
+	const verdict: AuthVerdict = {
+		spf: "none",
+		dkim: "none",
+		dmarc: "none",
+		dkimObservations: [],
+	};
+	// Local mutable observations buffer; we freeze into the readonly field at
+	// the end. Dedupe by `domain|selector` so a header carrying multiple
+	// signatures from the same selector (gmail re-sign chains do this)
+	// contributes once.
+	const observations: Array<{ domain: string; selector: string }> = [];
+	const seen = new Set<string>();
 	const headerValues = findAuthHeaders(rawHeaders);
 	if (headerValues.length === 0) return verdict;
 
@@ -126,7 +163,32 @@ export function parseAuthResults(rawHeaders: unknown, options: ParseAuthOptions 
 				set[method] = true;
 			}
 		}
+
+		// DKIM selector observations. Each `;`-separated method segment with a
+		// `dkim=pass` or `dkim=fail` result contributes one `(domain, selector)`
+		// pair when both `header.d=` and `header.s=` are present. The split on
+		// `;` matters: a single header like `auth; spf=pass header.d=other;
+		// dkim=pass header.s=sel1` would otherwise associate `header.d=other`
+		// (an SPF property) with the DKIM selector and emit a wrong domain.
+		for (const segment of raw.split(";")) {
+			if (!DKIM_PASS_OR_FAIL_RE.test(segment)) continue;
+			let domain = "";
+			let selector = "";
+			for (const m of segment.matchAll(HEADER_PROP_RE)) {
+				const name = m[1].toLowerCase();
+				const value = m[2] ?? m[3] ?? "";
+				if (!value) continue;
+				if (name === "d" && !domain) domain = value.toLowerCase();
+				else if (name === "s" && !selector) selector = value.toLowerCase();
+			}
+			if (!domain || !selector) continue;
+			const key = `${domain}|${selector}`;
+			if (seen.has(key)) continue;
+			seen.add(key);
+			observations.push({ domain, selector });
+		}
 	}
+	verdict.dkimObservations = observations;
 	return verdict;
 }
 

--- a/workers/security/index.ts
+++ b/workers/security/index.ts
@@ -101,6 +101,23 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 	const auth = parseAuthResults(parsedEmail.headers, {
 		trustedAuthservIds: settings.trusted_authserv_ids,
 	});
+
+	// DKIM selector observation rollup (#170). Best-effort — a slow / failed
+	// DO write must NOT delay the verdict path. Trusted-id gating already
+	// happened inside `parseAuthResults`, so anything in `auth.dkimObservations`
+	// is safe to persist; the DO method de-dupes and runs the lazy 30d GC.
+	if (auth.dkimObservations.length > 0) {
+		const stub = getMailboxStub(env, mailboxId);
+		void stub
+			.recordDkimSelectorsObserved(auth.dkimObservations)
+			.catch((e) =>
+				console.error(
+					"recordDkimSelectorsObserved failed:",
+					(e as Error).message,
+				),
+			);
+	}
+
 	const urls = extractUrls(bodyHtml);
 
 	// Intel feed lookup — first confirmed hit wins. Kept early (pre-triage)


### PR DESCRIPTION
Closes #170. Sub-issue 6/7 of #156.

## Summary

- Lift DKIM selectors from inbound `Authentication-Results.dkim header.s=` over a 30-day per-mailbox-DO window, then resolve each `<selector>._domainkey.<domain>` over DoH to confirm the record is still published.
- New `DkimPostureCard` tile on `/domains/:domain` lists observed selectors with "published" / "missing" affordances; empty state when no DKIM signed inbound mail has been seen in the window.
- Multi-tenant safety preserved — observation storage is per-mailbox-DO; the domain handler unions the observed-selector set across the domain's mailboxes only (mirrors the existing DMARC-alignment fan-out).

## Test plan

- [x] `npm test` — 763 passing, 0 failing
- [x] `npm run typecheck` — clean
- [x] Backend tests: `tests/dkim/posture.test.ts` covers the five Acceptance scenarios — zero observations (no DoH calls), single passing TXT, NXDOMAIN, mixed, and the 30-day expiry boundary via the `dkimObservationCutoffIso` pure helper. Mocks use `new URL(url).hostname === 'cloudflare-dns.com'` per the repo's CodeQL invariant.
- [x] AR-parser tests: `tests/security/auth.test.ts` covers selector extraction (single signature, multiple signatures, dedup, case-insensitivity, dkim=none/temperror/permerror skipped, segment-scoping so SPF `header.d=` doesn't pair with DKIM `header.s=`, trusted-authserv-id gating).
- [x] Aggregation plumbing: `tests/lib/domain-aggregation.test.ts`.
- [x] UI tile: `tests/frontend/domain-detail.test.tsx` — empty state, mixed published/missing rendering.

## Acceptance

- [x] New migration `15_dkim_selectors_observed` with `(domain, selector)` PRIMARY KEY plus `idx_dkim_selectors_observed_domain` and `idx_dkim_selectors_observed_last_seen` indexes.
- [x] `Authentication-Results` parser writes `(domain, selector)` on every `dkim=pass` / `dkim=fail` evaluation. Observation honours the existing trusted-authserv-id gate so forged headers from untrusted relays never persist.
- [x] `workers/dkim/posture.ts` reads the 30d selector set per domain (fanned out from per-mailbox-DO observations) and resolves each `<selector>._domainkey.<domain>` over DoH; per-selector results cached in KV under `dkim-published:v1:<domain>:<selector>` with the same 1h TTL and "never cache the transient `null` sentinel" rule as `tlsrpt/posture.ts`.
- [x] `/domains/:domain` renders a DKIM tile listing observed selectors with per-selector "published" / "missing" affordance. "Unavailable" (`published=null`) and "genuinely missing" (`published=false`) render the same affordance per the issue Constraints; the cache layer keeps them separate so a transient blip doesn't poison the cache.
- [x] Tests cover all five scenarios called out in Acceptance.

## Architecture notes

- **Slightly larger than sibling posture PRs** (#178/#179/#180/#196 each landed at 10 files; this is 14). The delta is intrinsic: DKIM posture is per-selector lifted from inbound mail, not single-record DoH like the siblings — so `workers/security/auth.ts` (selector extraction), `workers/durableObject/{index,migrations}.ts` (per-mailbox observation + 30d GC), and `workers/security/index.ts` (fire-and-forget DO write) are all required. Total LOC (~1250) is well under the 1500-line auto-decompose threshold; no slice would ship as a coherent independent PR without creating dead code.
- **Per-mailbox-DO observation only.** Cross-mailbox aggregation across tenant boundaries stays out of scope per the issue. The domain handler unions selectors across the *domain's own* mailboxes (same authorization scope as the rest of `/domains/:domain`); selectors observed by mailboxes of other domains never enter this fan-out.
- **Lazy delete-on-write GC** on `recordDkimSelectorsObserved` keeps the table size bounded by the active 30-day set. Reads apply the same horizon as defence in depth — a domain that hasn't sent inbound mail in months won't surface stale rows even if no GC pass has run.
- **No `SECURITY_SPEC.md` changes** — DKIM posture isn't a SECURITY_SPEC-tracked invariant. No follow-up `docs:` PR needed.

## Out of scope (unchanged from #170)

- DKIM key strength / algorithm checks.
- DKIM key rotation alerting.
- Cross-mailbox aggregation of selectors across organizational boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)