### PR TITLE
feat(security): expose confidence-aware quarantine toggle in settings UI (closes #105)

### DIFF
--- a/app/components/SecuritySettingsPanel.tsx
+++ b/app/components/SecuritySettingsPanel.tsx
@@ -222,6 +222,34 @@ export function SecuritySettingsPanel({ value, onChange }: SecuritySettingsPanel
 						Senders with at least this many prior messages and an average score &lt; 20 auto-allow when DMARC passes.
 						Set to 0 to require an explicit allowlist entry.
 					</p>
+
+					<Switch
+						label="Confidence-aware quarantine (demote low-confidence verdicts to tag)"
+						checked={!!s.confidence_aware_actions}
+						onCheckedChange={(v) => patch({ confidence_aware_actions: v })}
+						disabled={!s.enabled}
+					/>
+					<p className="text-xs text-ink-3 -mt-2">
+						When on, a verdict that would quarantine but whose aggregate pipeline confidence
+						is below the threshold is demoted to "tag" instead — routing it for review
+						rather than hard quarantine. Useful when the LLM timed out or only one signal
+						fired. Off by default; existing mailboxes are unaffected until you enable this.
+					</p>
+					<Input
+						label="Min confidence for quarantine (0–1)"
+						type="number"
+						min={0}
+						max={1}
+						step={0.05}
+						value={String(s.min_confidence_for_quarantine ?? 0.6)}
+						onChange={(e) => patch({ min_confidence_for_quarantine: clampConfidence(e.target.value, 0.6) })}
+						disabled={!s.enabled || !s.confidence_aware_actions}
+					/>
+					<p className="text-xs text-ink-3 -mt-2">
+						Quarantine verdicts with confidence strictly below this value are demoted to tag.
+						Default 0.6. Raise to catch more uncertain verdicts; lower to only rescue
+						extremely shaky ones.
+					</p>
 				</div>
 			</div>
 
@@ -602,6 +630,12 @@ function parseExtensionList(raw: string): string[] {
 
 function clampScore(raw: string, fallback: number): number {
 	return clampInt(raw, fallback, 0, 100);
+}
+
+function clampConfidence(raw: string, fallback: number): number {
+	const n = parseFloat(raw);
+	if (!Number.isFinite(n)) return fallback;
+	return Math.max(0, Math.min(1, Math.round(n * 100) / 100));
 }
 
 function clampInt(raw: string, fallback: number, min: number, max: number): number {

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -69,6 +69,15 @@ export interface SecuritySettings {
 	trusted_auto_allow?: boolean;
 	trusted_auto_allow_min_messages?: number;
 	intel_auto_block?: boolean;
+	/**
+	 * Issue #105: when true, post-aggregation verdicts whose action is
+	 * `quarantine` but whose aggregate confidence is below
+	 * `min_confidence_for_quarantine` are demoted to `tag`.
+	 * Default false — existing mailboxes keep today's behaviour.
+	 */
+	confidence_aware_actions?: boolean;
+	/** Threshold in [0,1] for the confidence-aware demote. Default 0.6. */
+	min_confidence_for_quarantine?: number;
 	business_hours?: BusinessHoursSettings;
 	attachment_policy?: AttachmentPolicySettings;
 	folder_policies?: Record<string, FolderPolicySettings>;


### PR DESCRIPTION
## Summary

- Adds `confidence_aware_actions` and `min_confidence_for_quarantine` to the frontend `SecuritySettings` type (`app/types/index.ts`)
- Adds a **Switch** + explanatory copy + **number Input** in `SecuritySettingsPanel` so operators can enable the confidence-aware demote path and tune the min-confidence threshold

The backend implementation (per-scorer confidence, `FinalVerdict.confidence`, `aggregateConfidence`, `applyConfidenceDemote`, mailbox defaults, pipeline wiring) and all associated tests were already shipped in earlier PRs. This PR closes the settings-UI gap that kept AC5 of the issue open.

Closes #105

## Test plan

- [ ] 897 tests pass (`npm test`) — no new test files needed; backend logic already covered
- [ ] `npm run typecheck` clean — new fields are optional (`?`) so existing usages continue to compile
- [ ] In the mailbox settings UI: new "Confidence-aware quarantine" Switch appears in the Automations section, disabled when security pipeline is off
- [ ] Toggling the Switch on reveals the min-confidence threshold input; toggling off greys it out
- [ ] Saving with `confidence_aware_actions: true` and a threshold round-trips through R2 and applies the demote in the next pipeline run

## Acceptance criteria shipped

- [x] Each `score*` function returns `{ score, reasons, confidence }` — already in prior PRs
- [x] `FinalVerdict` carries `confidence` derived from per-scorer confidences — already in prior PRs
- [x] LLM timeout → `classification` confidence ≤ 0.3 — already tested in `tests/security/verdict.test.ts`
- [x] Multi-scorer corroboration → aggregate confidence ≥ 0.85 — already tested
- [x] `confidence_aware_actions` mailbox setting demotes low-confidence quarantines to tag — **UI surface added in this PR**
- [x] Security UI surfaces confidence alongside the score (`ConfidenceChip`) — already in `SecurityVerdictPanel.tsx`

## Deferred

None — all six acceptance items are now shipped.

## Spec follow-up needed

No — this change does not narrow or extend any rule in `SECURITY_SPEC.md`.

https://claude.ai/code/session_01XaiaNu9GmBLJU8N6TpnpRW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaiaNu9GmBLJU8N6TpnpRW)_