### PR TITLE
docs: add per-subsystem CLAUDE.md files for workers/, app/, hub/, sidecar/

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -1,0 +1,30 @@
+# app/ — React Router v7 SPA
+
+Additive to root CLAUDE.md. Frontend-specific conventions only.
+
+## Scoped commands
+
+Run from the **repo root**:
+
+```bash
+npm test           # vitest run — includes tests/frontend/
+npm run typecheck  # cf-typegen + react-router typegen + tsc -b
+```
+
+`react-router typegen` regenerates `app/routes.ts` type stubs; run typecheck before assuming types are current.
+
+## Code layout
+
+- **`app/routes/`** — React Router route modules. One file per page (`home.tsx`, `mailbox.tsx`, `settings.tsx`, etc.).
+- **`app/components/`** — Shared UI components. Uses **Cloudflare Kumo** design system (`@cloudflare/kumo`) for all primitives (Button, Input, Dialog, etc.).
+- **`app/hooks/`** — Custom hooks. `useUIStore` owns global UI state (compose modal open/close, active mailbox, etc.).
+- **`app/queries/`** — React Query wrappers. One file per domain (`mailboxes.ts`, `emails.ts`, `domains.ts`, etc.). All server data fetching goes through these wrappers — don't call `fetch` directly from components.
+- **`app/services/api.ts`** — Typed API client (`get`, `post`, `put`, `patch`, `del` helpers). All new API calls are added here, not inlined in components.
+- **`app/lib/`** — Pure frontend utilities (feedback toasts, compose helpers, etc.).
+- **`app/types/`** — TypeScript types shared across the SPA.
+
+## Test conventions
+
+Frontend tests live in `tests/frontend/`. URL mock dispatchers must use `new URL(url).pathname` or `new URL(url).hostname === 'hostname'` — never `url.startsWith(...)` or `url.includes(...)` (CodeQL gate, root CLAUDE.md Rule 1).
+
+Use `renderWithProviders` from `tests/frontend/test-utils.tsx` and `tests/frontend/shell-mocks.ts` for mocking shell queries.

--- a/hub/CLAUDE.md
+++ b/hub/CLAUDE.md
@@ -1,0 +1,38 @@
+# hub/ — MISP-compatible Threat-Intel Hub
+
+Additive to root CLAUDE.md. Hub-specific conventions only.
+
+The hub is a **separate deployment** (Worker `ais-hub`) with its own D1 database, migrations, test suite, and CI job. It is nearly independent of the main PhishSOC Worker.
+
+## Scoped commands
+
+Run from the **`hub/` directory**:
+
+```bash
+npm test           # vitest run — hub/tests/
+npm run typecheck  # wrangler types && tsc --noEmit
+
+# D1 migrations
+npm run db:migrate:local   # apply migrations locally
+npm run db:migrate:remote  # apply migrations to production
+```
+
+The root `npm test` does **not** cover hub tests — use the scoped command above or rely on the dedicated `Typecheck & Test (hub)` CI job in `.github/workflows/ci.yml`.
+
+## Code layout
+
+- **`hub/src/index.ts`** — Hono entry point; all API routes.
+- **`hub/src/routes/`** — Route handlers (events, feeds, orgs, sharing groups, admin peers).
+- **`hub/src/lib/`** — Core logic: `sync.ts` (MISP inbound pull), `aggregate.ts` (attribute promotion), `push.ts` (outbound push stub).
+- **`hub/src/agent/`** — Optional AI agent for hub-level analysis.
+- **`hub/src/types.ts`** — Hub-specific `Env` and domain types.
+- **`hub/migrations/`** — D1 SQL migrations. Add a new `.sql` file for every schema change; never edit existing migrations.
+- **`hub/tests/`** — Vitest tests scoped to the hub.
+- **`hub/wrangler.jsonc`** — Hub's own Worker config (name: `ais-hub`, D1 binding, AI binding).
+
+## Key invariants
+
+- **MISP-compatible API format.** Existing MISP peers and the main app's destroylist pull depend on the response shape — don't change field names or status codes without verifying compatibility.
+- **Attribute promotion is sybil-resistant:** `score ≥ 2.0 AND contributors ≥ 2` (see `hub/src/lib/aggregate.ts`). Don't lower this threshold without a security review.
+- **Loop prevention on pull:** `hub/src/lib/sync.ts` skips events where `orgc_uuid` matches our own org UUID. Preserve this check when modifying sync logic.
+- **Admin routes use `HUB_ADMIN_KEY`.** Per-org API routes use per-org `Authorization` bearer tokens (SHA-256 hashed in D1). Don't mix the two auth models.

--- a/sidecar/CLAUDE.md
+++ b/sidecar/CLAUDE.md
@@ -1,0 +1,34 @@
+# sidecar/ — YaraMail YARA Attachment Scanner
+
+Additive to root CLAUDE.md. Sidecar-specific conventions only.
+
+The sidecar is a **Python service**, not TypeScript. Workers and npm conventions from root CLAUDE.md do **not** apply here.
+
+## Runtime
+
+Python 3.11+, FastAPI, YARA-python. Operator-deployed as a Docker container on any HTTPS-reachable host (Cloud Run, Fly.io, self-hosted). The main Worker dispatches attachment scan requests to it over HTTP.
+
+## Test / typecheck
+
+No npm scripts. If you add or modify Python logic:
+
+```bash
+cd sidecar/example
+pip install -r requirements.txt
+pytest          # if tests exist
+mypy main.py    # type-check with mypy
+```
+
+## Code layout
+
+- **`sidecar/example/main.py`** — Reference FastAPI stub illustrating the expected HTTP request/response contract. Not production-ready; real deployments extend this.
+- **`sidecar/example/requirements.txt`** — Python dependencies (FastAPI, uvicorn, yara-python, httpx, pydantic).
+
+## Interface contract
+
+Documented in `docs/yaramail-sidecar.md`. Key points:
+- Worker sends `POST <endpointUrl>` with JSON (`emailId`, `r2Key`, `mailboxId`, `presignedUrl`).
+- Sidecar responds with `{ matches: string[], score: number }`.
+- Sidecar must validate inbound requests via `YARAMAIL_CALLBACK_SECRET` HMAC-SHA256.
+- The sidecar is **never on the critical path** — the Worker proceeds with the pre-sidecar verdict if the sidecar does not respond within 30 seconds.
+- Configured per-mailbox under `yaraMailScanner.endpointUrl` in mailbox settings.

--- a/workers/CLAUDE.md
+++ b/workers/CLAUDE.md
@@ -1,0 +1,39 @@
+# workers/ — Hono on Cloudflare Workers
+
+Additive to root CLAUDE.md. Workers-specific conventions only.
+
+## Scoped commands
+
+Run from the **repo root** (Workers tests live in root `test/` and `tests/`):
+
+```bash
+npm test           # vitest run — workers + frontend
+npm run typecheck  # cf-typegen + react-router typegen + tsc -b
+```
+
+## Runtime invariants
+
+- **Workers runtime only.** No `node:` imports, no `Buffer`, no `process.env`. Use `crypto.subtle`, `Response`, `ReadableStream` from the Workers global scope.
+- **MTA-STS fetches must include `redirect: "manual"`.** Any `fetch()` of a policy URL in `workers/mta-sts/` must pass `redirect: "manual"` or the security pipeline is bypassed. Covered by root CLAUDE.md Rule 3.
+- **Every settings-tier write runs `stripDefaultEqual`.** See root CLAUDE.md for the full rule. Applies to `mailboxes/<id>.json`, `domains/<domain>.json`, and `org/settings.json` writes.
+
+## Code layout
+
+- **`workers/app.ts`** — main Worker export. Wires the Hono API (`workers/index.ts`), React Router SSR, `EmailAgent`/`EmailMCP` DO exports, `email()` inbound handler, and `scheduled()` cron handler.
+- **`workers/index.ts`** — Hono router for all `/api/v1/` endpoints. New API routes go here.
+- **`workers/durableObject/`** — `MailboxDO`: per-mailbox Durable Object with SQLite (drizzle), R2 attachment refs, ACL, sender-graph, and verdict store. Schema changes require a new migration in `workers/durableObject/migrations.ts`.
+- **`workers/agent/`** — `EmailAgent` (per-mailbox AI agent via Cloudflare Agents SDK) and `OrgAgent` (org-wide agent).
+- **`workers/mcp/`** — `EmailMCP`: Model Context Protocol server exposing mailbox tools over SSE.
+- **`workers/security/`** — Synchronous security pipeline (SPF/DKIM/DMARC parse → sender reputation → URL heuristics → LLM classification → verdict). Runs inline during `receiveEmail()`.
+- **`workers/intel/`** — Threat-intel layer: bloom-filter feed lookups, async deep-scan (URL fetch + RDAP), CrowdSec CTI, MISP corroboration, hub reporting.
+- **`workers/lib/`** — Shared helpers: mailbox/domain/org settings resolvers, attachment storage, email helpers, ACL, AI wrappers, confirm tokens.
+- **`workers/db/`** — Drizzle schema for the DO's SQLite.
+- **`workers/routes/`** — Thin Hono route handlers extracted from `index.ts`: ACL members, cases, reply/forward, send-email, DMARC/TLSRPT ingest, hub-ui proxy, yaramail callback, confirm.
+- **`workers/dmarc/`** — DMARC record parsing, RUA/RUF ingestion, and posture checks.
+- **`workers/dkim/`** — DKIM record lookup and posture scoring.
+- **`workers/spf/`** — SPF record lookup and posture scoring.
+- **`workers/bimi/`** — BIMI record lookup and posture checks.
+- **`workers/tlsrpt/`** — TLSRPT report ingestion and parsing.
+- **`workers/mta-sts/`** — MTA-STS policy fetch and posture check (always `redirect: "manual"`).
+- **`workers/email-sender.ts`** — Outbound email via Resend (`EMAIL` binding).
+- **`workers/types.ts`** — `Env` interface shared across all workers files.


### PR DESCRIPTION
## Summary

- Add `workers/CLAUDE.md`: Workers-only runtime constraints, scoped test/typecheck commands, and layout of all 14 subsystems.
- Add `app/CLAUDE.md`: React Router v7 SPA conventions, Kumo design system, query/API patterns, test URL-mock rule.
- Add `hub/CLAUDE.md`: Separate deployment context, scoped `hub/` commands, D1 migration workflow, MISP invariants, CI job name.
- Add `sidecar/CLAUDE.md`: Python/YARA runtime (not TypeScript), Docker deployment model, interface contract reference.

Each file is additive to root CLAUDE.md — local conventions and scoped commands only, no duplication of root rules.

Closes #279

## Test plan

- [x] `npm test` — 1043 passing, 0 failing (81 files) — docs-only change, no test impact
- [x] `npm run typecheck` — clean

## Deferred follow-ups

- Optional one-line pointer in root `CLAUDE.md` deferred to avoid racing PR #281, which also edits `CLAUDE.md` (adds the codebase map). Add after whichever lands second.

https://claude.ai/code/session_016Mz6tjTcxyvHXzYyQGwPXm

---
_Generated by [Claude Code](https://claude.ai/code/session_016Mz6tjTcxyvHXzYyQGwPXm)_