### PR TITLE
feat(mailbox-settings): per-mailbox model overrides with confirmation modal (#151 PR A)

### DIFF
--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { Badge, Button, Input, Loader } from "@cloudflare/kumo";
+import { Badge, Button, Dialog, Input, Loader } from "@cloudflare/kumo";
 import { RobotIcon, ArrowCounterClockwiseIcon } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router";
@@ -19,7 +19,13 @@ import {
 	type HubFieldErrors,
 } from "~/components/HubSettingsPanel";
 import type { HubConfigSettings, SecuritySettings } from "~/types";
-import { TEXT_MODELS } from "shared/mailbox-settings";
+import {
+	TEXT_MODELS,
+	SECURITY_MODELS,
+	DEFAULT_INJECTION_SCANNER_MODEL,
+	DEFAULT_DRAFT_VERIFIER_MODEL,
+	DEFAULT_CLASSIFIER_MODEL,
+} from "shared/mailbox-settings";
 
 // Placeholder shown in the textarea when no custom prompt is set.
 // The authoritative default prompt lives in workers/agent/index.ts (DEFAULT_SYSTEM_PROMPT).
@@ -29,6 +35,9 @@ interface OrgSettingsShape {
 	agentSystemPrompt?: string;
 	agentModel?: string;
 	autoDraft?: { enabled?: boolean };
+	injectionScannerModel?: string;
+	draftVerifierModel?: string;
+	classifierModel?: string;
 	security?: SecuritySettings;
 	intel?: { hub?: HubConfigSettings };
 }
@@ -119,6 +128,19 @@ export default function SettingsRoute() {
 	const [modelChoice, setModelChoice] = useState<string>(TEXT_MODELS[0]);
 	const [customModel, setCustomModel] = useState("");
 
+	const [injectionScannerOverride, setInjectionScannerOverride] = useState(false);
+	const [injectionScannerModelChoice, setInjectionScannerModelChoice] = useState<string>(SECURITY_MODELS[0]);
+	const [draftVerifierOverride, setDraftVerifierOverride] = useState(false);
+	const [draftVerifierModelChoice, setDraftVerifierModelChoice] = useState<string>(SECURITY_MODELS[0]);
+	const [classifierOverride, setClassifierOverride] = useState(false);
+	const [classifierModelChoice, setClassifierModelChoice] = useState<string>(SECURITY_MODELS[0]);
+
+	const [pendingSecurityModel, setPendingSecurityModel] = useState<{
+		field: "injectionScannerModel" | "draftVerifierModel" | "classifierModel";
+		from: string;
+		to: string;
+	} | null>(null);
+
 	const [securityOverride, setSecurityOverride] = useState(false);
 	const [security, setSecurity] = useState<SecuritySettings | undefined>(undefined);
 
@@ -202,6 +224,41 @@ export default function SettingsRoute() {
 			}
 		}
 
+		// security model overrides (#151 PR A): mailbox > org > default.
+		// Domain tier intentionally excluded — same risk without UI guardrails.
+		const rawSettings = mailbox.settings as Record<string, unknown> | undefined;
+		const mailboxISM = rawSettings?.injectionScannerModel as string | undefined;
+		const mailboxDVM = rawSettings?.draftVerifierModel as string | undefined;
+		const mailboxCM = rawSettings?.classifierModel as string | undefined;
+
+		if (mailboxISM) {
+			setInjectionScannerOverride(true);
+			setInjectionScannerModelChoice(mailboxISM);
+		} else {
+			setInjectionScannerOverride(false);
+			setInjectionScannerModelChoice(
+				orgSettings.injectionScannerModel ?? DEFAULT_INJECTION_SCANNER_MODEL,
+			);
+		}
+		if (mailboxDVM) {
+			setDraftVerifierOverride(true);
+			setDraftVerifierModelChoice(mailboxDVM);
+		} else {
+			setDraftVerifierOverride(false);
+			setDraftVerifierModelChoice(
+				orgSettings.draftVerifierModel ?? DEFAULT_DRAFT_VERIFIER_MODEL,
+			);
+		}
+		if (mailboxCM) {
+			setClassifierOverride(true);
+			setClassifierModelChoice(mailboxCM);
+		} else {
+			setClassifierOverride(false);
+			setClassifierModelChoice(
+				orgSettings.classifierModel ?? DEFAULT_CLASSIFIER_MODEL,
+			);
+		}
+
 		// security: domain block wins over org block when the mailbox doesn't
 		// override. Whole-object semantics — never deep-merged.
 		if (mailbox.settings?.security) {
@@ -275,6 +332,9 @@ export default function SettingsRoute() {
 			agentSystemPrompt: promptOverride ? agentPrompt.trim() || undefined : undefined,
 			autoDraft: autoDraftOverride ? { enabled: autoDraftEnabled } : undefined,
 			agentModel: modelOverride ? resolvedModel || undefined : undefined,
+			injectionScannerModel: injectionScannerOverride ? injectionScannerModelChoice : undefined,
+			draftVerifierModel: draftVerifierOverride ? draftVerifierModelChoice : undefined,
+			classifierModel: classifierOverride ? classifierModelChoice : undefined,
 			security: securityOverride ? security : undefined,
 			intel: nextIntel,
 		};
@@ -323,6 +383,23 @@ export default function SettingsRoute() {
 		setHubOverride(false);
 		setHub(domainSettings.intel?.hub ?? orgSettings.intel?.hub);
 		setHubErrors(undefined);
+	};
+
+	const resetInjectionScannerModel = () => {
+		setInjectionScannerOverride(false);
+		setInjectionScannerModelChoice(
+			orgSettings.injectionScannerModel ?? DEFAULT_INJECTION_SCANNER_MODEL,
+		);
+	};
+	const resetDraftVerifierModel = () => {
+		setDraftVerifierOverride(false);
+		setDraftVerifierModelChoice(
+			orgSettings.draftVerifierModel ?? DEFAULT_DRAFT_VERIFIER_MODEL,
+		);
+	};
+	const resetClassifierModel = () => {
+		setClassifierOverride(false);
+		setClassifierModelChoice(orgSettings.classifierModel ?? DEFAULT_CLASSIFIER_MODEL);
 	};
 
 	// Gate on every tier query — the init useEffect uses all of mailbox,
@@ -509,6 +586,122 @@ export default function SettingsRoute() {
 					</div>
 				</div>
 
+				{/* Detection models — per-mailbox override for the three security
+				    AI surfaces (#151 PR A). Chain is mailbox > org > default;
+				    domain tier excluded (same risk without UI guardrails). */}
+				<div className="pp-card p-5">
+					<div className="text-sm font-medium text-ink mb-2">Detection models</div>
+					<p className="text-xs text-ink-3 mb-4">
+						Override the AI models the security pipeline uses for this mailbox.
+						Inherits from the org when not set. Only pre-vetted models are
+						offered — switching to an untested model can significantly degrade
+						detection accuracy. A confirmation is required for every override.
+					</p>
+					<SecurityModelDropdown
+						label="Prompt-injection scanner"
+						description="Checks incoming mail for prompt-injection attempts before routing to the agent."
+						fieldName="injectionScannerModel"
+						override={injectionScannerOverride}
+						value={injectionScannerModelChoice}
+						orgValue={orgSettings.injectionScannerModel ?? DEFAULT_INJECTION_SCANNER_MODEL}
+						onChange={(to) => {
+							const from = injectionScannerOverride
+								? injectionScannerModelChoice
+								: (orgSettings.injectionScannerModel ?? DEFAULT_INJECTION_SCANNER_MODEL);
+							if (to !== from) setPendingSecurityModel({ field: "injectionScannerModel", from, to });
+						}}
+						onReset={resetInjectionScannerModel}
+					/>
+					<SecurityModelDropdown
+						label="Draft verifier"
+						description="Reviews auto-drafted replies for accuracy and safety before surfacing them."
+						fieldName="draftVerifierModel"
+						override={draftVerifierOverride}
+						value={draftVerifierModelChoice}
+						orgValue={orgSettings.draftVerifierModel ?? DEFAULT_DRAFT_VERIFIER_MODEL}
+						onChange={(to) => {
+							const from = draftVerifierOverride
+								? draftVerifierModelChoice
+								: (orgSettings.draftVerifierModel ?? DEFAULT_DRAFT_VERIFIER_MODEL);
+							if (to !== from) setPendingSecurityModel({ field: "draftVerifierModel", from, to });
+						}}
+						onReset={resetDraftVerifierModel}
+					/>
+					<SecurityModelDropdown
+						label="Classifier"
+						description="Classifies incoming mail as safe / spam / phishing / BEC / suspicious."
+						fieldName="classifierModel"
+						override={classifierOverride}
+						value={classifierModelChoice}
+						orgValue={orgSettings.classifierModel ?? DEFAULT_CLASSIFIER_MODEL}
+						onChange={(to) => {
+							const from = classifierOverride
+								? classifierModelChoice
+								: (orgSettings.classifierModel ?? DEFAULT_CLASSIFIER_MODEL);
+							if (to !== from) setPendingSecurityModel({ field: "classifierModel", from, to });
+						}}
+						onReset={resetClassifierModel}
+					/>
+				</div>
+
+				{/* Confirmation dialog for security model overrides */}
+				<Dialog.Root
+					open={pendingSecurityModel !== null}
+					onOpenChange={(open) => { if (!open) setPendingSecurityModel(null); }}
+				>
+					<Dialog size="sm" className="p-6">
+						<Dialog.Title className="text-base font-semibold mb-2">
+							Override detection model?
+						</Dialog.Title>
+						{pendingSecurityModel && (
+							<Dialog.Description className="text-sm text-ink-3 mb-4 space-y-2">
+								<p>
+									Switching from{" "}
+									<code className="text-ink">{pendingSecurityModel.from}</code> to{" "}
+									<code className="text-ink">{pendingSecurityModel.to}</code> for this mailbox.
+									This affects detection.
+								</p>
+								{pendingSecurityModel.field === "injectionScannerModel" && (
+									<p className="font-medium text-amber-700 dark:text-amber-400">
+										This is a security-critical model. Operators have downgraded detection
+										by 60%+ when overriding without testing.
+									</p>
+								)}
+							</Dialog.Description>
+						)}
+						<div className="flex justify-end gap-2">
+							<Dialog.Close
+								render={(props) => (
+									<Button {...props} variant="secondary" size="sm" type="button">
+										Cancel
+									</Button>
+								)}
+							/>
+							<Button
+								variant="primary"
+								size="sm"
+								onClick={() => {
+									if (!pendingSecurityModel) return;
+									const { field, to } = pendingSecurityModel;
+									if (field === "injectionScannerModel") {
+										setInjectionScannerModelChoice(to);
+										setInjectionScannerOverride(true);
+									} else if (field === "draftVerifierModel") {
+										setDraftVerifierModelChoice(to);
+										setDraftVerifierOverride(true);
+									} else {
+										setClassifierModelChoice(to);
+										setClassifierOverride(true);
+									}
+									setPendingSecurityModel(null);
+								}}
+							>
+								Override
+							</Button>
+						</div>
+					</Dialog>
+				</Dialog.Root>
+
 				{/* Security — block-level inheritance. Override carries the WHOLE
 				    security object (incl. allowlists). v1 has no extend-merge for
 				    arrays; tracked as #149. */}
@@ -600,6 +793,71 @@ export default function SettingsRoute() {
 					</Button>
 				</div>
 			</div>
+		</div>
+	);
+}
+
+interface SecurityModelDropdownProps {
+	label: string;
+	description: string;
+	fieldName: string;
+	override: boolean;
+	value: string;
+	orgValue: string;
+	onChange: (to: string) => void;
+	onReset: () => void;
+}
+
+function SecurityModelDropdown({
+	label,
+	description,
+	fieldName,
+	override,
+	value,
+	orgValue,
+	onChange,
+	onReset,
+}: SecurityModelDropdownProps) {
+	const displayValue = override ? value : orgValue;
+	return (
+		<div className="mb-4">
+			<div className="flex items-center justify-between mb-1">
+				<label htmlFor={`${fieldName}-select`} className="text-sm text-ink">
+					<span className="inline-flex items-center gap-2">
+						{label}
+						{override ? (
+							<span data-testid={`override-badge-${fieldName}`}>
+								<Badge variant="primary">Override</Badge>
+							</span>
+						) : (
+							<span data-testid={`inherited-badge-${fieldName}`}>
+								<Badge variant="secondary">Inherited from org</Badge>
+							</span>
+						)}
+					</span>
+				</label>
+				{override && (
+					<button
+						type="button"
+						onClick={onReset}
+						className="text-xs text-ink-3 underline hover:text-ink"
+						data-testid={`reset-${fieldName}`}
+					>
+						Reset to inherited
+					</button>
+				)}
+			</div>
+			<p className="text-xs text-ink-3 mb-2">{description}</p>
+			<select
+				id={`${fieldName}-select`}
+				value={displayValue}
+				onChange={(e) => onChange(e.target.value)}
+				className="w-full rounded-md border border-line bg-paper-2 px-3 py-2 text-sm text-ink focus:outline-none focus:ring-1 focus:ring-accent"
+			>
+				{SECURITY_MODELS.map((m) => (
+					<option key={m} value={m}>{m}</option>
+				))}
+			</select>
 		</div>
 	);
 }

--- a/shared/mailbox-settings.ts
+++ b/shared/mailbox-settings.ts
@@ -123,16 +123,20 @@ export const AutoDraftSettings = z
  * the inheritance hierarchy can't distinguish from an intentional one.
  *
  * Three security-critical model fields (`injectionScannerModel`,
- * `draftVerifierModel`, `classifierModel` from #67) are intentionally NOT in
- * MailboxSettings — they live only in OrgSettings. Per-mailbox overrides
- * for these are tracked as a separate feature (see follow-up: per-mailbox
- * model overrides with user choice / local models / own API keys) so the
- * UI can surface the security trade-off explicitly when shipped.
+ * `draftVerifierModel`, `classifierModel`) are declared here as optional
+ * strings (#151 PR A). The resolver chain is `mailbox > org > default` —
+ * domain tier is intentionally excluded (per-domain override carries the
+ * same risk as per-mailbox without UI guardrails). The UI surfaces a
+ * confirmation modal and a curated dropdown so the security trade-off is
+ * explicit.
  */
 export const MailboxSettings = z.object({
   agentSystemPrompt: z.string().optional(),
   autoDraft: AutoDraftSettings.optional(),
   agentModel: z.string().optional(),
+  injectionScannerModel: z.string().optional(),
+  draftVerifierModel: z.string().optional(),
+  classifierModel: z.string().optional(),
   security: SecuritySettings.optional(),
   intel: IntelSettings.optional(),
 }).passthrough();
@@ -174,3 +178,15 @@ export const DEFAULT_INJECTION_SCANNER_MODEL =
 export const DEFAULT_DRAFT_VERIFIER_MODEL =
   "@cf/meta/llama-4-scout-17b-16e-instruct";
 export const DEFAULT_CLASSIFIER_MODEL = "@cf/meta/llama-3.1-8b-instruct-fast";
+
+/**
+ * Pre-vetted model list for the three security-critical model dropdowns
+ * (#151 PR A). Only these models are offered in the per-mailbox UI — no
+ * free-form string entry. The first entry is the system default for
+ * `injectionScannerModel` and `classifierModel`; the second is the default
+ * for `draftVerifierModel`. BYO-key and local-model support land in PR B/C.
+ */
+export const SECURITY_MODELS = [
+  "@cf/meta/llama-3.1-8b-instruct-fast",
+  "@cf/meta/llama-4-scout-17b-16e-instruct",
+] as const;

--- a/tests/agent/settings.test.ts
+++ b/tests/agent/settings.test.ts
@@ -31,32 +31,30 @@ describe("MailboxSettings", () => {
     expect(parsed.agentSystemPrompt).toBe("Hi");
   });
 
-  // Post-#106: the three security-critical model fields
-  // (injectionScannerModel, draftVerifierModel, classifierModel) have been
-  // moved off MailboxSettings entirely. They live on OrgSettings only, with
-  // per-mailbox overrides forbidden in v1 — the wrong choice can let
-  // prompt-injection through. A future feature (per-mailbox model overrides
-  // with user choice / local models / own API keys) will reintroduce them
-  // with explicit UI guardrails. Until then the schema's `.passthrough()`
-  // means stale fields in existing mailbox JSON ride through harmlessly,
-  // but they are NOT typed as MailboxSettings keys.
-  it("does not declare security-model fields on MailboxSettings (now org-only)", () => {
-    const parsed = MailboxSettings.parse({});
-    expect((parsed as Record<string, unknown>).injectionScannerModel).toBeUndefined();
-    expect((parsed as Record<string, unknown>).draftVerifierModel).toBeUndefined();
-    expect((parsed as Record<string, unknown>).classifierModel).toBeUndefined();
+  // #151 PR A: the three security-critical model fields are back on
+  // MailboxSettings as per-mailbox overrides, with UI guardrails (curated
+  // dropdown + confirmation modal). The resolver chain is mailbox > org >
+  // default; domain tier is excluded (same risk without guardrails).
+  it("declares injectionScannerModel / draftVerifierModel / classifierModel as optional strings", () => {
+    // Fields round-trip as typed strings when set.
+    const parsed = MailboxSettings.parse({
+      injectionScannerModel: "@cf/meta/llama-3.1-8b-instruct-fast",
+      draftVerifierModel: "@cf/meta/llama-4-scout-17b-16e-instruct",
+      classifierModel: "@cf/meta/llama-3.1-8b-instruct-fast",
+    });
+    expect(parsed.injectionScannerModel).toBe("@cf/meta/llama-3.1-8b-instruct-fast");
+    expect(parsed.draftVerifierModel).toBe("@cf/meta/llama-4-scout-17b-16e-instruct");
+    expect(parsed.classifierModel).toBe("@cf/meta/llama-3.1-8b-instruct-fast");
+    // Absent = inherit (not defaulted at schema layer — resolver fills in defaults).
+    const empty = MailboxSettings.parse({});
+    expect(empty.injectionScannerModel).toBeUndefined();
+    expect(empty.draftVerifierModel).toBeUndefined();
+    expect(empty.classifierModel).toBeUndefined();
   });
 
-  it("ignores stale per-mailbox security-model fields on read (passthrough only)", () => {
-    // Existing R2 mailbox JSON written before #106 may still carry these
-    // fields. They survive the parse via passthrough but the worker call
-    // sites no longer read them — see workers/agent/index.ts and
-    // workers/security/index.ts which now source classifier/verifier/scanner
-    // models from the org tier.
-    const parsed = MailboxSettings.parse({
-      injectionScannerModel: "@cf/custom/injection",
-    });
-    expect((parsed as Record<string, unknown>).injectionScannerModel).toBe("@cf/custom/injection");
+  it("rejects a non-string injectionScannerModel", () => {
+    const result = MailboxSettings.safeParse({ injectionScannerModel: 42 });
+    expect(result.success).toBe(false);
   });
 
   // The security sub-shape is opt-in: an undefined `security` block must

--- a/tests/lib/resolve-mailbox-settings.test.ts
+++ b/tests/lib/resolve-mailbox-settings.test.ts
@@ -1012,6 +1012,92 @@ describe("stripDefaultEqual — symmetric across mailbox / domain / org tiers", 
 	});
 });
 
+describe("resolveMailboxSettings — security model fields (#151 PR A)", () => {
+	it("(a) per-mailbox override wins over org — injectionScannerModel", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": { injectionScannerModel: "@cf/org/scanner" },
+			[MAILBOX_KEY]: { injectionScannerModel: "@cf/mailbox/scanner" },
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.injectionScannerModel).toBe("@cf/mailbox/scanner");
+	});
+
+	it("(a) per-mailbox override wins over org — draftVerifierModel", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": { draftVerifierModel: "@cf/org/verifier" },
+			[MAILBOX_KEY]: { draftVerifierModel: "@cf/mailbox/verifier" },
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.draftVerifierModel).toBe("@cf/mailbox/verifier");
+	});
+
+	it("(a) per-mailbox override wins over org — classifierModel", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": { classifierModel: "@cf/org/classifier" },
+			[MAILBOX_KEY]: { classifierModel: "@cf/mailbox/classifier" },
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.classifierModel).toBe("@cf/mailbox/classifier");
+	});
+
+	it("(b) mailbox absent → org value wins (all three fields)", async () => {
+		const bucket = makeFakeBucket({
+			"org/settings.json": {
+				injectionScannerModel: "@cf/org/scanner",
+				draftVerifierModel: "@cf/org/verifier",
+				classifierModel: "@cf/org/classifier",
+			},
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.injectionScannerModel).toBe("@cf/org/scanner");
+		expect(resolved.draftVerifierModel).toBe("@cf/org/verifier");
+		expect(resolved.classifierModel).toBe("@cf/org/classifier");
+	});
+
+	it("(c) both mailbox and org absent → system default", async () => {
+		const bucket = makeFakeBucket({ [MAILBOX_KEY]: {} });
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.injectionScannerModel).toBe(DEFAULT_MAILBOX_SETTINGS.injectionScannerModel);
+		expect(resolved.draftVerifierModel).toBe(DEFAULT_MAILBOX_SETTINGS.draftVerifierModel);
+		expect(resolved.classifierModel).toBe(DEFAULT_MAILBOX_SETTINGS.classifierModel);
+	});
+
+	it("domain tier is still excluded — org wins when mailbox is absent", async () => {
+		// Domain tier is intentionally NOT in the chain for these fields.
+		// Per the #151 issue, per-domain override carries the same risk as
+		// per-mailbox without UI guardrails. Org wins when mailbox is absent.
+		const bucket = makeFakeBucket({
+			"org/settings.json": { injectionScannerModel: "@cf/org/scanner" },
+			[DOMAIN_KEY]: { injectionScannerModel: "@cf/domain/should-be-ignored" },
+			[MAILBOX_KEY]: {},
+		});
+		const resolved = await resolveMailboxSettings(makeEnv(bucket), MAILBOX_ID);
+		expect(resolved.injectionScannerModel).toBe("@cf/org/scanner");
+	});
+
+	it("stripDefaultEqual strips injectionScannerModel when equal to system default", () => {
+		const stripped = stripDefaultEqual({
+			injectionScannerModel: DEFAULT_MAILBOX_SETTINGS.injectionScannerModel,
+		});
+		expect((stripped as Record<string, unknown>).injectionScannerModel).toBeUndefined();
+	});
+
+	it("stripDefaultEqual keeps injectionScannerModel when set to a non-default value", () => {
+		const stripped = stripDefaultEqual({ injectionScannerModel: "@cf/custom/scanner" });
+		expect((stripped as Record<string, unknown>).injectionScannerModel).toBe("@cf/custom/scanner");
+	});
+
+	it("stripDefaultEqual strips draftVerifierModel and classifierModel at default", () => {
+		const stripped = stripDefaultEqual({
+			draftVerifierModel: DEFAULT_MAILBOX_SETTINGS.draftVerifierModel,
+			classifierModel: DEFAULT_MAILBOX_SETTINGS.classifierModel,
+		});
+		expect((stripped as Record<string, unknown>).draftVerifierModel).toBeUndefined();
+		expect((stripped as Record<string, unknown>).classifierModel).toBeUndefined();
+	});
+});
+
 describe("domainFromMailboxId / domainSettingsKey", () => {
 	it("extracts the domain part of an email-style mailboxId", () => {
 		expect(domainFromMailboxId("user@example.com")).toBe("example.com");

--- a/workers/lib/mailbox-settings.ts
+++ b/workers/lib/mailbox-settings.ts
@@ -194,16 +194,15 @@ export async function resolveMailboxSettings(
 		agentModel:
 			mailbox.agentModel ?? domain.agentModel ?? org.agentModel ?? DEFAULT_MAILBOX_SETTINGS.agentModel,
 		autoDraft: resolveAutoDraft(mailbox.autoDraft, domain.autoDraft, org.autoDraft),
-		// The three security-critical model fields stay org-only by design
-		// (#106 audit Q7). Domain tier intentionally NOT consulted here —
-		// per-domain override is the same foot-gun as per-mailbox without
-		// the UI guardrails. Tracked as #151 if/when we want to allow it.
+		// Security-critical model fields: mailbox > org > default (#151 PR A).
+		// Domain tier is intentionally excluded — per-domain override carries
+		// the same risk as per-mailbox without the UI guardrails shipped here.
 		injectionScannerModel:
-			org.injectionScannerModel ?? DEFAULT_MAILBOX_SETTINGS.injectionScannerModel,
+			mailbox.injectionScannerModel ?? org.injectionScannerModel ?? DEFAULT_MAILBOX_SETTINGS.injectionScannerModel,
 		draftVerifierModel:
-			org.draftVerifierModel ?? DEFAULT_MAILBOX_SETTINGS.draftVerifierModel,
+			mailbox.draftVerifierModel ?? org.draftVerifierModel ?? DEFAULT_MAILBOX_SETTINGS.draftVerifierModel,
 		classifierModel:
-			org.classifierModel ?? DEFAULT_MAILBOX_SETTINGS.classifierModel,
+			mailbox.classifierModel ?? org.classifierModel ?? DEFAULT_MAILBOX_SETTINGS.classifierModel,
 		security: normalizeSecurity(security),
 		intel: {
 			hub: intelRaw.hub,
@@ -435,6 +434,12 @@ function isDefaultEqual(key: string, value: unknown): boolean {
 	switch (key) {
 		case "agentModel":
 			return value === DEFAULT_MAILBOX_SETTINGS.agentModel;
+		case "injectionScannerModel":
+			return value === DEFAULT_MAILBOX_SETTINGS.injectionScannerModel;
+		case "draftVerifierModel":
+			return value === DEFAULT_MAILBOX_SETTINGS.draftVerifierModel;
+		case "classifierModel":
+			return value === DEFAULT_MAILBOX_SETTINGS.classifierModel;
 		case "autoDraft":
 			return deepEqual(value, DEFAULT_MAILBOX_SETTINGS.autoDraft);
 		case "agentSystemPrompt":


### PR DESCRIPTION
## Summary

- Adds `injectionScannerModel`, `draftVerifierModel`, and `classifierModel` as optional strings on `MailboxSettings` (schema + resolver).
- Resolver chain is `mailbox > org > default`; domain tier intentionally excluded (same risk without UI guardrails).
- Settings page gains a **Detection models** card: curated dropdown per field (`SECURITY_MODELS` list) with an inline confirmation dialog — injection scanner shows an additional 60%-downgrade warning per the issue.
- `stripDefaultEqual` strips each field when equal to its system default so a form save with defaults doesn't silently shadow the org tier.

Closes #151 (PR A)

## What's in scope (PR A only)

- [x] `MailboxSettings` declares the three fields as optional strings
- [x] Resolver: `mailbox > org > default` for all three; domain tier skipped
- [x] Per-mailbox settings page renders a curated dropdown (pre-vetted models only; no free-form string)
- [x] Confirmation dialog on every override surface; injection scanner shows the security-critical 60%-downgrade warning
- [x] Tests: per-mailbox override wins; unset falls to org; both unset falls to default; domain tier excluded; `stripDefaultEqual` strips defaults
- [x] Regression: PR1 test "does not declare security-model fields on MailboxSettings" flipped to assert the fields are present with correct optional semantics

## Out of scope (deferred per #151 Constraints)

- PR B: BYO-key (`mailboxModel: { id, key_secret_name }`) — follow-up issue to be filed
- PR C: local models / on-prem inference — follow-up issue to be filed

## Test plan

- [x] `npm test` — 897 passing, 0 failing
- [x] `npm run typecheck` — exit 0 (clean)
- [ ] Manual: navigate to a mailbox settings page, expand Detection models, change the Classifier dropdown → confirm dialog appears with "Continue?" copy; cancel reverts; confirm sets the Override badge
- [ ] Manual: change Injection scanner dropdown → confirm dialog shows the 60% warning in addition to the standard copy
- [ ] Manual: save with an override → reload → the override value is pre-selected; Reset to inherited clears it

https://claude.ai/code/session_0185fxXnonsfADQMn32FTu2L

---
_Generated by [Claude Code](https://claude.ai/code/session_0185fxXnonsfADQMn32FTu2L)_