### PR TITLE
feat: yaramail async sidecar signal module, schema, and migration (#256)

### DIFF
--- a/shared/mailbox-settings.ts
+++ b/shared/mailbox-settings.ts
@@ -113,6 +113,22 @@ export const AutoDraftSettings = z
   .passthrough();
 
 /**
+ * Per-mailbox opt-in configuration for the yaramail async attachment-scanning
+ * sidecar (issue #256). Off by default — a fresh mailbox never contacts the
+ * sidecar unless the operator explicitly sets `enabled: true` and supplies
+ * `endpoint_url`. The sidecar runs as an operator-supplied Docker container;
+ * no Python code ships inside the Worker runtime.
+ */
+export const YaraMailScannerSettings = z
+  .object({
+    enabled: z.boolean().optional(),
+    endpoint_url: z.string().optional(),
+  })
+  .passthrough();
+
+export type YaraMailScannerSettings = z.infer<typeof YaraMailScannerSettings>;
+
+/**
  * Per-mailbox settings stored at R2 key `mailboxes/<mailboxId>.json`.
  *
  * Semantic shift introduced by #106: **field absence = inherit**. Defaults
@@ -139,6 +155,7 @@ export const MailboxSettings = z.object({
   classifierModel: z.string().optional(),
   security: SecuritySettings.optional(),
   intel: IntelSettings.optional(),
+  yaramail_scanner: YaraMailScannerSettings.optional(),
 }).passthrough();
 
 export type MailboxSettings = z.infer<typeof MailboxSettings>;

--- a/tests/security/yaramail-signal.test.ts
+++ b/tests/security/yaramail-signal.test.ts
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	computeYaraScoreDelta,
+	fireYaraScan,
+	YARA_SCORE_CAP,
+	DEFAULT_YARA_RULE_SCORES,
+	type YaraMatchResult,
+} from "../../workers/security/yaramail-signal";
+
+// Mock resolveMailboxSettings so tests don't need a real R2 bucket.
+// vi.mock is hoisted so this runs before any import evaluation.
+vi.mock("../../workers/lib/mailbox-settings", () => ({
+	resolveMailboxSettings: vi.fn(),
+	stripDefaultEqual: <T>(x: T) => x,
+	YaraMailScannerSettings: { parse: (x: unknown) => x },
+}));
+
+// After the mock is set up we can import the mocked function.
+import { resolveMailboxSettings } from "../../workers/lib/mailbox-settings";
+const mockedResolve = vi.mocked(resolveMailboxSettings);
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function makeEnv() {
+	return { BUCKET: {} } as unknown as { BUCKET: R2Bucket };
+}
+
+function makeCtx() {
+	const scheduled: Promise<unknown>[] = [];
+	return {
+		ctx: { waitUntil: (p: Promise<unknown>) => { scheduled.push(p); } },
+		scheduled,
+	};
+}
+
+function makeRawSettings(scanner: { enabled?: boolean; endpoint_url?: string } | undefined) {
+	return {
+		raw: { yaramail_scanner: scanner },
+		security: { enabled: false },
+	} as unknown as Awaited<ReturnType<typeof resolveMailboxSettings>>;
+}
+
+// ── computeYaraScoreDelta ──────────────────────────────────────────────────
+
+describe("computeYaraScoreDelta", () => {
+	it("returns 0 for an empty match list", () => {
+		expect(computeYaraScoreDelta([])).toBe(0);
+	});
+
+	it("maps known rule names via DEFAULT_YARA_RULE_SCORES", () => {
+		const matches: YaraMatchResult[] = [{ rule_name: "pdf_phishing" }];
+		expect(computeYaraScoreDelta(matches)).toBe(DEFAULT_YARA_RULE_SCORES.pdf_phishing);
+	});
+
+	it("uses explicit score override when provided", () => {
+		const matches: YaraMatchResult[] = [{ rule_name: "pdf_phishing", score: 7 }];
+		expect(computeYaraScoreDelta(matches)).toBe(7);
+	});
+
+	it("defaults unknown rule names to +5", () => {
+		const matches: YaraMatchResult[] = [{ rule_name: "unknown_custom_rule" }];
+		expect(computeYaraScoreDelta(matches)).toBe(5);
+	});
+
+	it("sums multiple match contributions", () => {
+		const matches: YaraMatchResult[] = [
+			{ rule_name: "nested_archive" },   // 10
+			{ rule_name: "eml_attachment" },   // 5
+		];
+		expect(computeYaraScoreDelta(matches)).toBe(15);
+	});
+
+	it("caps total at YARA_SCORE_CAP regardless of match count", () => {
+		const manyMatches: YaraMatchResult[] = Array.from({ length: 20 }, () => ({
+			rule_name: "macro_dropper",  // 25 each
+		}));
+		expect(computeYaraScoreDelta(manyMatches)).toBe(YARA_SCORE_CAP);
+		expect(YARA_SCORE_CAP).toBe(30);
+	});
+
+	it("caps even when explicit scores sum beyond the cap", () => {
+		const matches: YaraMatchResult[] = [
+			{ rule_name: "x", score: 20 },
+			{ rule_name: "y", score: 20 },
+		];
+		expect(computeYaraScoreDelta(matches)).toBe(YARA_SCORE_CAP);
+	});
+});
+
+// ── fireYaraScan ───────────────────────────────────────────────────────────
+
+describe("fireYaraScan — sidecar disabled", () => {
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok"));
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.clearAllMocks();
+	});
+
+	it("does not fire a request when yaramail_scanner is absent", async () => {
+		mockedResolve.mockResolvedValue(makeRawSettings(undefined));
+		const { ctx } = makeCtx();
+		await fireYaraScan(makeEnv(), ctx, "user@example.com", "msg-1", "attachments/msg-1/att-1/file.pdf");
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("does not fire a request when enabled is false", async () => {
+		mockedResolve.mockResolvedValue(makeRawSettings({ enabled: false, endpoint_url: "https://sidecar.example.com/scan" }));
+		const { ctx } = makeCtx();
+		await fireYaraScan(makeEnv(), ctx, "user@example.com", "msg-1", "attachments/msg-1/att-1/file.pdf");
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("does not fire a request when endpoint_url is missing", async () => {
+		mockedResolve.mockResolvedValue(makeRawSettings({ enabled: true }));
+		const { ctx } = makeCtx();
+		await fireYaraScan(makeEnv(), ctx, "user@example.com", "msg-1", "attachments/msg-1/att-1/file.pdf");
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe("fireYaraScan — sidecar enabled", () => {
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok"));
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.clearAllMocks();
+	});
+
+	it("fires a POST to the configured endpoint with the correct payload", async () => {
+		const endpointUrl = "https://sidecar.example.com/scan";
+		mockedResolve.mockResolvedValue(
+			makeRawSettings({ enabled: true, endpoint_url: endpointUrl }),
+		);
+		const { ctx, scheduled } = makeCtx();
+
+		await fireYaraScan(
+			makeEnv(),
+			ctx,
+			"user@example.com",
+			"msg-abc",
+			"attachments/msg-abc/att-1/report.pdf",
+			"https://presigned.example.com/token",
+		);
+
+		// The request must be scheduled (fire-and-forget via waitUntil)
+		expect(scheduled).toHaveLength(1);
+
+		// Drain the scheduled promise so fetch is actually called
+		await scheduled[0];
+
+		expect(fetchSpy).toHaveBeenCalledOnce();
+		const [calledUrl, calledInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+
+		// CodeQL URL parse rule: compare hostname, not substring
+		expect(new URL(calledUrl).hostname).toBe("sidecar.example.com");
+
+		const body = JSON.parse(calledInit.body as string);
+		expect(body).toMatchObject({
+			emailId: "msg-abc",
+			r2Key: "attachments/msg-abc/att-1/report.pdf",
+			mailboxId: "user@example.com",
+			presignedUrl: "https://presigned.example.com/token",
+		});
+	});
+
+	it("uses an empty string for presignedUrl when not provided", async () => {
+		mockedResolve.mockResolvedValue(
+			makeRawSettings({ enabled: true, endpoint_url: "https://sidecar.example.com/scan" }),
+		);
+		const { ctx, scheduled } = makeCtx();
+
+		await fireYaraScan(makeEnv(), ctx, "user@example.com", "msg-1", "attachments/msg-1/att-1/file.pdf");
+		await scheduled[0];
+
+		const body = JSON.parse((fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string);
+		expect(body.presignedUrl).toBe("");
+	});
+
+	it("swallows sidecar timeout — verdict is unchanged, no error propagates", async () => {
+		mockedResolve.mockResolvedValue(
+			makeRawSettings({ enabled: true, endpoint_url: "https://sidecar.example.com/scan" }),
+		);
+		// Simulate a network timeout (AbortError)
+		fetchSpy.mockRejectedValue(Object.assign(new Error("The operation was aborted"), { name: "AbortError" }));
+
+		const { ctx, scheduled } = makeCtx();
+		// fireYaraScan itself must not throw
+		await expect(
+			fireYaraScan(makeEnv(), ctx, "user@example.com", "msg-1", "attachments/msg-1/att-1/file.pdf"),
+		).resolves.toBeUndefined();
+
+		// Draining the scheduled promise must also not throw
+		await expect(scheduled[0]).resolves.toBeUndefined();
+	});
+
+	it("swallows other network errors — no propagation", async () => {
+		mockedResolve.mockResolvedValue(
+			makeRawSettings({ enabled: true, endpoint_url: "https://sidecar.example.com/scan" }),
+		);
+		fetchSpy.mockRejectedValue(new Error("Network unreachable"));
+
+		const { ctx, scheduled } = makeCtx();
+		await fireYaraScan(makeEnv(), ctx, "user@example.com", "msg-1", "attachments/msg-1/att-1/file.pdf");
+		await expect(scheduled[0]).resolves.toBeUndefined();
+	});
+});

--- a/workers/durableObject/migrations.ts
+++ b/workers/durableObject/migrations.ts
@@ -454,4 +454,19 @@ export const mailboxMigrations: Migration[] = [
             CREATE INDEX IF NOT EXISTS idx_dmarc_ruf_source_ip ON dmarc_ruf_records(source_ip);
         `,
 	},
+	{
+		// Async yaramail sidecar scan results (issue #256). One row per email
+		// submitted to the sidecar. `results` is a JSON array of YaraMatchResult
+		// objects returned by the callback; `scanned_at` is a Unix epoch integer
+		// so range queries stay index-friendly. The callback route and DO methods
+		// that populate this table are wired in the follow-up issue.
+		name: "20_yaramail_scan_results",
+		sql: `
+            CREATE TABLE IF NOT EXISTS yaramail_scan_results (
+                email_id TEXT PRIMARY KEY,
+                results JSON NOT NULL,
+                scanned_at INTEGER NOT NULL
+            );
+        `,
+	},
 ];

--- a/workers/lib/mailbox-settings.ts
+++ b/workers/lib/mailbox-settings.ts
@@ -7,7 +7,10 @@ import {
 	DEFAULT_DRAFT_VERIFIER_MODEL,
 	DEFAULT_INJECTION_SCANNER_MODEL,
 	MailboxSettings,
+	YaraMailScannerSettings,
 } from "../../shared/mailbox-settings";
+
+export { YaraMailScannerSettings } from "../../shared/mailbox-settings";
 import type { OrgSettings } from "../../shared/org-settings";
 import { getOrgSettings } from "./org-settings";
 import type { DomainSettings } from "../../shared/domain-settings";
@@ -453,6 +456,10 @@ function isDefaultEqual(key: string, value: unknown): boolean {
 			// Empty domains array is the default; strip it so absent-key semantics
 			// are preserved and the blob doesn't accumulate `"domains": []` on every write.
 			return Array.isArray(value) && value.length === 0;
+		case "yaramail_scanner":
+			// Off by default — strip when disabled or empty so absent-key semantics
+			// are preserved and a fresh save doesn't persist an inert block.
+			return deepEqual(value, { enabled: false }) || deepEqual(value, {});
 		default:
 			return false;
 	}

--- a/workers/security/yaramail-signal.ts
+++ b/workers/security/yaramail-signal.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Async yaramail sidecar enrichment signal (issue #256).
+ *
+ * The sidecar is an operator-supplied Python container that receives
+ * attachment references from PhishSOC, runs yaramail-powered scanning
+ * (PDF extraction, password-protected ZIPs, nested archives, .eml recursion),
+ * and POSTs YARA match results back to a callback route.
+ *
+ * This module handles the outbound side only:
+ *   - `computeYaraScoreDelta` normalises raw YARA match lists to a bounded
+ *     score contribution (capped at YARA_SCORE_CAP = 30).
+ *   - `fireYaraScan` fires the fire-and-forget enrichment request via
+ *     ctx.waitUntil when the mailbox has the scanner enabled.
+ *
+ * Wiring `fireYaraScan` into the email-receive pipeline, the callback route
+ * that accepts sidecar responses, and the DO methods for storing results are
+ * tracked in the follow-up issue filed against #256.
+ */
+
+import { resolveMailboxSettings } from "../lib/mailbox-settings";
+
+/** Maximum score contribution from YARA signals — mirrors the deep-scan cap. */
+export const YARA_SCORE_CAP = 30;
+
+/**
+ * Default YARA rule name → score contribution table. Unknown rule names fall
+ * back to +5 so a new rule in the operator's YARA ruleset contributes a small
+ * signal rather than nothing. Operators can extend this via the mapping table
+ * documented in docs/yaramail-sidecar.md (follow-up).
+ */
+export const DEFAULT_YARA_RULE_SCORES: Record<string, number> = {
+	pdf_phishing: 20,
+	macro_dropper: 25,
+	encrypted_zip: 15,
+	nested_archive: 10,
+	eml_attachment: 5,
+};
+
+/** A single YARA rule match as returned by the sidecar. */
+export interface YaraMatchResult {
+	/** YARA rule name, e.g. "pdf_phishing". */
+	rule_name: string;
+	/** Optional signal category for display purposes. */
+	category?: string;
+	/** Explicit score override — takes precedence over DEFAULT_YARA_RULE_SCORES. */
+	score?: number;
+}
+
+/** Payload sent to the sidecar endpoint. */
+export interface YaraScanPayload {
+	emailId: string;
+	/** R2 object key for the attachment to scan. */
+	r2Key: string;
+	mailboxId: string;
+	/**
+	 * Presigned download URL for the attachment.
+	 * Requires R2 S3-compatible API presigned URL support; see
+	 * docs/yaramail-sidecar.md for deployment guidance. Empty string when
+	 * not yet configured — the sidecar MUST treat an empty presignedUrl as a
+	 * signal to call back to PhishSOC's attachment download endpoint instead.
+	 */
+	presignedUrl: string;
+}
+
+/**
+ * Map a list of YARA match results to a single bounded score delta.
+ *
+ * Each match contributes `match.score` (explicit) or the value from
+ * DEFAULT_YARA_RULE_SCORES keyed on `rule_name`, or 5 for unknown rules.
+ * The total is capped at YARA_SCORE_CAP so no combination of YARA matches
+ * can dominate the verdict on its own.
+ */
+export function computeYaraScoreDelta(matches: YaraMatchResult[]): number {
+	let total = 0;
+	for (const m of matches) {
+		total += m.score ?? DEFAULT_YARA_RULE_SCORES[m.rule_name] ?? 5;
+	}
+	return Math.min(YARA_SCORE_CAP, total);
+}
+
+type R2BucketEnv = { BUCKET: R2Bucket };
+type CtxLike = { waitUntil: (p: Promise<unknown>) => void };
+
+/**
+ * Fire a fire-and-forget enrichment request to the configured yaramail
+ * sidecar endpoint.
+ *
+ * Returns immediately after scheduling the request via ctx.waitUntil.
+ * If the sidecar is disabled for this mailbox (or has no endpoint_url
+ * configured), this is a no-op. Network failures and timeouts are caught
+ * and logged so they never propagate to the email-receive path.
+ *
+ * @param env        Worker environment (needs BUCKET for settings resolution).
+ * @param ctx        ExecutionContext — waitUntil keeps the request alive after
+ *                   the outer handler returns.
+ * @param mailboxId  Per-mailbox identifier (also the R2 settings key suffix).
+ * @param emailId    Message ID of the email being scanned.
+ * @param r2Key      R2 object key for the attachment to scan.
+ * @param presignedUrl  Pre-generated download URL for the attachment (may be
+ *                      empty — see YaraScanPayload.presignedUrl).
+ */
+export async function fireYaraScan(
+	env: R2BucketEnv,
+	ctx: CtxLike,
+	mailboxId: string,
+	emailId: string,
+	r2Key: string,
+	presignedUrl = "",
+): Promise<void> {
+	const resolved = await resolveMailboxSettings(env, mailboxId);
+	const scanner = resolved.raw.yaramail_scanner;
+	if (!scanner?.enabled || !scanner.endpoint_url) return;
+
+	const endpointUrl = scanner.endpoint_url;
+	const payload: YaraScanPayload = { emailId, r2Key, mailboxId, presignedUrl };
+
+	ctx.waitUntil(
+		fetch(endpointUrl, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(payload),
+			signal: AbortSignal.timeout(30_000),
+		}).catch((err: unknown) => {
+			console.error("yaramail sidecar request failed:", (err as Error).message);
+		}),
+	);
+}


### PR DESCRIPTION
## Summary

- Adds `YaraMailScannerSettings` Zod schema (`{ enabled, endpoint_url }`) to `shared/mailbox-settings.ts` and the `yaramail_scanner` optional field to `MailboxSettings`.
- Exports `YaraMailScannerSettings` from `workers/lib/mailbox-settings.ts`; adds `isDefaultEqual` case so disabled/empty blocks are stripped on every settings-tier write (preserving absent-key = off semantics).
- New `workers/security/yaramail-signal.ts` implements `computeYaraScoreDelta` (YARA matches → bounded score, capped at 30) and `fireYaraScan` (checks `yaramail_scanner.enabled`, fires fire-and-forget POST via `ctx.waitUntil`; all failures/timeouts are caught and never propagated).
- Migration `20_yaramail_scan_results` adds the `yaramail_scan_results(email_id PK, results JSON, scanned_at INTEGER)` table to the per-mailbox DO SQLite.
- 14 new unit tests covering all acceptance-required scenarios.

Closes #256

## Test plan

- [x] `computeYaraScoreDelta` — empty matches → 0; known rule → mapped score; explicit score override; unknown rule → +5; sum of multiple matches; cap at +30 with many/large matches.
- [x] `fireYaraScan` disabled — no fetch when `yaramail_scanner` absent; `enabled: false`; or `endpoint_url` missing.
- [x] `fireYaraScan` enabled — fetch fired via `waitUntil` with correct payload (`emailId`, `r2Key`, `mailboxId`, `presignedUrl`); empty presignedUrl default.
- [x] `fireYaraScan` timeout/network error — swallowed, no throw.
- [x] 963 passing, 0 failing (`npm test`).
- [x] TypeScript typecheck clean (`npm run typecheck`).

## Acceptance shipped

- ✅ `workers/security/yaramail-signal.ts` fires async enrichment request when `yaramail_scanner.enabled === true`
- ✅ Fire-and-forget via `ctx.waitUntil` — initial verdict not delayed
- ✅ Migration `20_yaramail_scan_results` table added
- ✅ `workers/lib/mailbox-settings.ts` exports `YaraMailScannerSettings`; `stripDefaultEqual` handles `yaramail_scanner` on every settings-tier write
- ✅ Unit tests covering all 5 required scenarios

## Acceptance deferred

- ⏳ Wiring `fireYaraScan` into `receiveEmail` + callback route + DO methods → **#257**
- ⏳ Per-mailbox settings UI "Attachment scanner" toggle → **#258**
- ⏳ `docs/yaramail-sidecar.md` + sidecar example → **#259**

## Notes

- `SECURITY_SPEC.md` is untouched (no spec rule changes from this PR).
- No wrangler.jsonc changes → no `npm run cf-typegen` regen needed.
- URL hostname comparison in tests uses `new URL(url).hostname` per CodeQL `js/incomplete-url-substring-sanitization` rule (CLAUDE.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJbXLHpJgAdzNcRUM4HakE)_