### PR TITLE
feat(security): compensating-control mitigations layer (closes #100)

### DIFF
--- a/tests/security/verdict.test.ts
+++ b/tests/security/verdict.test.ts
@@ -3,6 +3,8 @@ import {
 	aggregateVerdict,
 	applyConfidenceDemote,
 	DEFAULT_THRESHOLDS,
+	DEFAULT_MITIGATION_CONFIG,
+	DMARC_PASS_COMPENSATES_METHOD_FAIL,
 	type FinalVerdict,
 } from "../../workers/security/verdict";
 import { DEFAULT_ATTACHMENT_POLICY } from "../../workers/security/attachments";
@@ -311,5 +313,95 @@ describe("applyConfidenceDemote (issue #219)", () => {
 		// existing applyBoost behaviour).
 		expect(out.explanation).toBe("s1; s2; s3; s4");
 		expect(out.signals).toContain("confidence-aware demote (0.45 < 0.6)");
+	});
+});
+
+// ── Mitigations layer (issue #100) ──────────────────────────────────────────
+
+describe("dmarc_pass_compensates_method_fail mitigation", () => {
+	// Shared helpers
+	const safeClass: import("../../workers/security/classification").ClassificationResult = {
+		label: "safe",
+		confidence: 0.9,
+		reasoning: "ok",
+	};
+	// Auth where DMARC passes but both per-method checks fail — the textbook
+	// mailing-list / forwarded-mail shape that produces false positives today.
+	const dmarcPassMethodFail = {
+		spf: "fail" as const,
+		dkim: "fail" as const,
+		dmarc: "pass" as const,
+		dkimObservations: [],
+	};
+
+	it("mitigation applies: spf=fail dkim=fail dmarc=pass → auth contribution ≤ 0", () => {
+		// AC: "spf=fail dkim=fail dmarc=pass produces auth contribution ≤ 0
+		// (currently +10 net)." With only auth signals (no classifier/rep/url
+		// noise), the final score should be 0 (clamped from the negative delta).
+		const noMitigation = aggregateVerdict(
+			{ auth: dmarcPassMethodFail, classification: safeClass, urls: [], reputation: null },
+			DEFAULT_THRESHOLDS,
+			{ dmarc_pass_compensates_method_fail: false },
+		);
+		const withMitigation = aggregateVerdict(
+			{ auth: dmarcPassMethodFail, classification: safeClass, urls: [], reputation: null },
+			DEFAULT_THRESHOLDS,
+			DEFAULT_MITIGATION_CONFIG,
+		);
+		// Without mitigation: spf_fail(+10) + dkim_fail(+10) + dmarc_pass(−10)
+		// = +10; classify(safe)=0; rep(null/first-time)=+5 → net=15.
+		expect(noMitigation.score).toBeGreaterThan(0);
+		// With mitigation: spf_fail and dkim_fail zeroed → only dmarc_pass(−10)
+		// + rep(+5) remain on the negative side; clamped to 0.
+		expect(withMitigation.score).toBeLessThan(noMitigation.score);
+	});
+
+	it("mitigation fires → 'mitigated:dmarc_pass_compensates_method_fail' appears in signals", () => {
+		const v = aggregateVerdict(
+			{ auth: dmarcPassMethodFail, classification: safeClass, urls: [], reputation: null },
+			DEFAULT_THRESHOLDS,
+			DEFAULT_MITIGATION_CONFIG,
+		);
+		expect(v.signals).toContain("mitigated:dmarc_pass_compensates_method_fail");
+	});
+
+	it("mitigation disabled per-mailbox is a no-op (same score as baseline)", () => {
+		const inputs = { auth: dmarcPassMethodFail, classification: safeClass, urls: [], reputation: null };
+		const baseline = aggregateVerdict(inputs, DEFAULT_THRESHOLDS, { dmarc_pass_compensates_method_fail: false });
+		const noopDisabled = aggregateVerdict(inputs, DEFAULT_THRESHOLDS, { dmarc_pass_compensates_method_fail: false });
+		expect(noopDisabled.score).toBe(baseline.score);
+		expect(noopDisabled.signals).not.toContain("mitigated:dmarc_pass_compensates_method_fail");
+	});
+
+	it("mitigation enabled but inputs don't match (dmarc=fail) → no signal, score unchanged", () => {
+		// dmarc=fail: DMARC_PASS_COMPENSATES_METHOD_FAIL.applies() returns false.
+		const failAuth = {
+			spf: "fail" as const,
+			dkim: "fail" as const,
+			dmarc: "fail" as const,
+			dkimObservations: [],
+		};
+		const v = aggregateVerdict(
+			{ auth: failAuth, classification: safeClass, urls: [], reputation: null },
+			DEFAULT_THRESHOLDS,
+			DEFAULT_MITIGATION_CONFIG,
+		);
+		expect(v.signals).not.toContain("mitigated:dmarc_pass_compensates_method_fail");
+	});
+
+	it("DMARC_PASS_COMPENSATES_METHOD_FAIL.apply zeroes only spf_fail and dkim_fail", () => {
+		const contribs = [
+			{ scorer: "auth" as const, rule: "spf_fail", weight: 10, reason: "SPF failed" },
+			{ scorer: "auth" as const, rule: "dkim_fail", weight: 10, reason: "DKIM failed" },
+			{ scorer: "auth" as const, rule: "dmarc_pass", weight: -10, reason: "DMARC passed" },
+		];
+		const modified = DMARC_PASS_COMPENSATES_METHOD_FAIL.apply(contribs);
+		expect(modified.find((c) => c.rule === "spf_fail")?.weight).toBe(0);
+		expect(modified.find((c) => c.rule === "dkim_fail")?.weight).toBe(0);
+		expect(modified.find((c) => c.rule === "dmarc_pass")?.weight).toBe(-10); // untouched
+	});
+
+	it("mitigation default: DEFAULT_MITIGATION_CONFIG has dmarc_pass_compensates_method_fail enabled", () => {
+		expect(DEFAULT_MITIGATION_CONFIG.dmarc_pass_compensates_method_fail).toBe(true);
 	});
 });

--- a/workers/security/auth.ts
+++ b/workers/security/auth.ts
@@ -204,19 +204,48 @@ export function parseAuthResults(rawHeaders: unknown, options: ParseAuthOptions 
  *     `Authentication-Results` header before the authentic one).
  *   - 0.2 — no `Authentication-Results` headers found at all (verdict is
  *     all-`none`); whatever we contributed has very little to back it up.
+ *
+ * `contributions` (issue #100): structured per-rule breakdown for the
+ * mitigations layer. Each entry carries the raw weight before the 30-cap so
+ * mitigations can zero out individual rule contributions without needing to
+ * know about the cap. The cap case (dmarc_fail + spf_fail + dkim_fail → raw
+ * 40, capped 30) never triggers `dmarc_pass_compensates_method_fail` because
+ * that mitigation only fires when dmarc=pass — so the delta computed from
+ * uncapped contributions is always correct in practice.
  */
-export function scoreAuth(verdict: AuthVerdict): { score: number; reasons: string[]; confidence: number } {
+export function scoreAuth(verdict: AuthVerdict): {
+	score: number;
+	reasons: string[];
+	confidence: number;
+	contributions: Array<{ scorer: "auth"; rule: string; weight: number; reason: string }>;
+} {
 	const reasons: string[] = [];
+	const contributions: Array<{ scorer: "auth"; rule: string; weight: number; reason: string }> = [];
 	let score = 0;
-	if (verdict.dmarc === "fail") { score += 20; reasons.push("DMARC failed"); }
-	if (verdict.spf === "fail" || verdict.spf === "softfail") { score += 10; reasons.push("SPF failed"); }
-	if (verdict.dkim === "fail") { score += 10; reasons.push("DKIM failed"); }
+	if (verdict.dmarc === "fail") {
+		score += 20;
+		reasons.push("DMARC failed");
+		contributions.push({ scorer: "auth", rule: "dmarc_fail", weight: 20, reason: "DMARC failed" });
+	}
+	if (verdict.spf === "fail" || verdict.spf === "softfail") {
+		score += 10;
+		reasons.push("SPF failed");
+		contributions.push({ scorer: "auth", rule: "spf_fail", weight: 10, reason: "SPF failed" });
+	}
+	if (verdict.dkim === "fail") {
+		score += 10;
+		reasons.push("DKIM failed");
+		contributions.push({ scorer: "auth", rule: "dkim_fail", weight: 10, reason: "DKIM failed" });
+	}
 	if (score > 30) score = 30;
-	if (verdict.dmarc === "pass") score -= 10;
+	if (verdict.dmarc === "pass") {
+		score -= 10;
+		contributions.push({ scorer: "auth", rule: "dmarc_pass", weight: -10, reason: "DMARC passed" });
+	}
 	const allNone =
 		verdict.spf === "none" && verdict.dkim === "none" && verdict.dmarc === "none";
 	const confidence = verdict.trusted ? 0.9 : allNone ? 0.2 : 0.5;
-	return { score, reasons, confidence };
+	return { score, reasons, confidence, contributions };
 }
 
 /**

--- a/workers/security/defaults.ts
+++ b/workers/security/defaults.ts
@@ -9,7 +9,12 @@
  * Without this split the import graph cycles.
  */
 
-import { DEFAULT_THRESHOLDS, type VerdictThresholds } from "./verdict";
+import {
+	DEFAULT_THRESHOLDS,
+	DEFAULT_MITIGATION_CONFIG,
+	type VerdictThresholds,
+	type MitigationConfig,
+} from "./verdict";
 import { DEFAULT_ATTACHMENT_POLICY, type AttachmentPolicy } from "./attachments";
 
 /**
@@ -100,7 +105,16 @@ export interface MailboxSecuritySettings {
 	 * this value is demoted to `tag`. Default 0.6.
 	 */
 	min_confidence_for_quarantine: number;
+	/**
+	 * Issue #100: per-mailbox compensating-control mitigations. Each field
+	 * enables or disables a named mitigation. Absent key = on by default
+	 * (matching the "absent-key-inherits" convention). See `MitigationConfig`
+	 * and `DEFAULT_MITIGATION_CONFIG` in `workers/security/verdict.ts`.
+	 */
+	mitigations: MitigationConfig;
 }
+
+export type { MitigationConfig };
 
 /**
  * Default for the new classification block. Skip-on-timeout is ON so the
@@ -125,4 +139,5 @@ export const DEFAULT_SECURITY_SETTINGS: MailboxSecuritySettings = {
 	classification: DEFAULT_CLASSIFICATION_SETTINGS,
 	confidence_aware_actions: false,
 	min_confidence_for_quarantine: 0.6,
+	mitigations: DEFAULT_MITIGATION_CONFIG,
 };

--- a/workers/security/index.ts
+++ b/workers/security/index.ts
@@ -272,6 +272,7 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 				firstTimeSenderPrior,
 			},
 			settings.thresholds,
+			settings.mitigations,
 		);
 		// Intel-feed boost. Confirmed hit bumps score by 20; unconfirmed bloom-only
 		// hit bumps by 5 (low-signal — bloom FPR is configured at ~1%).

--- a/workers/security/verdict.ts
+++ b/workers/security/verdict.ts
@@ -22,6 +22,82 @@ import { scoreUrls } from "./urls";
 import { scoreReputation } from "./reputation";
 import { scoreAttachments } from "./attachments";
 
+/**
+ * A single named rule contribution from one scorer. Used by the mitigations
+ * layer (issue #100) to identify and rewrite specific contributions without
+ * touching the scorer itself.
+ *
+ * `weight` is the raw per-rule value before any scorer-internal capping. The
+ * mitigations pass computes a delta from the rewritten contributions and
+ * applies it to the post-sum, pre-clamp score.
+ *
+ * v1 coverage: only `scoreAuth` emits structured contributions. The remaining
+ * scorers will add breakdowns in the follow-up for #100.
+ */
+export interface ScorerContribution {
+	scorer: "auth" | "classification" | "urls" | "reputation" | "attachments";
+	rule: string;    // stable id, e.g. "spf_fail", "dkim_fail"
+	weight: number;  // raw per-rule value (not capped)
+	reason: string;  // matches the reasons[] string
+}
+
+/**
+ * Declarative mitigation: inspects the full `VerdictInputs` plus per-scorer
+ * contributions and returns a rewritten contribution list. The aggregator
+ * computes the score delta from the before/after sums and applies it before
+ * clamping. Mitigation names appear in `FinalVerdict.signals` with the
+ * `mitigated:` prefix so operator explanations stay auditable.
+ */
+export interface Mitigation {
+	name: string;
+	applies(inputs: VerdictInputs, contribs: ScorerContribution[]): boolean;
+	apply(contribs: ScorerContribution[]): ScorerContribution[];
+}
+
+/**
+ * Per-mailbox mitigation toggles. Each field corresponds to one named
+ * mitigation; absent or `true` means the mitigation is active, `false`
+ * disables it. Mirrors the `VerdictThresholds` pattern: operator-configurable,
+ * with defaults in `DEFAULT_MITIGATION_CONFIG`.
+ */
+export interface MitigationConfig {
+	/**
+	 * When DMARC=pass, zero out the SPF and DKIM per-method fail contributions.
+	 * A passing DMARC is itself the compensating control — the spec says SPF OR
+	 * DKIM aligning is sufficient, so a failing method alongside a passing
+	 * aggregate verdict should not add suspicion. Default: true (on by default).
+	 */
+	dmarc_pass_compensates_method_fail: boolean;
+}
+
+export const DEFAULT_MITIGATION_CONFIG: MitigationConfig = {
+	dmarc_pass_compensates_method_fail: true,
+};
+
+/**
+ * v1 mitigation: when DMARC=pass, the per-method SPF/DKIM fail contributions
+ * are zeroed out. DMARC alignment already proves either SPF or DKIM validated
+ * the sending domain — penalising the other method's raw result double-counts
+ * the failure and produces false positives on mailing-list and forwarded mail.
+ *
+ * Applied by `aggregateVerdict` before the [0,100] clamp, so the delta can
+ * push the score below the auth subtotal (legitimate mail scoring -10 net
+ * instead of today's +10 net for spf=fail dkim=fail dmarc=pass).
+ */
+export const DMARC_PASS_COMPENSATES_METHOD_FAIL: Mitigation = {
+	name: "dmarc_pass_compensates_method_fail",
+	applies(inputs) {
+		return inputs.auth.dmarc === "pass";
+	},
+	apply(contribs) {
+		return contribs.map((c) =>
+			c.scorer === "auth" && (c.rule === "spf_fail" || c.rule === "dkim_fail")
+				? { ...c, weight: 0 }
+				: c,
+		);
+	},
+};
+
 export type VerdictAction = "allow" | "tag" | "quarantine" | "block";
 
 export interface FinalVerdict {
@@ -88,6 +164,7 @@ export const DEFAULT_THRESHOLDS: VerdictThresholds = {
 export function aggregateVerdict(
 	inputs: VerdictInputs,
 	thresholds: VerdictThresholds = DEFAULT_THRESHOLDS,
+	mitigations: MitigationConfig = DEFAULT_MITIGATION_CONFIG,
 ): FinalVerdict {
 	const signals: string[] = [];
 	let score = 0;
@@ -126,6 +203,25 @@ export function aggregateVerdict(
 		score += att.score;
 		signals.push(...att.reasons);
 		contributions.push({ score: att.score, confidence: att.confidence });
+	}
+
+	// ── Mitigations pass (issue #100) ─────────────────────────────────────────
+	// Collect structured contributions from scorers that emit them (v1: auth
+	// only; others added in the follow-up). Apply each enabled mitigation, sum
+	// the weight delta, and adjust `score` before the final clamp so the
+	// mitigation can push the auth subtotal negative on legitimate mail.
+	const mitigContribs: ScorerContribution[] = [...auth.contributions];
+	if (mitigations.dmarc_pass_compensates_method_fail) {
+		if (DMARC_PASS_COMPENSATES_METHOD_FAIL.applies(inputs, mitigContribs)) {
+			const modified = DMARC_PASS_COMPENSATES_METHOD_FAIL.apply(mitigContribs);
+			const origSum = mitigContribs.reduce((s, c) => s + c.weight, 0);
+			const newSum = modified.reduce((s, c) => s + c.weight, 0);
+			const delta = newSum - origSum;
+			if (delta !== 0) {
+				score += delta;
+				signals.push(`mitigated:${DMARC_PASS_COMPENSATES_METHOD_FAIL.name}`);
+			}
+		}
 	}
 
 	score = Math.max(0, Math.min(100, Math.round(score)));


### PR DESCRIPTION
## Summary

- Adds a **mitigations framework** (Option B from issue #100) to `aggregateVerdict`: scorers remain pure; a post-sum, pre-clamp mitigations pass inspects `VerdictInputs` plus structured `ScorerContribution` breakdowns and rewrites specific rule weights before the aggregate is clamped to `[0,100]`.
- Ships the v1 mitigation **`dmarc_pass_compensates_method_fail`** on by default: when `dmarc=pass`, the per-method SPF and DKIM fail contributions are zeroed out. DMARC alignment already proves either method validated the sending domain — the current pipeline double-counts the failure and produces false positives on mailing-list and forwarded mail.
  - Before: `spf=fail dkim=fail dmarc=pass` → auth contribution **+10 net**
  - After: `spf=fail dkim=fail dmarc=pass` → auth contribution **≤ 0**
- When a mitigation fires its name appears in `FinalVerdict.signals` with the stable greppable prefix `mitigated:`.
- `MitigationConfig` is operator-configurable per-mailbox (mirrors `VerdictThresholds`); `settings.mitigations` is wired through `runSecurityPipeline` → `aggregateVerdict`.
- `scoreAuth` now returns `contributions: ScorerContribution[]` — the per-rule structured breakdown the mitigations layer needs (v1 only; see follow-up #229 for the other four scorers).

Closes #100

## Test plan

- [x] `npm test` — 824 passing, 0 failing (full suite)
- [x] `npm run typecheck` — no errors
- [x] New test: mitigation fires → score reduced vs. disabled baseline
- [x] New test: mitigation fires → `"mitigated:dmarc_pass_compensates_method_fail"` in signals
- [x] New test: mitigation disabled per-mailbox is a no-op (same score, no signal)
- [x] New test: mitigation enabled but `dmarc=fail` → does not fire
- [x] New test: `DMARC_PASS_COMPENSATES_METHOD_FAIL.apply` zeroes only `spf_fail` and `dkim_fail`, leaves `dmarc_pass` untouched
- [x] New test: `DEFAULT_MITIGATION_CONFIG` has mitigation enabled by default
- [x] Existing verdict + auth tests unaffected (no test uses dmarc=pass with spf/dkim fail, so the new default mitigation doesn't break any baseline)

## Deferred follow-ups

- **#229** — Add `ScorerContribution` breakdowns to `scoreClassification`, `scoreUrls`, `scoreReputation`, `scoreAttachments` (AC1 partial from #100). Deferred to stay under the 6-file size escalation threshold; the v1 mitigation only uses auth contributions.

## Spec follow-up

No `SECURITY_SPEC.md` changes needed — this is additive scoring logic, not a change to any existing rule.

https://claude.ai/code/session_014QbdCvrmy5bY7Jz6pAdpWd

---
_Generated by [Claude Code](https://claude.ai/code/session_014QbdCvrmy5bY7Jz6pAdpWd)_