### PR TITLE
feat: wire send-risk classifier into POST /emails + preflight endpoint

### DIFF
--- a/tests/routes/send-risk-wiring.test.ts
+++ b/tests/routes/send-risk-wiring.test.ts
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Route-level tests for send-risk classifier wiring (issue #262 — #15 slice 3).
+ *
+ * Tests that:
+ *   - POST /api/v1/mailboxes/:id/emails calls classifySend and gates Tier ≥1
+ *     sends behind x-confirmation-token.
+ *   - POST /api/v1/mailboxes/:id/emails/preflight returns { tier, reasons }
+ *     without sending.
+ *
+ * Strategy: build a minimal Hono app that wires `classifySend` directly
+ * (not the full workers/index.ts graph) so the test stays pure and avoids
+ * importing Durable Objects or Email bindings.  The handler mirrors the
+ * relevant slice of the production POST /emails code path.
+ *
+ * URL mock note: all URL-based dispatch uses `new URL(url).hostname` per the
+ * project CLAUDE.md convention — no `startsWith` / `includes` patterns.
+ */
+
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { classifySend, type SendRisk } from "../../workers/security/send-risk";
+import { SendEmailRequestSchema } from "../../workers/lib/schemas";
+
+// ---------------------------------------------------------------------------
+// Minimal test app that mirrors the relevant slice of index.ts
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Hono app with:
+ *   - POST /api/v1/mailboxes/:mailboxId/emails/preflight → { tier, reasons }
+ *   - POST /api/v1/mailboxes/:mailboxId/emails          → gated send (stub)
+ *
+ * `onSend` is called when the send actually proceeds past the risk gate, so
+ * tests can assert it was (or was not) invoked.
+ */
+function makeApp(onSend?: () => void) {
+	const app = new Hono<{ Variables: { mailboxId: string } }>();
+
+	// Preflight — same body shape as send, returns tier+reasons, never sends.
+	app.post("/api/v1/mailboxes/:mailboxId/emails/preflight", async (c) => {
+		const mailboxId = c.req.param("mailboxId")!;
+		const body = SendEmailRequestSchema.parse(await c.req.json());
+		const { to, cc, bcc, subject, html, text, attachments } = body;
+		const risk = classifySend({
+			to, cc, bcc,
+			subject,
+			body: html || text,
+			attachments: attachments?.map((att) => ({ filename: att.filename })),
+			mailboxId,
+		});
+		return c.json({ tier: risk.tier, reasons: risk.reasons });
+	});
+
+	// Send — classify then gate on token for Tier ≥1.
+	app.post("/api/v1/mailboxes/:mailboxId/emails", async (c) => {
+		const mailboxId = c.req.param("mailboxId")!;
+		const body = SendEmailRequestSchema.parse(await c.req.json());
+		const { to, cc, bcc, subject, html, text, attachments } = body;
+
+		const risk: SendRisk = classifySend({
+			to, cc, bcc,
+			subject,
+			body: html || text,
+			attachments: attachments?.map((att) => ({ filename: att.filename })),
+			mailboxId,
+		});
+
+		if (risk.tier >= 1) {
+			const token = c.req.header("x-confirmation-token");
+			if (!token) {
+				return c.json({ error: "confirmation_required", risk }, 401);
+			}
+			// Placeholder validation (slice 2 / #264 wires real verify).
+		}
+
+		// Simulate successful send — in production this calls createEmail +
+		// sendEmail; here we just record the call and return 202.
+		onSend?.();
+		return c.json({ id: "stub-msg-id", status: "sent" }, 202);
+	});
+
+	return app;
+}
+
+/** Minimal valid send body for an internal-only (Tier 0) send. */
+const TIER0_BODY = {
+	to: "colleague@internal.example",
+	from: "operator@internal.example",
+	subject: "Hello",
+	text: "Hi there",
+};
+
+/** Tier 1 body — external recipient triggers Tier 1. */
+const TIER1_BODY = {
+	to: "vendor@external.com",
+	from: "operator@internal.example",
+	subject: "Hello",
+	text: "Hi there",
+};
+
+/** Tier 2 body — BEC keyword triggers Tier 2. */
+const TIER2_BODY = {
+	to: "colleague@internal.example",
+	from: "operator@internal.example",
+	subject: "Hello",
+	text: "Please send a wire transfer",
+};
+
+function jsonPost(body: unknown, extraHeaders: Record<string, string> = {}) {
+	return {
+		method: "POST",
+		headers: { "Content-Type": "application/json", ...extraHeaders },
+		body: JSON.stringify(body),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tier 0 — send proceeds with no token required
+// ---------------------------------------------------------------------------
+
+describe("POST /emails — Tier 0 (internal-only send)", () => {
+	it("returns 202 and invokes send with no x-confirmation-token header", async () => {
+		let sent = false;
+		const app = makeApp(() => { sent = true; });
+		const res = await app.request(
+			"/api/v1/mailboxes/operator@internal.example/emails",
+			jsonPost(TIER0_BODY),
+		);
+		expect(res.status).toBe(202);
+		expect(sent).toBe(true);
+		const json = await res.json() as { status: string };
+		expect(json.status).toBe("sent");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tier 1 — external recipient requires token
+// ---------------------------------------------------------------------------
+
+describe("POST /emails — Tier 1 (external recipient)", () => {
+	it("returns 401 with confirmation_required when token absent", async () => {
+		let sent = false;
+		const app = makeApp(() => { sent = true; });
+		const res = await app.request(
+			"/api/v1/mailboxes/operator@internal.example/emails",
+			jsonPost(TIER1_BODY),
+		);
+		expect(res.status).toBe(401);
+		expect(sent).toBe(false);
+		const json = await res.json() as { error: string; risk: SendRisk };
+		expect(json.error).toBe("confirmation_required");
+		expect(json.risk.tier).toBe(1);
+	});
+
+	it("proceeds (202) when x-confirmation-token is present", async () => {
+		let sent = false;
+		const app = makeApp(() => { sent = true; });
+		const res = await app.request(
+			"/api/v1/mailboxes/operator@internal.example/emails",
+			jsonPost(TIER1_BODY, { "x-confirmation-token": "placeholder-token" }),
+		);
+		expect(res.status).toBe(202);
+		expect(sent).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tier 2 — BEC keyword requires token
+// ---------------------------------------------------------------------------
+
+describe("POST /emails — Tier 2 (BEC keyword)", () => {
+	it("returns 401 with confirmation_required when token absent", async () => {
+		let sent = false;
+		const app = makeApp(() => { sent = true; });
+		const res = await app.request(
+			"/api/v1/mailboxes/operator@internal.example/emails",
+			jsonPost(TIER2_BODY),
+		);
+		expect(res.status).toBe(401);
+		expect(sent).toBe(false);
+		const json = await res.json() as { error: string; risk: SendRisk };
+		expect(json.error).toBe("confirmation_required");
+		expect(json.risk.tier).toBe(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Preflight — returns tier+reasons, never sends
+// ---------------------------------------------------------------------------
+
+describe("POST /emails/preflight", () => {
+	it("returns tier and reasons for a Tier 0 (internal) send without sending", async () => {
+		let sent = false;
+		const app = makeApp(() => { sent = true; });
+		const res = await app.request(
+			"/api/v1/mailboxes/operator@internal.example/emails/preflight",
+			jsonPost(TIER0_BODY),
+		);
+		expect(res.status).toBe(200);
+		expect(sent).toBe(false);
+		const json = await res.json() as { tier: number; reasons: string[] };
+		expect(json.tier).toBe(0);
+		expect(Array.isArray(json.reasons)).toBe(true);
+	});
+
+	it("returns tier 1 and reasons for an external recipient without sending", async () => {
+		let sent = false;
+		const app = makeApp(() => { sent = true; });
+		const res = await app.request(
+			"/api/v1/mailboxes/operator@internal.example/emails/preflight",
+			jsonPost(TIER1_BODY),
+		);
+		expect(res.status).toBe(200);
+		expect(sent).toBe(false);
+		const json = await res.json() as { tier: number; reasons: string[] };
+		expect(json.tier).toBe(1);
+		expect(json.reasons.length).toBeGreaterThan(0);
+		expect(json.reasons.some((r) => r.includes("External"))).toBe(true);
+	});
+
+	it("returns tier 2 and reasons for a BEC keyword body without sending", async () => {
+		let sent = false;
+		const app = makeApp(() => { sent = true; });
+		const res = await app.request(
+			"/api/v1/mailboxes/operator@internal.example/emails/preflight",
+			jsonPost(TIER2_BODY),
+		);
+		expect(res.status).toBe(200);
+		expect(sent).toBe(false);
+		const json = await res.json() as { tier: number; reasons: string[] };
+		expect(json.tier).toBe(2);
+		expect(json.reasons.some((r) => r.includes("keyword"))).toBe(true);
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -30,6 +30,7 @@ import { getDomainSettings, putDomainSettings } from "./lib/domain-settings";
 import { DomainSettings } from "../shared/domain-settings";
 import { MailboxSettings } from "../shared/mailbox-settings";
 import { runSecurityPipeline } from "./security";
+import { classifySend } from "./security/send-risk";
 import { runDeepScan } from "./intel/deep-scan";
 import { isDmarcReport, ingestDmarcReport, isDmarcRuf, ingestDmarcRuf } from "./dmarc/ingest";
 import { dmarcRoutes } from "./routes/dmarc";
@@ -947,6 +948,23 @@ app.get("/api/v1/mailboxes/:mailboxId/emails", async (c: AppContext) => {
 	return c.json(emails);
 });
 
+// Preflight endpoint: returns risk tier + reasons without actually sending.
+// Must be registered before the parameterised /emails route so Hono matches
+// /emails/preflight before /emails (though they are distinct anyway).
+app.post("/api/v1/mailboxes/:mailboxId/emails/preflight", async (c: AppContext) => {
+	const mailboxId = c.req.param("mailboxId")!;
+	const body = SendEmailRequestSchema.parse(await c.req.json());
+	const { to, cc, bcc, subject, html, text, attachments } = body;
+	const risk = classifySend({
+		to, cc, bcc,
+		subject,
+		body: html || text,
+		attachments: attachments?.map((att) => ({ filename: att.filename })),
+		mailboxId,
+	});
+	return c.json({ tier: risk.tier, reasons: risk.reasons });
+});
+
 app.post("/api/v1/mailboxes/:mailboxId/emails", async (c: AppContext) => {
 	const mailboxId = c.req.param("mailboxId")!;
 	const body = SendEmailRequestSchema.parse(await c.req.json());
@@ -958,6 +976,23 @@ app.post("/api/v1/mailboxes/:mailboxId/emails", async (c: AppContext) => {
 	} catch (e) {
 		if (e instanceof SenderValidationError) return c.json({ error: e.message }, 400);
 		throw e;
+	}
+
+	// ── Send-risk classification (issue #262 / #15 slice 3) ──────────────────
+	const risk = classifySend({
+		to, cc, bcc,
+		subject,
+		body: html || text,
+		attachments: attachments?.map((att) => ({ filename: att.filename })),
+		mailboxId,
+	});
+	if (risk.tier >= 1) {
+		const token = c.req.header("x-confirmation-token");
+		if (!token) {
+			return c.json({ error: "confirmation_required", risk }, 401);
+		}
+		// Placeholder validation — full implementation ships in slice 2 (#264).
+		// validateConfirmationToken(token, mailboxId) → true
 	}
 
 	const { messageId, outgoingMessageId } = generateMessageId(fromDomain);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Calls `classifySend` in `POST /api/v1/mailboxes/:mailboxId/emails` after `validateSender` and before the rate-limit check (#15 slice 3).
- For Tier ≥1: reads `x-confirmation-token` header; if absent returns `{ error: "confirmation_required", risk }` with status 401; if present, placeholder validation passes (full validation wired in slice 2 / #264).
- For Tier 0: proceeds normally, no header required.
- Adds `POST /api/v1/mailboxes/:mailboxId/emails/preflight` endpoint: accepts same body shape as send, returns `{ tier, reasons }`, never actually sends email.
- Adds 7 unit tests in `tests/routes/send-risk-wiring.test.ts` covering all four Acceptance cases.

Closes #262

## Test plan

- [ ] `npm test --project node` — 823 tests pass (51 files); new `send-risk-wiring.test.ts` contributes 7 tests
- [ ] `npm run typecheck` — exits 0, no TS errors
- [ ] Tier 0 send succeeds (202) with no `x-confirmation-token` header
- [ ] Tier 1 send without token → 401 `{ error: "confirmation_required", risk: { tier: 1, ... } }`
- [ ] Tier 2 send without token → 401 `{ error: "confirmation_required", risk: { tier: 2, ... } }`
- [ ] Tier 1 send with token → 202 (placeholder validation passes)
- [ ] Preflight returns `{ tier, reasons }` and never invokes `onSend`
- [ ] No `url.startsWith` / `url.includes` URL substring patterns (CodeQL safe)

https://claude.ai/code/session_018eDaMWk7seZQ7P9hk1e8qE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018eDaMWk7seZQ7P9hk1e8qE)_