### PR TITLE
feat: acl_status on mailbox list + one-time lock-down endpoint (#241)

### DIFF
--- a/app/queries/mailboxes.ts
+++ b/app/queries/mailboxes.ts
@@ -59,3 +59,13 @@ export function useDeleteMailbox() {
 		},
 	});
 }
+
+export function useLockDownMailbox() {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (mailboxId: string) => api.lockDownMailbox(mailboxId),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: queryKeys.mailboxes.all });
+		},
+	});
+}

--- a/app/routes/mailboxes.tsx
+++ b/app/routes/mailboxes.tsx
@@ -12,7 +12,7 @@ import {
 } from "@cloudflare/kumo";
 import { EnvelopeIcon, PlusIcon, TrashIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
-import { type FormEvent, useEffect, useState } from "react";
+import { type FormEvent, type MouseEvent, useEffect, useState } from "react";
 import { Link as RouterLink } from "react-router";
 import Shell from "~/components/phishsoc/Shell";
 import { useAutoProvisionMailboxes } from "~/hooks/useAutoProvisionMailboxes";
@@ -21,6 +21,7 @@ import api from "~/services/api";
 import {
 	useCreateMailbox,
 	useDeleteMailbox,
+	useLockDownMailbox,
 	useMailboxes,
 } from "~/queries/mailboxes";
 import { queryKeys } from "~/queries/keys";
@@ -34,6 +35,7 @@ export default function MailboxesRoute() {
 	const { data: mailboxes = [] } = useMailboxes();
 	const createMailbox = useCreateMailbox();
 	const deleteMailbox = useDeleteMailbox();
+	const lockDownMailbox = useLockDownMailbox();
 
 	useAutoProvisionMailboxes();
 
@@ -113,6 +115,19 @@ export default function MailboxesRoute() {
 			}))
 		: mailboxes;
 
+	const mailboxAclStatusMap = new Map(mailboxes.map((m) => [m.id, m.acl_status]));
+
+	const handleLockDown = async (mailboxId: string, e: MouseEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		try {
+			await lockDownMailbox.mutateAsync(mailboxId);
+			feedback.success("Mailbox locked down successfully");
+		} catch {
+			feedback.error("Failed to lock down mailbox");
+		}
+	};
+
 	const isLoading = !configData;
 
 	return (
@@ -163,6 +178,24 @@ export default function MailboxesRoute() {
 										{account.email}
 									</div>
 								</div>
+								{mailboxAclStatusMap.get(account.id) === "unscoped" && (
+									<>
+										<span className="shrink-0 inline-flex items-center rounded px-1.5 py-0.5 text-[10.5px] font-medium bg-amber-50 text-amber-700 border border-amber-200">
+											Unscoped
+										</span>
+										<Button
+											variant="ghost"
+											size="sm"
+											loading={
+												lockDownMailbox.isPending &&
+												lockDownMailbox.variables === account.id
+											}
+											onClick={(e) => handleLockDown(account.id, e)}
+										>
+											Lock down
+										</Button>
+									</>
+								)}
 								{!isConfigured && (
 									<Button
 										variant="ghost"

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -128,6 +128,8 @@ const api = {
 		put<Mailbox>(`/api/v1/mailboxes/${mailboxId}`, { settings }),
 	deleteMailbox: (mailboxId: string) =>
 		del<void>(`/api/v1/mailboxes/${mailboxId}`),
+	lockDownMailbox: (mailboxId: string) =>
+		post<{ owner: string; members: string[] }>(`/api/v1/mailboxes/${mailboxId}/acl`),
 	// Org-level settings (#106). Backed by R2 key org/settings.json behind a
 	// module-scope ETag cache; the GET returns the raw blob (or {} if missing),
 	// PUT validates through the OrgSettings Zod schema worker-side.

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -111,6 +111,7 @@ export interface Mailbox {
 	email: string;
 	name: string;
 	settings?: MailboxSettings;
+	acl_status?: "scoped" | "unscoped";
 }
 
 export interface Email {

--- a/tests/routes/mailboxes-acl-status.test.ts
+++ b/tests/routes/mailboxes-acl-status.test.ts
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Tests for issue #241: acl_status field on GET /api/v1/mailboxes and
+ * the POST /api/v1/mailboxes/:id/acl lock-down endpoint.
+ *
+ * Uses in-memory R2 stubs and minimal Hono apps — same pattern as
+ * tests/routes/acl-members.test.ts.
+ */
+
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { requireMailbox, type MailboxContext } from "../../workers/lib/mailbox";
+import { aclMemberRoutes } from "../../workers/routes/acl-members";
+import { readMailboxAcl, callerInAcl } from "../../workers/lib/mailbox-acl";
+import { listMailboxes } from "../../workers/lib/email-helpers";
+import type { MailboxAcl } from "../../workers/lib/mailbox-acl";
+
+// ---------------------------------------------------------------------------
+// In-memory R2 stub (supports head / get / put / delete / list)
+// ---------------------------------------------------------------------------
+
+function makeR2Stub(initial: Record<string, string> = {}) {
+	const store = { ...initial };
+	return {
+		async head(key: string) {
+			return store[key] !== undefined ? { key } : null;
+		},
+		async get(key: string) {
+			const val = store[key];
+			if (!val) return null;
+			return { json: async <T>() => JSON.parse(val) as T };
+		},
+		async put(key: string, value: string) {
+			store[key] = value;
+		},
+		async delete(key: string) {
+			delete store[key];
+		},
+		async list({ prefix }: { prefix: string }) {
+			const objects = Object.keys(store)
+				.filter((k) => k.startsWith(prefix))
+				.map((key) => ({ key }));
+			return { objects };
+		},
+		_store: store,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Minimal list-endpoint app (replicates GET /api/v1/mailboxes from index.ts)
+// ---------------------------------------------------------------------------
+
+function makeListApp(bucketStore: Record<string, string>, callerEmail: string | null) {
+	const bucket = makeR2Stub(bucketStore);
+	const MAILBOX = { idFromName: () => "fake-id", get: () => ({}) };
+
+	const app = new Hono<{ Bindings: { BUCKET: typeof bucket; MAILBOX: typeof MAILBOX } }>();
+
+	app.get("/api/v1/mailboxes", async (c) => {
+		const caller = callerEmail;
+		const allMailboxes = await listMailboxes(c.env.BUCKET as unknown as R2Bucket);
+		const acls = await Promise.all(
+			allMailboxes.map((m) => readMailboxAcl(c.env as unknown as { BUCKET: R2Bucket }, m.id)),
+		);
+
+		if (!caller) {
+			return c.json(
+				allMailboxes.map((m, i) => ({
+					...m,
+					name: m.id,
+					acl_status: acls[i] ? "scoped" : "unscoped",
+				})),
+			);
+		}
+
+		const visible = allMailboxes
+			.map((m, i) => ({ mailbox: m, acl: acls[i] }))
+			.filter(({ acl }) => callerInAcl(acl, caller));
+
+		return c.json(
+			visible.map(({ mailbox, acl }) => ({
+				...mailbox,
+				name: mailbox.id,
+				acl_status: acl ? "scoped" : "unscoped",
+			})),
+		);
+	});
+
+	return {
+		fetch() {
+			return app.request(
+				"/api/v1/mailboxes",
+				{},
+				{
+					BUCKET: bucket as unknown as R2Bucket,
+					MAILBOX: MAILBOX as unknown as DurableObjectNamespace,
+				},
+			);
+		},
+		bucket,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Lock-down endpoint app
+// ---------------------------------------------------------------------------
+
+function makeLockDownApp(bucketStore: Record<string, string>, callerEmail: string | null) {
+	const bucket = makeR2Stub(bucketStore);
+	const MAILBOX = { idFromName: () => "fake-id", get: () => ({}) };
+
+	const app = new Hono<MailboxContext>();
+	app.use("/api/v1/mailboxes/:mailboxId/*", requireMailbox as Parameters<typeof app.use>[1]);
+	app.route("/api/v1/mailboxes/:mailboxId/acl", aclMemberRoutes);
+
+	return {
+		post(mailboxId: string) {
+			const hdrs: Record<string, string> = {};
+			if (callerEmail) hdrs["cf-access-authenticated-user-email"] = callerEmail;
+			return app.request(
+				`/api/v1/mailboxes/${mailboxId}/acl`,
+				{ method: "POST", headers: hdrs },
+				{
+					BUCKET: bucket as unknown as R2Bucket,
+					MAILBOX: MAILBOX as unknown as DurableObjectNamespace,
+				},
+			);
+		},
+		bucket,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mailboxId = "alice@example.com";
+const mailboxKey = `mailboxes/${mailboxId}.json`;
+const aclKey = `mailboxes-acl/${mailboxId}.json`;
+
+const scopedAcl: MailboxAcl = {
+	owner: "alice@example.com",
+	members: ["alice@example.com"],
+};
+
+// ---------------------------------------------------------------------------
+// acl_status on GET /api/v1/mailboxes
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/mailboxes — acl_status field", () => {
+	it("returns acl_status: unscoped for a mailbox with no ACL blob", async () => {
+		const { fetch } = makeListApp({ [mailboxKey]: "{}" }, null);
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as Array<{ id: string; acl_status: string }>;
+		const mailbox = body.find((m) => m.id === mailboxId);
+		expect(mailbox).toBeDefined();
+		expect(mailbox?.acl_status).toBe("unscoped");
+	});
+
+	it("returns acl_status: scoped for a mailbox that has an ACL blob", async () => {
+		const { fetch } = makeListApp(
+			{ [mailboxKey]: "{}", [aclKey]: JSON.stringify(scopedAcl) },
+			null,
+		);
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as Array<{ id: string; acl_status: string }>;
+		const mailbox = body.find((m) => m.id === mailboxId);
+		expect(mailbox?.acl_status).toBe("scoped");
+	});
+
+	it("includes acl_status when callerEmail is set and filters by ACL", async () => {
+		const secondId = "bob@example.com";
+		const secondKey = `mailboxes/${secondId}.json`;
+		const secondAclKey = `mailboxes-acl/${secondId}.json`;
+		// alice has an ACL (visible to alice); bob has no ACL (visible to everyone)
+		const store = {
+			[mailboxKey]: "{}",
+			[aclKey]: JSON.stringify(scopedAcl),
+			[secondKey]: "{}",
+			// no ACL for bob's mailbox → unscoped, visible to anyone
+		};
+		const { fetch } = makeListApp(store, "alice@example.com");
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as Array<{ id: string; acl_status: string }>;
+		const aliceMailbox = body.find((m) => m.id === mailboxId);
+		const bobMailbox = body.find((m) => m.id === secondId);
+		expect(aliceMailbox?.acl_status).toBe("scoped");
+		expect(bobMailbox?.acl_status).toBe("unscoped");
+
+		// suppress unused import warning
+		void secondAclKey;
+	});
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/mailboxes/:id/acl — lock-down endpoint
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/mailboxes/:id/acl — lock down", () => {
+	it("returns 201 and persists ACL with caller as owner for an unscoped mailbox", async () => {
+		const { post, bucket } = makeLockDownApp({ [mailboxKey]: "{}" }, "alice@example.com");
+		const res = await post(mailboxId);
+		expect(res.status).toBe(201);
+		const body = await res.json() as MailboxAcl;
+		expect(body.owner).toBe("alice@example.com");
+		expect(body.members).toContain("alice@example.com");
+		// ACL was actually written to the stub
+		const stored = JSON.parse(bucket._store[aclKey]) as MailboxAcl;
+		expect(stored.owner).toBe("alice@example.com");
+		expect(stored.members).toContain("alice@example.com");
+	});
+
+	it("returns 409 when the mailbox already has an ACL", async () => {
+		const store = { [mailboxKey]: "{}", [aclKey]: JSON.stringify(scopedAcl) };
+		const { post } = makeLockDownApp(store, "alice@example.com");
+		const res = await post(mailboxId);
+		expect(res.status).toBe(409);
+		const body = await res.json() as { error: string };
+		expect(body.error).toBeTruthy();
+	});
+
+	it("returns 400 when no CF Access email is present (dev mode)", async () => {
+		const { post } = makeLockDownApp({ [mailboxKey]: "{}" }, null);
+		const res = await post(mailboxId);
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 404 when the mailbox does not exist", async () => {
+		const { post } = makeLockDownApp({}, "alice@example.com");
+		const res = await post(mailboxId);
+		expect(res.status).toBe(404);
+	});
+
+	it("normalises caller email to lower-case in the persisted ACL", async () => {
+		const { post, bucket } = makeLockDownApp({ [mailboxKey]: "{}" }, "ALICE@EXAMPLE.COM");
+		const res = await post(mailboxId);
+		expect(res.status).toBe(201);
+		const stored = JSON.parse(bucket._store[aclKey]) as MailboxAcl;
+		expect(stored.owner).toBe("alice@example.com");
+		expect(stored.members).toContain("alice@example.com");
+	});
+
+	it("subsequent GET /api/v1/mailboxes shows acl_status: scoped after lock-down", async () => {
+		// Start unscoped
+		const store: Record<string, string> = { [mailboxKey]: "{}" };
+		const lockDown = makeLockDownApp(store, "alice@example.com");
+
+		// Lock it down
+		const lockRes = await lockDown.post(mailboxId);
+		expect(lockRes.status).toBe(201);
+
+		// Now query the list — the shared store now has the ACL blob
+		const { fetch } = makeListApp(lockDown.bucket._store, "alice@example.com");
+		const listRes = await fetch();
+		expect(listRes.status).toBe(200);
+		const body = await listRes.json() as Array<{ id: string; acl_status: string }>;
+		const mailbox = body.find((m) => m.id === mailboxId);
+		expect(mailbox?.acl_status).toBe("scoped");
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -245,15 +245,27 @@ app.get("/api/v1/mailboxes", async (c) => {
 	const callerEmail = c.req.header("cf-access-authenticated-user-email") ?? null;
 	const allMailboxes = await listMailboxes(c.env.BUCKET);
 
+	// Read ACLs for all mailboxes — needed for acl_status (#241) in both branches.
+	const acls = await Promise.all(allMailboxes.map((m) => readMailboxAcl(c.env, m.id)));
+
 	// In dev mode or on pre-#27 single-user deploys (no callerEmail) show all.
 	if (!callerEmail) {
-		return c.json(allMailboxes.map((m) => ({ ...m, name: m.id })));
+		return c.json(allMailboxes.map((m, i) => ({
+			...m,
+			name: m.id,
+			acl_status: acls[i] ? "scoped" : "unscoped",
+		})));
 	}
 
 	// Filter to mailboxes the caller is allowed to see (#27).
-	const acls = await Promise.all(allMailboxes.map((m) => readMailboxAcl(c.env, m.id)));
-	const visible = allMailboxes.filter((_, i) => callerInAcl(acls[i], callerEmail));
-	return c.json(visible.map((m) => ({ ...m, name: m.id })));
+	const visible = allMailboxes
+		.map((m, i) => ({ mailbox: m, acl: acls[i] }))
+		.filter(({ acl }) => callerInAcl(acl, callerEmail));
+	return c.json(visible.map(({ mailbox, acl }) => ({
+		...mailbox,
+		name: mailbox.id,
+		acl_status: acl ? "scoped" : "unscoped",
+	})));
 });
 
 // -- Org overview ---------------------------------------------------

--- a/workers/routes/acl-members.ts
+++ b/workers/routes/acl-members.ts
@@ -17,6 +17,30 @@ export const aclMemberRoutes = new Hono<MailboxContext>();
 
 aclMemberRoutes.use("*", requireMailbox);
 
+/**
+ * Lock down an unscoped (pre-#27) mailbox by creating its first ACL with the
+ * caller as owner (#241). Returns 201 on success, 409 if an ACL already exists,
+ * 400 when CF Access email is absent (dev mode).
+ */
+aclMemberRoutes.post("/", async (c) => {
+	const mailboxId = c.req.param("mailboxId")!;
+	const callerEmail =
+		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+
+	if (!callerEmail) {
+		return c.json({ error: "CF Access email required to lock down a mailbox" }, 400);
+	}
+
+	const existing = await readMailboxAcl(c.env, mailboxId);
+	if (existing) {
+		return c.json({ error: "Mailbox is already scoped" }, 409);
+	}
+
+	const acl = { owner: callerEmail, members: [callerEmail] };
+	await writeMailboxAcl(c.env, mailboxId, acl);
+	return c.json({ owner: acl.owner, members: acl.members }, 201);
+});
+
 /** Add a member to the mailbox ACL. Idempotent if the email is already present. */
 aclMemberRoutes.post("/members", async (c) => {
 	const mailboxId = c.req.param("mailboxId")!;


### PR DESCRIPTION
## Summary

- `GET /api/v1/mailboxes` now includes a per-mailbox `acl_status: "scoped" | "unscoped"` field indicating whether a `mailboxes-acl/<id>.json` blob exists in R2. Both the authenticated and dev-mode branches of the endpoint return this field.
- `POST /api/v1/mailboxes/:id/acl` (new endpoint) writes an ACL with the CF Access caller as owner, returning 201. Returns 409 when the mailbox is already scoped, 400 when no CF Access email is present (dev mode).
- Mailbox list UI (`/mailboxes`) shows an "Unscoped" badge and "Lock down" button for any mailbox with `acl_status === "unscoped"`. Once locked down, the list re-fetches and the badge/button disappear.

## Test plan

- [x] `GET /api/v1/mailboxes` returns `acl_status: "unscoped"` for mailboxes with no ACL blob
- [x] `GET /api/v1/mailboxes` returns `acl_status: "scoped"` for mailboxes with an ACL blob
- [x] `POST /api/v1/mailboxes/:id/acl` returns 201 and persists ACL with caller as owner
- [x] `POST /api/v1/mailboxes/:id/acl` returns 409 when ACL already exists
- [x] `POST /api/v1/mailboxes/:id/acl` returns 400 in dev mode (no CF Access email)
- [x] `POST /api/v1/mailboxes/:id/acl` returns 404 when mailbox does not exist
- [x] Caller email is normalised to lower-case in the persisted ACL
- [x] Subsequent `GET /api/v1/mailboxes` shows `acl_status: "scoped"` after lock-down
- [x] 9 new tests in `tests/routes/mailboxes-acl-status.test.ts`, all passing (930 total, 0 failing)
- [x] TypeScript typecheck clean

## Deferred follow-ups

None — all Acceptance items from #241 are shipped.

## Spec follow-up

No changes to `SECURITY_SPEC.md` — this is a UX/migration concern, not a security invariant change (per issue constraints).

Closes #241

https://claude.ai/code/session_012gh5MvpgPN1SS8oqyAkdTn

---
_Generated by [Claude Code](https://claude.ai/code/session_012gh5MvpgPN1SS8oqyAkdTn)_