### PR TITLE
feat(security): confidence-aware action mapping (AC5 of #105)

### DIFF
--- a/tests/lib/resolve-mailbox-settings.test.ts
+++ b/tests/lib/resolve-mailbox-settings.test.ts
@@ -726,6 +726,31 @@ describe("stripDefaultEqual", () => {
 		expect((stripped.security as { enabled: boolean }).enabled).toBe(true);
 	});
 
+	it("still drops a security block at default after the #219 fields are added", () => {
+		// Issue #219 added confidence_aware_actions + min_confidence_for_quarantine
+		// to DEFAULT_SECURITY_SETTINGS. A fresh-defaults POST/PUT must continue
+		// to strip the whole security block — adding fields to the default
+		// object is sufficient because stripDefaultEqual deep-equals.
+		const stripped = stripDefaultEqual({ security: { ...DEFAULT_SECURITY_SETTINGS } });
+		expect((stripped as Record<string, unknown>).security).toBeUndefined();
+	});
+
+	it("keeps a security block when confidence_aware_actions is overridden to true", () => {
+		const stripped = stripDefaultEqual({
+			security: { ...DEFAULT_SECURITY_SETTINGS, confidence_aware_actions: true },
+		});
+		expect(stripped.security).toBeDefined();
+		expect((stripped.security as { confidence_aware_actions: boolean }).confidence_aware_actions).toBe(true);
+	});
+
+	it("keeps a security block when min_confidence_for_quarantine is overridden to a non-default value", () => {
+		const stripped = stripDefaultEqual({
+			security: { ...DEFAULT_SECURITY_SETTINGS, min_confidence_for_quarantine: 0.8 },
+		});
+		expect(stripped.security).toBeDefined();
+		expect((stripped.security as { min_confidence_for_quarantine: number }).min_confidence_for_quarantine).toBe(0.8);
+	});
+
 	it("preserves per-mailbox-only fields (fromName, signature) untouched", () => {
 		const stripped = stripDefaultEqual({
 			fromName: "Daisy",

--- a/tests/security/verdict.test.ts
+++ b/tests/security/verdict.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { aggregateVerdict, DEFAULT_THRESHOLDS } from "../../workers/security/verdict";
+import {
+	aggregateVerdict,
+	applyConfidenceDemote,
+	DEFAULT_THRESHOLDS,
+	type FinalVerdict,
+} from "../../workers/security/verdict";
 import { DEFAULT_ATTACHMENT_POLICY } from "../../workers/security/attachments";
 import type { AuthVerdict } from "../../workers/security/auth";
 import { scoreClassification, type ClassificationResult } from "../../workers/security/classification";
@@ -235,5 +240,76 @@ describe("aggregateVerdict", () => {
 		const lenient = aggregateVerdict(base, { tag: 90, quarantine: 95, block: 99 });
 		expect(strict.action).not.toBe("allow");
 		expect(lenient.action).toBe("allow");
+	});
+});
+
+describe("applyConfidenceDemote (issue #219)", () => {
+	const baseQuarantine: FinalVerdict = {
+		action: "quarantine",
+		score: 65,
+		confidence: 0.45,
+		explanation: "auth fail; suspicious url",
+		auth: { spf: "fail", dkim: "fail", dmarc: "fail" },
+		classification: { label: "suspicious", confidence: 0.4, reasoning: "" },
+		signals: ["auth fail", "suspicious url"],
+	};
+
+	it("is a no-op when the toggle is disabled", () => {
+		const out = applyConfidenceDemote(baseQuarantine, false, 0.6);
+		expect(out).toBe(baseQuarantine);
+	});
+
+	it("demotes quarantine to tag and surfaces a signal when confidence is below threshold", () => {
+		const out = applyConfidenceDemote(baseQuarantine, true, 0.6);
+		expect(out.action).toBe("tag");
+		expect(out.score).toBe(baseQuarantine.score); // score is unchanged
+		expect(out.signals).toEqual([
+			"auth fail",
+			"suspicious url",
+			"confidence-aware demote (0.45 < 0.6)",
+		]);
+		expect(out.explanation).toContain("confidence-aware demote (0.45 < 0.6)");
+	});
+
+	it("leaves quarantine alone when confidence meets the threshold (strict <)", () => {
+		const equalConf = { ...baseQuarantine, confidence: 0.6 };
+		const out = applyConfidenceDemote(equalConf, true, 0.6);
+		expect(out).toBe(equalConf);
+	});
+
+	it("leaves quarantine alone when confidence is above the threshold", () => {
+		const highConf = { ...baseQuarantine, confidence: 0.9 };
+		const out = applyConfidenceDemote(highConf, true, 0.6);
+		expect(out).toBe(highConf);
+	});
+
+	it("does not touch block, tag, or allow actions even with low confidence", () => {
+		for (const action of ["block", "tag", "allow"] as const) {
+			const v: FinalVerdict = { ...baseQuarantine, action, confidence: 0.1 };
+			const out = applyConfidenceDemote(v, true, 0.6);
+			expect(out.action).toBe(action);
+			expect(out).toBe(v);
+		}
+	});
+
+	it("does not mutate the input verdict (returns a fresh object)", () => {
+		const out = applyConfidenceDemote(baseQuarantine, true, 0.6);
+		expect(out).not.toBe(baseQuarantine);
+		expect(baseQuarantine.action).toBe("quarantine");
+		expect(baseQuarantine.signals).toEqual(["auth fail", "suspicious url"]);
+	});
+
+	it("rebuilds explanation from the first four signals (mirrors applyBoost)", () => {
+		const many: FinalVerdict = {
+			...baseQuarantine,
+			signals: ["s1", "s2", "s3", "s4", "s5"],
+			explanation: "s1; s2; s3; s4",
+		};
+		const out = applyConfidenceDemote(many, true, 0.6);
+		// Demote signal is appended to the end → falls outside the first 4
+		// in the explanation; original signals dominate (acceptable, mirrors
+		// existing applyBoost behaviour).
+		expect(out.explanation).toBe("s1; s2; s3; s4");
+		expect(out.signals).toContain("confidence-aware demote (0.45 < 0.6)");
 	});
 });

--- a/workers/security/defaults.ts
+++ b/workers/security/defaults.ts
@@ -86,6 +86,20 @@ export interface MailboxSecuritySettings {
 	attachment_policy: AttachmentPolicy;
 	/** Classifier-stage settings (issue #28). */
 	classification: ClassificationSettings;
+	/**
+	 * Issue #219: when true, post-aggregation verdicts whose `action` is
+	 * `quarantine` but whose `confidence` is below
+	 * `min_confidence_for_quarantine` are demoted to `tag` so operators can
+	 * review them rather than seeing a hard quarantine on a shaky verdict.
+	 * Defaults to false — existing mailboxes keep today's behaviour.
+	 */
+	confidence_aware_actions: boolean;
+	/**
+	 * Threshold in [0,1] used by `confidence_aware_actions`. A
+	 * post-aggregation `quarantine` whose confidence is strictly less than
+	 * this value is demoted to `tag`. Default 0.6.
+	 */
+	min_confidence_for_quarantine: number;
 }
 
 /**
@@ -109,4 +123,6 @@ export const DEFAULT_SECURITY_SETTINGS: MailboxSecuritySettings = {
 	intel_auto_block: true,
 	attachment_policy: DEFAULT_ATTACHMENT_POLICY,
 	classification: DEFAULT_CLASSIFICATION_SETTINGS,
+	confidence_aware_actions: false,
+	min_confidence_for_quarantine: 0.6,
 };

--- a/workers/security/index.ts
+++ b/workers/security/index.ts
@@ -25,7 +25,7 @@ import { getMailboxStub } from "../lib/email-helpers";
 import { parseAuthResults, extractReceivedFromIp, scoreAuth } from "./auth";
 import { classifyEmail, scoreClassification } from "./classification";
 import { extractUrls, scoreUrls } from "./urls";
-import { aggregateVerdict, type FinalVerdict } from "./verdict";
+import { aggregateVerdict, applyConfidenceDemote, type FinalVerdict } from "./verdict";
 import { resolveMailboxSettings } from "../lib/mailbox-settings";
 import { checkUrlAgainstFeeds, type FeedMatch } from "../intel/feeds";
 import { evaluateTriage, type IntelMatchInfo } from "./triage";
@@ -290,6 +290,17 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 		if (settings.learning_mode && (v.action === "quarantine" || v.action === "block")) {
 			v = { ...v, action: "tag" };
 		}
+		// Confidence-aware action mapping (issue #219). Evaluated against the
+		// post-boost state so an intel/off-hours bump that pushed the score
+		// over the quarantine threshold can still be demoted when confidence
+		// is low. No-op when the toggle is off (default) or the verdict
+		// isn't a quarantine; learning_mode ran first so a capped verdict is
+		// already `tag` and falls through unchanged.
+		v = applyConfidenceDemote(
+			v,
+			settings.confidence_aware_actions,
+			settings.min_confidence_for_quarantine,
+		);
 		return v;
 	});
 	const intelBoost = intelMatch?.confirmed ? 20 : intelMatch ? 5 : 0;

--- a/workers/security/verdict.ts
+++ b/workers/security/verdict.ts
@@ -151,6 +151,40 @@ export function aggregateVerdict(
 }
 
 /**
+ * Issue #219: confidence-aware action mapping. Demotes a post-aggregation
+ * `quarantine` verdict to `tag` when the aggregate confidence is strictly
+ * below `minConfidence`. Pure function — does NOT mutate `verdict`.
+ *
+ * Applies only to the `quarantine` action: `block`, `tag`, and `allow` are
+ * left untouched (the issue scopes this to the high-score-low-confidence
+ * demote case; the symmetric "low-score-high-confidence" path is already
+ * today's behaviour). Triage-tier short-circuit verdicts carry
+ * `confidence: 1` so the threshold check naturally exempts them — the
+ * pipeline also returns early on the short-circuit branch.
+ *
+ * The demote signal is appended to `signals` and the explanation is rebuilt
+ * from the first four signals, mirroring `applyBoost` in
+ * `workers/security/index.ts`.
+ */
+export function applyConfidenceDemote(
+	verdict: FinalVerdict,
+	enabled: boolean,
+	minConfidence: number,
+): FinalVerdict {
+	if (!enabled) return verdict;
+	if (verdict.action !== "quarantine") return verdict;
+	if (verdict.confidence >= minConfidence) return verdict;
+	const reason = `confidence-aware demote (${verdict.confidence} < ${minConfidence})`;
+	const signals = [...verdict.signals, reason];
+	return {
+		...verdict,
+		action: "tag",
+		signals,
+		explanation: signals.slice(0, 4).join("; "),
+	};
+}
+
+/**
  * Combine per-scorer confidences into a single value in [0,1].
  *
  * v1 (issue #105): score-weighted average using `|score_i|` as the weight.


### PR DESCRIPTION
## Summary

- Two new opt-in mailbox security settings on top of the #105 confidence foundation: `confidence_aware_actions` (default `false`) and `min_confidence_for_quarantine` (default `0.6`).
- New pure helper `applyConfidenceDemote` in `workers/security/verdict.ts`. Called from `runSecurityPipeline` after the existing intel/off-hours `applyBoost` calls and the `learning_mode` cap, so a post-boost `quarantine` with low confidence is demoted to `tag` with an explicit `confidence-aware demote (c < min)` signal.
- Triage-tier short-circuit verdicts already carry `confidence: 1` and return before the demote step, so they're naturally exempt — matches the issue's invariant.

## Behavior

- Setting **off** (default): identical to today. All 818 pre-existing tests stay green without the new toggle.
- Setting **on**, `score >= thresholds.quarantine && confidence < min_confidence_for_quarantine`: action becomes `tag`, signal `confidence-aware demote (0.45 < 0.6)` (or similar) is appended.
- Setting **on**, `confidence >= min_confidence_for_quarantine`: unchanged.
- Demote applies only to `quarantine`; `block`, `allow`, and pre-existing `tag` are untouched.
- `stripDefaultEqual` continues to drop the whole `security` block when both new fields equal their defaults — no migration needed for existing mailbox JSON.

Closes #219

## Test plan

- [x] `npm test` — 818 passing, 0 failing (66 test files).
- [x] `npm run typecheck` — clean.
- [x] New unit tests (`tests/security/verdict.test.ts`):
  - toggle off → no-op
  - on + low confidence quarantine → demote with signal
  - on + confidence equal to threshold → unchanged (strict `<`)
  - on + confidence above threshold → unchanged
  - non-quarantine actions (block / tag / allow) untouched even with low confidence
  - immutability: original verdict unchanged
  - explanation rebuild mirrors `applyBoost`
- [x] New round-trip tests (`tests/lib/resolve-mailbox-settings.test.ts`):
  - `stripDefaultEqual` still drops a security block at default after the new fields are added
  - keeps the block when `confidence_aware_actions: true` overrides the default
  - keeps the block when `min_confidence_for_quarantine` is overridden

## Out of scope (deferred per issue)

- Auto-tuning of `min_confidence_for_quarantine` — separate issue if needed.
- Symmetric "promote low-score-high-confidence to tag" — separate issue.
- UI surface for the toggle — part of the broader settings UI work; the feature ships API-only and the API accepts it via the existing passthrough Zod schema.

## Spec follow-up

No `SECURITY_SPEC.md` change needed — this adds a new opt-in toggle without narrowing or contradicting any existing rule.

## Cross-references

- Parent: #105
- Companion: #220 (AC6 — UI confidence display)

https://claude.ai/code/session_01NHM96wfqffPPurws29UPp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHM96wfqffPPurws29UPp7)_