### PR TITLE
feat: composer send-risk UI — Tier 0/1/2 button states, preflight call, Tier-2 phrase confirm

### DIFF
--- a/app/components/ComposeEmail.tsx
+++ b/app/components/ComposeEmail.tsx
@@ -33,10 +33,18 @@ export default function ComposeEmail() {
 		error,
 		isSavingDraft,
 		isSending,
+		preflight,
+		confirmPhrase,
+		setConfirmPhrase,
 		formTitle,
 		handleSaveDraft,
 		handleSend,
 	} = useComposeForm(mailboxId, folder);
+
+	const sendTier = preflight?.tier ?? 0;
+	const sendLabel = sendTier === 2 ? "Send (verify)" : sendTier === 1 ? "Send (re-auth)" : "Send";
+	const sendTestId = sendTier === 2 ? "send-button-tier2" : sendTier === 1 ? "send-button-tier1" : "send-button-tier0";
+	const primaryRecipient = to.split(/[,;]/)[0].trim();
 
 	return (
 		<Dialog.Root
@@ -106,6 +114,18 @@ export default function ComposeEmail() {
 						</Text>
 						<RichTextEditor value={body} onChange={setBody} />
 					</div>
+					{sendTier >= 2 && (
+						<div className="mt-2">
+							<Input
+								label={`Type "${primaryRecipient}" to confirm`}
+								type="text"
+								size="sm"
+								value={confirmPhrase}
+								onChange={(e) => setConfirmPhrase(e.target.value)}
+								data-testid="confirm-phrase-input"
+							/>
+						</div>
+					)}
 					<div className="flex justify-between items-center pt-2">
 						<Button
 							type="button"
@@ -135,8 +155,9 @@ export default function ComposeEmail() {
 								loading={isSending}
 								disabled={isSavingDraft || isSending}
 								icon={<PaperPlaneTiltIcon size={14} />}
+								data-testid={sendTestId}
 							>
-								{isSending ? "Sending..." : "Send"}
+								{isSending ? "Sending..." : sendLabel}
 							</Button>
 						</div>
 					</div>

--- a/app/components/ComposePanel.tsx
+++ b/app/components/ComposePanel.tsx
@@ -30,12 +30,20 @@ export default function ComposePanel() {
 		error,
 		isSavingDraft,
 		isSending,
+		preflight,
+		confirmPhrase,
+		setConfirmPhrase,
 		formTitle,
 		handleSaveDraft,
 		handleSend,
 		closeCompose,
 		closePanel,
 	} = useComposeForm(mailboxId, folder);
+
+	const sendTier = preflight?.tier ?? 0;
+	const sendLabel = sendTier === 2 ? "Send (verify)" : sendTier === 1 ? "Send (re-auth)" : "Send";
+	const sendTestId = sendTier === 2 ? "send-button-tier2" : sendTier === 1 ? "send-button-tier1" : "send-button-tier0";
+	const primaryRecipient = to.split(/[,;]/)[0].trim();
 
 	return (
 		<div className="flex flex-col h-full bg-paper">
@@ -146,6 +154,18 @@ export default function ComposePanel() {
 							onChange={setBody}
 						/>
 					</div>
+					{sendTier >= 2 && (
+						<div className="mt-2">
+							<Input
+								label={`Type "${primaryRecipient}" to confirm`}
+								type="text"
+								size="sm"
+								value={confirmPhrase}
+								onChange={(e) => setConfirmPhrase(e.target.value)}
+								data-testid="confirm-phrase-input"
+							/>
+						</div>
+					)}
 				</div>
 
 				{/* Footer actions */}
@@ -173,8 +193,9 @@ export default function ComposePanel() {
 								loading={isSending}
 								disabled={isSavingDraft || isSending}
 								icon={<PaperPlaneTiltIcon size={14} />}
+								data-testid={sendTestId}
 							>
-								{isSending ? "Sending..." : "Send"}
+								{isSending ? "Sending..." : sendLabel}
 							</Button>
 						</div>
 					</div>

--- a/app/hooks/useComposeForm.ts
+++ b/app/hooks/useComposeForm.ts
@@ -17,6 +17,7 @@ import {
 import { useDeleteEmail, useForwardEmail, useReplyToEmail, useSaveDraft, useSendEmail } from "~/queries/emails";
 import { useMailbox } from "~/queries/mailboxes";
 import { useUIStore } from "~/hooks/useUIStore";
+import api from "~/services/api";
 
 function appendUniqueAddress(
 	addresses: string[],
@@ -181,7 +182,12 @@ export function useComposeForm(mailboxId?: string, _folder?: string) {
 	const [error, setError] = useState<string | null>(null);
 	const [isSavingDraft, setIsSavingDraft] = useState(false);
 	const [isSending, setIsSending] = useState(false);
+	const [preflight, setPreflight] = useState<{ tier: 0 | 1 | 2; reasons: string[] } | null>(null);
+	const [isPreflighting, setIsPreflighting] = useState(false);
+	const [confirmPhrase, setConfirmPhrase] = useState("");
 	const lastInitializedOptionsRef = useRef<typeof composeOptions | null>(null);
+	const latestSubjectRef = useRef(subject);
+	const latestBodyRef = useRef(body);
 	const isDraftEdit = !!composeOptions.draftEmail;
 
 	const formTitle = useMemo(() => {
@@ -207,7 +213,37 @@ export function useComposeForm(mailboxId?: string, _folder?: string) {
 		setShowCcBcc(initialFields.showCcBcc);
 		setSubject(initialFields.subject);
 		setBody(initialFields.body);
+		setPreflight(null);
+		setConfirmPhrase("");
 	}, [composeOptions, currentMailbox?.email, sigBlock]);
+
+	useEffect(() => { latestSubjectRef.current = subject; }, [subject]);
+	useEffect(() => { latestBodyRef.current = body; }, [body]);
+
+	useEffect(() => {
+		if (!mailboxId || !to.trim()) {
+			setPreflight(null);
+			return;
+		}
+		const timer = setTimeout(async () => {
+			setIsPreflighting(true);
+			try {
+				const result = await api.preflightEmail(mailboxId, {
+					to,
+					from: mailboxId,
+					subject: latestSubjectRef.current || ".",
+					text: htmlToPlainText(latestBodyRef.current) || " ",
+				});
+				setPreflight(result);
+			} catch {
+				console.warn("[preflight] network error, defaulting to Tier 0");
+				setPreflight(null);
+			} finally {
+				setIsPreflighting(false);
+			}
+		}, 600);
+		return () => clearTimeout(timer);
+	}, [to, mailboxId]);
 
 	const handleSaveDraft = async () => {
 		if (!mailboxId || isSending) return; setIsSavingDraft(true); setError(null);
@@ -237,6 +273,20 @@ export function useComposeForm(mailboxId?: string, _folder?: string) {
 		if (!currentMailbox || !mailboxId) { setError("No mailbox selected."); return; }
 		const toRecipients = splitEmailList(to);
 		if (toRecipients.length === 0) { setError("Add at least one recipient."); return; }
+
+		const sendTier = preflight?.tier ?? 0;
+		if (sendTier >= 2) {
+			const primaryRecipient = toRecipients[0].trim().toLowerCase();
+			if (confirmPhrase.trim().toLowerCase() !== primaryRecipient) {
+				setError(`Type "${toRecipients[0]}" to confirm before sending.`);
+				return;
+			}
+		}
+		if (sendTier >= 1) {
+			feedback.info("Step-up auth not yet configured");
+			return;
+		}
+
 		const ccRecipients = splitEmailList(cc); const bccRecipients = splitEmailList(bcc);
 		const fromName = currentMailbox.settings?.fromName || currentMailbox.name;
 		const from = fromName && fromName !== currentMailbox.email ? { email: currentMailbox.email, name: fromName } : currentMailbox.email;
@@ -262,5 +312,5 @@ export function useComposeForm(mailboxId?: string, _folder?: string) {
 		finally { setIsSending(false); }
 	};
 
-	return { to, setTo, cc, setCc, bcc, setBcc, showCcBcc, setShowCcBcc, subject, setSubject, body, setBody, error, setError, isSavingDraft, isSending, formTitle, handleSaveDraft, handleSend, closeCompose, closePanel };
+	return { to, setTo, cc, setCc, bcc, setBcc, showCcBcc, setShowCcBcc, subject, setSubject, body, setBody, error, setError, isSavingDraft, isSending, preflight, isPreflighting, confirmPhrase, setConfirmPhrase, formTitle, handleSaveDraft, handleSend, closeCompose, closePanel };
 }

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -159,6 +159,11 @@ const api = {
 	// Emails
 	listEmails: (mailboxId: string, params: Record<string, string>, opts?: { signal?: AbortSignal }) =>
 		get<EmailListResponse | Email[]>(`/api/v1/mailboxes/${mailboxId}/emails`, { params, signal: opts?.signal }),
+	preflightEmail: (mailboxId: string, email: unknown) =>
+		post<{ tier: 0 | 1 | 2; reasons: string[] }>(
+			`/api/v1/mailboxes/${mailboxId}/emails/preflight`,
+			email,
+		),
 	sendEmail: (mailboxId: string, email: unknown) =>
 		post<void>(`/api/v1/mailboxes/${mailboxId}/emails`, email),
 	getEmail: (mailboxId: string, id: string, opts?: { signal?: AbortSignal }) =>

--- a/tests/frontend/compose-send-risk.test.tsx
+++ b/tests/frontend/compose-send-risk.test.tsx
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Acceptance tests for issue #263: composer send-risk UI.
+ * Covers: Tier 0/1/2 button labels, data-testid attributes,
+ * preflight network-failure fallback, and Tier-2 phrase confirmation.
+ */
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+import { renderWithProviders } from "./test-utils";
+
+// ── hoisted mocks ─────────────────────────────────────────────────────────────
+
+const feedbackInfo = vi.fn();
+
+vi.mock("~/lib/feedback", () => ({
+	useFeedback: () => ({
+		info: feedbackInfo,
+		error: vi.fn(),
+		success: vi.fn(),
+	}),
+}));
+
+vi.mock("~/services/api", async () => {
+	const actual = await vi.importActual<typeof import("~/services/api")>(
+		"~/services/api",
+	);
+	return {
+		...actual,
+		default: { ...actual.default, preflightEmail: vi.fn() },
+	};
+});
+
+vi.mock("~/queries/emails", () => ({
+	useSendEmail: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
+	useSaveDraft: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
+	useReplyToEmail: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
+	useForwardEmail: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
+	useDeleteEmail: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({
+		data: {
+			id: "m1",
+			email: "operator@internal.test",
+			name: "Operator",
+			settings: {},
+		},
+	}),
+}));
+
+// Tiptap/ProseMirror doesn't run in jsdom — replace with a no-op.
+vi.mock("~/components/RichTextEditor", () => ({
+	default: () => null,
+}));
+
+// ── deferred imports (after mocks are registered) ────────────────────────────
+
+import ComposePanel from "~/components/ComposePanel";
+import api from "~/services/api";
+
+const preflightMock = api.preflightEmail as unknown as ReturnType<typeof vi.fn>;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function renderPanel() {
+	return renderWithProviders(
+		<Routes>
+			<Route path="/mailbox/:mailboxId" element={<ComposePanel />} />
+		</Routes>,
+		{ initialEntries: ["/mailbox/m1"] },
+	);
+}
+
+/** Type into the "To" field and wait for the debounce to settle (≤2 s). */
+async function typeToAndWaitForPreflight(
+	user: ReturnType<typeof userEvent.setup>,
+	address: string,
+	expectedTestId: string,
+) {
+	await user.type(screen.getByPlaceholderText(/recipient@example.com/i), address);
+	await waitFor(
+		() => expect(screen.getByTestId(expectedTestId)).toBeInTheDocument(),
+		{ timeout: 2000 },
+	);
+}
+
+// ── test suite ────────────────────────────────────────────────────────────────
+
+describe("Composer send-risk UI (#263)", () => {
+	beforeEach(() => {
+		preflightMock.mockReset();
+		feedbackInfo.mockReset();
+	});
+
+	// ── Acceptance: button labels per tier ───────────────────────────────────
+
+	describe("Send button label by tier", () => {
+		it("shows 'Send' with data-testid tier0 before preflight fires", () => {
+			preflightMock.mockResolvedValue({ tier: 0, reasons: [] });
+			renderPanel();
+			const btn = screen.getByTestId("send-button-tier0");
+			expect(btn).toBeInTheDocument();
+			expect(btn).toHaveTextContent("Send");
+		});
+
+		it("shows 'Send (re-auth)' with data-testid tier1 when preflight returns tier 1", async () => {
+			preflightMock.mockResolvedValue({
+				tier: 1,
+				reasons: ["External recipient"],
+			});
+			const user = userEvent.setup();
+			renderPanel();
+			await typeToAndWaitForPreflight(user, "vendor@external.com", "send-button-tier1");
+			expect(screen.getByTestId("send-button-tier1")).toHaveTextContent("Send (re-auth)");
+		});
+
+		it("shows 'Send (verify)' with data-testid tier2 when preflight returns tier 2", async () => {
+			preflightMock.mockResolvedValue({
+				tier: 2,
+				reasons: ["BEC/credential keyword"],
+			});
+			const user = userEvent.setup();
+			renderPanel();
+			await typeToAndWaitForPreflight(user, "vendor@external.com", "send-button-tier2");
+			expect(screen.getByTestId("send-button-tier2")).toHaveTextContent("Send (verify)");
+		});
+	});
+
+	// ── Acceptance: preflight network failure does not block send ────────────
+
+	describe("Preflight network failure fallback", () => {
+		it("stays on tier0 button when preflight throws a network error", async () => {
+			preflightMock.mockRejectedValue(new Error("network error"));
+			const user = userEvent.setup();
+			renderPanel();
+			// Type the address — preflight fires but rejects; button stays tier0.
+			await user.type(
+				screen.getByPlaceholderText(/recipient@example.com/i),
+				"vendor@external.com",
+			);
+			// Give the debounce time to settle then confirm tier0 persists.
+			await waitFor(
+				() => expect(preflightMock).toHaveBeenCalled(),
+				{ timeout: 2000 },
+			);
+			expect(screen.getByTestId("send-button-tier0")).toBeInTheDocument();
+			expect(screen.queryByTestId("send-button-tier1")).not.toBeInTheDocument();
+		});
+	});
+
+	// ── Acceptance: Tier-2 confirmation phrase ───────────────────────────────
+
+	describe("Tier-2 confirmation phrase", () => {
+		it("renders the phrase input when tier is 2", async () => {
+			preflightMock.mockResolvedValue({ tier: 2, reasons: ["BEC keyword"] });
+			const user = userEvent.setup();
+			renderPanel();
+			await typeToAndWaitForPreflight(user, "vendor@external.com", "send-button-tier2");
+			expect(screen.getByTestId("confirm-phrase-input")).toBeInTheDocument();
+		});
+
+		it("does not render the phrase input when tier is 1", async () => {
+			preflightMock.mockResolvedValue({ tier: 1, reasons: ["External recipient"] });
+			const user = userEvent.setup();
+			renderPanel();
+			await typeToAndWaitForPreflight(user, "vendor@external.com", "send-button-tier1");
+			expect(screen.queryByTestId("confirm-phrase-input")).not.toBeInTheDocument();
+		});
+
+		it("shows an error when the form is submitted with the wrong phrase", async () => {
+			preflightMock.mockResolvedValue({ tier: 2, reasons: ["BEC keyword"] });
+			const user = userEvent.setup();
+			renderPanel();
+			await typeToAndWaitForPreflight(user, "vendor@external.com", "send-button-tier2");
+			await user.type(screen.getByPlaceholderText(/email subject/i), "Hello");
+			await user.type(screen.getByTestId("confirm-phrase-input"), "wrong@addr.com");
+			await user.click(screen.getByTestId("send-button-tier2"));
+			expect(
+				screen.getByText(/type.*vendor@external\.com.*to confirm.*before sending/i),
+			).toBeInTheDocument();
+		});
+
+		it("shows the step-up placeholder after the correct phrase is typed", async () => {
+			preflightMock.mockResolvedValue({ tier: 2, reasons: ["BEC keyword"] });
+			const user = userEvent.setup();
+			renderPanel();
+			await typeToAndWaitForPreflight(user, "vendor@external.com", "send-button-tier2");
+			await user.type(screen.getByPlaceholderText(/email subject/i), "Hello");
+			await user.type(
+				screen.getByTestId("confirm-phrase-input"),
+				"vendor@external.com",
+			);
+			await user.click(screen.getByTestId("send-button-tier2"));
+			expect(feedbackInfo).toHaveBeenCalledWith("Step-up auth not yet configured");
+		});
+	});
+
+	// ── Tier-1 submit placeholder ─────────────────────────────────────────────
+
+	describe("Tier-1 submit", () => {
+		it("shows the step-up auth placeholder when tier 1 send is attempted", async () => {
+			preflightMock.mockResolvedValue({ tier: 1, reasons: ["External recipient"] });
+			const user = userEvent.setup();
+			renderPanel();
+			await typeToAndWaitForPreflight(user, "vendor@external.com", "send-button-tier1");
+			await user.type(screen.getByPlaceholderText(/email subject/i), "Hello");
+			await user.click(screen.getByTestId("send-button-tier1"));
+			expect(feedbackInfo).toHaveBeenCalledWith("Step-up auth not yet configured");
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Wire `POST /api/v1/mailboxes/:mailboxId/emails/preflight` into both composer components via a debounced (600 ms) call in `useComposeForm`. Preflight failure silently defaults to Tier 0 — send is never blocked.
- Send button now shows **"Send"** / **"Send (re-auth)"** / **"Send (verify)"** based on the preflight result, each with a matching `data-testid` attribute (`send-button-tier0/1/2`).
- Tier-2 flow shows an inline phrase-confirmation `Input` (`data-testid="confirm-phrase-input"`). `handleSend` requires the typed phrase to match the primary recipient address before proceeding.
- Tier ≥ 1 send attempt shows **"Step-up auth not yet configured"** (via feedback toast) as a placeholder until `POST /api/v1/confirm` (slice 2, #263 constraint) lands.

Closes #263

## Test plan

- [x] 9 new frontend tests in `tests/frontend/compose-send-risk.test.tsx` covering all four Acceptance items
- [x] Full suite: **1052 passing, 0 failing**
- [x] `npm run typecheck` — clean

## Notes

- The `POST /api/v1/confirm` popup flow and `postMessage` token relay are explicitly deferred (slice 2 dependency). Clicking "Send (re-auth)" or "Send (verify)" (after phrase check) shows the placeholder info toast until that lands.
- No edits to `SECURITY_SPEC.md` — this change adds UI friction only and does not narrow any spec rule.

https://claude.ai/code/session_01CBoxcHDEAAq21u9mf57R8N

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBoxcHDEAAq21u9mf57R8N)_