### PR TITLE
feat: surface verdict confidence chip in SecurityVerdictPanel and case-detail (#220)

### DIFF
--- a/app/components/email-panel/SecurityVerdictPanel.tsx
+++ b/app/components/email-panel/SecurityVerdictPanel.tsx
@@ -53,6 +53,7 @@ export default function SecurityVerdictPanel({ email }: { email: Email }) {
 						</span>
 					)}
 					<span className="text-xs text-ink-3 ml-1">score {verdict.score}/100</span>
+					<ConfidenceChip confidence={verdict.confidence} />
 					<span className="ml-auto text-ink-3">
 						{expanded ? <CaretUpIcon size={16} /> : <CaretDownIcon size={16} />}
 					</span>
@@ -128,6 +129,24 @@ function AuthChip({ label, value }: { label: string; value: string }) {
 		<span className="text-xs rounded border border-line px-1.5 py-0.5 bg-paper-3">
 			<span className="text-ink-3">{label} </span>
 			<span className={`font-medium ${color}`}>{value}</span>
+		</span>
+	);
+}
+
+/** Aggregate pipeline confidence chip. Renders "—" when confidence is absent
+ * (pre-#105 persisted verdicts) so operators can distinguish "unknown" from
+ * "genuinely zero confidence". */
+function ConfidenceChip({ confidence }: { confidence?: number }) {
+	return (
+		<span
+			className="text-xs rounded border border-line px-1.5 py-0.5 bg-paper-3"
+			title="Aggregate pipeline confidence"
+			data-testid="verdict-confidence-chip"
+		>
+			<span className="text-ink-3">confidence </span>
+			<span className="font-medium text-ink">
+				{confidence != null ? `${Math.round(confidence * 100)}%` : "—"}
+			</span>
 		</span>
 	);
 }

--- a/app/routes/case-detail.tsx
+++ b/app/routes/case-detail.tsx
@@ -66,6 +66,9 @@ interface CaseRecord {
 	// pre-#126 rows) leave it null — render a muted "—" instead of the
 	// ring.
 	score: number | null;
+	// Aggregate pipeline confidence (issue #220). Optional: pre-#105
+	// persisted verdicts don't carry this field; render "—" instead of 0%.
+	confidence?: number | null;
 	// AI co-pilot summary (issue #127). `summary_status` lifecycle:
 	// 'pending' → 'ready' | 'failed'. NULL means no summary was
 	// requested for this case (manual API create with no linked email,
@@ -218,20 +221,28 @@ export default function CaseDetailRoute() {
 			    without score, or pre-#126 rows) we render a muted "—" in the
 			    same slot rather than fabricating a value. */}
 			<div className="pp-card p-5 flex items-start gap-5">
-				{data.score != null ? (
-					<div className="shrink-0">
+				<div className="shrink-0 flex flex-col items-center gap-1">
+					{data.score != null ? (
 						<ScoreRing score={data.score} />
-					</div>
-				) : (
-					<div
-						className="shrink-0 inline-flex items-center justify-center rounded-full border border-line text-ink-3 pp-serif"
-						style={{ width: 80, height: 80, fontSize: 28 }}
-						aria-label="No score"
-						data-testid="case-score-empty"
+					) : (
+						<div
+							className="inline-flex items-center justify-center rounded-full border border-line text-ink-3 pp-serif"
+							style={{ width: 80, height: 80, fontSize: 28 }}
+							aria-label="No score"
+							data-testid="case-score-empty"
+						>
+							—
+						</div>
+					)}
+					<span
+						className="text-[11px] text-ink-3 pp-mono"
+						data-testid="case-confidence"
 					>
-						—
-					</div>
-				)}
+						{data.confidence != null
+							? `${Math.round(data.confidence * 100)}% conf.`
+							: "— conf."}
+					</span>
+				</div>
 				<div className="flex-1 min-w-0">
 					<div className="flex items-center gap-2 mb-1.5">
 						<VerdictPill tone={tone}>{statusLabel(data.status)}</VerdictPill>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -121,6 +121,9 @@ export interface Email {
 export interface SecurityVerdict {
 	action: "allow" | "tag" | "quarantine" | "block";
 	score: number;
+	/** Aggregate pipeline confidence (0–1). Optional: pre-#105 persisted
+	 * verdicts do not carry this field. UI renders "—" when absent. */
+	confidence?: number;
 	explanation: string;
 	auth: {
 		spf: string;

--- a/tests/frontend/case-detail.test.tsx
+++ b/tests/frontend/case-detail.test.tsx
@@ -21,6 +21,8 @@ const baseCase = {
 	shared_to_hub: 0,
 	hub_event_uuid: null,
 	score: null as number | null,
+	// Aggregate confidence (issue #220). Null for pre-#105 cases, 0–1 otherwise.
+	confidence: null as number | null,
 	summary: null as string | null,
 	summary_status: null as "pending" | "ready" | "failed" | null,
 	stage_trace: null as
@@ -372,5 +374,55 @@ describe("CaseDetailRoute — pipeline trace timeline (#128)", () => {
 		expect(screen.getByTestId("pipeline-trace-error")).toHaveTextContent(
 			/Pipeline trace unavailable/i,
 		);
+	});
+});
+
+// ── Verdict confidence indicator in title bar (issue #220) ────────────
+//
+// The title bar shows a small confidence label below the ScoreRing (or the
+// muted-dash placeholder). When `confidence` is null (pre-#105 cases) the
+// label renders "— conf." so operators can distinguish "unknown" from 0%.
+describe("CaseDetailRoute — confidence indicator in title bar (#220)", () => {
+	beforeEach(() => { vi.unstubAllGlobals(); });
+	afterEach(() => { vi.unstubAllGlobals(); });
+
+	it("renders the confidence percentage when data.confidence is present", async () => {
+		mockFetchOnce({ case: { ...baseCase, score: 85, confidence: 0.85 } });
+		renderCaseDetail();
+
+		expect(
+			await screen.findByText(/Suspicious wire-transfer request/i),
+		).toBeInTheDocument();
+
+		const indicator = screen.getByTestId("case-confidence");
+		expect(indicator).toBeInTheDocument();
+		expect(indicator).toHaveTextContent("85% conf.");
+	});
+
+	it("renders '— conf.' when data.confidence is null (pre-#105 row)", async () => {
+		mockFetchOnce({ case: { ...baseCase, score: 75, confidence: null } });
+		renderCaseDetail();
+
+		expect(
+			await screen.findByText(/Suspicious wire-transfer request/i),
+		).toBeInTheDocument();
+
+		const indicator = screen.getByTestId("case-confidence");
+		expect(indicator).toHaveTextContent("— conf.");
+		expect(indicator).not.toHaveTextContent("0%");
+	});
+
+	it("renders '— conf.' when data.confidence is undefined (missing from API response)", async () => {
+		// API response omits the field entirely (pre-#220 API version)
+		const { confidence: _omit, ...baseCaseNoConfidence } = { ...baseCase, confidence: undefined };
+		mockFetchOnce({ case: baseCaseNoConfidence });
+		renderCaseDetail();
+
+		expect(
+			await screen.findByText(/Suspicious wire-transfer request/i),
+		).toBeInTheDocument();
+
+		const indicator = screen.getByTestId("case-confidence");
+		expect(indicator).toHaveTextContent("— conf.");
 	});
 });

--- a/tests/frontend/security-verdict-panel.test.tsx
+++ b/tests/frontend/security-verdict-panel.test.tsx
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Frontend tests for SecurityVerdictPanel confidence chip (issue #220).
+ *
+ * Acceptance:
+ * - Chip renders with the correct percentage text for a verdict with confidence: 0.85
+ * - Chip renders "—" (em dash) when confidence is absent (pre-#105 persisted verdicts)
+ * - Panel does not crash for allow verdicts (returns null)
+ */
+
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import SecurityVerdictPanel from "~/components/email-panel/SecurityVerdictPanel";
+import type { Email } from "~/types";
+
+function makeEmail(verdictOverrides: object | null): Email {
+	const verdict =
+		verdictOverrides === null
+			? null
+			: JSON.stringify({
+					action: "block",
+					score: 85,
+					explanation: "Phishing detected.",
+					auth: { spf: "pass", dkim: "pass", dmarc: "pass" },
+					classification: {
+						label: "phishing",
+						confidence: 0.92,
+						reasoning: "High-urgency credential-harvest template.",
+					},
+					signals: ["spf_pass", "known_phishing_kit"],
+					...verdictOverrides,
+				});
+
+	return {
+		id: "email_1",
+		subject: "Urgent: verify your account",
+		sender: "attacker@evil.example",
+		recipient: "victim@corp.example",
+		date: "2026-05-06T10:00:00Z",
+		read: false,
+		starred: false,
+		security_verdict: verdict,
+	};
+}
+
+describe("SecurityVerdictPanel — confidence chip (issue #220)", () => {
+	it("renders the confidence chip with 85% for confidence: 0.85", () => {
+		const email = makeEmail({ confidence: 0.85 });
+		render(<SecurityVerdictPanel email={email} />);
+
+		const chip = screen.getByTestId("verdict-confidence-chip");
+		expect(chip).toBeInTheDocument();
+		// The chip should show the rounded percentage
+		expect(chip).toHaveTextContent("85%");
+		expect(chip).toHaveTextContent("confidence");
+	});
+
+	it("renders '—' in the confidence chip when confidence is absent (pre-#105 verdict)", () => {
+		// Old persisted verdicts do not have a top-level `confidence` field.
+		const email = makeEmail({ /* no confidence field */ });
+		render(<SecurityVerdictPanel email={email} />);
+
+		const chip = screen.getByTestId("verdict-confidence-chip");
+		expect(chip).toBeInTheDocument();
+		expect(chip).toHaveTextContent("—");
+		// Must NOT show "0%" — that would misrepresent "unknown" as "zero"
+		expect(chip).not.toHaveTextContent("0%");
+	});
+
+	it("rounds fractional confidence values correctly (0.856 → 86%)", () => {
+		const email = makeEmail({ confidence: 0.856 });
+		render(<SecurityVerdictPanel email={email} />);
+
+		const chip = screen.getByTestId("verdict-confidence-chip");
+		expect(chip).toHaveTextContent("86%");
+	});
+
+	it("does not render the panel at all for a clean allow verdict", () => {
+		const email = makeEmail({
+			action: "allow",
+			score: 5,
+			classification: { label: "safe", confidence: 0.99, reasoning: "No signals." },
+			signals: [],
+		});
+		render(<SecurityVerdictPanel email={email} />);
+
+		// Panel returns null for allow (no hard-block/attachment-block triage)
+		expect(screen.queryByTestId("verdict-confidence-chip")).toBeNull();
+	});
+
+	it("does not crash when security_verdict is null", () => {
+		const email = makeEmail(null);
+		render(<SecurityVerdictPanel email={email} />);
+
+		// Panel renders nothing — no crash.
+		expect(screen.queryByTestId("verdict-confidence-chip")).toBeNull();
+	});
+});
+
+describe("SecurityVerdictPanel — confidence chip in case-detail title bar (issue #220)", () => {
+	/**
+	 * The case-detail confidence indicator is tested in case-detail.test.tsx.
+	 * These tests cover the SecurityVerdictPanel surface only.
+	 */
+	it("renders confidence chip next to the score for a quarantine verdict", () => {
+		const email = makeEmail({ action: "quarantine", score: 70, confidence: 0.72 });
+		render(<SecurityVerdictPanel email={email} />);
+
+		expect(screen.getByTestId("verdict-confidence-chip")).toHaveTextContent("72%");
+		// Score label still present — additive, not replacing
+		expect(screen.getByText(/score 70\/100/)).toBeInTheDocument();
+	});
+
+	it("renders confidence chip next to the score for a tag verdict", () => {
+		const email = makeEmail({ action: "tag", score: 45, confidence: 0.5 });
+		render(<SecurityVerdictPanel email={email} />);
+
+		expect(screen.getByTestId("verdict-confidence-chip")).toHaveTextContent("50%");
+	});
+});

--- a/workers/routes/cases.ts
+++ b/workers/routes/cases.ts
@@ -74,7 +74,27 @@ caseRoutes.post("/", async (c) => {
 caseRoutes.get("/:caseId", async (c) => {
 	const caseData = await c.var.mailboxStub.getCase(c.req.param("caseId"));
 	if (!caseData) return c.json({ error: "Not found" }, 404);
-	return c.json({ case: caseData });
+
+	// Expose aggregate confidence alongside score (issue #220). Confidence
+	// is not a dedicated column — it lives in the persisted verdict JSON on
+	// the originating email. Pull it from the first linked email's
+	// security_verdict at read time so pre-#105 rows (no `confidence` field)
+	// naturally fall back to null without any migration.
+	let confidence: number | null = null;
+	const firstEmailRef = caseData.emails?.[0];
+	if (firstEmailRef) {
+		const email = await c.var.mailboxStub.getEmail(firstEmailRef.email_id);
+		if (email?.security_verdict) {
+			try {
+				const verdict = JSON.parse(email.security_verdict as string) as { confidence?: number };
+				confidence = typeof verdict.confidence === "number" ? verdict.confidence : null;
+			} catch {
+				// malformed verdict JSON — confidence stays null
+			}
+		}
+	}
+
+	return c.json({ case: { ...caseData, confidence } });
 });
 
 caseRoutes.patch("/:caseId", async (c) => {


### PR DESCRIPTION
## Summary

- Adds a `ConfidenceChip` component to `SecurityVerdictPanel` that renders the aggregate pipeline confidence (e.g. `confidence 85%`) inline next to the score for every non-allow verdict; missing confidence (pre-#105 persisted verdicts) renders as `—` to distinguish "unknown" from 0%.
- Adds a confidence label below the `ScoreRing` in the `case-detail` title bar with the same `—` fallback; backed by extracting `confidence` from the linked email's verdict JSON at GET time in `workers/routes/cases.ts`.
- Adds `confidence?: number` to the `SecurityVerdict` interface (optional, so old verdicts parse without error) and 7 new frontend tests confirming the chip, the fallback, and rounding behavior.

Closes #220

## Test plan

- [x] `npm test` — 828 passing, 0 failing
- [x] `npm run typecheck` — no errors
- [x] `SecurityVerdictPanel` renders `confidence 85%` chip for `confidence: 0.85`
- [x] `SecurityVerdictPanel` renders `—` chip when `confidence` is absent (pre-#105 verdict)
- [x] `SecurityVerdictPanel` does not render panel for clean `allow` verdict
- [x] `case-detail` confidence indicator renders `85% conf.` when data.confidence is present
- [x] `case-detail` confidence indicator renders `— conf.` when data.confidence is null or undefined
- [x] Existing `cases.test.ts` still passes (the `GET /:caseId` handler safely handles stubs without `emails` via optional chaining)

## Follow-ups

None — confidence ring visualization and trend/sparkline are explicitly out of scope per issue.

https://claude.ai/code/session_01FZivw5p5jnwaWkn5t2tv5v

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZivw5p5jnwaWkn5t2tv5v)_