### PR TITLE
feat: per-mailbox Attachment scanner settings UI toggle (yaramail sidecar)

### DIFF
--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { Badge, Button, Dialog, Input, Loader } from "@cloudflare/kumo";
+import { Badge, Button, Dialog, Input, Loader, Switch } from "@cloudflare/kumo";
 import { RobotIcon, ArrowCounterClockwiseIcon } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router";
@@ -18,7 +18,7 @@ import {
 	validateHubConfig,
 	type HubFieldErrors,
 } from "~/components/HubSettingsPanel";
-import type { HubConfigSettings, SecuritySettings } from "~/types";
+import type { HubConfigSettings, SecuritySettings, YaraMailScannerSettings } from "~/types";
 import {
 	TEXT_MODELS,
 	SECURITY_MODELS,
@@ -147,6 +147,11 @@ export default function SettingsRoute() {
 	const [hubOverride, setHubOverride] = useState(false);
 	const [hub, setHub] = useState<HubConfigSettings | undefined>(undefined);
 	const [hubErrors, setHubErrors] = useState<HubFieldErrors | undefined>(undefined);
+
+	// Attachment scanner (yaramail sidecar, #258 / #256). Off by default —
+	// a fresh mailbox never contacts the sidecar unless the operator opts in.
+	const [yaraScannerEnabled, setYaraScannerEnabled] = useState(false);
+	const [yaraScannerEndpointUrl, setYaraScannerEndpointUrl] = useState("");
 
 	const [isSaving, setIsSaving] = useState(false);
 
@@ -279,6 +284,18 @@ export default function SettingsRoute() {
 		}
 		setHubErrors(undefined);
 
+		// yaramail_scanner — off by default; never pre-populate endpoint URL
+		// unless the mailbox has an explicit saved config with enabled: true.
+		const savedYara = (mailbox.settings as Record<string, unknown> | undefined)
+			?.yaramail_scanner as YaraMailScannerSettings | undefined;
+		if (savedYara?.enabled) {
+			setYaraScannerEnabled(true);
+			setYaraScannerEndpointUrl(savedYara.endpoint_url ?? "");
+		} else {
+			setYaraScannerEnabled(false);
+			setYaraScannerEndpointUrl("");
+		}
+
 		// availableModels intentionally omitted from deps — see commit
 		// message for the rationale (re-running this effect would clobber
 		// edits when the dynamic models list resolves).
@@ -326,6 +343,12 @@ export default function SettingsRoute() {
 		// Build the PUT payload. Per audit Q5/Q6/Q8: undefined fields get
 		// stripped server-side via stripDefaultEqual (PR1) so the resolver
 		// can fall through to the org tier on the next read.
+		// yaramail_scanner: include only when enabled; absent key strips via
+		// stripDefaultEqual on the server, consistent with absent-key semantics.
+		const nextYaraScanner: YaraMailScannerSettings | undefined = yaraScannerEnabled
+			? { enabled: true, endpoint_url: yaraScannerEndpointUrl.trim() || undefined }
+			: undefined;
+
 		const settings = {
 			...mailbox.settings,
 			fromName: displayName,
@@ -337,6 +360,7 @@ export default function SettingsRoute() {
 			classifierModel: classifierOverride ? classifierModelChoice : undefined,
 			security: securityOverride ? security : undefined,
 			intel: nextIntel,
+			yaramail_scanner: nextYaraScanner,
 		};
 		try {
 			await updateMailboxMutation.mutateAsync({ mailboxId, settings });
@@ -784,6 +808,45 @@ export default function SettingsRoute() {
 						}}
 						errors={hubErrors}
 					/>
+				</div>
+
+				{/* Attachment scanner (yaramail sidecar, #258 / #256) */}
+				<div className="pp-card p-5">
+					<div className="text-sm font-medium text-ink mb-2">Attachment scanner</div>
+					<p className="text-xs text-ink-3 mb-4">
+						Optional async attachment-scanning sidecar (yaramail). When enabled,
+						attachments are forwarded to the configured sidecar endpoint for
+						deep content inspection. Disabled by default — only enable when you
+						have a sidecar container deployed and the endpoint URL ready.
+					</p>
+					<div className="space-y-3">
+						<Switch
+							label="Enable attachment scanner"
+							checked={yaraScannerEnabled}
+							onCheckedChange={(v) => {
+								setYaraScannerEnabled(v);
+								if (!v) setYaraScannerEndpointUrl("");
+							}}
+							data-testid="yaramail-scanner-toggle"
+						/>
+						{yaraScannerEnabled && (
+							<div className="border-t border-line pt-4">
+								<Input
+									label="Sidecar endpoint URL"
+									type="url"
+									placeholder="https://yaramail.internal/scan"
+									value={yaraScannerEndpointUrl}
+									onChange={(e) => setYaraScannerEndpointUrl(e.target.value)}
+								/>
+								<p className="text-xs text-ink-3 mt-2">
+									URL of the yaramail sidecar container's HTTP scan endpoint.
+									Must be reachable from the Worker runtime. No format validation
+									beyond <code className="pp-mono">type="url"</code> — the server
+									validates on save.
+								</p>
+							</div>
+						)}
+					</div>
 				</div>
 
 				{/* Save */}

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -96,6 +96,15 @@ export interface DmarcRufRecord {
 	original_headers: string | null;
 }
 
+/**
+ * Per-mailbox yaramail async attachment-scanning sidecar config (#258 / #256).
+ * Mirrors `YaraMailScannerSettings` in `shared/mailbox-settings.ts`.
+ */
+export interface YaraMailScannerSettings {
+	enabled?: boolean;
+	endpoint_url?: string;
+}
+
 export interface MailboxSettings {
 	fromName?: string;
 	forwarding?: { enabled: boolean; email: string };
@@ -104,6 +113,7 @@ export interface MailboxSettings {
 	agentSystemPrompt?: string;
 	security?: SecuritySettings;
 	intel?: IntelSettings;
+	yaramail_scanner?: YaraMailScannerSettings;
 }
 
 export interface Mailbox {

--- a/tests/frontend/settings-attachment-scanner.test.tsx
+++ b/tests/frontend/settings-attachment-scanner.test.tsx
@@ -1,0 +1,175 @@
+// Coverage for the per-mailbox "Attachment scanner" section (#258 / #256)
+// in `app/routes/settings.tsx`. Verifies the yaramail sidecar toggle:
+//   - off by default (no pre-populated URL)
+//   - enabling shows the endpoint URL input
+//   - disabling hides the endpoint URL input
+//   - saving with toggle on includes yaramail_scanner in PUT payload
+//   - saving with toggle off omits yaramail_scanner from PUT payload
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+import type { Mailbox, MailboxSettings } from "~/types";
+
+const mutateAsync = vi.fn();
+const updateMailboxMock = {
+	mutateAsync,
+	isPending: false,
+} as unknown as ReturnType<typeof import("~/queries/mailboxes").useUpdateMailbox>;
+
+let mailboxFixture: Mailbox;
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({ data: mailboxFixture }),
+	useUpdateMailbox: () => updateMailboxMock,
+}));
+
+vi.mock("~/queries/org-settings", () => ({
+	useOrgSettings: () => ({ data: { settings: {} }, isLoading: false }),
+}));
+
+vi.mock("~/queries/domain-settings", () => ({
+	useDomainSettings: () => ({
+		data: { domain: "example.com", settings: {} },
+		isLoading: false,
+	}),
+}));
+
+import SettingsRoute from "~/routes/settings";
+import { renderWithProviders } from "./test-utils";
+
+function renderSettings() {
+	return renderWithProviders(
+		<Routes>
+			<Route path="/mailbox/:mailboxId/settings" element={<SettingsRoute />} />
+		</Routes>,
+		{ initialEntries: ["/mailbox/m1/settings"] },
+	);
+}
+
+function makeMailbox(overrides: Partial<MailboxSettings> = {}): Mailbox {
+	return {
+		id: "m1",
+		email: "ops@example.com",
+		name: "Ops",
+		settings: {
+			autoDraft: { enabled: true },
+			agentModel: "@cf/moonshotai/kimi-k2.5",
+			...overrides,
+		} as MailboxSettings,
+	} as unknown as Mailbox;
+}
+
+async function lastSavedSettings(): Promise<MailboxSettings> {
+	await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+	const payload = mutateAsync.mock.calls[0][0] as {
+		mailboxId: string;
+		settings: MailboxSettings;
+	};
+	return payload.settings;
+}
+
+describe("Settings · Attachment scanner section (#258)", () => {
+	beforeEach(() => {
+		mutateAsync.mockReset();
+		mutateAsync.mockResolvedValue(undefined);
+	});
+
+	it("renders the toggle off by default (no saved config)", async () => {
+		mailboxFixture = makeMailbox();
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /enable attachment scanner/i,
+		});
+		expect(toggle).not.toBeChecked();
+	});
+
+	it("does not show the endpoint URL input when toggle is off", async () => {
+		mailboxFixture = makeMailbox();
+		renderSettings();
+
+		await screen.findByRole("switch", { name: /enable attachment scanner/i });
+		expect(screen.queryByLabelText(/sidecar endpoint url/i)).toBeNull();
+	});
+
+	it("shows the endpoint URL input when the toggle is enabled", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox();
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /enable attachment scanner/i,
+		});
+		await user.click(toggle);
+
+		expect(screen.getByLabelText(/sidecar endpoint url/i)).toBeInTheDocument();
+	});
+
+	it("hides the endpoint URL input when the toggle is disabled after being on", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox();
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /enable attachment scanner/i,
+		});
+		// Enable then disable.
+		await user.click(toggle);
+		expect(screen.getByLabelText(/sidecar endpoint url/i)).toBeInTheDocument();
+		await user.click(toggle);
+		expect(screen.queryByLabelText(/sidecar endpoint url/i)).toBeNull();
+	});
+
+	it("includes yaramail_scanner in the PUT payload when toggle is on", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox();
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /enable attachment scanner/i,
+		});
+		await user.click(toggle);
+
+		const urlInput = screen.getByLabelText(/sidecar endpoint url/i);
+		await user.type(urlInput, "https://yaramail.internal/scan");
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		expect((saved as Record<string, unknown>).yaramail_scanner).toEqual({
+			enabled: true,
+			endpoint_url: "https://yaramail.internal/scan",
+		});
+	});
+
+	it("omits yaramail_scanner from the PUT payload when toggle is off", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox();
+		renderSettings();
+
+		await screen.findByRole("switch", { name: /enable attachment scanner/i });
+		// Do NOT enable the toggle — leave it off.
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		// undefined is dropped by JSON.stringify, consistent with absent-key semantics.
+		expect((saved as Record<string, unknown>).yaramail_scanner).toBeUndefined();
+	});
+
+	it("restores saved config when mailbox has yaramail_scanner.enabled=true", async () => {
+		mailboxFixture = makeMailbox({
+			yaramail_scanner: { enabled: true, endpoint_url: "https://sidecar.example.com/scan" },
+		} as Record<string, unknown>);
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /enable attachment scanner/i,
+		});
+		expect(toggle).toBeChecked();
+		expect(screen.getByLabelText(/sidecar endpoint url/i)).toHaveValue(
+			"https://sidecar.example.com/scan",
+		);
+	});
+});


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds an **Attachment scanner** section to the per-mailbox settings page (`app/routes/settings.tsx`) below the Threat-intel hub panel.
- Section contains a `Switch` for enable/disable (`data-testid="yaramail-scanner-toggle"`) and — when enabled — an `Input` for the sidecar endpoint URL (`type="url"`).
- Toggle defaults **off**; no pre-populated endpoint URL is ever rendered for a fresh mailbox.
- When the toggle is off, `yaramail_scanner` is set to `undefined` in the PUT payload; `stripDefaultEqual` on the server removes the key, preserving absent-key-inherits semantics.
- Adds `YaraMailScannerSettings` frontend interface to `app/types/index.ts` (mirrors `shared/mailbox-settings.ts`).
- 6 new vitest tests in `tests/frontend/settings-attachment-scanner.test.tsx` covering: default-off rendering, URL field visibility on enable/disable, PUT payload inclusion/omission, and saved-config restoration.

Closes #258

## Test plan

- [ ] `npm test` — all 79 test files (1025 tests) pass including the 6 new attachment-scanner tests.
- [ ] `tsc --project tsconfig.json` — no type errors.
- [ ] Manual: navigate to a mailbox settings page, confirm "Attachment scanner" section renders below "Threat-intel hub", toggle is off by default, enabling shows the URL input, disabling hides it again.
- [ ] Manual: enable scanner, enter a URL, save — confirm `yaramail_scanner.enabled=true` and `endpoint_url` are in the persisted mailbox settings.
- [ ] Manual: disable scanner, save — confirm `yaramail_scanner` key is absent from the stored JSON (check R2 directly or re-load settings page to see toggle off).

## Deferred

- Test-connection button to validate sidecar reachability (tracked as follow-up per issue Out-of-scope).
- Docs.

https://claude.ai/code/session_018eDaMWk7seZQ7P9hk1e8qE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018eDaMWk7seZQ7P9hk1e8qE)_