### PR TITLE
feat: created_by drafts column + agent-authored tier bump (#15 slice 6)

### DIFF
--- a/tests/security/send-risk.test.ts
+++ b/tests/security/send-risk.test.ts
@@ -194,3 +194,61 @@ describe("classifySend — edge cases", () => {
 		expect(result.tier).toBe(1); // b@external.org is external
 	});
 });
+
+// ── Agent-authored tier bump (issue #266) ────────────────────────────────────
+
+describe("classifySend — createdBy: 'agent' bumps tier (issue #266)", () => {
+	it("agent-authored external send (Tier 1 base) becomes Tier 2", () => {
+		const result = classifySend(
+			make({ to: "vendor@external.com", createdBy: "agent" }),
+		);
+		expect(result.tier).toBe(2);
+		expect(result.reasons.some((r) => r.includes("Agent-authored"))).toBe(true);
+		// Original Tier-1 reason still surfaces.
+		expect(result.reasons.some((r) => r.includes("External"))).toBe(true);
+	});
+
+	it("agent-authored internal-only send stays Tier 0", () => {
+		const result = classifySend(
+			make({ to: "colleague@internal.example", createdBy: "agent" }),
+		);
+		expect(result.tier).toBe(0);
+		expect(result.reasons).toHaveLength(0);
+	});
+
+	it("user-authored external send remains Tier 1 (unchanged)", () => {
+		const result = classifySend(
+			make({ to: "vendor@external.com", createdBy: "user" }),
+		);
+		expect(result.tier).toBe(1);
+		expect(result.reasons.some((r) => r.includes("Agent-authored"))).toBe(false);
+	});
+
+	it("omitting createdBy preserves base tier (default behavior)", () => {
+		const result = classifySend(make({ to: "vendor@external.com" }));
+		expect(result.tier).toBe(1);
+		expect(result.reasons.some((r) => r.includes("Agent-authored"))).toBe(false);
+	});
+
+	it("agent-authored Tier-2 send stays Tier 2 (no double bump) and surfaces provenance", () => {
+		const result = classifySend(
+			make({
+				to: "vendor@external.com",
+				body: "wire transfer please",
+				createdBy: "agent",
+			}),
+		);
+		expect(result.tier).toBe(2);
+		// Reason emitted so audit reviewers see provenance on every non-zero
+		// agent send, not just the ones that got bumped from Tier 1.
+		expect(result.reasons.some((r) => r.includes("Agent-authored"))).toBe(true);
+	});
+
+	it("agent-authored high-recipient-count send (Tier 1 base) becomes Tier 2", () => {
+		const many = Array.from({ length: 11 }, (_, i) => `user${i}@internal.example`);
+		const result = classifySend(make({ to: many, createdBy: "agent" }));
+		expect(result.tier).toBe(2);
+		expect(result.reasons.some((r) => r.includes("High recipient count"))).toBe(true);
+		expect(result.reasons.some((r) => r.includes("Agent-authored"))).toBe(true);
+	});
+});

--- a/workers/agent/index.ts
+++ b/workers/agent/index.ts
@@ -187,6 +187,7 @@ function createEmailTools(env: Env, mailboxId: string) {
 					subject,
 					body,
 					isPlainText: true,
+					createdBy: "agent",
 				});
 			},
 		}),
@@ -216,6 +217,7 @@ function createEmailTools(env: Env, mailboxId: string) {
 					body,
 					isPlainText: true,
 					runVerifyDraft: true,
+					createdBy: "agent",
 				});
 			},
 		}),

--- a/workers/db/schema.ts
+++ b/workers/db/schema.ts
@@ -41,6 +41,7 @@ export const emails = sqliteTable("emails", {
 	// migration, or pipeline threw before persistence).
 	stage_trace: text("stage_trace"),
 	deep_scan_status: text("deep_scan_status").default("pending"),
+	created_by: text("created_by").default("user"),
 });
 
 export const attachments = sqliteTable("attachments", {

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -92,6 +92,13 @@ interface EmailData {
 	thread_id?: string | null;
 	message_id?: string | null;
 	raw_headers?: string | null;
+	/**
+	 * Provenance of the row (issue #266): "agent" when the draft was
+	 * authored by the agent's draft_reply / draft_email tools, "user"
+	 * otherwise. Read by the outbound send-risk classifier to bump tier.
+	 * Omit to inherit the column default ("user") at the SQL layer.
+	 */
+	created_by?: "agent" | "user";
 }
 
 interface AttachmentData {
@@ -906,6 +913,7 @@ export class MailboxDO extends DurableObject<Env> {
 				thread_id: email.thread_id ?? null,
 				message_id: email.message_id ?? null,
 				raw_headers: email.raw_headers ?? null,
+				created_by: email.created_by ?? "user",
 			})
 			.run();
 

--- a/workers/durableObject/migrations.ts
+++ b/workers/durableObject/migrations.ts
@@ -469,4 +469,14 @@ export const mailboxMigrations: Migration[] = [
             );
         `,
 	},
+	{
+		// Provenance flag for outbound drafts (issue #266, slice 6 of #15).
+		// 'user' for human-authored sends (default); 'agent' when the row
+		// was written by the agent's draft_reply / draft_email tools. Read
+		// by the send-risk classifier to bump tier on agent-authored
+		// external sends. Forward-only ALTER; pre-#266 rows get the
+		// 'user' default which preserves existing behavior.
+		name: "21_emails_created_by",
+		sql: `ALTER TABLE emails ADD COLUMN created_by TEXT DEFAULT 'user';`,
+	},
 ];

--- a/workers/lib/tools.ts
+++ b/workers/lib/tools.ts
@@ -142,6 +142,12 @@ export async function toolDraftReply(
 		body: string;
 		isPlainText?: boolean;
 		runVerifyDraft?: boolean;
+		/**
+		 * Provenance for the persisted draft (issue #266). Pass "agent" from
+		 * the email-handling agent; omit (or pass "user") from MCP / human
+		 * paths so the row defaults to "user".
+		 */
+		createdBy?: "agent" | "user";
 	},
 ): Promise<
 	| { status: "draft_saved"; draftId: string; message: string; draft: Record<string, string> }
@@ -192,6 +198,7 @@ export async function toolDraftReply(
 			in_reply_to: params.originalEmailId,
 			email_references: null,
 			thread_id: threadId,
+			created_by: params.createdBy,
 		},
 		[],
 	);
@@ -224,6 +231,12 @@ export async function toolDraftEmail(
 		in_reply_to?: string;
 		/** Optional thread_id for create_draft style */
 		thread_id?: string;
+		/**
+		 * Provenance for the persisted draft (issue #266). Pass "agent" from
+		 * the email-handling agent; omit (or pass "user") from MCP / human
+		 * paths so the row defaults to "user".
+		 */
+		createdBy?: "agent" | "user";
 	},
 ): Promise<
 	| { status: string; draftId: string; threadId?: string; message: string; draft?: Record<string, string> }
@@ -268,6 +281,7 @@ export async function toolDraftEmail(
 			in_reply_to: params.in_reply_to || null,
 			email_references: null,
 			thread_id: resolvedThreadId,
+			created_by: params.createdBy,
 		},
 		[],
 	);

--- a/workers/security/send-risk.ts
+++ b/workers/security/send-risk.ts
@@ -31,6 +31,13 @@ export interface ClassifySendInput {
 	attachments?: Array<{ filename?: string | null }>;
 	/** The mailboxId is an email address; its domain is the "internal" domain. */
 	mailboxId: string;
+	/**
+	 * Provenance of the draft (issue #266). When "agent", the computed tier is
+	 * bumped by +1 (capped at 2): a Tier-1 agent send (e.g. external recipient)
+	 * becomes Tier 2; Tier-0 stays Tier 0; Tier-2 stays Tier 2. Omitted /
+	 * "user" preserves the human-authored behavior.
+	 */
+	createdBy?: "agent" | "user";
 }
 
 // ── Tier-2 BEC / credential keyword list ────────────────────────────────────
@@ -134,6 +141,18 @@ export function classifySend(input: ClassifySendInput): SendRisk {
 			const sample = external.slice(0, 3).join(", ");
 			raise(1, `External recipient(s): ${sample}${external.length > 3 ? ` (+${external.length - 3} more)` : ""}`);
 		}
+	}
+
+	// ── Agent-authored bump (issue #266) ─────────────────────────────────────
+	// Bump tier by +1 (capped at 2) when the draft was written by the agent
+	// rather than a human. Tier 0 stays Tier 0 (purely internal traffic gets
+	// no bump — there is nothing risky to elevate); Tier 2 stays Tier 2
+	// (already at the ceiling). The reason is emitted on every non-zero
+	// agent send so audit reviewers see provenance on Tier-2 keyword/macro
+	// drafts too, not just the bumped ones.
+	if (input.createdBy === "agent" && tier > 0) {
+		reasons.push("Agent-authored draft");
+		if (tier < 2) tier = 2;
 	}
 
 	return { tier, reasons };


### PR DESCRIPTION
## Summary

- Threads draft provenance from the agent's `draft_reply` / `draft_email` tools through the mailbox DO down to the outbound send-risk classifier.
- Agent-authored sends with any non-zero base risk are bumped to **Tier 2** (capped) so they require step-up confirmation; user-authored sends are unaffected.
- Slice 6 of #15 (after #261 shipped slice 1's classifier).

## What changed

| File | Change |
|---|---|
| `workers/durableObject/migrations.ts` | Migration 21: `ALTER TABLE emails ADD COLUMN created_by TEXT DEFAULT 'user'` (literal-constant DEFAULT backfills existing rows). |
| `workers/db/schema.ts` | Drizzle column for the new field. |
| `workers/durableObject/index.ts` | `EmailData` and `createEmail` accept optional `created_by`; SQL default fills in for any caller that doesn't pass one. |
| `workers/lib/tools.ts` | `toolDraftReply` / `toolDraftEmail` accept `createdBy` and forward to `createEmail`. |
| `workers/agent/index.ts` | Agent passes `createdBy: "agent"` at both `draft_reply` and `draft_email` call sites. MCP and human paths leave it unset → `"user"`. |
| `workers/security/send-risk.ts` | `classifySend` accepts optional `createdBy`; when `"agent"` and base tier > 0, emits an `Agent-authored draft` reason and caps the result at Tier 2. |
| `tests/security/send-risk.test.ts` | 6 new unit tests covering all four Acceptance bullets plus two edge cases (Tier-0 stays clean, high-recipient-count agent send). |

## Acceptance (issue #266)

- [x] `emails` table has `created_by TEXT DEFAULT 'user'` column via a new migration.
- [x] Agent `toolDraftReply` / `toolDraftEmail` passes `created_by: "agent"` to `createEmail`.
- [x] `classifySend` accepts optional `createdBy` and bumps tier by +1 (capped at 2) when `"agent"`.
- [x] Unit tests: agent-authored Tier-1 input → Tier 2; agent-authored Tier-0 input → Tier 0; user-authored Tier-1 input → Tier 1 (unchanged).

## Deferred follow-ups

- **Worker-handler integration** — the issue's Pointers list `workers/index.ts` (read `created_by` from the draft row when `in_reply_to` is present, pass it to `classifySend`). That path requires `classifySend` to be called from `POST /api/v1/mailboxes/:id/emails`, which **slice 3 (#262)** introduces. This PR ships the field + classifier wiring; the handler integration lands with #262.
- **`toolUpdateDraft` does not preserve `created_by`** — it deletes the old draft and re-creates without forwarding the field, so an updated draft becomes `"user"`. Today the agent doesn't expose `update_draft`, so this only affects human-edit / future MCP paths. Not in scope of #266.

## Why one PR despite 7 files

A single field threading vertically through migration → Drizzle schema → DO interface → tool layer → agent call sites → classifier → tests. Splitting this would yield either a migration with no writer or a half-wired pipeline. Net: +112 lines.

## Test plan

- [x] `npm run typecheck` — clean (`tsc -b` succeeded after `cf-typegen` regen produced no diff to `worker-configuration.d.ts`)
- [x] `npm test` — **1018 passing, 0 failing** (78 files, 8.15s) on the pre-refinement state
- [x] `npx vitest run tests/security/send-risk.test.ts` — **35 passing, 0 failing** after the post-advisor refinement (29 prior + 6 new)
- [x] No `SECURITY_SPEC.md` edits, no URL substring patterns, no `wrangler.jsonc` edits, no secrets staged

Closes #266
Part of #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)