### PR TITLE
docs: add codebase map to CLAUDE.md (#280)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,43 @@ conventions surfaced by real incidents so future agents inherit the lesson
 without re-discovering it. Keep entries grounded in observed events; this is a
 seed, not a comprehensive style guide.
 
+## Codebase map
+
+| Folder | Purpose |
+| --- | --- |
+| `app/` | React 19 / React Router v7 SPA — routes, components, hooks, and client-side queries for the mailbox UI |
+| `shared/` | Zod schemas and pure helpers shared by both the React app and Workers (mailbox/domain/org settings, folder constants) |
+| `workers/` | All Cloudflare Workers backend code; see subsystems below |
+| `hub/` | MISP-compatible community threat-intel hub — exposes a destroylist feed and admin UI for corroborated phishing reports |
+| `sidecar/` | Stand-alone YARA attachment scanner sidecar Worker with its own `wrangler.jsonc`, package, and tests |
+| `test/` | Vitest unit-test fixtures and per-subsystem test suites mirroring the `workers/` tree |
+| `tests/` | Integration and frontend Vitest test suites (routes, intel, security, lib) |
+| `docs/` | Developer and operator documentation (architecture notes, setup guides) |
+| `public/` | Static assets served by the Worker (favicon, theme bootstrap script) |
+
+### `workers/` subsystems
+
+| Subsystem | Purpose |
+| --- | --- |
+| `workers/agent/` | `EmailAgent` and `OrgAgent` Durable Objects — AI chat agents with 9 email tools, auto-draft, and streaming responses |
+| `workers/security/` | Synchronous security pipeline: SPF/DKIM/DMARC, URL heuristics, LLM classifier, sender reputation, off-hours scoring, and verdict aggregation |
+| `workers/intel/` | Async deep-scan stage: redirect-chain resolution, RDAP domain age, CrowdSec CTI, Spamhaus DROP/EDROP CIDR, attachment heuristics, and threat-intel feed management |
+| `workers/lib/` | Shared backend helpers: mailbox/domain/org settings resolution, attachment storage, email helpers, token handling, and schema definitions |
+| `workers/routes/` | Hono sub-apps for scoped API routes: reply/forward, DMARC, TLS-RPT, cases, send-email, hub UI, ACL |
+| `workers/durableObject/` | `MailboxDO` — per-mailbox Durable Object with SQLite schema/migrations and R2 attachment storage |
+| `workers/mcp/` | `EmailMCP` — MCP server exposing email tools over HTTP so external AI clients (Claude Code, Cursor) can act on mailboxes |
+| `workers/dmarc/` | DMARC aggregate-report ingest and RUF forensic-report ingest |
+| `workers/spf/` | SPF TXT record fetch and posture scoring for the per-domain posture surface |
+| `workers/dkim/` | DKIM public-key lookup and posture check for the per-domain posture surface |
+| `workers/bimi/` | BIMI TXT record presence check for the per-domain posture surface |
+| `workers/mta-sts/` | MTA-STS policy fetch and caching for the per-domain posture surface |
+| `workers/tlsrpt/` | TLS-RPT posture check and aggregate-report ingest for the per-domain posture surface |
+| `workers/db/` | SQLite schema definition and migration runner used by `MailboxDO` |
+| `workers/app.ts` | Top-level Worker entry point: Cloudflare Access auth, Hono routing, cron handler, Durable Object exports |
+| `workers/index.ts` | Core Hono API app: mailbox CRUD, email receive pipeline, settings endpoints, send-email handler |
+| `workers/types.ts` | `Env` interface binding all Worker environment variables and Durable Object stubs |
+| `workers/email-sender.ts` | Outbound email send helper wrapping the `send_email` binding |
+
 ## Conventions
 
 ### URL host checks in test mocks must parse, not substring

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ An **AI agent** runs alongside the inbox: it reads incoming mail, auto-drafts re
 
 Read the blog post to learn more about Cloudflare Email Service and how to use it with the Agents SDK, MCP, and from the Wrangler CLI: [Email for Agents](https://blog.cloudflare.com/email-for-agents/).
 
+For a folder-by-folder orientation of the repo, see the [Codebase map](./CLAUDE.md#codebase-map) in CLAUDE.md.
+
 ## How to setup
 
 **Important**: Clicking the 'Deploy to Cloudflare' button is only one part of the setup. You must follow the **After deploying** steps as well. For a full step-by-step guide with screenshots, refer to the upstream setup walkthrough — its deploy/Email-Routing/Access steps still apply to PhishSOC: 


### PR DESCRIPTION
## Summary

- Adds a `## Codebase map` section to `CLAUDE.md` with two markdown tables: one for all top-level directories (9 entries) and one for every `workers/` subsystem (18 entries including named files).
- Adds a one-line link from `README.md` to the new section.
- Map is ~37 lines — fits on one screen, not a design doc.

Closes #280.

## Test plan

- [x] `npm test`: 81 test files passed, 1043 tests passed, 0 failing
- [x] `npm run typecheck`: no errors
- [x] Every top-level directory observed via `ls` is present in the map
- [x] Every `workers/` subdirectory observed via `ls` is present in the map
- [x] Map is reachable from both CLAUDE.md (inline) and README.md (link)

## Acceptance criteria check

- [x] A single map exists listing every top-level dir and every `workers/` subsystem with a one-line purpose
- [x] Reachable from both CLAUDE.md and README (link in README, inline in CLAUDE.md)
- [x] No folder in the tree is missing from the map
- [x] Total addition is ~37 lines — one screen, not a design doc

https://claude.ai/code/session_016Mz6tjTcxyvHXzYyQGwPXm

---
_Generated by [Claude Code](https://claude.ai/code/session_016Mz6tjTcxyvHXzYyQGwPXm)_