### PR TITLE
feat(security): confidence dimension on verdict (foundation for #105)

### DIFF
--- a/test/security/classification.test.ts
+++ b/test/security/classification.test.ts
@@ -158,6 +158,6 @@ describe("scoreClassification — unavailable contributes 0", () => {
 
 	it("safe verdict still contributes 0 with no reasons", () => {
 		const result: ClassificationResult = { label: "safe", confidence: 1, reasoning: "" };
-		expect(scoreClassification(result)).toEqual({ score: 0, reasons: [] });
+		expect(scoreClassification(result)).toEqual({ score: 0, reasons: [], confidence: 1 });
 	});
 });

--- a/tests/security/urls.test.ts
+++ b/tests/security/urls.test.ts
@@ -100,7 +100,7 @@ describe("scoreUrls", () => {
 		const urls: ExtractedUrl[] = [
 			{ url: "https://a.com", hostname: "a.com", is_homograph: false, is_shortener: false },
 		];
-		expect(scoreUrls(urls)).toEqual({ score: 0, reasons: [] });
+		expect(scoreUrls(urls)).toEqual({ score: 0, reasons: [], confidence: 1.0 });
 	});
 
 	it("scores a homograph URL at +20", () => {

--- a/tests/security/verdict.test.ts
+++ b/tests/security/verdict.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { aggregateVerdict, DEFAULT_THRESHOLDS } from "../../workers/security/verdict";
 import { DEFAULT_ATTACHMENT_POLICY } from "../../workers/security/attachments";
 import type { AuthVerdict } from "../../workers/security/auth";
-import type { ClassificationResult } from "../../workers/security/classification";
+import { scoreClassification, type ClassificationResult } from "../../workers/security/classification";
 
 const cleanAuth: AuthVerdict = { spf: "pass", dkim: "pass", dmarc: "pass" };
 const safeClass: ClassificationResult = { label: "safe", confidence: 0.9, reasoning: "ok" };
@@ -113,6 +113,115 @@ describe("aggregateVerdict", () => {
 			attachmentPolicy: DEFAULT_ATTACHMENT_POLICY,
 		});
 		expect(withPdf.score).toBe(without.score);
+	});
+
+	// ── Confidence dimension (issue #105) ──────────────────────────
+
+	it("classifier timeout → classification scorer confidence ≤ 0.3 and aggregate reflects it", () => {
+		// AC3 (issue #105): an LLM timeout (`label: "unavailable"`) yields
+		// scorer confidence ≤ 0.3 — the per-scorer guarantee. The aggregate
+		// "reflects that" via the score-weighted average: the same email
+		// with a real classifier verdict produces a meaningfully higher
+		// aggregate confidence. We assert both properties.
+		const timeoutResult: ClassificationResult = { label: "unavailable", confidence: 0, reasoning: "timeout" };
+		expect(scoreClassification(timeoutResult).confidence).toBeLessThanOrEqual(0.3);
+
+		const baseInputs = {
+			auth: { spf: "fail" as const, dkim: "fail" as const, dmarc: "fail" as const, trusted: true },
+			urls: [],
+			reputation: null,
+		};
+		const withTimeout = aggregateVerdict({ ...baseInputs, classification: timeoutResult });
+		const withRealVerdict = aggregateVerdict({
+			...baseInputs,
+			classification: { label: "phishing", confidence: 0.9, reasoning: "fake login" },
+		});
+		// The timeout case must be lower than the high-confidence case —
+		// that's what "aggregate reflects the low classifier confidence"
+		// means in practice.
+		expect(withTimeout.confidence).toBeLessThan(withRealVerdict.confidence);
+	});
+
+	it("multi-scorer corroboration → aggregate confidence ≥ 0.85", () => {
+		// AC4: trusted-authserv DMARC-fail + high-confidence phishing label +
+		// homograph URL + flagged-sender reputation. Every scorer is in its
+		// high-confidence band; weighted average lands well above 0.85.
+		const v = aggregateVerdict({
+			auth: { spf: "fail", dkim: "fail", dmarc: "fail", trusted: true },
+			classification: { label: "phishing", confidence: 0.95, reasoning: "fake login" },
+			urls: [
+				{ url: "https://paypa1.com", hostname: "paypa1.com", is_homograph: true, is_shortener: false },
+			],
+			reputation: {
+				sender: "x@y.com",
+				first_seen: "2026-01-01T00:00:00Z",
+				last_seen: "2026-01-01T00:00:00Z",
+				message_count: 20,
+				avg_score: 80,
+				flagged: true,
+			},
+		});
+		expect(v.confidence).toBeGreaterThanOrEqual(0.85);
+		// Sanity: this is the textbook "auto-quarantine, no review needed"
+		// shape from the issue's failure-mode table.
+		expect(v.score).toBeGreaterThanOrEqual(DEFAULT_THRESHOLDS.quarantine);
+	});
+
+	it("confidence is in [0,1] across a spread of inputs", () => {
+		const cases = [
+			aggregateVerdict({ auth: cleanAuth, classification: safeClass, urls: [], reputation: null }),
+			aggregateVerdict({
+				auth: { spf: "fail", dkim: "fail", dmarc: "fail" },
+				classification: { label: "phishing", confidence: 0.9, reasoning: "" },
+				urls: [],
+				reputation: null,
+			}),
+		];
+		for (const v of cases) {
+			expect(v.confidence).toBeGreaterThanOrEqual(0);
+			expect(v.confidence).toBeLessThanOrEqual(1);
+		}
+	});
+
+	it("score-weighted aggregation: high-magnitude scorer dominates", () => {
+		// Auth contributes -10 (clean DMARC pass), confidence 0.5 (no
+		// trusted-authserv-id). Classifier returns `unavailable`: score 0,
+		// confidence 0.1. Urls: 0/1.0. Reputation null → first-time +5/0.3.
+		// Weights: |−10|=10, 0, 0, 5. Weighted = (10*0.5 + 5*0.3) / 15 ≈
+		// 0.433. Locks in the score-weighted-average rule rather than a
+		// plain mean (which would be (0.5+0.1+1.0+0.3)/4 = 0.475).
+		const v = aggregateVerdict({
+			auth: { spf: "pass", dkim: "pass", dmarc: "pass" },
+			classification: { label: "unavailable", confidence: 0, reasoning: "timeout" },
+			urls: [],
+			reputation: null,
+		});
+		// Allow ±0.005 tolerance for the 3-decimal-place rounding.
+		expect(v.confidence).toBeGreaterThan(0.42);
+		expect(v.confidence).toBeLessThan(0.45);
+	});
+
+	it("zero-weight fallback: every scorer contributes 0 → plain mean of confidences", () => {
+		// Auth: all-none. spf/dkim/dmarc all "none" → score 0, confidence 0.2.
+		// Classifier: safe high-confidence → 0, 1.0.
+		// Urls: empty → 0, 1.0.
+		// Reputation: well-known sender, score 0 → 0, 0.9.
+		// Sum of |scores| = 0; aggregator falls back to plain mean.
+		// (0.2 + 1.0 + 1.0 + 0.9) / 4 = 0.775.
+		const v = aggregateVerdict({
+			auth: { spf: "none", dkim: "none", dmarc: "none" },
+			classification: { label: "safe", confidence: 1, reasoning: "ok" },
+			urls: [],
+			reputation: {
+				sender: "a@b.com",
+				first_seen: "2026-01-01T00:00:00Z",
+				last_seen: "2026-01-01T00:00:00Z",
+				message_count: 10,
+				avg_score: 0,
+				flagged: false,
+			},
+		});
+		expect(v.confidence).toBe(0.775);
 	});
 
 	it("respects custom thresholds", () => {

--- a/workers/security/attachments.ts
+++ b/workers/security/attachments.ts
@@ -67,6 +67,14 @@ export interface AttachmentScoreResult {
 	hardBlock: boolean;
 	/** Which attachment triggered the hard-block, if any — useful for UI/logging. */
 	hardBlockReason?: string;
+	/**
+	 * Per-issue-#105 confidence in this scorer's contribution, in [0,1].
+	 * Always 0.95 when any policy rule fired (extension-class matching is
+	 * deterministic given filename) and 1.0 when no contribution was made
+	 * (nothing to be uncertain about). Mimetype-inferred classification —
+	 * if/when added — would justify a lower value; not in v1.
+	 */
+	confidence: number;
 }
 
 /**
@@ -125,7 +133,7 @@ export function scoreAttachments(
 	policy: AttachmentPolicy,
 ): AttachmentScoreResult {
 	if (!attachments || attachments.length === 0) {
-		return { score: 0, reasons: [], hardBlock: false };
+		return { score: 0, reasons: [], hardBlock: false, confidence: 1.0 };
 	}
 
 	// Normalise once — callers may pass user-supplied config, and duplicates
@@ -177,7 +185,8 @@ export function scoreAttachments(
 		reasons.push(`attachment ${category} .${ext} (${name}) +${boost}`);
 	}
 
-	return { score, reasons, hardBlock, hardBlockReason };
+	const fired = reasons.length > 0;
+	return { score, reasons, hardBlock, hardBlockReason, confidence: fired ? 0.95 : 1.0 };
 }
 
 // Hand-traced examples (kept in code so the intent is grep-able):

--- a/workers/security/auth.ts
+++ b/workers/security/auth.ts
@@ -192,8 +192,20 @@ export function parseAuthResults(rawHeaders: unknown, options: ParseAuthOptions 
 	return verdict;
 }
 
-/** Auth-signal score contribution (positive = suspicious). */
-export function scoreAuth(verdict: AuthVerdict): { score: number; reasons: string[] } {
+/**
+ * Auth-signal score contribution (positive = suspicious).
+ *
+ * Confidence (issue #105, v1):
+ *   - 0.9 — at least one trusted authserv-id matched the verdict (the
+ *     pipeline gating made spoofing the result expensive).
+ *   - 0.5 — auth headers were present but no `trusted_authserv_ids` was
+ *     configured, so we fell back to first-header-wins (still useful as a
+ *     signal, but exploitable by an attacker who can inject their own
+ *     `Authentication-Results` header before the authentic one).
+ *   - 0.2 — no `Authentication-Results` headers found at all (verdict is
+ *     all-`none`); whatever we contributed has very little to back it up.
+ */
+export function scoreAuth(verdict: AuthVerdict): { score: number; reasons: string[]; confidence: number } {
 	const reasons: string[] = [];
 	let score = 0;
 	if (verdict.dmarc === "fail") { score += 20; reasons.push("DMARC failed"); }
@@ -201,7 +213,10 @@ export function scoreAuth(verdict: AuthVerdict): { score: number; reasons: strin
 	if (verdict.dkim === "fail") { score += 10; reasons.push("DKIM failed"); }
 	if (score > 30) score = 30;
 	if (verdict.dmarc === "pass") score -= 10;
-	return { score, reasons };
+	const allNone =
+		verdict.spf === "none" && verdict.dkim === "none" && verdict.dmarc === "none";
+	const confidence = verdict.trusted ? 0.9 : allNone ? 0.2 : 0.5;
+	return { score, reasons, confidence };
 }
 
 /**

--- a/workers/security/classification.ts
+++ b/workers/security/classification.ts
@@ -191,7 +191,18 @@ function normalizeLabel(raw: unknown): ClassificationLabel {
 	return "suspicious";
 }
 
-export function scoreClassification(result: ClassificationResult): { score: number; reasons: string[] } {
+/**
+ * Confidence sources (issue #105, v1):
+ *   - `unavailable` (timeout / AbortError) → 0.1. The classifier never
+ *     reached a verdict; whatever the score (zero, here) contributed is
+ *     near-meaningless on its own. `scoreAuth`/`scoreUrls`/etc. are
+ *     uneffected and still drive the verdict.
+ *   - All other labels → directly use the model's reported `confidence`
+ *     (already clamped to [0,1] at parse time). High-confidence `safe`
+ *     produces high confidence in a zero contribution; high-confidence
+ *     `phishing` produces high confidence in a +50 contribution.
+ */
+export function scoreClassification(result: ClassificationResult): { score: number; reasons: string[]; confidence: number } {
 	// `unavailable` (issue #28 / Rule 5 narrowed): the classifier hit a
 	// timeout/AbortError. Contribute 0 to the score and tag the verdict so
 	// operators can see why the classifier didn't weigh in. Other scorers
@@ -199,7 +210,7 @@ export function scoreClassification(result: ClassificationResult): { score: numb
 	// and a clean inbound that scores well on auth + URLs + reputation +
 	// intel still reaches `allow`.
 	if (result.label === "unavailable") {
-		return { score: 0, reasons: ["llm_unavailable"] };
+		return { score: 0, reasons: ["llm_unavailable"], confidence: 0.1 };
 	}
 	const map: Record<Exclude<ClassificationLabel, "unavailable">, number> = {
 		safe: 0, spam: 20, suspicious: 30, bec: 45, phishing: 50,
@@ -211,5 +222,5 @@ export function scoreClassification(result: ClassificationResult): { score: numb
 	const reasons = result.label === "safe"
 		? []
 		: [`classifier: ${result.label} (${Math.round(result.confidence * 100)}%)`];
-	return { score: scaled, reasons };
+	return { score: scaled, reasons, confidence: result.confidence };
 }

--- a/workers/security/reputation.ts
+++ b/workers/security/reputation.ts
@@ -38,21 +38,35 @@ export interface FirstTimeSenderPrior {
  * returned null — no key, 404, 429, network error) keep the original
  * behaviour.
  */
+/**
+ * Confidence sources (issue #105, v1):
+ *   - History-known sender → confidence ramps with `message_count`,
+ *     reaching a high plateau at ~10 messages (`min(0.9, 0.3 + 0.06 *
+ *     count)`). 10 messages is the same threshold as
+ *     `trusted_auto_allow_min_messages` so the ramp aligns with the
+ *     operator's intuition for "we know this sender".
+ *   - `flagged` history → 0.95 regardless of count: an operator has
+ *     explicitly marked this sender bad.
+ *   - First-time sender with a CTI prior → 0.7 (we have an external
+ *     signal, but only one).
+ *   - First-time sender with no CTI → 0.3 (the legacy +5 is a
+ *     low-information default).
+ */
 export function scoreReputation(
 	rep: SenderReputation | null,
 	prior?: FirstTimeSenderPrior,
-): { score: number; reasons: string[] } {
+): { score: number; reasons: string[]; confidence: number } {
 	const reasons: string[] = [];
 	let score = 0;
 	if (!rep || rep.message_count === 0) {
 		if (prior) {
 			score += prior.score;
 			reasons.push(prior.reason);
-		} else {
-			score += 5;
-			reasons.push("first-time sender");
+			return { score, reasons, confidence: 0.7 };
 		}
-		return { score, reasons };
+		score += 5;
+		reasons.push("first-time sender");
+		return { score, reasons, confidence: 0.3 };
 	}
 	if (rep.flagged) { score += 15; reasons.push("sender previously flagged"); }
 	// Consistently-bad history adds suspicion. The score here is a small
@@ -63,7 +77,10 @@ export function scoreReputation(
 		score += 10;
 		reasons.push(`bad sender history (avg ${rep.avg_score.toFixed(0)})`);
 	}
-	return { score, reasons };
+	const confidence = rep.flagged
+		? 0.95
+		: Math.min(0.9, 0.3 + 0.06 * rep.message_count);
+	return { score, reasons, confidence };
 }
 
 /**

--- a/workers/security/triage.ts
+++ b/workers/security/triage.ts
@@ -100,6 +100,12 @@ export function evaluateTriage(inputs: TriageInputs): TriageResult {
 		const verdict: FinalVerdict = {
 			action: "allow",
 			score: 0,
+			// Triage tiers fire on deterministic operator-configured rules
+			// (folder policy, allowlist, intel match, attachment extension).
+			// The confidence in the short-circuit verdict is 1.0 because the
+			// rule itself is unambiguous; whether the rule was the *right*
+			// rule for the email is the operator's call, not the verdict's.
+			confidence: 1,
 			explanation: reason,
 			auth: inputs.auth,
 			classification: { ...SKIP_CLASSIFICATION, reasoning: "pipeline skipped by folder policy" },
@@ -147,6 +153,7 @@ function evaluateAttachmentGate(inputs: TriageInputs): TriageShortCircuit | null
 	const verdict: FinalVerdict = {
 		action: "quarantine",
 		score: 100,
+		confidence: 1,
 		explanation: reason,
 		auth: inputs.auth,
 		classification: { ...SKIP_CLASSIFICATION, label: "suspicious", reasoning: "classifier skipped by attachment-gate triage" },
@@ -170,6 +177,7 @@ function evaluateHardBlock(inputs: TriageInputs): TriageShortCircuit | null {
 	const verdict: FinalVerdict = {
 		action: "quarantine",
 		score: 100,
+		confidence: 1,
 		explanation: reasons.join("; "),
 		auth: inputs.auth,
 		classification: { ...SKIP_CLASSIFICATION, label: "phishing", reasoning: "classifier skipped by hard-block triage" },
@@ -213,6 +221,7 @@ function evaluateHardAllow(inputs: TriageInputs): TriageShortCircuit | null {
 	const verdict: FinalVerdict = {
 		action: "allow",
 		score: 0,
+		confidence: 1,
 		explanation: reasons.join("; "),
 		auth: inputs.auth,
 		classification: SKIP_CLASSIFICATION,

--- a/workers/security/urls.ts
+++ b/workers/security/urls.ts
@@ -164,12 +164,22 @@ function pushUrl(out: ExtractedUrl[], seen: Set<string>, rawUrl: string, display
 	});
 }
 
-export function scoreUrls(urls: ExtractedUrl[]): { score: number; reasons: string[] } {
+/**
+ * Confidence sources (issue #105, v1):
+ *   - 0.9 — a homograph fired (non-ASCII, bare punycode, or close
+ *     Levenshtein to a high-value domain). These checks are deterministic
+ *     once the URL is parsed.
+ *   - 0.6 — only a shortener match fired. Shortener-by-itself is a weak
+ *     signal (legit users do shorten links).
+ *   - 1.0 — no URL signals fired; nothing to be uncertain about.
+ */
+export function scoreUrls(urls: ExtractedUrl[]): { score: number; reasons: string[]; confidence: number } {
 	const reasons: string[] = [];
 	let score = 0;
 	const homograph = urls.find((u) => u.is_homograph);
 	if (homograph) { score += 20; reasons.push(`homograph URL (${homograph.hostname})`); }
 	const shortener = urls.find((u) => u.is_shortener);
 	if (shortener) { score += 5; reasons.push(`link shortener (${shortener.hostname})`); }
-	return { score, reasons };
+	const confidence = homograph ? 0.9 : shortener ? 0.6 : 1.0;
+	return { score, reasons, confidence };
 }

--- a/workers/security/verdict.ts
+++ b/workers/security/verdict.ts
@@ -27,6 +27,18 @@ export type VerdictAction = "allow" | "tag" | "quarantine" | "block";
 export interface FinalVerdict {
 	action: VerdictAction;
 	score: number;
+	/**
+	 * Aggregate confidence in [0,1]. Independent dimension from `score`:
+	 * a high-score-low-confidence verdict (LLM timed out, only one signal
+	 * fired) is fundamentally different from a high-score-high-confidence
+	 * verdict (multiple corroborating signals). Computed as a score-weighted
+	 * average of per-scorer confidences with `|score_i|` as the weight, so
+	 * scorers that contributed more to the verdict influence overall
+	 * confidence more. When the sum of weights is zero (every scorer
+	 * contributed zero) we fall back to the plain mean of confidences. See
+	 * {@link aggregateVerdict} and issue #105.
+	 */
+	confidence: number;
 	explanation: string;
 	auth: AuthVerdict;
 	classification: ClassificationResult;
@@ -79,22 +91,30 @@ export function aggregateVerdict(
 ): FinalVerdict {
 	const signals: string[] = [];
 	let score = 0;
+	// Per-scorer (score, confidence) pairs collected for the weighted-average
+	// aggregation below. Each scorer pushes one entry; the attachment scorer
+	// is skipped entirely when no policy/attachments are present (see below).
+	const contributions: Array<{ score: number; confidence: number }> = [];
 
 	const auth = scoreAuth(inputs.auth);
 	score += auth.score;
 	signals.push(...auth.reasons);
+	contributions.push({ score: auth.score, confidence: auth.confidence });
 
 	const cls = scoreClassification(inputs.classification);
 	score += cls.score;
 	signals.push(...cls.reasons);
+	contributions.push({ score: cls.score, confidence: cls.confidence });
 
 	const urls = scoreUrls(inputs.urls);
 	score += urls.score;
 	signals.push(...urls.reasons);
+	contributions.push({ score: urls.score, confidence: urls.confidence });
 
 	const rep = scoreReputation(inputs.reputation, inputs.firstTimeSenderPrior);
 	score += rep.score;
 	signals.push(...rep.reasons);
+	contributions.push({ score: rep.score, confidence: rep.confidence });
 
 	// Attachment-type gate. Hard-blocks are handled by the triage tier before
 	// we ever reach aggregation; here we only pick up the "score" action
@@ -105,6 +125,7 @@ export function aggregateVerdict(
 		const att = scoreAttachments(inputs.attachments, inputs.attachmentPolicy);
 		score += att.score;
 		signals.push(...att.reasons);
+		contributions.push({ score: att.score, confidence: att.confidence });
 	}
 
 	score = Math.max(0, Math.min(100, Math.round(score)));
@@ -121,9 +142,43 @@ export function aggregateVerdict(
 	return {
 		action,
 		score,
+		confidence: aggregateConfidence(contributions),
 		explanation,
 		auth: inputs.auth,
 		classification: inputs.classification,
 		signals,
 	};
+}
+
+/**
+ * Combine per-scorer confidences into a single value in [0,1].
+ *
+ * v1 (issue #105): score-weighted average using `|score_i|` as the weight.
+ * Scorers that drove the verdict more dominate the aggregate. The absolute
+ * value matters because `scoreAuth` can contribute negative score (DMARC
+ * pass = -10) — that's still a strong signal worth weighting at 10, not 0.
+ *
+ * Edge case: every scorer contributed exactly zero (a pristine-but-uncertain
+ * email — no auth headers, no urls, classifier returned safe-with-zero).
+ * Sum of weights is zero so the weighted-average is undefined; we fall back
+ * to the plain mean of confidences. Result is rounded to 3 decimal places
+ * so JSON-serialised verdicts don't churn on float dust.
+ */
+function aggregateConfidence(
+	contributions: ReadonlyArray<{ score: number; confidence: number }>,
+): number {
+	if (contributions.length === 0) return 1;
+	let weightedSum = 0;
+	let weightTotal = 0;
+	let plainSum = 0;
+	for (const c of contributions) {
+		const w = Math.abs(c.score);
+		weightedSum += w * c.confidence;
+		weightTotal += w;
+		plainSum += c.confidence;
+	}
+	const raw = weightTotal > 0
+		? weightedSum / weightTotal
+		: plainSum / contributions.length;
+	return Math.round(raw * 1000) / 1000;
 }


### PR DESCRIPTION
## Summary

- Each `score*` function (auth, classification, urls, reputation, attachments) now returns `{ score, reasons, confidence }` with `confidence` in [0,1]. v1 sources documented inline per scorer.
- `FinalVerdict` carries an aggregate `confidence` computed as a score-weighted average of per-scorer confidences (`|score_i|` as the weight; falls back to plain mean when all weights are zero).
- Triage-tier short-circuit verdicts (hard_block, attachment_block, hard_allow, folder_bypass) all carry `confidence: 1` — they're deterministic operator-configured rules.

Closes part of #105 (AC1–AC4 — the foundation). AC5 (mailbox setting `confidence_aware_actions` + demote) and AC6 (UI display) are deferred to follow-ups so this PR stays scoped to the load-bearing scoring change.

## Decomposition note

#105's Acceptance lists six items. Per the size-escalation rule (≥6 files), this PR ships the irreducible foundation only:

- **Shipped here:** AC1 (per-scorer signature), AC2 (FinalVerdict.confidence + aggregator), AC3 (LLM-timeout → low classifier confidence + lower aggregate), AC4 (multi-scorer corroboration → aggregate ≥ 0.85).
- **Deferred to #219:** AC5 — `confidence_aware_actions` mailbox setting + `quarantine→tag` demote logic in `runSecurityPipeline`.
- **Deferred to #220:** AC6 — UI surface in `SecurityVerdictPanel` and case-detail.

The deferred items each need to coordinate with separate subsystems (settings inheritance + pipeline order for AC5; client types + UI for AC6) and ship cleanly on top of this foundation.

## Test plan

- [x] `tests/security/verdict.test.ts` — added 5 cases:
  - Classifier timeout: per-scorer confidence ≤ 0.3 and aggregate strictly less than the same email with a real verdict
  - Multi-scorer corroboration: aggregate ≥ 0.85
  - Confidence stays in [0,1] across mixed inputs
  - Score-weighted aggregation: high-magnitude scorer dominates (locks the rule against a plain-mean regression)
  - Zero-weight fallback: every scorer contributes 0 → plain mean of confidences
- [x] Existing `toEqual({ score, reasons })` assertions in `tests/security/urls.test.ts` and `test/security/classification.test.ts` updated to include the new `confidence` field
- [x] `npm test` — 808 passing, 0 failing (was 803)
- [x] `npm run typecheck` — clean

## Notes

- No spec follow-up (`SECURITY_SPEC.md`) needed — this PR adds a new dimension; it doesn't narrow or contradict any existing rule.
- `package-lock.json` deltas from `npm install` were reverted (spurious `peer: true` churn from a different npm version, not related to the change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6YEXLeRoZBWGpNCZAQJkD)_