### PR TITLE
feat: mailbox ACL member management API (add/remove members)

### DIFF
--- a/tests/routes/acl-members.test.ts
+++ b/tests/routes/acl-members.test.ts
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Route-level tests for `workers/routes/acl-members.ts` (#240).
+ *
+ * Covers all acceptance cases using an in-memory R2 stub (same pattern as
+ * `tests/lib/mailbox-acl.test.ts`). `requireMailbox` is NOT mocked — the
+ * inline app wires it up with a real bucket stub so both the middleware ACL
+ * check and the route-level owner check are exercised end-to-end.
+ */
+
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { requireMailbox, type MailboxContext } from "../../workers/lib/mailbox";
+import { aclMemberRoutes } from "../../workers/routes/acl-members";
+import type { MailboxAcl } from "../../workers/lib/mailbox-acl";
+
+// ---------------------------------------------------------------------------
+// Shared in-memory R2 stub (mirrors makeFullR2Stub from mailbox-acl.test.ts)
+// ---------------------------------------------------------------------------
+
+function makeR2Stub(initial: Record<string, string> = {}) {
+	const store = { ...initial };
+	return {
+		async head(key: string) {
+			return store[key] !== undefined ? { key } : null;
+		},
+		async get(key: string) {
+			const val = store[key];
+			if (!val) return null;
+			return { json: async <T>() => JSON.parse(val) as T };
+		},
+		async put(key: string, value: string) {
+			store[key] = value;
+		},
+		async delete(key: string) {
+			delete store[key];
+		},
+		_store: store,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Test app factory
+// ---------------------------------------------------------------------------
+
+function makeApp(bucketStore: Record<string, string>, callerEmail: string | null) {
+	const bucket = makeR2Stub(bucketStore);
+	const MAILBOX = {
+		idFromName: (_: string) => "fake-id",
+		get: (_: unknown) => ({}),
+	};
+
+	const app = new Hono<MailboxContext>();
+	// Wire the same middleware chain the production app uses.
+	app.use("/api/v1/mailboxes/:mailboxId/*", requireMailbox as Parameters<typeof app.use>[1]);
+	app.route("/api/v1/mailboxes/:mailboxId/acl", aclMemberRoutes);
+
+	return {
+		fetch(path: string, options?: RequestInit) {
+			const hdrs: Record<string, string> = {};
+			if (callerEmail) hdrs["cf-access-authenticated-user-email"] = callerEmail;
+			if (options?.headers) Object.assign(hdrs, options.headers as Record<string, string>);
+			return app.request(
+				path,
+				{ ...options, headers: hdrs },
+				{
+					BUCKET: bucket as unknown as R2Bucket,
+					MAILBOX: MAILBOX as unknown as DurableObjectNamespace,
+				},
+			);
+		},
+		bucket,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const mailboxId = "alice@example.com";
+const mailboxKey = `mailboxes/${mailboxId}.json`;
+const aclKey = `mailboxes-acl/${mailboxId}.json`;
+
+function storeWithAcl(acl: MailboxAcl): Record<string, string> {
+	return {
+		[mailboxKey]: "{}",
+		[aclKey]: JSON.stringify(acl),
+	};
+}
+
+const aliceOnlyAcl: MailboxAcl = {
+	owner: "alice@example.com",
+	members: ["alice@example.com"],
+};
+
+const aliceAndBobAcl: MailboxAcl = {
+	owner: "alice@example.com",
+	members: ["alice@example.com", "bob@example.com"],
+};
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/mailboxes/:mailboxId/acl/members
+// ---------------------------------------------------------------------------
+
+describe("POST /acl/members — add member", () => {
+	it("owner adds a new member → 200 with updated ACL", async () => {
+		const { fetch, bucket } = makeApp(storeWithAcl(aliceOnlyAcl), "alice@example.com");
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl/members`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "bob@example.com" }),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json() as MailboxAcl;
+		expect(body.owner).toBe("alice@example.com");
+		expect(body.members).toContain("bob@example.com");
+		// Persisted to R2
+		const stored = JSON.parse(bucket._store[aclKey]) as MailboxAcl;
+		expect(stored.members).toContain("bob@example.com");
+	});
+
+	it("idempotent: POST with already-present email → 200, no duplicate in members", async () => {
+		const { fetch, bucket } = makeApp(storeWithAcl(aliceAndBobAcl), "alice@example.com");
+		const before = bucket._store[aclKey];
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl/members`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "bob@example.com" }),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json() as MailboxAcl;
+		const bobCount = body.members.filter((m) => m === "bob@example.com").length;
+		expect(bobCount).toBe(1);
+		// R2 was not written (no change)
+		expect(bucket._store[aclKey]).toBe(before);
+	});
+
+	it("non-owner admitted caller → 403", async () => {
+		// Bob is in members (requireMailbox passes) but is not the owner.
+		const { fetch } = makeApp(storeWithAcl(aliceAndBobAcl), "bob@example.com");
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl/members`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "carol@example.com" }),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it("email input is normalised to lower-case before writing", async () => {
+		const { fetch, bucket } = makeApp(storeWithAcl(aliceOnlyAcl), "alice@example.com");
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl/members`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "BOB@EXAMPLE.COM" }),
+		});
+		expect(res.status).toBe(200);
+		const stored = JSON.parse(bucket._store[aclKey]) as MailboxAcl;
+		expect(stored.members).toContain("bob@example.com");
+		expect(stored.members).not.toContain("BOB@EXAMPLE.COM");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/mailboxes/:mailboxId/acl/members/:memberEmail
+// ---------------------------------------------------------------------------
+
+describe("DELETE /acl/members/:memberEmail — remove member", () => {
+	it("owner removes an existing member → 200 with updated ACL", async () => {
+		const { fetch, bucket } = makeApp(storeWithAcl(aliceAndBobAcl), "alice@example.com");
+		const res = await fetch(
+			`/api/v1/mailboxes/${mailboxId}/acl/members/bob@example.com`,
+			{ method: "DELETE" },
+		);
+		expect(res.status).toBe(200);
+		const body = await res.json() as MailboxAcl;
+		expect(body.members).not.toContain("bob@example.com");
+		// Persisted to R2
+		const stored = JSON.parse(bucket._store[aclKey]) as MailboxAcl;
+		expect(stored.members).not.toContain("bob@example.com");
+	});
+
+	it("DELETE on owner's own email → 400", async () => {
+		const { fetch } = makeApp(storeWithAcl(aliceOnlyAcl), "alice@example.com");
+		const res = await fetch(
+			`/api/v1/mailboxes/${mailboxId}/acl/members/alice@example.com`,
+			{ method: "DELETE" },
+		);
+		expect(res.status).toBe(400);
+		const body = await res.json() as { error: string };
+		expect(body.error).toBeTruthy();
+	});
+
+	it("non-owner admitted caller → 403", async () => {
+		// Bob is in members (requireMailbox passes) but is not the owner.
+		const { fetch } = makeApp(storeWithAcl(aliceAndBobAcl), "bob@example.com");
+		const res = await fetch(
+			`/api/v1/mailboxes/${mailboxId}/acl/members/bob@example.com`,
+			{ method: "DELETE" },
+		);
+		expect(res.status).toBe(403);
+	});
+
+	it("email path param is URL-decoded and normalised to lower-case", async () => {
+		const { fetch, bucket } = makeApp(storeWithAcl(aliceAndBobAcl), "alice@example.com");
+		// Percent-encoded uppercase email in the path
+		const encoded = encodeURIComponent("BOB@EXAMPLE.COM");
+		const res = await fetch(
+			`/api/v1/mailboxes/${mailboxId}/acl/members/${encoded}`,
+			{ method: "DELETE" },
+		);
+		expect(res.status).toBe(200);
+		const stored = JSON.parse(bucket._store[aclKey]) as MailboxAcl;
+		expect(stored.members).not.toContain("bob@example.com");
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -66,6 +66,7 @@ import { fetchHubCorroborationCount } from "./intel/hub-corroboration";
 import { loadHubCredentials } from "./lib/hub-config";
 import { aggregateOrgSearch, type PerMailboxSearchResult } from "./lib/org-search";
 import { readMailboxAcl, writeMailboxAcl, deleteMailboxAcl, callerInAcl } from "./lib/mailbox-acl";
+import { aclMemberRoutes } from "./routes/acl-members";
 
 type AppContext = Context<MailboxContext>;
 
@@ -131,6 +132,7 @@ app.use("/api/v1/mailboxes/:mailboxId/*", requireMailbox);
 
 // -- Config ---------------------------------------------------------
 
+app.route("/api/v1/mailboxes/:mailboxId/acl", aclMemberRoutes);
 app.route("/api/v1/mailboxes/:mailboxId/dmarc", dmarcRoutes);
 app.route("/api/v1/mailboxes/:mailboxId/tlsrpt", tlsrptRoutes);
 app.route("/api/v1/mailboxes/:mailboxId/cases", caseRoutes);

--- a/workers/routes/acl-members.ts
+++ b/workers/routes/acl-members.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * ACL member management endpoints (#240). Mounted under
+ * `/api/v1/mailboxes/:mailboxId/acl`.
+ *
+ * Only the mailbox owner (the email stored in `acl.owner`) may call these
+ * write endpoints. A caller admitted by CF Access but not the owner receives
+ * 403. The ACL blob is not a settings tier; `stripDefaultEqual` is not used.
+ */
+
+import { Hono } from "hono";
+import { requireMailbox, type MailboxContext } from "../lib/mailbox";
+import { readMailboxAcl, writeMailboxAcl } from "../lib/mailbox-acl";
+
+export const aclMemberRoutes = new Hono<MailboxContext>();
+
+aclMemberRoutes.use("*", requireMailbox);
+
+/** Add a member to the mailbox ACL. Idempotent if the email is already present. */
+aclMemberRoutes.post("/members", async (c) => {
+	const mailboxId = c.req.param("mailboxId")!;
+	const callerEmail =
+		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+
+	const acl = await readMailboxAcl(c.env, mailboxId);
+	if (!acl || callerEmail !== acl.owner) {
+		return c.json({ error: "Forbidden" }, 403);
+	}
+
+	const body = (await c.req.json().catch(() => ({}))) as { email?: unknown };
+	const rawEmail = typeof body.email === "string" ? body.email.trim() : "";
+	if (!rawEmail) return c.json({ error: "Email required" }, 400);
+
+	const memberEmail = rawEmail.toLowerCase();
+	if (acl.members.includes(memberEmail)) {
+		return c.json({ owner: acl.owner, members: acl.members });
+	}
+
+	const updated = { owner: acl.owner, members: [...acl.members, memberEmail] };
+	await writeMailboxAcl(c.env, mailboxId, updated);
+	return c.json({ owner: updated.owner, members: updated.members });
+});
+
+/** Remove a member from the mailbox ACL. The owner cannot remove themselves. */
+aclMemberRoutes.delete("/members/:memberEmail", async (c) => {
+	const mailboxId = c.req.param("mailboxId")!;
+	const callerEmail =
+		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+	const memberEmail = decodeURIComponent(c.req.param("memberEmail")!).toLowerCase();
+
+	const acl = await readMailboxAcl(c.env, mailboxId);
+	if (!acl || callerEmail !== acl.owner) {
+		return c.json({ error: "Forbidden" }, 403);
+	}
+
+	if (memberEmail === acl.owner) {
+		return c.json({ error: "Cannot remove the mailbox owner" }, 400);
+	}
+
+	const updated = {
+		owner: acl.owner,
+		members: acl.members.filter((m) => m !== memberEmail),
+	};
+	await writeMailboxAcl(c.env, mailboxId, updated);
+	return c.json({ owner: updated.owner, members: updated.members });
+});


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/mailboxes/:id/acl/members` — owner adds a member to the per-mailbox ACL (idempotent, email lowercased)
- Adds `DELETE /api/v1/mailboxes/:id/acl/members/:email` — owner removes a member; 400 if attempting to remove the owner themselves
- Both endpoints enforce owner-only access: callers admitted by CF Access but not the `acl.owner` receive 403

## Implementation notes

New route file `workers/routes/acl-members.ts` mounted at `/api/v1/mailboxes/:mailboxId/acl` (same pattern as `caseRoutes`, `dmarcRoutes`, etc.). The ACL blob is not a settings tier so `stripDefaultEqual` is intentionally not used.

## Test plan

- [x] `POST /acl/members` as owner adds new member, returns `{ owner, members }` 200
- [x] `POST /acl/members` with already-present email → idempotent 200, no duplicate
- [x] `POST /acl/members` as non-owner admitted caller → 403
- [x] Email input normalised to lower-case before writing
- [x] `DELETE /acl/members/:email` as owner removes member, returns updated ACL 200
- [x] `DELETE /acl/members/:email` targeting owner's own email → 400
- [x] `DELETE /acl/members/:email` as non-owner admitted caller → 403
- [x] URL-encoded + uppercase path param decoded and lowercased correctly
- [x] 921 tests passing, 0 failing; typecheck clean

Closes #240
Part of #27

Deferred follow-ups: none
Spec follow-up needed: no (UX/API addition, no existing SECURITY_SPEC.md invariant changed)

https://claude.ai/code/session_01PLgJgqSgU5ZE4rZX2jQG7P

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLgJgqSgU5ZE4rZX2jQG7P)_