### PR TITLE
feat: SOC-framed first-run checklist + CF Access error UX in home (#68)

### DIFF
--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -4,7 +4,6 @@ import { Loader } from "@cloudflare/kumo";
 import {
 	BriefcaseIcon,
 	BuildingsIcon,
-	EnvelopeIcon,
 	ShieldCheckIcon,
 	WarningIcon,
 } from "@phosphor-icons/react";
@@ -15,6 +14,7 @@ import { useAutoProvisionMailboxes } from "~/hooks/useAutoProvisionMailboxes";
 import { useDomains } from "~/queries/domains";
 import { useMailboxes } from "~/queries/mailboxes";
 import { useOrgOverview } from "~/queries/org";
+import { ApiError } from "~/services/api";
 import type { OrgOverview, OrgVerdictMix } from "~/types";
 
 export function meta() {
@@ -23,7 +23,7 @@ export function meta() {
 
 export default function HomeRoute() {
 	useAutoProvisionMailboxes();
-	const { data, isLoading, isError, refetch } = useOrgOverview();
+	const { data, isLoading, isError, error, refetch } = useOrgOverview();
 	const { data: mailboxes = [] } = useMailboxes();
 
 	return (
@@ -36,7 +36,7 @@ export default function HomeRoute() {
 						<Loader size="lg" />
 					</div>
 				) : isError ? (
-					<OrgError onRetry={() => refetch()} />
+					<OrgError onRetry={() => refetch()} error={error} />
 				) : data ? (
 					<OrgBody data={data} mailboxCount={mailboxes.length} />
 				) : null}
@@ -69,7 +69,47 @@ function OrgHeader({
 	);
 }
 
-function OrgError({ onRetry }: { onRetry: () => void }) {
+function OrgError({ onRetry, error }: { onRetry: () => void; error?: unknown }) {
+	const isCfAccessError =
+		error instanceof ApiError && (error.status === 401 || error.status === 403);
+
+	if (isCfAccessError) {
+		return (
+			<div className="pp-card p-6 flex items-start gap-3">
+				<span className="flex h-8 w-8 items-center justify-center rounded-full bg-paper-2 text-ink-3 shrink-0">
+					<WarningIcon size={18} />
+				</span>
+				<div>
+					<div className="text-[14px] font-medium text-ink mb-1">
+						CF Access not configured
+					</div>
+					<p className="text-[12.5px] text-ink-3 leading-relaxed mb-2">
+						The Worker is reachable but Cloudflare Access rejected the request.
+						This usually means the Access application isn't assigned to your account
+						or the JWT cookie has expired.
+					</p>
+					<div className="flex items-center gap-4">
+						<a
+							href="https://github.com/schmug/PhishSOC/blob/main/README.md#troubleshooting-access"
+							target="_blank"
+							rel="noreferrer"
+							className="text-[12px] underline text-accent hover:opacity-80"
+						>
+							Troubleshooting steps
+						</a>
+						<button
+							type="button"
+							onClick={onRetry}
+							className="text-[12px] underline text-accent hover:opacity-80"
+						>
+							Retry
+						</button>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
 	return (
 		<div className="pp-card p-6 flex items-start gap-3">
 			<span className="flex h-8 w-8 items-center justify-center rounded-full bg-paper-2 text-ink-3 shrink-0">
@@ -118,24 +158,51 @@ function OrgBody({
 
 function EmptyOrg() {
 	return (
-		<div className="pp-card py-16 px-6">
-			<div className="flex flex-col items-center text-center">
-				<div className="mb-4">
-					<EnvelopeIcon size={48} weight="thin" className="text-ink-3" />
-				</div>
-				<h3 className="text-base font-semibold text-ink mb-1.5">
-					No mailboxes yet
-				</h3>
-				<p className="text-sm text-ink-3 max-w-sm mb-5">
-					Provision a mailbox to start aggregating org-wide threat activity.
-				</p>
-				<RouterLink
-					to="/mailboxes"
-					className="text-[13px] underline text-accent hover:opacity-80"
-				>
-					Go to Mailboxes
-				</RouterLink>
-			</div>
+		<div className="pp-card py-10 px-8">
+			<h3 className="text-base font-semibold text-ink mb-1.5">
+				No mailboxes yet — set one up to start triaging mail.
+			</h3>
+			<p className="text-sm text-ink-3 mb-6">Start here:</p>
+			<ol className="space-y-5">
+				<li className="flex gap-3">
+					<span className="pp-mono text-[11px] font-semibold text-ink-3 mt-0.5 w-4 shrink-0">1.</span>
+					<div>
+						<div className="text-sm font-medium text-ink">Configure Cloudflare Email Routing</div>
+						<p className="text-[12.5px] text-ink-3 mt-0.5 leading-relaxed">
+							Forward your domain's catch-all to this Worker.
+						</p>
+					</div>
+				</li>
+				<li className="flex gap-3">
+					<span className="pp-mono text-[11px] font-semibold text-ink-3 mt-0.5 w-4 shrink-0">2.</span>
+					<div>
+						<div className="text-sm font-medium text-ink">Create your first mailbox</div>
+						<RouterLink to="/mailboxes" className="text-[12.5px] text-accent hover:opacity-80 mt-0.5 block">
+							Go to Mailboxes →
+						</RouterLink>
+					</div>
+				</li>
+				<li className="flex gap-3">
+					<span className="pp-mono text-[11px] font-semibold text-ink-3 mt-0.5 w-4 shrink-0">3.</span>
+					<div>
+						<div className="text-sm font-medium text-ink">Set up domain security (DMARC / SPF / DKIM)</div>
+						<RouterLink to="/domains" className="text-[12.5px] text-accent hover:opacity-80 mt-0.5 block">
+							Go to Domains →
+						</RouterLink>
+					</div>
+				</li>
+				<li className="flex gap-3">
+					<span className="pp-mono text-[11px] font-semibold text-ink-3 mt-0.5 w-4 shrink-0">4.</span>
+					<div>
+						<div className="text-sm font-medium text-ink">
+							Connect a threat-intel hub <span className="text-ink-3 font-normal">(optional)</span>
+						</div>
+						<RouterLink to="/hub" className="text-[12.5px] text-accent hover:opacity-80 mt-0.5 block">
+							Go to Hub →
+						</RouterLink>
+					</div>
+				</li>
+			</ol>
 		</div>
 	);
 }

--- a/tests/frontend/home-empty-state.test.tsx
+++ b/tests/frontend/home-empty-state.test.tsx
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+//
+// Tests for the home-route empty-state and CF Access error UX (#68 Option A).
+// Covers: EmptyOrg first-run checklist (G1, G3) and OrgError CF Access
+// detection (G2).
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+import { ApiError } from "~/services/api";
+import type { OrgOverview } from "~/types";
+import {
+	shellDashboardMock,
+	shellDomainsMock,
+	shellMailboxesMock,
+} from "./shell-mocks";
+
+// Mutable query state threaded through the vi.mock factory.
+const refetch = vi.fn();
+let orgQueryState: {
+	data: OrgOverview | undefined;
+	isLoading: boolean;
+	isError: boolean;
+	error: unknown;
+	refetch: () => void;
+};
+
+vi.mock("~/queries/org", () => ({
+	useOrgOverview: () => orgQueryState,
+}));
+
+vi.mock("~/queries/mailboxes", () => shellMailboxesMock());
+vi.mock("~/queries/dashboard", () => shellDashboardMock());
+vi.mock("~/queries/domains", () =>
+	shellDomainsMock({
+		useDomains: () => ({ data: [] }),
+	}),
+);
+
+vi.mock("~/hooks/useAutoProvisionMailboxes", () => ({
+	useAutoProvisionMailboxes: () => undefined,
+}));
+
+import HomeRoute from "~/routes/home";
+import { renderWithProviders } from "./test-utils";
+
+const EMPTY_ORG: OrgOverview = {
+	now: "2026-05-14T00:00:00Z",
+	threatsBlocked24h: 0,
+	threatsBlocked7d: 0,
+	openCasesTotal: 0,
+	mailboxesCount: 0,
+	domainsCount: 0,
+	hubContributions24h: 0,
+	verdictMix: { safe: 0, suspicious: 0, phishing: 0, spam: 0, bec: 0 },
+	verdictMix7d: { safe: 0, suspicious: 0, phishing: 0, spam: 0, bec: 0 },
+	topThreats: [],
+	pipelineHealth: { successRate24h: null, p95Ms: null, runs24h: 0 },
+};
+
+function renderHome() {
+	return renderWithProviders(
+		<Routes>
+			<Route path="/" element={<HomeRoute />} />
+		</Routes>,
+		{ initialEntries: ["/"] },
+	);
+}
+
+describe("HomeRoute — EmptyOrg (G1, G3)", () => {
+	beforeEach(() => {
+		refetch.mockReset();
+		orgQueryState = {
+			data: EMPTY_ORG,
+			isLoading: false,
+			isError: false,
+			error: null,
+			refetch,
+		};
+	});
+
+	it("shows the SOC-framed heading when there are no mailboxes", () => {
+		renderHome();
+		expect(
+			screen.getByText(/No mailboxes yet — set one up to start triaging mail/i),
+		).toBeInTheDocument();
+	});
+
+	it("renders all four first-run checklist items", () => {
+		renderHome();
+		expect(screen.getByText(/Configure Cloudflare Email Routing/i)).toBeInTheDocument();
+		expect(screen.getByText(/Create your first mailbox/i)).toBeInTheDocument();
+		expect(screen.getByText(/Set up domain security/i)).toBeInTheDocument();
+		expect(screen.getByText(/Connect a threat-intel hub/i)).toBeInTheDocument();
+	});
+
+	it("links checklist items to the correct routes", () => {
+		renderHome();
+		const mailboxLink = screen.getByRole("link", { name: /Go to Mailboxes/i });
+		const domainsLink = screen.getByRole("link", { name: /Go to Domains/i });
+		const hubLink = screen.getByRole("link", { name: /Go to Hub/i });
+		expect(mailboxLink).toHaveAttribute("href", "/mailboxes");
+		expect(domainsLink).toHaveAttribute("href", "/domains");
+		expect(hubLink).toHaveAttribute("href", "/hub");
+	});
+});
+
+describe("HomeRoute — OrgError (G2)", () => {
+	beforeEach(() => {
+		refetch.mockReset();
+	});
+
+	it("shows the generic error message for non-Access errors", () => {
+		orgQueryState = {
+			data: undefined,
+			isLoading: false,
+			isError: true,
+			error: new Error("network timeout"),
+			refetch,
+		};
+		renderHome();
+		expect(screen.getByText(/Couldn't load the org overview/i)).toBeInTheDocument();
+		expect(screen.queryByText(/CF Access not configured/i)).not.toBeInTheDocument();
+	});
+
+	it("shows the CF Access card for a 401 ApiError", () => {
+		orgQueryState = {
+			data: undefined,
+			isLoading: false,
+			isError: true,
+			error: new ApiError(401, {}),
+			refetch,
+		};
+		renderHome();
+		expect(screen.getByText(/CF Access not configured/i)).toBeInTheDocument();
+		expect(screen.queryByText(/Couldn't load the org overview/i)).not.toBeInTheDocument();
+	});
+
+	it("shows the CF Access card for a 403 ApiError", () => {
+		orgQueryState = {
+			data: undefined,
+			isLoading: false,
+			isError: true,
+			error: new ApiError(403, {}),
+			refetch,
+		};
+		renderHome();
+		expect(screen.getByText(/CF Access not configured/i)).toBeInTheDocument();
+	});
+
+	it("CF Access card has a troubleshooting link", () => {
+		orgQueryState = {
+			data: undefined,
+			isLoading: false,
+			isError: true,
+			error: new ApiError(401, {}),
+			refetch,
+		};
+		renderHome();
+		const link = screen.getByRole("link", { name: /Troubleshooting steps/i });
+		expect(link).toHaveAttribute(
+			"href",
+			"https://github.com/schmug/PhishSOC/blob/main/README.md#troubleshooting-access",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- **G1 + G3** — Replace the generic `EmptyOrg` icon/text/link with a numbered four-step first-run checklist: Configure Email Routing → Create first mailbox → Set up domain security (DMARC/SPF/DKIM) → Connect intel hub (optional). Each step links to the relevant app route. Heading updated to "No mailboxes yet — set one up to start triaging mail."
- **G2** — `OrgError` now accepts an `error` prop and detects `ApiError` with status 401 or 403 (Cloudflare Access rejection). When detected, it renders a "CF Access not configured" card with a link to the README `#troubleshooting-access` section instead of the generic "endpoint didn't respond" message.

Closes #68 (Option A — `home.tsx` only)

## Test plan

- [x] 7 new frontend tests in `tests/frontend/home-empty-state.test.tsx`
  - `EmptyOrg` renders SOC-framed heading
  - `EmptyOrg` renders all four checklist items
  - `EmptyOrg` checklist links point to `/mailboxes`, `/domains`, `/hub`
  - `OrgError` (generic `Error`) shows "Couldn't load the org overview"
  - `OrgError` (`ApiError` 401) shows "CF Access not configured"
  - `OrgError` (`ApiError` 403) shows "CF Access not configured"
  - CF Access card has troubleshooting link to README anchor
- [x] Full suite: **1050 passing, 0 failing** (82 files)
- [x] `npm run typecheck` — clean

## Deferred follow-ups

- `/setup` route with stripped Shell variant (Option B from #68 spec) — file a separate issue once operator feedback confirms the wizard shape
- Health-check API endpoint for dynamic infra status (G4) — requires a new Worker endpoint, file separately

No edits to `SECURITY_SPEC.md` — this change is UI/copy only.

https://claude.ai/code/session_01CX6gEM31yT3pHjojcFPKDm

---
_Generated by [Claude Code](https://claude.ai/code/session_01CX6gEM31yT3pHjojcFPKDm)_