### PR TITLE
test(tlsrpt): pin NXDOMAIN → unavailable-sentinel behaviour in posture tests

### DIFF
--- a/tests/tlsrpt/posture.test.ts
+++ b/tests/tlsrpt/posture.test.ts
@@ -210,6 +210,23 @@ describe("fetchTlsRptPosture", () => {
 		expect(r).toEqual({ configured: false, endpoints: [] });
 	});
 
+	it("treats DNS NXDOMAIN (Status 3, no Answer field) as the unavailable sentinel", async () => {
+		// Real NXDOMAIN from Cloudflare DoH returns Status:3 with no Answer key.
+		// This is distinct from Status:0 + empty Answer (NOERROR / no records),
+		// which we map to the durable-negative { configured: false }. NXDOMAIN
+		// signals the label itself doesn't exist — we treat that as transient
+		// unavailability rather than caching "no record" for an hour.
+		const fetchImpl = async (url: string) => {
+			expect(new URL(url).hostname).toBe("cloudflare-dns.com");
+			return new Response(
+				JSON.stringify({ Status: 3, TC: false, RD: true, RA: true }),
+				{ status: 200, headers: { "content-type": "application/dns-json" } },
+			);
+		};
+		const r = await fetchTlsRptPosture("acme.com", { fetchImpl });
+		expect(r).toEqual(emptyTlsRptPosture()); // configured: null
+	});
+
 	it("treats a TXT label with non-TLSRPT entries as 'no record'", async () => {
 		const fetchImpl = async () =>
 			dohTxtResponse(['"some other txt"', '"google-site-verification=abc"']);


### PR DESCRIPTION
## Summary

- Adds one `fetchTlsRptPosture` test asserting that a real DNS NXDOMAIN response (`Status: 3`, no `Answer` field) returns `emptyTlsRptPosture()` — the transient unavailable sentinel (`configured: null`) — rather than the durable-negative (`configured: false`).
- The implementation already handles this path correctly via `if (!Array.isArray(answer)) return emptyTlsRptPosture()`. The test pins the intentional design decision and closes the explicit acceptance gap in #248 ("Unit tests cover: … NXDOMAIN …").

Closes #248. Part of #156.

## Background

Issue #248's acceptance requires tests for three cases: TXT present with rua, NXDOMAIN, and DoH timeout. The existing suite covered the first and third, but the "NXDOMAIN" case was tested only via `Status: 0, Answer: []` (NOERROR-with-no-records), not via true NXDOMAIN (`Status: 3`, no `Answer` field). The two are deliberately handled differently:

| DoH response | Behaviour | Rationale |
|---|---|---|
| `Status: 0, Answer: []` | `configured: false` (cached) | Domain published nothing — durable "no record" |
| `Status: 3, no Answer` | `configured: null` (not cached) | Label doesn't exist — treat as transient blip, don't cache |

## Test plan

- [x] `npm test` — **922 passing, 0 failing**
- [x] `npm run typecheck` — no errors
- [x] New test `"treats DNS NXDOMAIN (Status 3, no Answer field) as the unavailable sentinel"` passes
- [x] All URL host checks use `new URL(url).hostname === 'cloudflare-dns.com'` — CodeQL `js/incomplete-url-substring-sanitization` invariant honoured

## Acceptance check (issue #248)

| Item | Status |
|---|---|
| `fetchTlsRptPosture` resolves `_smtp._tls.<domain>` TXT via DoH | ✅ `workers/tlsrpt/posture.ts` (shipped in #196) |
| Returns configured/not-configured posture with rua endpoints | ✅ (`endpoints` field) |
| DoH timeout / NXDOMAIN → not-configured sentinel | ✅ existing + this PR |
| `/domains/:domain` route includes TLS-RPT posture tile | ✅ `TlsRptPostureCard` in `domain-detail.tsx` |
| Unit tests cover TXT present, NXDOMAIN, DoH timeout | ✅ all three now explicit |

## Spec follow-up needed

No — `SECURITY_SPEC.md` Rule 5 already covers DoH timeout behaviour; no new invariants introduced.

https://claude.ai/code/session_012csWQQjhkjcrvtcJPaXX59

---
_Generated by [Claude Code](https://claude.ai/code/session_012csWQQjhkjcrvtcJPaXX59)_