### PR TITLE
feat: per-mailbox ACL scoping (#27)

### DIFF
--- a/tests/lib/mailbox-acl.test.ts
+++ b/tests/lib/mailbox-acl.test.ts
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { callerInAcl, readMailboxAcl, writeMailboxAcl, deleteMailboxAcl } from "../../workers/lib/mailbox-acl";
+import type { MailboxAcl } from "../../workers/lib/mailbox-acl";
+import { requireMailbox } from "../../workers/lib/mailbox";
+
+// ---------------------------------------------------------------------------
+// callerInAcl — pure function, no mocking needed
+// ---------------------------------------------------------------------------
+
+describe("callerInAcl", () => {
+	it("returns true when acl is null (backwards-compat, no ACL written yet)", () => {
+		expect(callerInAcl(null, "alice@example.com")).toBe(true);
+		expect(callerInAcl(null, null)).toBe(true);
+	});
+
+	it("returns true when callerEmail is falsy (dev mode, no Access in front)", () => {
+		const acl: MailboxAcl = { owner: "alice@example.com", members: ["alice@example.com"] };
+		expect(callerInAcl(acl, null)).toBe(true);
+		expect(callerInAcl(acl, "")).toBe(true);
+		expect(callerInAcl(acl, undefined)).toBe(true);
+	});
+
+	it("returns true when caller is in members list", () => {
+		const acl: MailboxAcl = {
+			owner: "alice@example.com",
+			members: ["alice@example.com", "bob@example.com"],
+		};
+		expect(callerInAcl(acl, "alice@example.com")).toBe(true);
+		expect(callerInAcl(acl, "bob@example.com")).toBe(true);
+	});
+
+	it("returns false when caller is not in members list", () => {
+		const acl: MailboxAcl = { owner: "alice@example.com", members: ["alice@example.com"] };
+		expect(callerInAcl(acl, "eve@example.com")).toBe(false);
+	});
+
+	it("comparison is case-insensitive", () => {
+		const acl: MailboxAcl = { owner: "alice@example.com", members: ["alice@example.com"] };
+		expect(callerInAcl(acl, "ALICE@EXAMPLE.COM")).toBe(true);
+		expect(callerInAcl(acl, "Alice@Example.Com")).toBe(true);
+		expect(callerInAcl(acl, "EVE@EXAMPLE.COM")).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// readMailboxAcl / writeMailboxAcl / deleteMailboxAcl — in-memory R2 stub
+// ---------------------------------------------------------------------------
+
+function makeR2Stub(initial: Record<string, string> = {}) {
+	const store = { ...initial };
+	return {
+		async get(key: string) {
+			const val = store[key];
+			if (!val) return null;
+			return { json: async <T>() => JSON.parse(val) as T };
+		},
+		async put(key: string, value: string) {
+			store[key] = value;
+		},
+		async delete(key: string) {
+			delete store[key];
+		},
+		_store: store,
+	};
+}
+
+describe("readMailboxAcl", () => {
+	it("returns null when no ACL blob exists", async () => {
+		const bucket = makeR2Stub();
+		const result = await readMailboxAcl({ BUCKET: bucket as unknown as R2Bucket }, "user@example.com");
+		expect(result).toBeNull();
+	});
+
+	it("returns the parsed ACL when present", async () => {
+		const acl: MailboxAcl = { owner: "alice@example.com", members: ["alice@example.com"] };
+		const bucket = makeR2Stub({
+			"mailboxes-acl/user@example.com.json": JSON.stringify(acl),
+		});
+		const result = await readMailboxAcl({ BUCKET: bucket as unknown as R2Bucket }, "user@example.com");
+		expect(result).toEqual(acl);
+	});
+
+	it("returns null when the blob is malformed JSON", async () => {
+		const bucket = makeR2Stub({ "mailboxes-acl/user@example.com.json": "not-json" });
+		const result = await readMailboxAcl({ BUCKET: bucket as unknown as R2Bucket }, "user@example.com");
+		expect(result).toBeNull();
+	});
+});
+
+describe("writeMailboxAcl + deleteMailboxAcl", () => {
+	it("writes then reads back the ACL", async () => {
+		const bucket = makeR2Stub();
+		const env = { BUCKET: bucket as unknown as R2Bucket };
+		const acl: MailboxAcl = { owner: "alice@example.com", members: ["alice@example.com"] };
+		await writeMailboxAcl(env, "alice@example.com", acl);
+		const read = await readMailboxAcl(env, "alice@example.com");
+		expect(read).toEqual(acl);
+	});
+
+	it("deleteMailboxAcl removes the blob so readMailboxAcl returns null", async () => {
+		const bucket = makeR2Stub();
+		const env = { BUCKET: bucket as unknown as R2Bucket };
+		const acl: MailboxAcl = { owner: "alice@example.com", members: ["alice@example.com"] };
+		await writeMailboxAcl(env, "alice@example.com", acl);
+		await deleteMailboxAcl(env, "alice@example.com");
+		const read = await readMailboxAcl(env, "alice@example.com");
+		expect(read).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// requireMailbox — inline Hono app with stub R2 + DO namespace
+// ---------------------------------------------------------------------------
+
+function makeFullR2Stub(initial: Record<string, string> = {}) {
+	const store = { ...initial };
+	return {
+		async head(key: string) {
+			return store[key] !== undefined ? { key } : null;
+		},
+		async get(key: string) {
+			const val = store[key];
+			if (!val) return null;
+			return { json: async <T>() => JSON.parse(val) as T };
+		},
+		async put(key: string, value: string) {
+			store[key] = value;
+		},
+		async delete(key: string) {
+			delete store[key];
+		},
+	};
+}
+
+function makeFakeMailboxApp(
+	bucketStore: Record<string, string>,
+	callerEmail: string | null,
+) {
+	const bucket = makeFullR2Stub(bucketStore);
+	// Minimal DO namespace stub — just needs idFromName / get
+	const mailboxStub = { id: "fake-do-id" };
+	const MAILBOX = {
+		idFromName: (_name: string) => "fake-id",
+		get: (_id: unknown) => mailboxStub,
+	};
+
+	const app = new Hono<{ Bindings: { BUCKET: typeof bucket; MAILBOX: typeof MAILBOX } }>();
+
+	app.use("/mailboxes/:mailboxId/*", requireMailbox as Parameters<typeof app.use>[1]);
+
+	app.get("/mailboxes/:mailboxId/test", (c) => c.json({ ok: true }));
+
+	return {
+		fetch: (path: string) => {
+			const headers: Record<string, string> = {};
+			if (callerEmail) headers["cf-access-authenticated-user-email"] = callerEmail;
+			return app.request(path, { headers }, { BUCKET: bucket as unknown as R2Bucket, MAILBOX: MAILBOX as unknown as DurableObjectNamespace });
+		},
+	};
+}
+
+describe("requireMailbox — ACL enforcement", () => {
+	const mailboxKey = "mailboxes/alice@example.com.json";
+	const aclKey = "mailboxes-acl/alice@example.com.json";
+	const aliceAcl: MailboxAcl = {
+		owner: "alice@example.com",
+		members: ["alice@example.com"],
+	};
+
+	it("returns 404 when mailbox does not exist", async () => {
+		const app = makeFakeMailboxApp({}, "alice@example.com");
+		const res = await app.fetch("/mailboxes/alice@example.com/test");
+		expect(res.status).toBe(404);
+	});
+
+	it("allows access when no ACL is set (backwards-compat)", async () => {
+		const store = { [mailboxKey]: "{}" };
+		const app = makeFakeMailboxApp(store, "anyone@example.com");
+		const res = await app.fetch("/mailboxes/alice@example.com/test");
+		expect(res.status).toBe(200);
+	});
+
+	it("allows access when callerEmail matches ACL", async () => {
+		const store = {
+			[mailboxKey]: "{}",
+			[aclKey]: JSON.stringify(aliceAcl),
+		};
+		const app = makeFakeMailboxApp(store, "alice@example.com");
+		const res = await app.fetch("/mailboxes/alice@example.com/test");
+		expect(res.status).toBe(200);
+	});
+
+	it("returns 403 when callerEmail is not in ACL", async () => {
+		const store = {
+			[mailboxKey]: "{}",
+			[aclKey]: JSON.stringify(aliceAcl),
+		};
+		const app = makeFakeMailboxApp(store, "eve@example.com");
+		const res = await app.fetch("/mailboxes/alice@example.com/test");
+		expect(res.status).toBe(403);
+	});
+
+	it("allows access in dev mode (no callerEmail) regardless of ACL", async () => {
+		const store = {
+			[mailboxKey]: "{}",
+			[aclKey]: JSON.stringify(aliceAcl),
+		};
+		const app = makeFakeMailboxApp(store, null);
+		const res = await app.fetch("/mailboxes/alice@example.com/test");
+		expect(res.status).toBe(200);
+	});
+
+	it("ACL comparison is case-insensitive", async () => {
+		const store = {
+			[mailboxKey]: "{}",
+			[aclKey]: JSON.stringify(aliceAcl),
+		};
+		const app = makeFakeMailboxApp(store, "ALICE@EXAMPLE.COM");
+		const res = await app.fetch("/mailboxes/alice@example.com/test");
+		expect(res.status).toBe(200);
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -65,6 +65,7 @@ import { listTextModels } from "./lib/text-models";
 import { fetchHubCorroborationCount } from "./intel/hub-corroboration";
 import { loadHubCredentials } from "./lib/hub-config";
 import { aggregateOrgSearch, type PerMailboxSearchResult } from "./lib/org-search";
+import { readMailboxAcl, writeMailboxAcl, deleteMailboxAcl, callerInAcl } from "./lib/mailbox-acl";
 
 type AppContext = Context<MailboxContext>;
 
@@ -239,8 +240,18 @@ app.get("/api/v1/ai/text-models", async (c) => {
 // -- Mailboxes ------------------------------------------------------
 
 app.get("/api/v1/mailboxes", async (c) => {
+	const callerEmail = c.req.header("cf-access-authenticated-user-email") ?? null;
 	const allMailboxes = await listMailboxes(c.env.BUCKET);
-	return c.json(allMailboxes.map((m) => ({ ...m, name: m.id })));
+
+	// In dev mode or on pre-#27 single-user deploys (no callerEmail) show all.
+	if (!callerEmail) {
+		return c.json(allMailboxes.map((m) => ({ ...m, name: m.id })));
+	}
+
+	// Filter to mailboxes the caller is allowed to see (#27).
+	const acls = await Promise.all(allMailboxes.map((m) => readMailboxAcl(c.env, m.id)));
+	const visible = allMailboxes.filter((_, i) => callerInAcl(acls[i], callerEmail));
+	return c.json(visible.map((m) => ({ ...m, name: m.id })));
 });
 
 // -- Org overview ---------------------------------------------------
@@ -709,6 +720,16 @@ app.post("/api/v1/mailboxes", async (c) => {
 	const cleanedSettings = stripDefaultEqual((settings ?? {}) as MailboxSettings);
 	const finalSettings = { ...defaultSettings, ...cleanedSettings };
 	await c.env.BUCKET.put(key, JSON.stringify(finalSettings));
+
+	// Bootstrap owner ACL (#27). Skipped when callerEmail is absent (dev
+	// mode / no Access) — those deploys get the backwards-compat "anyone
+	// past Access can see all mailboxes" behaviour.
+	const creatorEmail = c.req.header("cf-access-authenticated-user-email");
+	if (creatorEmail) {
+		const owner = creatorEmail.toLowerCase();
+		await writeMailboxAcl(c.env, email, { owner, members: [owner] });
+	}
+
 	const stub = c.env.MAILBOX.get(c.env.MAILBOX.idFromName(email));
 	await stub.getFolders();
 	return c.json({ id: email, email, name, settings: finalSettings }, 201);
@@ -877,6 +898,13 @@ async function reapMailbox(env: Env, mailboxId: string): Promise<void> {
 	);
 	await (agentStub as any).reset().catch(
 		(e: Error) => console.error(`reapMailbox(${mailboxId}): agent DO reset failed:`, e.message),
+	);
+
+	// 4. Delete ACL blob (#27). Best-effort — an orphaned ACL is harmless
+	//    because the settings JSON is already gone, so the mailbox can never
+	//    be found via list/get again.
+	await deleteMailboxAcl(env, mailboxId).catch(
+		(e: Error) => console.error(`reapMailbox(${mailboxId}): ACL delete failed:`, e.message),
 	);
 }
 

--- a/workers/lib/mailbox-acl.ts
+++ b/workers/lib/mailbox-acl.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Per-mailbox access-control list (#27).
+ *
+ * ACLs are stored at R2 key `mailboxes-acl/<mailboxId>.json` — separate
+ * from the settings blob at `mailboxes/<mailboxId>.json` so a settings PUT
+ * never clobbers them, and the existing `listMailboxes` prefix scan over
+ * `mailboxes/` doesn't pick them up.
+ *
+ * Backwards-compat invariant: when no ACL blob exists (pre-#27 mailboxes or
+ * single-user deploys without CF Access in front), `callerInAcl` returns
+ * true — anyone admitted by the global CF Access policy retains full access.
+ */
+
+export interface MailboxAcl {
+	/** Email of the user who created the mailbox (lower-cased). */
+	owner: string;
+	/** All emails permitted to access the mailbox (always includes owner). */
+	members: string[];
+}
+
+function aclKey(mailboxId: string): string {
+	return `mailboxes-acl/${mailboxId}.json`;
+}
+
+export async function readMailboxAcl(
+	env: { BUCKET: R2Bucket },
+	mailboxId: string,
+): Promise<MailboxAcl | null> {
+	const obj = await env.BUCKET.get(aclKey(mailboxId));
+	if (!obj) return null;
+	try {
+		return await obj.json<MailboxAcl>();
+	} catch {
+		return null;
+	}
+}
+
+export async function writeMailboxAcl(
+	env: { BUCKET: R2Bucket },
+	mailboxId: string,
+	acl: MailboxAcl,
+): Promise<void> {
+	await env.BUCKET.put(aclKey(mailboxId), JSON.stringify(acl));
+}
+
+export async function deleteMailboxAcl(
+	env: { BUCKET: R2Bucket },
+	mailboxId: string,
+): Promise<void> {
+	await env.BUCKET.delete(aclKey(mailboxId));
+}
+
+/**
+ * Returns true when `callerEmail` should be granted access to the mailbox.
+ *
+ * - `acl === null`: no ACL written yet → allow anyone (backwards-compat for
+ *   pre-#27 mailboxes and single-user deploys).
+ * - `callerEmail` falsy: CF Access not in front (local dev) → allow.
+ * - Otherwise: caller must appear in `acl.members` (case-insensitive).
+ */
+export function callerInAcl(
+	acl: MailboxAcl | null,
+	callerEmail: string | null | undefined,
+): boolean {
+	if (acl === null) return true;
+	if (!callerEmail) return true;
+	const lower = callerEmail.toLowerCase();
+	return acl.members.some((m) => m.toLowerCase() === lower);
+}

--- a/workers/lib/mailbox.ts
+++ b/workers/lib/mailbox.ts
@@ -10,6 +10,7 @@
 import { createMiddleware } from "hono/factory";
 import type { MailboxDO } from "../durableObject";
 import type { Env } from "../types";
+import { readMailboxAcl, callerInAcl } from "./mailbox-acl";
 
 export type MailboxContext = {
 	Bindings: Env;
@@ -23,19 +24,22 @@ export const requireMailbox = createMiddleware<MailboxContext>(async (c, next) =
 	if (!rawId) return c.json({ error: "Mailbox ID required" }, 400);
 	const mailboxId = decodeURIComponent(rawId);
 
-	// Verify mailbox exists
+	const callerEmail = c.req.header("cf-access-authenticated-user-email") ?? null;
 	const key = `mailboxes/${mailboxId}.json`;
-	const obj = await c.env.BUCKET.head(key);
-	if (!obj) {
-		return c.json({ error: "Not found" }, 404);
-	}
 
-	// Instantiate DO stub
+	// Parallel: existence check + ACL read (#27)
+	const [obj, acl] = await Promise.all([
+		c.env.BUCKET.head(key),
+		readMailboxAcl(c.env, mailboxId),
+	]);
+
+	if (!obj) return c.json({ error: "Not found" }, 404);
+	if (!callerInAcl(acl, callerEmail)) return c.json({ error: "Forbidden" }, 403);
+
 	const ns = c.env.MAILBOX;
 	const id = ns.idFromName(mailboxId);
 	const stub = ns.get(id);
 
 	c.set("mailboxStub", stub);
-	
 	await next();
 });

--- a/workers/mcp/index.ts
+++ b/workers/mcp/index.ts
@@ -22,6 +22,7 @@ import {
 } from "../lib/tools";
 import { Folders, FOLDER_TOOL_DESCRIPTION, MOVE_FOLDER_TOOL_DESCRIPTION } from "../../shared/folders";
 import type { Env } from "../types";
+import { readMailboxAcl, callerInAcl } from "../lib/mailbox-acl";
 
 /** Wrap a plain result object into MCP content format. */
 function mcpText(result: unknown) {
@@ -67,17 +68,33 @@ export class EmailMCP extends McpAgent<Env> {
 		version: "1.0.0",
 	});
 
+	// Caller email from the CF Access header on the initial connection
+	// request. Each McpAgent DO instance handles exactly one session so
+	// this instance field is safe to use across tool calls (#27).
+	#callerEmail: string | null = null;
+
+	async fetch(request: Request): Promise<Response> {
+		this.#callerEmail = request.headers.get("cf-access-authenticated-user-email");
+		return super.fetch(request);
+	}
+
 	async init() {
 		const env = this.env;
 
 		/**
-		 * Verify a mailbox exists in R2 before operating on it.
-		 * Returns an MCP error response if the mailbox is not found, or null if valid.
+		 * Verify a mailbox exists and the caller is permitted to access it (#27).
+		 * Returns an MCP error response on not-found or forbidden, null if valid.
 		 */
 		const verifyMailbox = async (mailboxId: string) => {
-			const obj = await env.BUCKET.head(`mailboxes/${mailboxId}.json`);
+			const [obj, acl] = await Promise.all([
+				env.BUCKET.head(`mailboxes/${mailboxId}.json`),
+				readMailboxAcl(env, mailboxId),
+			]);
 			if (!obj) {
 				return mcpError(`Mailbox "${mailboxId}" not found. Use list_mailboxes to see available mailboxes.`);
+			}
+			if (!callerInAcl(acl, this.#callerEmail)) {
+				return mcpError(`Access denied for mailbox "${mailboxId}".`);
 			}
 			return null;
 		};
@@ -85,11 +102,19 @@ export class EmailMCP extends McpAgent<Env> {
 		// ── list_mailboxes ─────────────────────────────────────────
 		this.server.tool(
 			"list_mailboxes",
-			"List all available mailboxes",
+			"List available mailboxes",
 			{},
 			async () => {
-				const result = await toolListMailboxes(env);
-				return mcpText(result);
+				const all = await toolListMailboxes(env);
+				const callerEmail = this.#callerEmail;
+				if (!callerEmail) return mcpText(all);
+				const acls = await Promise.all(
+					(all as Array<{ id: string }>).map((m) => readMailboxAcl(env, m.id)),
+				);
+				const filtered = (all as Array<{ id: string }>).filter((_, i) =>
+					callerInAcl(acls[i], callerEmail),
+				);
+				return mcpText(filtered);
 			},
 		);
 


### PR DESCRIPTION
## Summary

- Adds per-mailbox access-control lists so users on the same CF Access policy see only the mailboxes they own, and MCP tool calls targeting another user's mailbox are rejected with a clear error.
- ACL is stored at `mailboxes-acl/<mailboxId>.json` (separate from the settings blob so settings PUTs never clobber it, and the `listMailboxes` prefix scan never picks it up).
- Full backwards compatibility: when no ACL blob exists (pre-#27 mailboxes, single-user deploys) everyone admitted by the global CF Access policy retains access unchanged.

## What changed

| File | Change |
|---|---|
| `workers/lib/mailbox-acl.ts` | **New** — `MailboxAcl` type, `readMailboxAcl`, `writeMailboxAcl`, `deleteMailboxAcl`, `callerInAcl` |
| `workers/lib/mailbox.ts` | `requireMailbox` reads ACL in parallel with the existence check; returns 403 when caller not in `acl.members` |
| `workers/index.ts` | `POST /api/v1/mailboxes` writes owner ACL; `GET /api/v1/mailboxes` filters by ACL; `reapMailbox` deletes the ACL blob |
| `workers/mcp/index.ts` | `EmailMCP` captures `cf-access-authenticated-user-email` on `fetch`; `verifyMailbox` and `list_mailboxes` apply the same gate |
| `tests/lib/mailbox-acl.test.ts` | **New** — 16 tests covering `callerInAcl`, R2 helpers, and middleware (404 / 403 / 200 cases) |

## Acceptance coverage

- [x] Two Access users can each create mailboxes and not see each other's (`GET /api/v1/mailboxes` now filters; `POST` bootstraps owner ACL)
- [x] MCP calls with the wrong JWT for a `mailboxId` get a "Access denied" error (`verifyMailbox` checks ACL; `list_mailboxes` filters)

## MCP auth model

Option **(a)** from the issue: the CF Access email header (`cf-access-authenticated-user-email`) is captured on the initial WebSocket upgrade request and stored as an instance field on the `EmailMCP` Durable Object. Each `McpAgent` DO instance handles exactly one session, so the field is safe to use across tool calls.

## Deferred (not in Acceptance)

- **Member add/remove API** — follow-up: #240
- **One-time migration prompt** for existing single-user deploys — follow-up: #241. The backwards-compat fallback (`null ACL → allow all`) handles correctness in the interim.

## Test plan

- [x] `npm test` — 913 passing, 0 failing (16 new)
- [x] `npm run typecheck` — clean
- [ ] End-to-end: create two mailboxes as two different CF Access users; verify each user sees only their own in the mailbox list and gets 403 on the other's routes

Closes #27

https://claude.ai/code/session_0133nnKX6EQd16fpPczd11NE