### PR TITLE
feat(security): outbound send-risk classifier + agent guard for "tag" verdict (#15)

### DIFF
--- a/tests/security/send-risk.test.ts
+++ b/tests/security/send-risk.test.ts
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, expect, it } from "vitest";
+import { classifySend, type ClassifySendInput } from "../../workers/security/send-risk";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function make(overrides: Partial<ClassifySendInput> = {}): ClassifySendInput {
+	return {
+		to: "alice@external.com",
+		mailboxId: "operator@internal.example",
+		...overrides,
+	};
+}
+
+// ── Tier 0 ───────────────────────────────────────────────────────────────────
+
+describe("classifySend — Tier 0 (no restriction)", () => {
+	it("internal-only send returns Tier 0", () => {
+		const result = classifySend(make({ to: "colleague@internal.example" }));
+		expect(result.tier).toBe(0);
+		expect(result.reasons).toHaveLength(0);
+	});
+
+	it("internal CC and BCC do not trigger Tier 1", () => {
+		const result = classifySend(
+			make({
+				to: "a@internal.example",
+				cc: "b@internal.example",
+				bcc: "c@internal.example",
+			}),
+		);
+		expect(result.tier).toBe(0);
+	});
+
+	it("reply with no suspicious content stays Tier 0 (internal)", () => {
+		const result = classifySend(
+			make({
+				to: "boss@internal.example",
+				subject: "Re: Team lunch",
+				body: "Sounds great, see you then!",
+			}),
+		);
+		expect(result.tier).toBe(0);
+	});
+});
+
+// ── Tier 1 ───────────────────────────────────────────────────────────────────
+
+describe("classifySend — Tier 1 (Access re-prompt)", () => {
+	it("external recipient triggers Tier 1", () => {
+		const result = classifySend(make({ to: "vendor@external.com" }));
+		expect(result.tier).toBe(1);
+		expect(result.reasons.some((r) => r.includes("External recipient"))).toBe(true);
+	});
+
+	it("external recipient in CC triggers Tier 1", () => {
+		const result = classifySend(
+			make({ to: "colleague@internal.example", cc: "external@other.org" }),
+		);
+		expect(result.tier).toBe(1);
+		expect(result.reasons.some((r) => r.includes("External"))).toBe(true);
+	});
+
+	it("more than 10 recipients triggers Tier 1 even if all internal", () => {
+		const many = Array.from({ length: 11 }, (_, i) => `user${i}@internal.example`);
+		const result = classifySend(make({ to: many }));
+		expect(result.tier).toBe(1);
+		expect(result.reasons.some((r) => r.includes("High recipient count"))).toBe(true);
+	});
+
+	it("exactly 10 recipients does NOT trigger count check", () => {
+		const ten = Array.from({ length: 10 }, (_, i) => `user${i}@internal.example`);
+		const result = classifySend(make({ to: ten }));
+		// Still Tier 0 if all internal (count ≤ 10)
+		expect(result.tier).toBe(0);
+	});
+});
+
+// ── Tier 2 ───────────────────────────────────────────────────────────────────
+
+describe("classifySend — Tier 2 (step-up required)", () => {
+	it.each([
+		["wire transfer", "Please send a wire transfer of $10,000"],
+		["wire funds", "I need you to wire funds immediately"],
+		["bank details", "Here are my bank details for the transfer"],
+		["gift card", "Buy $500 in gift card codes and share them"],
+		["mfa code", "Enter the MFA code 123456 now"],
+		["one-time code", "Share your one-time code with me"],
+		["reset my password", "Help me reset my password via this link"],
+		["urgent payment", "This is an urgent payment request"],
+	])("keyword '%s' in body triggers Tier 2", (_kw, body) => {
+		const result = classifySend(make({ to: "colleague@internal.example", body }));
+		expect(result.tier).toBe(2);
+		expect(result.reasons.some((r) => r.includes("keyword"))).toBe(true);
+	});
+
+	it("keyword in subject triggers Tier 2", () => {
+		const result = classifySend(
+			make({
+				to: "colleague@internal.example",
+				subject: "Wire transfer request",
+				body: "Please process.",
+			}),
+		);
+		expect(result.tier).toBe(2);
+	});
+
+	it("keyword matching is case-insensitive", () => {
+		const result = classifySend(
+			make({ to: "colleague@internal.example", body: "WIRE TRANSFER details below" }),
+		);
+		expect(result.tier).toBe(2);
+	});
+
+	it.each([
+		"invoice.pdf.exe",
+		"report.docx.bat",
+		"document.pdf.vbs",
+		"file.txt.cmd",
+		"setup.zip.scr",
+	])("double-extension attachment '%s' triggers Tier 2", (filename) => {
+		const result = classifySend(
+			make({ to: "colleague@internal.example", attachments: [{ filename }] }),
+		);
+		expect(result.tier).toBe(2);
+		expect(result.reasons.some((r) => r.includes("Suspicious attachment"))).toBe(true);
+	});
+
+	it("single-extension attachment does NOT trigger Tier 2", () => {
+		const result = classifySend(
+			make({ to: "colleague@internal.example", attachments: [{ filename: "report.pdf" }] }),
+		);
+		expect(result.tier).toBe(0);
+	});
+});
+
+// ── Tier 2 overrides Tier 1 ──────────────────────────────────────────────────
+
+describe("classifySend — tier precedence", () => {
+	it("Tier-2 keyword on an external send returns Tier 2, not Tier 1", () => {
+		const result = classifySend(
+			make({
+				to: "vendor@external.com",
+				body: "Send me gift card codes",
+			}),
+		);
+		expect(result.tier).toBe(2);
+		// Both reasons present
+		expect(result.reasons.some((r) => r.includes("keyword"))).toBe(true);
+		expect(result.reasons.some((r) => r.includes("External"))).toBe(true);
+	});
+
+	it("multiple Tier-2 signals all appear in reasons", () => {
+		const result = classifySend(
+			make({
+				to: "colleague@internal.example",
+				body: "wire transfer now",
+				attachments: [{ filename: "proof.pdf.exe" }],
+			}),
+		);
+		expect(result.tier).toBe(2);
+		expect(result.reasons.length).toBeGreaterThanOrEqual(2);
+	});
+});
+
+// ── edge cases ───────────────────────────────────────────────────────────────
+
+describe("classifySend — edge cases", () => {
+	it("empty to array with no mailboxId domain is Tier 0", () => {
+		const result = classifySend({ to: [], mailboxId: "noemail" });
+		expect(result.tier).toBe(0);
+	});
+
+	it("null body and subject do not throw", () => {
+		expect(() =>
+			classifySend(make({ subject: null, body: null })),
+		).not.toThrow();
+	});
+
+	it("attachment with no filename does not throw", () => {
+		expect(() =>
+			classifySend(make({ attachments: [{ filename: null }] })),
+		).not.toThrow();
+	});
+
+	it("comma-separated string in 'to' is parsed correctly", () => {
+		const result = classifySend(
+			make({
+				to: "a@internal.example, b@external.org",
+				mailboxId: "me@internal.example",
+			}),
+		);
+		expect(result.tier).toBe(1); // b@external.org is external
+	});
+});

--- a/workers/agent/index.ts
+++ b/workers/agent/index.ts
@@ -326,11 +326,14 @@ export class EmailAgent extends AIChatAgent<any> {
 		threadId: string;
 		securityVerdict?: { action: string; score: number; explanation: string } | null;
 	}) {
-		// Respect the security pipeline: if the email was quarantined/blocked,
-		// skip the auto-draft and log why. See workers/security/index.ts.
-		if (emailData.securityVerdict && (emailData.securityVerdict.action === "quarantine" || emailData.securityVerdict.action === "block")) {
+		// Respect the security pipeline: if the email was quarantined, blocked, or
+		// tagged as suspicious, skip the auto-draft and log why.
+		// "tag" = suspicious verdict; "quarantine"/"block" = higher severity.
+		// See workers/security/verdict.ts for VerdictAction definitions.
+		if (emailData.securityVerdict && (emailData.securityVerdict.action === "quarantine" || emailData.securityVerdict.action === "block" || emailData.securityVerdict.action === "tag")) {
 			const v = emailData.securityVerdict;
-			const note = `🛡️ Security pipeline ${v.action === "block" ? "blocked" : "quarantined"} this email (score ${v.score}). ${v.explanation}`;
+			const actionLabel = v.action === "block" ? "blocked" : v.action === "quarantine" ? "quarantined" : "tagged as suspicious";
+			const note = `🛡️ Security pipeline ${actionLabel} this email (score ${v.score}). ${v.explanation} — auto-draft suspended, review required.`;
 			const newMessages = [
 				{
 					id: crypto.randomUUID(),

--- a/workers/security/send-risk.ts
+++ b/workers/security/send-risk.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Outbound send-risk classifier for PhishSOC (issue #15 slice 1).
+ *
+ * Classifies a draft send into one of three tiers:
+ *   Tier 0 — no restriction (internal-only, or trusted reply)
+ *   Tier 1 — Access re-prompt (external recipient, high count, novel link domains)
+ *   Tier 2 — Confirm + step-up required (BEC/credential keywords, macro attachment)
+ *
+ * This module is intentionally stateless — it does not call the DO or fetch
+ * external data.  Signals that need DO state (first-seen recipient age, inbound
+ * thread verdict) are reserved for a follow-up slice that wraps this function.
+ */
+
+export type SendRiskTier = 0 | 1 | 2;
+
+export interface SendRisk {
+	tier: SendRiskTier;
+	reasons: string[];
+}
+
+export interface ClassifySendInput {
+	/** Primary recipient(s) — string or array of RFC-5322 address strings. */
+	to: string | string[];
+	cc?: string | string[] | null;
+	bcc?: string | string[] | null;
+	subject?: string | null;
+	/** Plain-text or HTML body — used for keyword matching. */
+	body?: string | null;
+	attachments?: Array<{ filename?: string | null }>;
+	/** The mailboxId is an email address; its domain is the "internal" domain. */
+	mailboxId: string;
+}
+
+// ── Tier-2 BEC / credential keyword list ────────────────────────────────────
+
+const TIER2_KEYWORDS: readonly string[] = [
+	"wire transfer",
+	"wire funds",
+	"bank details",
+	"bank account",
+	"routing number",
+	"gift card",
+	"mfa code",
+	"one-time code",
+	"authenticator code",
+	"reset my password",
+	"change my password",
+	"urgent payment",
+];
+
+// File extensions whose presence in a double-extension filename signals a
+// macro dropper (e.g. "invoice.pdf.exe", "report.docx.vbs").
+const MACRO_EXTENSIONS = new Set(["exe", "bat", "cmd", "vbs", "js", "jar", "com", "scr", "pif", "ps1", "hta"]);
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function parseAddresses(field: string | string[] | null | undefined): string[] {
+	if (!field) return [];
+	const addresses = Array.isArray(field) ? field : [field];
+	return addresses.flatMap((a) => a.split(",").map((s) => s.trim())).filter(Boolean);
+}
+
+/** Extract the @domain part from an RFC-5322 address or bare email. */
+function extractDomain(address: string): string {
+	// Handle "Display Name <user@domain>" and bare "user@domain" forms.
+	const match = address.match(/<([^>]+)>/) || address.match(/(\S+@\S+)/);
+	if (!match) return "";
+	const email = match[1];
+	const atIdx = email.lastIndexOf("@");
+	return atIdx >= 0 ? email.slice(atIdx + 1).toLowerCase() : "";
+}
+
+function hasSuspiciousExtension(filename: string): boolean {
+	const parts = filename.split(".");
+	// Need at least "name.ext1.ext2" to be a double-extension.
+	if (parts.length < 3) return false;
+	return MACRO_EXTENSIONS.has(parts[parts.length - 1].toLowerCase());
+}
+
+// ── classifier ───────────────────────────────────────────────────────────────
+
+/**
+ * Classify the outbound send risk of a draft.
+ *
+ * Returns a tier (0–2) and a list of human-readable reasons.
+ * The caller decides what to do with the tier (block, re-prompt, allow).
+ */
+export function classifySend(input: ClassifySendInput): SendRisk {
+	const reasons: string[] = [];
+	let tier: SendRiskTier = 0;
+
+	const raise = (t: SendRiskTier, reason: string) => {
+		reasons.push(reason);
+		if (t > tier) tier = t;
+	};
+
+	// ── gather all recipients ────────────────────────────────────────────────
+	const allRecipients = [
+		...parseAddresses(input.to),
+		...parseAddresses(input.cc),
+		...parseAddresses(input.bcc),
+	];
+
+	// ── derive internal domain from mailboxId ────────────────────────────────
+	const internalDomain = extractDomain(input.mailboxId);
+
+	// ── Tier-2: BEC / credential keyword detection ───────────────────────────
+	const searchText = [input.subject ?? "", input.body ?? ""].join(" ").toLowerCase();
+	const matchedKeyword = TIER2_KEYWORDS.find((kw) => searchText.includes(kw));
+	if (matchedKeyword) {
+		raise(2, `BEC/credential keyword: "${matchedKeyword}"`);
+	}
+
+	// ── Tier-2: attachment with macro/double-extension ───────────────────────
+	for (const att of input.attachments ?? []) {
+		if (att.filename && hasSuspiciousExtension(att.filename)) {
+			raise(2, `Suspicious attachment extension: "${att.filename}"`);
+		}
+	}
+
+	// ── Tier-1: high recipient count ─────────────────────────────────────────
+	if (allRecipients.length > 10) {
+		raise(1, `High recipient count: ${allRecipients.length}`);
+	}
+
+	// ── Tier-1: any external recipient ───────────────────────────────────────
+	if (internalDomain) {
+		const external = allRecipients.filter(
+			(r) => extractDomain(r) !== internalDomain,
+		);
+		if (external.length > 0) {
+			const sample = external.slice(0, 3).join(", ");
+			raise(1, `External recipient(s): ${sample}${external.length > 3 ? ` (+${external.length - 3} more)` : ""}`);
+		}
+	}
+
+	return { tier, reasons };
+}


### PR DESCRIPTION
## Summary

- New `workers/security/send-risk.ts` — stateless `classifySend` function mapping a draft send to a risk tier (0–2):
  - **Tier 2** (step-up required): BEC/credential keywords (`"wire transfer"`, `"gift card"`, `"mfa code"`, …) or attachment with macro double-extension (`invoice.pdf.exe`, `report.docx.bat`, …)
  - **Tier 1** (re-auth): any external recipient, or >10 total recipients
  - **Tier 0**: all recipients on the mailbox's own domain (extracted from `mailboxId`)
- `workers/agent/index.ts`: extend the auto-draft guard to skip when `securityVerdict.action === "tag"` (suspicious). Previously the guard only fired on `"quarantine"` / `"block"` — a suspicious-tagged inbound could still trigger an auto-draft, creating a BEC-via-agent vector.

Partially closes #15

## Test plan

- [x] 29 new unit tests in `tests/security/send-risk.test.ts` covering all tier rules, tier precedence (Tier 2 > Tier 1), and edge cases (null body/subject, comma-separated address strings, no-filename attachment)
- [x] 978 passing, 0 failing (`npm test`)
- [x] TypeScript typecheck clean (`npm run typecheck`)

## Acceptance shipped (this PR)

- ✅ `workers/security/send-risk.ts` pure classifier with `SendRisk`, `SendRiskTier`, `ClassifySendInput` types
- ✅ Tier-2 BEC/credential keyword detection (case-insensitive, subject + body)
- ✅ Tier-2 macro/double-extension attachment detection
- ✅ Tier-1 external recipient detection (domain extracted from `mailboxId`)
- ✅ Tier-1 high-recipient-count detection (>10)
- ✅ Agent guard extended to include `"tag"` (suspicious) verdict — suppresses auto-draft with descriptive note

## Acceptance deferred (follow-up issues needed)

- ⏳ **Slice 2** — Step-up Access app setup + `POST /api/v1/confirm` endpoint + one-shot JWT with `jti` replay protection (requires CF Access operator action — Bucket D)
- ⏳ **Slice 3** — Wire `classifySend` into `POST /api/v1/mailboxes/:id/emails` + new `POST .../emails/preflight` endpoint
- ⏳ **Slice 4** — Composer UI: preflight call, Tier 0/1/2 button states, popup confirm flow
- ⏳ **Slice 6** — `created_by: "agent" | "user"` on drafts schema + tier-bump (+1) for agent-authored sends

## Notes

- `classifySend` is intentionally synchronous and stateless. Signals requiring DO state (first-seen recipient age, inbound thread verdict lookup) are reserved for slice 3 when the function is wired into the route and has access to `env`.
- `SECURITY_SPEC.md` untouched — no spec invariant changes in this PR.
- The classifier open design questions from #15 were resolved conservatively: Tier 1 uses "any external recipient" (strict start), MCP gating deferred to slice 3.

https://claude.ai/code/session_01JMPnx2GMU9cpDWJzVHRwAa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMPnx2GMU9cpDWJzVHRwAa)_