### PR TITLE
docs: yaramail sidecar deployment guide and interface contract (#259)

### DIFF
--- a/docs/yaramail-sidecar.md
+++ b/docs/yaramail-sidecar.md
@@ -1,0 +1,224 @@
+# YaraMail Sidecar: Deployment Guide and Interface Contract
+
+The YaraMail sidecar is an optional, operator-supplied HTTP service that performs
+YARA-based attachment scanning on behalf of PhishSOC. When configured, the Worker
+dispatches each incoming email to the sidecar for analysis and incorporates the
+resulting YARA signal into the verdict score. The sidecar is never on the critical
+path: if it does not respond within 30 seconds, PhishSOC proceeds with the
+pre-sidecar verdict and treats the absence of a signal as a non-error.
+
+---
+
+## Deployment Model
+
+The sidecar runs as a Docker container and can be hosted anywhere it can receive
+HTTP POST requests from Cloudflare Workers over the public internet (or, if you
+route Workers egress through a private network, on a private endpoint):
+
+| Platform      | Notes                                                                   |
+|---------------|-------------------------------------------------------------------------|
+| Google Cloud Run | Scale-to-zero; assign a stable HTTPS URL; use Cloud Run secrets for the HMAC secret. |
+| Fly.io        | Small always-on VM; use Fly secrets for the HMAC secret.                |
+| Self-hosted   | Any host reachable by the Worker; terminate TLS with nginx or Caddy.    |
+
+Once the container is running, set its public URL in the mailbox settings under
+**YaraMail scanner endpoint** (`yaraMailScanner.endpointUrl`). Each mailbox can
+point to a different sidecar instance, or all mailboxes can share one.
+
+---
+
+## Inbound Payload (Worker → Sidecar)
+
+The Worker sends a `POST` request to the configured endpoint with a JSON body
+matching the following shape:
+
+```json
+{
+  "emailId":    "01JMPnx2GMU9cpDWJzVHRwAa",
+  "r2Key":      "raw/2026/05/01JMPnx2GMU9cpDWJzVHRwAa.eml",
+  "mailboxId":  "mbx_abc123",
+  "presignedUrl": "https://..."
+}
+```
+
+### Field Descriptions
+
+| Field          | Type   | Description                                                                                                    |
+|----------------|--------|----------------------------------------------------------------------------------------------------------------|
+| `emailId`      | string | Unique identifier for the email within PhishSOC.                                                               |
+| `r2Key`        | string | R2 object key for the raw message. Only useful if the sidecar has direct R2 access via a service binding.      |
+| `mailboxId`    | string | Identifies which mailbox received the email; used when posting the callback.                                   |
+| `presignedUrl` | string | A time-limited URL the sidecar can use to `GET` the raw message bytes. **May be an empty string in the current release** (see note below). |
+
+> **Note on `presignedUrl`:** Pre-signed URL support is still being rolled out.
+> When `presignedUrl` is an empty string, the sidecar must fall back to fetching
+> the attachment via the PhishSOC attachment download endpoint, using an API key
+> provisioned in the sidecar's environment. Operators should implement this
+> fallback path until pre-signed URL delivery is generally available.
+
+The Worker sets `AbortSignal.timeout(30_000)` on the outbound request. If the
+sidecar does not respond within **30 seconds** the Worker abandons the request,
+skips the YARA signal, and continues scoring with the pre-sidecar verdict. No
+error is surfaced to the operator or end user.
+
+---
+
+## Outbound Callback (Sidecar → Worker)
+
+After completing the YARA scan the sidecar must `POST` its results back to
+PhishSOC:
+
+```
+POST /api/v1/mailboxes/:mailboxId/yaramail-callback
+```
+
+where `:mailboxId` is the value received in the inbound payload.
+
+### Callback Body
+
+```json
+{
+  "emailId": "01JMPnx2GMU9cpDWJzVHRwAa",
+  "matches": [
+    { "rule_name": "pdf_phishing", "category": "phishing", "score": 20 },
+    { "rule_name": "encrypted_zip", "category": "evasion", "score": 15 }
+  ]
+}
+```
+
+| Field              | Type             | Description                                                        |
+|--------------------|------------------|--------------------------------------------------------------------|
+| `emailId`          | string           | Must match the `emailId` from the inbound payload.                 |
+| `matches`          | `YaraMatchResult[]` | Zero or more YARA rule matches (see structure below).           |
+
+#### `YaraMatchResult` Structure
+
+```ts
+interface YaraMatchResult {
+  rule_name: string;   // Name of the triggered YARA rule
+  category?: string;   // Optional human-readable category tag
+  score?: number;      // Optional override; defaults to DEFAULT_YARA_RULE_SCORES[rule_name]
+}
+```
+
+If `score` is omitted, PhishSOC looks up `rule_name` in the default score table
+(see [YARA Rule Score Mapping](#yara-rule-score-mapping) below). If the rule name
+is not in the table and no inline `score` is provided, the match contributes 0
+points.
+
+### Authentication: HMAC-SHA256 Signature
+
+Every callback request must include the header:
+
+```
+X-PhishSOC-Signature: <hex-encoded HMAC-SHA256>
+```
+
+The signature is computed over the raw JSON request body using the shared secret
+stored in the Worker binding `YARAMAIL_CALLBACK_SECRET`. The sidecar must read
+the same secret from its environment and produce a matching signature; the Worker
+rejects callbacks with a missing or invalid signature.
+
+**Signing algorithm (Python reference):**
+
+```python
+import hashlib, hmac, json, os
+
+secret = os.environ["YARAMAIL_CALLBACK_SECRET"].encode()
+body   = json.dumps(payload, separators=(",", ":")).encode()
+sig    = hmac.new(secret, body, hashlib.sha256).hexdigest()
+headers = {"X-PhishSOC-Signature": sig, "Content-Type": "application/json"}
+```
+
+---
+
+## YARA Rule Score Mapping
+
+The Worker applies the following default scores to matched rule names. Scores can
+be overridden per-match by supplying an inline `score` value in `YaraMatchResult`.
+
+| Rule Name         | Default Score | Description                                    |
+|-------------------|:-------------:|------------------------------------------------|
+| `pdf_phishing`    | 20            | PDF containing phishing indicators             |
+| `macro_dropper`   | 25            | Office document with macro-based dropper       |
+| `encrypted_zip`   | 15            | Password-protected / encrypted ZIP attachment  |
+| `nested_archive`  | 10            | Archive-within-archive (evasion technique)     |
+| `eml_attachment`  | 5             | Email-as-attachment (potential forwarding abuse) |
+
+### Score Cap
+
+Regardless of how many rules match, the combined YARA contribution to the verdict
+score is capped at **+30** (`YARA_SCORE_CAP`). This prevents a flood of low-confidence
+matches from overwhelming other signal channels.
+
+---
+
+## Timeout Behavior
+
+| Scenario                                | Outcome                                                           |
+|-----------------------------------------|-------------------------------------------------------------------|
+| Sidecar responds within 30 s            | YARA matches are scored and merged into the verdict.              |
+| Sidecar times out (> 30 s)              | YARA signal is skipped; verdict proceeds without it. No error.    |
+| Sidecar returns an HTTP error (4xx/5xx) | YARA signal is skipped; verdict proceeds without it. No error.    |
+| Sidecar endpoint not configured         | YARA stage is bypassed entirely. No error.                        |
+
+The absence of a YARA signal is **never treated as an error state**. PhishSOC
+degrades gracefully when the sidecar is unavailable, overloaded, or deliberately
+disabled.
+
+---
+
+## Security Notes
+
+1. **Do not persist raw message bytes.** The sidecar receives the full email (via
+   `presignedUrl` or the attachment endpoint) solely to run the YARA scan. Raw
+   message content must be discarded immediately after scanning — it must not be
+   written to disk, logged, or forwarded to any third-party service.
+
+2. **Validate the inbound request source.** The Worker does not currently sign the
+   inbound dispatch payload. Operators should restrict the sidecar's listening
+   address or use network-layer controls (Cloud Run IAM, Fly.io private networking,
+   firewall rules) to ensure only the PhishSOC Worker can reach it.
+
+3. **Rotate `YARAMAIL_CALLBACK_SECRET` regularly.** Because the secret is shared
+   between the Worker and the sidecar, compromise of either side exposes it. Use
+   your platform's secret-management tooling (Wrangler secrets, Cloud Run Secret
+   Manager, Fly secrets) to rotate it without downtime.
+
+4. **TLS required.** The sidecar endpoint URL configured in mailbox settings must
+   use `https://`. Plain-HTTP endpoints are rejected by the Worker.
+
+---
+
+## Database Schema
+
+Scan results are persisted in the `yaramail_scan_results` Durable Object table
+(migration `20_yaramail_scan_results`):
+
+```sql
+CREATE TABLE yaramail_scan_results (
+  email_id   TEXT    PRIMARY KEY,
+  results    JSON    NOT NULL,
+  scanned_at INTEGER NOT NULL
+);
+```
+
+`results` stores the raw `YaraMatchResult[]` array; `scanned_at` is a Unix
+timestamp (seconds). Rows are written by the Worker after a successful callback
+and are used to populate the verdict audit trail.
+
+---
+
+## Quick Start: Running the Example Stub
+
+A minimal FastAPI stub is provided in `sidecar/example/` to illustrate the
+expected request/response shape. It is **not** a production implementation.
+
+```bash
+cd sidecar/example
+pip install -r requirements.txt
+YARAMAIL_CALLBACK_SECRET=dev-secret uvicorn main:app --port 8080
+```
+
+The stub listens on `POST /scan`, runs a placeholder YARA scan, and posts the
+callback to `http://localhost:8787` (configurable via `PHISHSOC_BASE_URL`).

--- a/docs/yaramail-sidecar.md
+++ b/docs/yaramail-sidecar.md
@@ -103,8 +103,8 @@ interface YaraMatchResult {
 
 If `score` is omitted, PhishSOC looks up `rule_name` in the default score table
 (see [YARA Rule Score Mapping](#yara-rule-score-mapping) below). If the rule name
-is not in the table and no inline `score` is provided, the match contributes 0
-points.
+is not in the table and no inline `score` is provided, the match contributes **+5
+points** (the unknown-rule default, from `workers/security/yaramail-signal.ts`).
 
 ### Authentication: HMAC-SHA256 Signature
 

--- a/sidecar/example/main.py
+++ b/sidecar/example/main.py
@@ -1,0 +1,257 @@
+"""
+YaraMail sidecar example stub — NOT for production use.
+
+This stub illustrates the expected request/response shape between PhishSOC
+and a YARA-scanning sidecar service.  Real implementations should:
+
+  - Fetch the raw message from `presignedUrl` (or the PhishSOC attachment
+    endpoint when `presignedUrl` is empty).
+  - Run a full YARA ruleset against the message and its attachments.
+  - Discard raw message bytes immediately after the scan.
+  - Validate inbound requests via network controls (not implemented here).
+
+Environment variables
+---------------------
+YARAMAIL_CALLBACK_SECRET  Shared HMAC-SHA256 secret (required).
+PHISHSOC_BASE_URL         Base URL of the PhishSOC instance that dispatched
+                          the scan.  Defaults to http://localhost:8787.
+"""
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+from typing import List, Optional
+
+import httpx
+import yara  # type: ignore[import-untyped]
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("yaramail-sidecar")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+CALLBACK_SECRET: bytes = os.environ.get("YARAMAIL_CALLBACK_SECRET", "").encode()
+PHISHSOC_BASE_URL: str = os.environ.get("PHISHSOC_BASE_URL", "http://localhost:8787").rstrip("/")
+
+if not CALLBACK_SECRET:
+    raise RuntimeError("YARAMAIL_CALLBACK_SECRET environment variable is required")
+
+# ---------------------------------------------------------------------------
+# Placeholder YARA rules — replace with your actual ruleset.
+# ---------------------------------------------------------------------------
+
+YARA_RULES_SOURCE = """
+rule pdf_phishing {
+    meta:
+        description = "PDF containing phishing indicators"
+    strings:
+        $uri = /\/URI\s*\(https?:\/\//
+        $js  = "/JavaScript"
+    condition:
+        $uri and $js
+}
+
+rule macro_dropper {
+    meta:
+        description = "Office document with macro-based dropper"
+    strings:
+        $ole  = { D0 CF 11 E0 }
+        $auto = "AutoOpen" nocase
+    condition:
+        $ole and $auto
+}
+
+rule encrypted_zip {
+    meta:
+        description = "Password-protected ZIP attachment"
+    strings:
+        $pk   = { 50 4B 03 04 }
+        $flag = { 01 00 }
+    condition:
+        $pk and $flag at 6
+}
+
+rule nested_archive {
+    meta:
+        description = "Archive-within-archive"
+    strings:
+        $rar = { 52 61 72 21 }
+        $pk  = { 50 4B 03 04 }
+    condition:
+        $rar and $pk
+}
+
+rule eml_attachment {
+    meta:
+        description = "Email-as-attachment"
+    strings:
+        $mime = "Content-Type: message/rfc822" nocase
+    condition:
+        $mime
+}
+"""
+
+_compiled_rules: Optional[yara.Rules] = None  # type: ignore[name-defined]
+
+
+def get_rules() -> "yara.Rules":  # type: ignore[name-defined]
+    global _compiled_rules
+    if _compiled_rules is None:
+        _compiled_rules = yara.compile(source=YARA_RULES_SOURCE)
+    return _compiled_rules
+
+
+# ---------------------------------------------------------------------------
+# Data models (mirror workers/security/yaramail-signal.ts)
+# ---------------------------------------------------------------------------
+
+class YaraScanPayload(BaseModel):
+    emailId: str
+    r2Key: str
+    mailboxId: str
+    presignedUrl: str  # may be empty string in current release
+
+
+class YaraMatchResult(BaseModel):
+    rule_name: str
+    category: Optional[str] = None
+    score: Optional[int] = None
+
+
+class YaraCallbackBody(BaseModel):
+    emailId: str
+    matches: List[YaraMatchResult]
+
+
+# ---------------------------------------------------------------------------
+# HMAC helper
+# ---------------------------------------------------------------------------
+
+def sign_body(body: bytes) -> str:
+    """Return hex-encoded HMAC-SHA256 of *body* using CALLBACK_SECRET."""
+    return hmac.new(CALLBACK_SECRET, body, hashlib.sha256).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Scan logic
+# ---------------------------------------------------------------------------
+
+def fetch_message(payload: YaraScanPayload) -> bytes:
+    """
+    Retrieve raw message bytes.
+
+    Uses presignedUrl when available; otherwise falls back to the PhishSOC
+    attachment download endpoint (requires PHISHSOC_API_KEY in environment).
+    """
+    if payload.presignedUrl:
+        logger.info("Fetching message via presignedUrl for emailId=%s", payload.emailId)
+        resp = httpx.get(payload.presignedUrl, timeout=25)
+        resp.raise_for_status()
+        return resp.content
+
+    # Fallback: PhishSOC attachment endpoint
+    api_key = os.environ.get("PHISHSOC_API_KEY", "")
+    if not api_key:
+        raise RuntimeError(
+            "presignedUrl is empty and PHISHSOC_API_KEY is not set; "
+            "cannot fetch message for emailId=" + payload.emailId
+        )
+    url = f"{PHISHSOC_BASE_URL}/api/v1/mailboxes/{payload.mailboxId}/emails/{payload.emailId}/raw"
+    logger.info("Fetching message via attachment endpoint: %s", url)
+    resp = httpx.get(url, headers={"Authorization": f"Bearer {api_key}"}, timeout=25)
+    resp.raise_for_status()
+    return resp.content
+
+
+def run_yara_scan(message_bytes: bytes) -> List[YaraMatchResult]:
+    """
+    Run YARA rules against *message_bytes* and return a list of matches.
+
+    Replace the placeholder rules above with your production ruleset.
+    """
+    rules = get_rules()
+    raw_matches = rules.match(data=message_bytes)
+
+    results: List[YaraMatchResult] = []
+    for m in raw_matches:
+        results.append(
+            YaraMatchResult(
+                rule_name=m.rule,
+                category=m.meta.get("description"),
+                # score omitted — Worker looks up DEFAULT_YARA_RULE_SCORES
+            )
+        )
+    return results
+
+
+def post_callback(mailbox_id: str, email_id: str, matches: List[YaraMatchResult]) -> None:
+    """POST scan results back to PhishSOC with HMAC-SHA256 signature."""
+    callback_url = f"{PHISHSOC_BASE_URL}/api/v1/mailboxes/{mailbox_id}/yaramail-callback"
+
+    body_obj = YaraCallbackBody(emailId=email_id, matches=matches)
+    # Compact JSON for deterministic signing
+    body_bytes = body_obj.model_dump_json(exclude_none=True).encode()
+
+    signature = sign_body(body_bytes)
+    headers = {
+        "Content-Type": "application/json",
+        "X-PhishSOC-Signature": signature,
+    }
+
+    logger.info(
+        "Posting callback to %s for emailId=%s (%d matches)",
+        callback_url,
+        email_id,
+        len(matches),
+    )
+    resp = httpx.post(callback_url, content=body_bytes, headers=headers, timeout=10)
+    resp.raise_for_status()
+    logger.info("Callback accepted: HTTP %d", resp.status_code)
+
+
+# ---------------------------------------------------------------------------
+# FastAPI application
+# ---------------------------------------------------------------------------
+
+app = FastAPI(title="YaraMail Sidecar Stub", version="0.1.0")
+
+
+@app.post("/scan", status_code=202)
+async def scan(request: Request) -> dict:
+    """
+    Receive a YaraScanPayload from PhishSOC, run YARA, and post the callback.
+
+    Returns 202 Accepted immediately once the payload is parsed; the callback
+    is sent synchronously before the response in this stub.  A production
+    implementation should use a task queue to avoid holding the connection.
+    """
+    try:
+        raw_body = await request.body()
+        payload = YaraScanPayload.model_validate_json(raw_body)
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    logger.info("Received scan request for emailId=%s mailboxId=%s", payload.emailId, payload.mailboxId)
+
+    try:
+        message_bytes = fetch_message(payload)
+        matches = run_yara_scan(message_bytes)
+    finally:
+        # Security: ensure raw bytes do not linger in memory
+        message_bytes = b""  # noqa: F821  (may be unbound if fetch raised)
+
+    post_callback(payload.mailboxId, payload.emailId, matches)
+
+    return {"status": "accepted", "emailId": payload.emailId, "matchCount": len(matches)}
+
+
+@app.get("/healthz")
+async def healthz() -> dict:
+    """Liveness probe."""
+    return {"status": "ok"}

--- a/sidecar/example/requirements.txt
+++ b/sidecar/example/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.111.0
+uvicorn[standard]>=0.29.0
+yara-python>=4.5.0
+httpx>=0.27.0
+pydantic>=2.7.0


### PR DESCRIPTION
## Summary

- Adds `docs/yaramail-sidecar.md` covering deployment model, inbound payload format, outbound callback format, YARA rule → score mapping table, score cap, timeout behavior, and security note.
- Adds `sidecar/example/` with a minimal Python + FastAPI stub showing the expected request/response shape including HMAC-SHA256 signature generation.

Closes #259

## Test plan

- [ ] `docs/yaramail-sidecar.md` covers all 7 Acceptance items from the issue
- [ ] `sidecar/example/` contains a runnable FastAPI stub with `requirements.txt`
- [ ] HMAC-SHA256 signature pattern matches the `X-PhishSOC-Signature` header documented in #257
- [ ] YARA score table in docs matches `DEFAULT_YARA_RULE_SCORES` in `workers/security/yaramail-signal.ts` (on PR #260 branch)

## Notes

- Depends on PR #260 (adds `workers/security/yaramail-signal.ts`) landing before the score table can be verified against main. The values used here are extracted from the PR #260 diff.
- No TypeScript changes, no test suite changes.
- `SECURITY_SPEC.md` untouched (no spec invariant changes).

https://claude.ai/code/session_01JMPnx2GMU9cpDWJzVHRwAa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMPnx2GMU9cpDWJzVHRwAa)_