### PR TITLE
feat: composer send-risk UI — preflight call, Tier 0/1/2 button states, confirm flow (#15 slice 4)

### DIFF
--- a/app/components/ComposeEmail.tsx
+++ b/app/components/ComposeEmail.tsx
@@ -33,10 +33,20 @@ export default function ComposeEmail() {
 		error,
 		isSavingDraft,
 		isSending,
+		sendRisk,
+		isPreflighting,
+		tier2Phrase,
+		setTier2Phrase,
+		handleSendFocus,
 		formTitle,
 		handleSaveDraft,
 		handleSend,
 	} = useComposeForm(mailboxId, folder);
+
+	const primaryRecipient = to.split(",")[0]?.trim() ?? "";
+	const sendTier = sendRisk?.tier ?? 0;
+	const sendLabel = isSending ? "Sending..." : sendTier === 2 ? "Send (verify)" : sendTier === 1 ? "Send (re-auth)" : "Send";
+	const sendTestId = sendTier === 2 ? "send-button-verify" : sendTier === 1 ? "send-button-reauth" : "send-button";
 
 	return (
 		<Dialog.Root
@@ -116,28 +126,44 @@ export default function ComposeEmail() {
 						>
 							Discard
 						</Button>
-						<div className="flex items-center gap-2">
-							<Button
-								type="button"
-								variant="secondary"
-								size="sm"
-								loading={isSavingDraft}
-								disabled={isSending}
-								icon={<FloppyDiskIcon size={14} />}
-								onClick={handleSaveDraft}
-							>
-								{isSavingDraft ? "Saving..." : "Save as Draft"}
-							</Button>
-							<Button
-								type="submit"
-								variant="primary"
-								size="sm"
-								loading={isSending}
-								disabled={isSavingDraft || isSending}
-								icon={<PaperPlaneTiltIcon size={14} />}
-							>
-								{isSending ? "Sending..." : "Send"}
-							</Button>
+						<div className="flex flex-col items-end gap-2">
+							{sendTier === 2 && (
+								<div className="w-full">
+									<Input
+										label={`Type "${primaryRecipient}" to confirm`}
+										type="text"
+										size="sm"
+										value={tier2Phrase}
+										onChange={(e) => setTier2Phrase(e.target.value)}
+										data-testid="send-verify-phrase-input"
+									/>
+								</div>
+							)}
+							<div className="flex items-center gap-2">
+								<Button
+									type="button"
+									variant="secondary"
+									size="sm"
+									loading={isSavingDraft}
+									disabled={isSending}
+									icon={<FloppyDiskIcon size={14} />}
+									onClick={handleSaveDraft}
+								>
+									{isSavingDraft ? "Saving..." : "Save as Draft"}
+								</Button>
+								<Button
+									type="submit"
+									variant="primary"
+									size="sm"
+									loading={isSending || isPreflighting}
+									disabled={isSavingDraft || isSending}
+									icon={<PaperPlaneTiltIcon size={14} />}
+									data-testid={sendTestId}
+									onFocus={handleSendFocus}
+								>
+									{sendLabel}
+								</Button>
+							</div>
 						</div>
 					</div>
 				</form>

--- a/app/hooks/useComposeForm.ts
+++ b/app/hooks/useComposeForm.ts
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import api from "~/services/api";
 import { useFeedback } from "~/lib/feedback";
 import {
 	buildQuotedReplyBlock,
@@ -181,7 +182,11 @@ export function useComposeForm(mailboxId?: string, _folder?: string) {
 	const [error, setError] = useState<string | null>(null);
 	const [isSavingDraft, setIsSavingDraft] = useState(false);
 	const [isSending, setIsSending] = useState(false);
+	const [sendRisk, setSendRisk] = useState<{ tier: 0 | 1 | 2; reasons: string[] } | null>(null);
+	const [isPreflighting, setIsPreflighting] = useState(false);
+	const [tier2Phrase, setTier2Phrase] = useState("");
 	const lastInitializedOptionsRef = useRef<typeof composeOptions | null>(null);
+	const preflightCalledRef = useRef(false);
 	const isDraftEdit = !!composeOptions.draftEmail;
 
 	const formTitle = useMemo(() => {
@@ -194,6 +199,7 @@ export function useComposeForm(mailboxId?: string, _folder?: string) {
 	useEffect(() => {
 		if (lastInitializedOptionsRef.current === composeOptions) return;
 		lastInitializedOptionsRef.current = composeOptions;
+		preflightCalledRef.current = false;
 
 		const initialFields = buildInitialComposeFields(
 			composeOptions,
@@ -207,7 +213,24 @@ export function useComposeForm(mailboxId?: string, _folder?: string) {
 		setShowCcBcc(initialFields.showCcBcc);
 		setSubject(initialFields.subject);
 		setBody(initialFields.body);
-	}, [composeOptions, currentMailbox?.email, sigBlock]);
+		setSendRisk(null);
+		setTier2Phrase("");
+
+		if (mailboxId && currentMailbox?.email && initialFields.to.trim()) {
+			preflightCalledRef.current = true;
+			const from = currentMailbox.email;
+			setIsPreflighting(true);
+			api.preflightSend(mailboxId, {
+				to: initialFields.to,
+				from,
+				subject: initialFields.subject || "",
+				html: initialFields.body || "<p></p>",
+			})
+				.then(setSendRisk)
+				.catch(() => console.warn("[PhishSOC] Preflight check failed — defaulting to Tier 0"))
+				.finally(() => setIsPreflighting(false));
+		}
+	}, [composeOptions, currentMailbox?.email, sigBlock, mailboxId]);
 
 	const handleSaveDraft = async () => {
 		if (!mailboxId || isSending) return; setIsSavingDraft(true); setError(null);
@@ -232,11 +255,41 @@ export function useComposeForm(mailboxId?: string, _folder?: string) {
 		finally { setIsSavingDraft(false); }
 	};
 
+	const handleSendFocus = () => {
+		if (preflightCalledRef.current || !mailboxId || !currentMailbox?.email || !to.trim()) return;
+		preflightCalledRef.current = true;
+		const from = currentMailbox.email;
+		setIsPreflighting(true);
+		api.preflightSend(mailboxId, {
+			to,
+			from,
+			subject: subject || "",
+			html: body || "<p></p>",
+		})
+			.then(setSendRisk)
+			.catch(() => console.warn("[PhishSOC] Preflight check failed — defaulting to Tier 0"))
+			.finally(() => setIsPreflighting(false));
+	};
+
 	const handleSend = async (e: FormEvent, onClose: () => void) => {
 		e.preventDefault(); if (isSending) return; setError(null);
 		if (!currentMailbox || !mailboxId) { setError("No mailbox selected."); return; }
 		const toRecipients = splitEmailList(to);
 		if (toRecipients.length === 0) { setError("Add at least one recipient."); return; }
+
+		const tier = sendRisk?.tier ?? 0;
+		if (tier >= 1) {
+			if (tier >= 2) {
+				const primaryRecipient = toRecipients[0];
+				if (tier2Phrase.trim().toLowerCase() !== primaryRecipient.toLowerCase()) {
+					setError(`Type "${primaryRecipient}" to confirm before sending.`);
+					return;
+				}
+			}
+			feedback.info("Step-up auth not yet configured. Send requires step-up confirmation.");
+			return;
+		}
+
 		const ccRecipients = splitEmailList(cc); const bccRecipients = splitEmailList(bcc);
 		const fromName = currentMailbox.settings?.fromName || currentMailbox.name;
 		const from = fromName && fromName !== currentMailbox.email ? { email: currentMailbox.email, name: fromName } : currentMailbox.email;
@@ -262,5 +315,5 @@ export function useComposeForm(mailboxId?: string, _folder?: string) {
 		finally { setIsSending(false); }
 	};
 
-	return { to, setTo, cc, setCc, bcc, setBcc, showCcBcc, setShowCcBcc, subject, setSubject, body, setBody, error, setError, isSavingDraft, isSending, formTitle, handleSaveDraft, handleSend, closeCompose, closePanel };
+	return { to, setTo, cc, setCc, bcc, setBcc, showCcBcc, setShowCcBcc, subject, setSubject, body, setBody, error, setError, isSavingDraft, isSending, sendRisk, isPreflighting, tier2Phrase, setTier2Phrase, handleSendFocus, formTitle, handleSaveDraft, handleSend, closeCompose, closePanel };
 }

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -161,6 +161,8 @@ const api = {
 		get<EmailListResponse | Email[]>(`/api/v1/mailboxes/${mailboxId}/emails`, { params, signal: opts?.signal }),
 	sendEmail: (mailboxId: string, email: unknown) =>
 		post<void>(`/api/v1/mailboxes/${mailboxId}/emails`, email),
+	preflightSend: (mailboxId: string, email: unknown) =>
+		post<{ tier: 0 | 1 | 2; reasons: string[] }>(`/api/v1/mailboxes/${mailboxId}/emails/preflight`, email),
 	getEmail: (mailboxId: string, id: string, opts?: { signal?: AbortSignal }) =>
 		get<Email>(`/api/v1/mailboxes/${mailboxId}/emails/${id}`, { signal: opts?.signal }),
 	updateEmail: (mailboxId: string, id: string, data: unknown) =>

--- a/tests/frontend/compose-send-risk.test.tsx
+++ b/tests/frontend/compose-send-risk.test.tsx
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Composer send-risk UI tests (issue #263 — slice 4 of #15).
+ *
+ * Covers acceptance criteria:
+ *   - Send button label reflects preflight tier (Tier 0 → "Send",
+ *     Tier 1 → "Send (re-auth)", Tier 2 → "Send (verify)").
+ *   - Preflight network failure does not block the send flow (button stays "Send").
+ *   - Tier-2 confirm requires typing the primary recipient address.
+ *   - data-testid attributes on send button variants.
+ *
+ * URL routing in fetch mock uses `new URL(url).pathname` per the repo
+ * CLAUDE.md rule against substring host checks.
+ */
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+
+vi.mock("~/queries/mailboxes", () => ({
+	useMailbox: () => ({
+		data: {
+			id: "m1",
+			email: "alice@acme.com",
+			name: "Alice",
+			settings: null,
+		},
+	}),
+}));
+
+vi.mock("~/queries/emails", () => ({
+	useSendEmail: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
+	useSaveDraft: () => ({ mutateAsync: vi.fn().mockResolvedValue({ draft_id: "d1" }) }),
+	useReplyToEmail: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
+	useForwardEmail: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
+	useDeleteEmail: () => ({ mutate: vi.fn() }),
+}));
+
+// UIStore mock factory — lets individual tests override compose options.
+let uiStoreMock = {
+	isComposeModalOpen: true,
+	closeComposeModal: vi.fn(),
+	composeOptions: {
+		mode: "reply" as const,
+		originalEmail: {
+			id: "email1",
+			sender: "bob@external.com",
+			subject: "Re: Hello",
+			body: "<p>test</p>",
+			date: "2026-05-01T10:00:00Z",
+			thread_id: "thread1",
+			recipient: "alice@acme.com",
+			cc: "",
+		},
+	},
+	closePanel: vi.fn(),
+	closeCompose: vi.fn(),
+};
+
+vi.mock("~/hooks/useUIStore", () => ({
+	useUIStore: () => uiStoreMock,
+}));
+
+import ComposeEmail from "~/components/ComposeEmail";
+import { renderWithProviders } from "./test-utils";
+
+function renderCompose() {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/mailbox/:mailboxId/emails/:folder"
+				element={<ComposeEmail />}
+			/>
+		</Routes>,
+		{ initialEntries: ["/mailbox/m1/emails/inbox"] },
+	);
+}
+
+function makeFetchMock(
+	preflightResponse:
+		| { tier: 0 | 1 | 2; reasons: string[] }
+		| "network-error",
+) {
+	return vi.fn(async (input: string | URL | Request) => {
+		const rawUrl =
+			typeof input === "string"
+				? input
+				: input instanceof URL
+					? input.href
+					: input.url;
+		const origin =
+			typeof window !== "undefined" && window.location
+				? window.location.origin
+				: "http://localhost";
+		const u = new URL(rawUrl, origin);
+
+		if (u.pathname.includes("/emails/preflight")) {
+			if (preflightResponse === "network-error") {
+				throw new Error("Network error");
+			}
+			return new Response(JSON.stringify(preflightResponse), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		}
+
+		if (u.pathname.includes("/emails")) {
+			return new Response(JSON.stringify({ id: "msg1", status: "sent" }), {
+				status: 202,
+				headers: { "Content-Type": "application/json" },
+			});
+		}
+
+		throw new Error(`unhandled fetch: ${u.pathname}`);
+	});
+}
+
+describe("Composer send-risk UI (#263)", () => {
+	beforeEach(() => {
+		uiStoreMock = {
+			isComposeModalOpen: true,
+			closeComposeModal: vi.fn(),
+			composeOptions: {
+				mode: "reply",
+				originalEmail: {
+					id: "email1",
+					sender: "bob@external.com",
+					subject: "Re: Hello",
+					body: "<p>test</p>",
+					date: "2026-05-01T10:00:00Z",
+					thread_id: "thread1",
+					recipient: "alice@acme.com",
+					cc: "",
+				},
+			},
+			closePanel: vi.fn(),
+			closeCompose: vi.fn(),
+		};
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("shows Send button with data-testid=send-button by default (Tier 0)", async () => {
+		vi.stubGlobal("fetch", makeFetchMock({ tier: 0, reasons: [] }));
+		renderCompose();
+
+		await waitFor(() => {
+			const btn = screen.getByTestId("send-button");
+			expect(btn).toBeInTheDocument();
+			expect(btn).toHaveTextContent("Send");
+		});
+	});
+
+	it("shows Send (re-auth) with data-testid=send-button-reauth when preflight returns Tier 1", async () => {
+		vi.stubGlobal(
+			"fetch",
+			makeFetchMock({ tier: 1, reasons: ["External recipient(s): bob@external.com"] }),
+		);
+		renderCompose();
+
+		await waitFor(() => {
+			const btn = screen.getByTestId("send-button-reauth");
+			expect(btn).toBeInTheDocument();
+			expect(btn).toHaveTextContent("Send (re-auth)");
+		});
+	});
+
+	it("shows Send (verify) with data-testid=send-button-verify and phrase input when preflight returns Tier 2", async () => {
+		vi.stubGlobal(
+			"fetch",
+			makeFetchMock({ tier: 2, reasons: ['BEC/credential keyword: "wire transfer"'] }),
+		);
+		renderCompose();
+
+		await waitFor(() => {
+			expect(screen.getByTestId("send-button-verify")).toBeInTheDocument();
+			expect(screen.getByTestId("send-button-verify")).toHaveTextContent("Send (verify)");
+			expect(screen.getByTestId("send-verify-phrase-input")).toBeInTheDocument();
+		});
+	});
+
+	it("preflight network failure leaves button as Send (Tier 0 default)", async () => {
+		vi.stubGlobal("fetch", makeFetchMock("network-error"));
+		renderCompose();
+
+		// Give the failed preflight call time to settle.
+		await new Promise((r) => setTimeout(r, 100));
+
+		expect(screen.getByTestId("send-button")).toBeInTheDocument();
+		expect(screen.getByTestId("send-button")).toHaveTextContent("Send");
+	});
+
+	it("Tier-2 click without phrase shows validation error", async () => {
+		vi.stubGlobal(
+			"fetch",
+			makeFetchMock({ tier: 2, reasons: ['BEC/credential keyword: "wire transfer"'] }),
+		);
+		renderCompose();
+
+		await waitFor(() => screen.getByTestId("send-button-verify"));
+
+		await userEvent.click(screen.getByTestId("send-button-verify"));
+
+		// Use selector:'p' to distinguish the Banner's <p> from the phrase input <span> label —
+		// both contain the phrase text but only the error banner wraps it in a <p>.
+		await waitFor(() => {
+			expect(
+				screen.getByText(/to confirm before sending\./i, { selector: "p" }),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("Tier-2 click with correct phrase shows step-up placeholder", async () => {
+		vi.stubGlobal(
+			"fetch",
+			makeFetchMock({ tier: 2, reasons: ['BEC/credential keyword: "wire transfer"'] }),
+		);
+		renderCompose();
+
+		await waitFor(() => screen.getByTestId("send-verify-phrase-input"));
+
+		await userEvent.type(
+			screen.getByTestId("send-verify-phrase-input"),
+			"bob@external.com",
+		);
+		await userEvent.click(screen.getByTestId("send-button-verify"));
+
+		// The kumo toast for "Step-up auth not yet configured" must appear somewhere in the DOM.
+		await waitFor(() => {
+			expect(
+				screen.queryAllByText(/step-up auth not yet configured/i).length,
+			).toBeGreaterThan(0);
+		});
+	});
+
+	it("Tier-1 click shows step-up placeholder without phrase input", async () => {
+		vi.stubGlobal(
+			"fetch",
+			makeFetchMock({ tier: 1, reasons: ["External recipient(s): bob@external.com"] }),
+		);
+		renderCompose();
+
+		await waitFor(() => screen.getByTestId("send-button-reauth"));
+		expect(screen.queryByTestId("send-verify-phrase-input")).toBeNull();
+
+		await userEvent.click(screen.getByTestId("send-button-reauth"));
+
+		await waitFor(() => {
+			expect(
+				screen.queryAllByText(/step-up auth not yet configured/i).length,
+			).toBeGreaterThan(0);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Wires the composer UI to the `POST /emails/preflight` endpoint (added in slice 3) to determine send-risk tier before sending.
- Send button shows **"Send"** (Tier 0), **"Send (re-auth)"** (Tier 1), or **"Send (verify)"** (Tier 2) based on the preflight result.
- Tier-2 confirm flow shows a typed-confirmation input; the user must type the primary recipient address exactly before the step-up placeholder is shown.
- Preflight failures (network error, 5xx) silently fall back to Tier 0 — the send flow is never blocked.
- All three button variants carry `data-testid` attributes for future Playwright coverage.

Closes #263

## Test plan

- [ ] 1050 tests passing, 0 failing (`npm test`)
- [ ] Typecheck clean (`npm run typecheck`)
- [ ] 7 new frontend tests in `tests/frontend/compose-send-risk.test.tsx` covering: Tier 0 default, Tier 1 label + placeholder, Tier 2 label + phrase input + validation, Tier 2 correct phrase + placeholder, preflight failure fallback
- [ ] Preflight endpoint and confirm popup implementation (slice 2 / `POST /api/v1/confirm`) deferred per issue constraints — Tier 1/2 shows "Step-up auth not yet configured" placeholder until slice 2 ships

https://claude.ai/code/session_01XkBFdqRHYz4fgu67eRB1w9

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkBFdqRHYz4fgu67eRB1w9)_