### PR TITLE
feat(cases): persist confidence on case row and surface in case-detail title bar (#224)

### DIFF
--- a/workers/db/schema.ts
+++ b/workers/db/schema.ts
@@ -177,6 +177,10 @@ export const cases = sqliteTable("cases", {
 	// email, or pre-#128 rows). The frontend hides the timeline card
 	// when this is NULL/empty.
 	stage_trace: text("stage_trace"),
+	// Aggregate pipeline confidence copied from FinalVerdict.confidence at
+	// case-creation time (issue #224). NULL for old rows and manual API
+	// creates; the frontend renders "—" in that case.
+	confidence: real("confidence"),
 });
 
 export const caseEmails = sqliteTable(

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -1322,6 +1322,12 @@ export class MailboxDO extends DurableObject<Env> {
 		 * — the UI hides the timeline card.
 		 */
 		stage_trace?: string | null;
+		/**
+		 * Aggregate pipeline confidence in [0,1] copied from
+		 * FinalVerdict.confidence at case-creation time (issue #224).
+		 * Null/undefined leaves the column NULL — the UI renders "—".
+		 */
+		confidence?: number | null;
 	}) {
 		const id = crypto.randomUUID();
 		const now = new Date().toISOString();
@@ -1346,6 +1352,7 @@ export class MailboxDO extends DurableObject<Env> {
 				summary: null,
 				summary_status: summaryStatus,
 				stage_trace: input.stage_trace ?? null,
+				confidence: input.confidence ?? null,
 			})
 			.run();
 		if (input.emailId) {
@@ -1412,7 +1419,14 @@ export class MailboxDO extends DurableObject<Env> {
 			stage_trace === null && typeof rawTrace === "string" && rawTrace.length > 0
 				? "malformed"
 				: null;
-		return { ...row, stage_trace, stage_trace_error, emails, observables };
+		return {
+			...row,
+			stage_trace,
+			stage_trace_error,
+			confidence: typeof row.confidence === "number" ? row.confidence : null,
+			emails,
+			observables,
+		};
 	}
 
 	async updateCase(

--- a/workers/durableObject/migrations.ts
+++ b/workers/durableObject/migrations.ts
@@ -420,4 +420,15 @@ export const mailboxMigrations: Migration[] = [
             CREATE INDEX IF NOT EXISTS idx_tlsrpt_records_sending_mta_ip ON tlsrpt_records(sending_mta_ip);
         `,
 	},
+	{
+		// Aggregate pipeline confidence on the case row (issue #224).
+		// Copied from FinalVerdict.confidence at case-creation time so the
+		// case-detail title bar can render the value without joining back to
+		// the originating email. Forward-only ALTER; pre-#224 rows get NULL
+		// and the frontend renders "—".
+		name: "18_cases_confidence",
+		sql: `
+            ALTER TABLE cases ADD COLUMN confidence REAL;
+        `,
+	},
 ];

--- a/workers/routes/cases.ts
+++ b/workers/routes/cases.ts
@@ -146,6 +146,21 @@ caseRoutes.post("/report-phish", async (c) => {
 		typeof (email as { stage_trace?: string | null }).stage_trace === "string"
 			? (email as { stage_trace?: string | null }).stage_trace!
 			: null;
+	// Aggregate pipeline confidence (issue #224). Stored in the
+	// security_verdict JSON as FinalVerdict.confidence; extract it here
+	// so the case row carries the value without a join at render time.
+	const verdictJson = (email as { security_verdict?: string | null }).security_verdict;
+	let verdictConfidence: number | null = null;
+	if (typeof verdictJson === "string") {
+		try {
+			const parsed = JSON.parse(verdictJson) as { confidence?: unknown };
+			if (typeof parsed?.confidence === "number") {
+				verdictConfidence = parsed.confidence;
+			}
+		} catch {
+			// malformed JSON — leave confidence null
+		}
+	}
 	const { id } = await c.var.mailboxStub.createCase({
 		title: `Reported phish: ${email.subject || "(no subject)"}`,
 		notes: `Reported from email ${emailId}. Sender: ${email.sender}.`,
@@ -153,6 +168,7 @@ caseRoutes.post("/report-phish", async (c) => {
 		observables,
 		score: verdictScore,
 		stage_trace: stageTrace,
+		confidence: verdictConfidence,
 	});
 
 	// Async AI co-pilot summary generation (issue #127). createCase


### PR DESCRIPTION
## Summary

- Adds migration `18_cases_confidence` (`ALTER TABLE cases ADD COLUMN confidence REAL`) so aggregate pipeline confidence is persisted on the case row at creation time.
- `report-phish` extracts `FinalVerdict.confidence` from the linked email's `security_verdict` JSON and passes it to `createCase` — same pattern as `verdictScore` / `stageTrace`.
- `getCase` explicitly surfaces `confidence: number | null` (type-safe extraction matching the `13_cases_score` pattern).
- Case-detail title bar renders `85% conf.` when confidence is present and `— conf.` when null/absent, shown below the `ScoreRing` (or the empty-score placeholder), so old rows never show `0%`.

Closes #224

## Test plan

- [x] `npm test` — 820 passing, 0 failing
- [x] `npm run typecheck` — exit 0, no errors
- [x] New test: `CaseDetailRoute — confidence indicator (#224)` — confidence chip renders `85% conf.` for `data.confidence: 0.85`
- [x] New test: null confidence renders `— conf.` and never renders `0%`
- [x] Existing case-detail tests unaffected (`baseCase` extended with `confidence: null`)

## Deferred follow-ups

None — confidence ring visualisation and cases-list column are explicitly out of scope per issue.

## Spec follow-up

No SECURITY_SPEC.md changes needed for this additive column.

https://claude.ai/code/session_01AkfTorTDmQrKoTrUKpGe3K

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkfTorTDmQrKoTrUKpGe3K)_