### PR TITLE
feat(security): scorer contribution breakdowns for classification, urls, reputation, attachments (closes #229)

### DIFF
--- a/test/security/classification.test.ts
+++ b/test/security/classification.test.ts
@@ -158,6 +158,6 @@ describe("scoreClassification — unavailable contributes 0", () => {
 
 	it("safe verdict still contributes 0 with no reasons", () => {
 		const result: ClassificationResult = { label: "safe", confidence: 1, reasoning: "" };
-		expect(scoreClassification(result)).toEqual({ score: 0, reasons: [], confidence: 1 });
+		expect(scoreClassification(result)).toMatchObject({ score: 0, reasons: [], confidence: 1 });
 	});
 });

--- a/tests/security/urls.test.ts
+++ b/tests/security/urls.test.ts
@@ -100,7 +100,7 @@ describe("scoreUrls", () => {
 		const urls: ExtractedUrl[] = [
 			{ url: "https://a.com", hostname: "a.com", is_homograph: false, is_shortener: false },
 		];
-		expect(scoreUrls(urls)).toEqual({ score: 0, reasons: [], confidence: 1.0 });
+		expect(scoreUrls(urls)).toMatchObject({ score: 0, reasons: [], confidence: 1.0, contributions: [] });
 	});
 
 	it("scores a homograph URL at +20", () => {

--- a/tests/security/verdict.test.ts
+++ b/tests/security/verdict.test.ts
@@ -7,9 +7,11 @@ import {
 	DMARC_PASS_COMPENSATES_METHOD_FAIL,
 	type FinalVerdict,
 } from "../../workers/security/verdict";
-import { DEFAULT_ATTACHMENT_POLICY } from "../../workers/security/attachments";
+import { scoreAttachments, DEFAULT_ATTACHMENT_POLICY } from "../../workers/security/attachments";
 import type { AuthVerdict } from "../../workers/security/auth";
 import { scoreClassification, type ClassificationResult } from "../../workers/security/classification";
+import { scoreUrls } from "../../workers/security/urls";
+import { scoreReputation } from "../../workers/security/reputation";
 
 const cleanAuth: AuthVerdict = { spf: "pass", dkim: "pass", dmarc: "pass" };
 const safeClass: ClassificationResult = { label: "safe", confidence: 0.9, reasoning: "ok" };
@@ -403,5 +405,161 @@ describe("dmarc_pass_compensates_method_fail mitigation", () => {
 
 	it("mitigation default: DEFAULT_MITIGATION_CONFIG has dmarc_pass_compensates_method_fail enabled", () => {
 		expect(DEFAULT_MITIGATION_CONFIG.dmarc_pass_compensates_method_fail).toBe(true);
+	});
+});
+
+// ── ScorerContribution breakdowns (#229) ─────────────────────────────────────
+
+describe("scoreClassification contributions (#229)", () => {
+	it("phishing label emits classifier_phishing contribution with scaled weight", () => {
+		const result = scoreClassification({ label: "phishing", confidence: 1.0, reasoning: "" });
+		expect(result.contributions).toHaveLength(1);
+		expect(result.contributions[0]).toMatchObject({
+			scorer: "classification",
+			rule: "classifier_phishing",
+			weight: result.score,
+		});
+	});
+
+	it("safe label emits classifier_safe contribution with weight 0", () => {
+		const result = scoreClassification({ label: "safe", confidence: 0.9, reasoning: "" });
+		expect(result.contributions).toHaveLength(1);
+		expect(result.contributions[0]).toMatchObject({
+			scorer: "classification",
+			rule: "classifier_safe",
+			weight: 0,
+			reason: "classifier: safe",
+		});
+	});
+
+	it("unavailable label emits classifier_unavailable contribution with weight 0", () => {
+		const result = scoreClassification({ label: "unavailable", confidence: 0, reasoning: "" });
+		expect(result.contributions).toHaveLength(1);
+		expect(result.contributions[0]).toMatchObject({
+			scorer: "classification",
+			rule: "classifier_unavailable",
+			weight: 0,
+		});
+	});
+});
+
+describe("scoreUrls contributions (#229)", () => {
+	it("homograph URL emits homograph_url contribution with weight 20", () => {
+		const urls = [{ url: "https://gооgle.com/login", hostname: "gооgle.com", is_homograph: true, is_shortener: false }];
+		const result = scoreUrls(urls);
+		const contrib = result.contributions.find((c) => c.rule === "homograph_url");
+		expect(contrib).toBeDefined();
+		expect(contrib).toMatchObject({ scorer: "urls", rule: "homograph_url", weight: 20 });
+	});
+
+	it("link shortener emits link_shortener contribution with weight 5", () => {
+		const urls = [{ url: "https://bit.ly/abc", hostname: "bit.ly", is_homograph: false, is_shortener: true }];
+		const result = scoreUrls(urls);
+		const contrib = result.contributions.find((c) => c.rule === "link_shortener");
+		expect(contrib).toBeDefined();
+		expect(contrib).toMatchObject({ scorer: "urls", rule: "link_shortener", weight: 5 });
+	});
+
+	it("no suspicious URLs → empty contributions", () => {
+		const result = scoreUrls([{ url: "https://example.com", hostname: "example.com", is_homograph: false, is_shortener: false }]);
+		expect(result.contributions).toHaveLength(0);
+	});
+});
+
+describe("scoreReputation contributions (#229)", () => {
+	it("first_time_sender (no prior) emits contribution with weight 5", () => {
+		const result = scoreReputation(null);
+		expect(result.contributions).toHaveLength(1);
+		expect(result.contributions[0]).toMatchObject({
+			scorer: "reputation",
+			rule: "first_time_sender",
+			weight: 5,
+		});
+	});
+
+	it("first_time_sender_cti emits contribution with prior weight", () => {
+		const prior = { score: 20, reason: "first-time sender from 1.2.3.4 CTI reputation=malicious" };
+		const result = scoreReputation(null, prior);
+		expect(result.contributions).toHaveLength(1);
+		expect(result.contributions[0]).toMatchObject({
+			scorer: "reputation",
+			rule: "first_time_sender_cti",
+			weight: 20,
+		});
+	});
+
+	it("flagged sender emits flagged_sender contribution with weight 15", () => {
+		const rep = { sender: "x@y.com", first_seen: "2025-01-01", last_seen: "2025-01-02", message_count: 5, avg_score: 40, flagged: true };
+		const result = scoreReputation(rep);
+		const contrib = result.contributions.find((c) => c.rule === "flagged_sender");
+		expect(contrib).toBeDefined();
+		expect(contrib).toMatchObject({ scorer: "reputation", rule: "flagged_sender", weight: 15 });
+	});
+
+	it("bad sender history emits bad_sender_history contribution with weight 10", () => {
+		const rep = { sender: "x@y.com", first_seen: "2025-01-01", last_seen: "2025-01-02", message_count: 5, avg_score: 80, flagged: false };
+		const result = scoreReputation(rep);
+		const contrib = result.contributions.find((c) => c.rule === "bad_sender_history");
+		expect(contrib).toBeDefined();
+		expect(contrib).toMatchObject({ scorer: "reputation", rule: "bad_sender_history", weight: 10 });
+	});
+});
+
+describe("scoreAttachments contributions (#229)", () => {
+	it("macro-office attachment under score policy emits attachment_macro_office_<ext> contribution", () => {
+		const atts = [{ filename: "report.docm", mimetype: "application/vnd.ms-word.document.macroEnabled.12" }];
+		const result = scoreAttachments(atts, DEFAULT_ATTACHMENT_POLICY);
+		expect(result.contributions).toHaveLength(1);
+		expect(result.contributions[0]).toMatchObject({
+			scorer: "attachments",
+			rule: "attachment_macro_office_docm",
+			weight: 15,
+		});
+	});
+
+	it("container attachment under score policy emits attachment_container_<ext> contribution", () => {
+		const atts = [{ filename: "installer.iso", mimetype: "application/x-iso9660-image" }];
+		const result = scoreAttachments(atts, DEFAULT_ATTACHMENT_POLICY);
+		expect(result.contributions).toHaveLength(1);
+		expect(result.contributions[0]).toMatchObject({
+			scorer: "attachments",
+			rule: "attachment_container_iso",
+			weight: 25,
+		});
+	});
+
+	it("hard-block attachment (executable) emits no contribution (weight comes from triage tier)", () => {
+		const atts = [{ filename: "malware.exe", mimetype: "application/octet-stream" }];
+		const result = scoreAttachments(atts, DEFAULT_ATTACHMENT_POLICY);
+		expect(result.hardBlock).toBe(true);
+		expect(result.contributions).toHaveLength(0);
+	});
+
+	it("no attachments → empty contributions", () => {
+		const result = scoreAttachments([], DEFAULT_ATTACHMENT_POLICY);
+		expect(result.contributions).toHaveLength(0);
+	});
+});
+
+describe("aggregateVerdict spreads all scorer contributions into mitigContribs (#229)", () => {
+	it("non-auth contributions are visible to mitigations: cls+urls+rep all participate", () => {
+		// This is validated indirectly: if mitigContribs only had auth contributions
+		// the mitigation delta would be -20 (zeroing spf_fail+dkim_fail); with all
+		// scorers present the mitigations pass still sees only auth rules per the
+		// v1 DMARC mitigation, but the call must not throw even with many contribs.
+		const v = aggregateVerdict(
+			{
+				auth: { spf: "fail", dkim: "fail", dmarc: "pass", dkimObservations: [] },
+				classification: { label: "safe", confidence: 0.9, reasoning: "" },
+				urls: [{ url: "https://bit.ly/x", hostname: "bit.ly", is_homograph: false, is_shortener: true }],
+				reputation: null,
+				attachmentPolicy: DEFAULT_ATTACHMENT_POLICY,
+				attachments: [{ filename: "report.docm", mimetype: null }],
+			},
+			DEFAULT_THRESHOLDS,
+			DEFAULT_MITIGATION_CONFIG,
+		);
+		expect(v.signals).toContain("mitigated:dmarc_pass_compensates_method_fail");
+		expect(v.signals).toContain("link shortener (bit.ly)");
 	});
 });

--- a/workers/security/attachments.ts
+++ b/workers/security/attachments.ts
@@ -75,6 +75,8 @@ export interface AttachmentScoreResult {
 	 * if/when added — would justify a lower value; not in v1.
 	 */
 	confidence: number;
+	/** Structured per-rule breakdown for the mitigations layer (issue #100/#229). */
+	contributions: Array<{ scorer: "attachments"; rule: string; weight: number; reason: string }>;
 }
 
 /**
@@ -133,7 +135,7 @@ export function scoreAttachments(
 	policy: AttachmentPolicy,
 ): AttachmentScoreResult {
 	if (!attachments || attachments.length === 0) {
-		return { score: 0, reasons: [], hardBlock: false, confidence: 1.0 };
+		return { score: 0, reasons: [], hardBlock: false, confidence: 1.0, contributions: [] };
 	}
 
 	// Normalise once — callers may pass user-supplied config, and duplicates
@@ -146,6 +148,7 @@ export function scoreAttachments(
 
 	let score = 0;
 	const reasons: string[] = [];
+	const contributions: Array<{ scorer: "attachments"; rule: string; weight: number; reason: string }> = [];
 	let hardBlock = false;
 	let hardBlockReason: string | undefined;
 
@@ -182,11 +185,13 @@ export function scoreAttachments(
 			: category === "macro_office" ? MACRO_OFFICE_SCORE_BOOST
 			: /* executable under "score" policy */ 40;
 		score += boost;
-		reasons.push(`attachment ${category} .${ext} (${name}) +${boost}`);
+		const reason = `attachment ${category} .${ext} (${name}) +${boost}`;
+		reasons.push(reason);
+		contributions.push({ scorer: "attachments", rule: `attachment_${category}_${ext}`, weight: boost, reason });
 	}
 
 	const fired = reasons.length > 0;
-	return { score, reasons, hardBlock, hardBlockReason, confidence: fired ? 0.95 : 1.0 };
+	return { score, reasons, hardBlock, hardBlockReason, confidence: fired ? 0.95 : 1.0, contributions };
 }
 
 // Hand-traced examples (kept in code so the intent is grep-able):

--- a/workers/security/classification.ts
+++ b/workers/security/classification.ts
@@ -202,7 +202,12 @@ function normalizeLabel(raw: unknown): ClassificationLabel {
  *     produces high confidence in a zero contribution; high-confidence
  *     `phishing` produces high confidence in a +50 contribution.
  */
-export function scoreClassification(result: ClassificationResult): { score: number; reasons: string[]; confidence: number } {
+export function scoreClassification(result: ClassificationResult): {
+	score: number;
+	reasons: string[];
+	confidence: number;
+	contributions: Array<{ scorer: "classification"; rule: string; weight: number; reason: string }>;
+} {
 	// `unavailable` (issue #28 / Rule 5 narrowed): the classifier hit a
 	// timeout/AbortError. Contribute 0 to the score and tag the verdict so
 	// operators can see why the classifier didn't weigh in. Other scorers
@@ -210,7 +215,12 @@ export function scoreClassification(result: ClassificationResult): { score: numb
 	// and a clean inbound that scores well on auth + URLs + reputation +
 	// intel still reaches `allow`.
 	if (result.label === "unavailable") {
-		return { score: 0, reasons: ["llm_unavailable"], confidence: 0.1 };
+		return {
+			score: 0,
+			reasons: ["llm_unavailable"],
+			confidence: 0.1,
+			contributions: [{ scorer: "classification", rule: "classifier_unavailable", weight: 0, reason: "llm_unavailable" }],
+		};
 	}
 	const map: Record<Exclude<ClassificationLabel, "unavailable">, number> = {
 		safe: 0, spam: 20, suspicious: 30, bec: 45, phishing: 50,
@@ -222,5 +232,13 @@ export function scoreClassification(result: ClassificationResult): { score: numb
 	const reasons = result.label === "safe"
 		? []
 		: [`classifier: ${result.label} (${Math.round(result.confidence * 100)}%)`];
-	return { score: scaled, reasons, confidence: result.confidence };
+	const contribReason = result.label === "safe"
+		? "classifier: safe"
+		: reasons[0];
+	return {
+		score: scaled,
+		reasons,
+		confidence: result.confidence,
+		contributions: [{ scorer: "classification", rule: `classifier_${result.label}`, weight: scaled, reason: contribReason }],
+	};
 }

--- a/workers/security/reputation.ts
+++ b/workers/security/reputation.ts
@@ -55,32 +55,46 @@ export interface FirstTimeSenderPrior {
 export function scoreReputation(
 	rep: SenderReputation | null,
 	prior?: FirstTimeSenderPrior,
-): { score: number; reasons: string[]; confidence: number } {
+): {
+	score: number;
+	reasons: string[];
+	confidence: number;
+	contributions: Array<{ scorer: "reputation"; rule: string; weight: number; reason: string }>;
+} {
 	const reasons: string[] = [];
+	const contributions: Array<{ scorer: "reputation"; rule: string; weight: number; reason: string }> = [];
 	let score = 0;
 	if (!rep || rep.message_count === 0) {
 		if (prior) {
 			score += prior.score;
 			reasons.push(prior.reason);
-			return { score, reasons, confidence: 0.7 };
+			contributions.push({ scorer: "reputation", rule: "first_time_sender_cti", weight: prior.score, reason: prior.reason });
+			return { score, reasons, confidence: 0.7, contributions };
 		}
 		score += 5;
 		reasons.push("first-time sender");
-		return { score, reasons, confidence: 0.3 };
+		contributions.push({ scorer: "reputation", rule: "first_time_sender", weight: 5, reason: "first-time sender" });
+		return { score, reasons, confidence: 0.3, contributions };
 	}
-	if (rep.flagged) { score += 15; reasons.push("sender previously flagged"); }
+	if (rep.flagged) {
+		score += 15;
+		reasons.push("sender previously flagged");
+		contributions.push({ scorer: "reputation", rule: "flagged_sender", weight: 15, reason: "sender previously flagged" });
+	}
 	// Consistently-bad history adds suspicion. The score here is a small
 	// nudge rather than a hard signal — the `flagged` branch above is the
 	// deliberate-action path; this catches senders whose verdicts have been
 	// piling up without anyone flipping the flag.
 	if (rep.avg_score > 70) {
 		score += 10;
-		reasons.push(`bad sender history (avg ${rep.avg_score.toFixed(0)})`);
+		const reason = `bad sender history (avg ${rep.avg_score.toFixed(0)})`;
+		reasons.push(reason);
+		contributions.push({ scorer: "reputation", rule: "bad_sender_history", weight: 10, reason });
 	}
 	const confidence = rep.flagged
 		? 0.95
 		: Math.min(0.9, 0.3 + 0.06 * rep.message_count);
-	return { score, reasons, confidence };
+	return { score, reasons, confidence, contributions };
 }
 
 /**

--- a/workers/security/urls.ts
+++ b/workers/security/urls.ts
@@ -173,13 +173,29 @@ function pushUrl(out: ExtractedUrl[], seen: Set<string>, rawUrl: string, display
  *     signal (legit users do shorten links).
  *   - 1.0 — no URL signals fired; nothing to be uncertain about.
  */
-export function scoreUrls(urls: ExtractedUrl[]): { score: number; reasons: string[]; confidence: number } {
+export function scoreUrls(urls: ExtractedUrl[]): {
+	score: number;
+	reasons: string[];
+	confidence: number;
+	contributions: Array<{ scorer: "urls"; rule: string; weight: number; reason: string }>;
+} {
 	const reasons: string[] = [];
+	const contributions: Array<{ scorer: "urls"; rule: string; weight: number; reason: string }> = [];
 	let score = 0;
 	const homograph = urls.find((u) => u.is_homograph);
-	if (homograph) { score += 20; reasons.push(`homograph URL (${homograph.hostname})`); }
+	if (homograph) {
+		score += 20;
+		const reason = `homograph URL (${homograph.hostname})`;
+		reasons.push(reason);
+		contributions.push({ scorer: "urls", rule: "homograph_url", weight: 20, reason });
+	}
 	const shortener = urls.find((u) => u.is_shortener);
-	if (shortener) { score += 5; reasons.push(`link shortener (${shortener.hostname})`); }
+	if (shortener) {
+		score += 5;
+		const reason = `link shortener (${shortener.hostname})`;
+		reasons.push(reason);
+		contributions.push({ scorer: "urls", rule: "link_shortener", weight: 5, reason });
+	}
 	const confidence = homograph ? 0.9 : shortener ? 0.6 : 1.0;
-	return { score, reasons, confidence };
+	return { score, reasons, confidence, contributions };
 }

--- a/workers/security/verdict.ts
+++ b/workers/security/verdict.ts
@@ -198,19 +198,24 @@ export function aggregateVerdict(
 	// contributions (container / macro-office under the defaults). If a
 	// policy set `executable_action: "score"`, its contribution also lands
 	// here rather than short-circuiting.
+	const mitigContribs: ScorerContribution[] = [
+		...auth.contributions,
+		...cls.contributions,
+		...urls.contributions,
+		...rep.contributions,
+	];
 	if (inputs.attachmentPolicy && inputs.attachments && inputs.attachments.length > 0) {
 		const att = scoreAttachments(inputs.attachments, inputs.attachmentPolicy);
 		score += att.score;
 		signals.push(...att.reasons);
 		contributions.push({ score: att.score, confidence: att.confidence });
+		mitigContribs.push(...att.contributions);
 	}
 
 	// ── Mitigations pass (issue #100) ─────────────────────────────────────────
-	// Collect structured contributions from scorers that emit them (v1: auth
-	// only; others added in the follow-up). Apply each enabled mitigation, sum
-	// the weight delta, and adjust `score` before the final clamp so the
-	// mitigation can push the auth subtotal negative on legitimate mail.
-	const mitigContribs: ScorerContribution[] = [...auth.contributions];
+	// Apply each enabled mitigation, sum the weight delta, and adjust `score`
+	// before the final clamp so the mitigation can push the auth subtotal
+	// negative on legitimate mail.
 	if (mitigations.dmarc_pass_compensates_method_fail) {
 		if (DMARC_PASS_COMPENSATES_METHOD_FAIL.applies(inputs, mitigContribs)) {
 			const modified = DMARC_PASS_COMPENSATES_METHOD_FAIL.apply(mitigContribs);


### PR DESCRIPTION
## Summary

- Adds `contributions: ScorerContribution[]` to `scoreClassification`, `scoreUrls`, `scoreReputation`, and `scoreAttachments`, following the exact pattern established by `scoreAuth` in #230. Each scorer uses a narrowly-typed inline array (`scorer: "classification"` etc.) that is structurally compatible with `ScorerContribution` — no circular import needed.
- Extends `aggregateVerdict` to spread all five scorers' contributions into `mitigContribs`, replacing the prior auth-only collection. Attachment contributions are pushed inside the existing conditional block so no scorer is collected before it runs.
- Updates two pre-existing `toEqual` assertions (`tests/security/urls.test.ts`, `test/security/classification.test.ts`) that matched the exact return shape; changed to `toMatchObject` so the new `contributions` field doesn't break them.

Closes #229

## Rule IDs

| Scorer | Rule IDs |
|---|---|
| classification | `classifier_<label>` (e.g. `classifier_phishing`, `classifier_safe`, `classifier_unavailable`) |
| urls | `homograph_url`, `link_shortener` |
| reputation | `first_time_sender`, `first_time_sender_cti`, `flagged_sender`, `bad_sender_history` |
| attachments | `attachment_<category>_<ext>` (e.g. `attachment_macro_office_docm`, `attachment_container_iso`) — only emitted on `action === "score"` path; hard-block items are not emitted here |

## Test plan

- [x] `npm test` — 839 passing, 0 failing
- [x] `npm run typecheck` — no errors
- [x] New test: `scoreClassification` phishing emits `classifier_phishing` contribution with correct weight
- [x] New test: `scoreClassification` safe emits `classifier_safe` with weight 0
- [x] New test: `scoreClassification` unavailable emits `classifier_unavailable` with weight 0
- [x] New test: `scoreUrls` homograph emits `homograph_url` with weight 20
- [x] New test: `scoreUrls` shortener emits `link_shortener` with weight 5
- [x] New test: `scoreUrls` clean URLs → empty contributions
- [x] New test: `scoreReputation` first-time-sender emits `first_time_sender` with weight 5
- [x] New test: `scoreReputation` CTI prior emits `first_time_sender_cti` with prior weight
- [x] New test: `scoreReputation` flagged emits `flagged_sender` with weight 15
- [x] New test: `scoreReputation` bad history emits `bad_sender_history` with weight 10
- [x] New test: `scoreAttachments` macro-office emits `attachment_macro_office_docm` with weight 15
- [x] New test: `scoreAttachments` container emits `attachment_container_iso` with weight 25
- [x] New test: `scoreAttachments` hard-block → no contributions
- [x] New test: `scoreAttachments` empty → no contributions
- [x] New test: `aggregateVerdict` spreads all contributions and mitigations still fire correctly with mixed-scorer inputs

## Deferred follow-ups

None — all four scorers from issue #229 Acceptance are shipped.

## Spec follow-up

No `SECURITY_SPEC.md` changes needed — this is purely additive scoring logic.

https://claude.ai/code/session_01Xf5Buejqudskdc2VoFKwuG