### PR TITLE
feat: committed .claude/settings.json hook enforcing stripDefaultEqual + MTA-STS invariants (#278)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "$comment": "Committed harness for PhishSOC. Enforces invariants documented in CLAUDE.md so they fail at edit time instead of in advisor review / CodeQL. See issue #278.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "$comment": "MTA-STS policy fetch must use redirect: \"manual\" (RFC 8461 §3.3 / global CLAUDE.md). Presence check on the bad pattern in the incoming edit; mirrors the dmarcheck hook that stopped PRs #58/#92 regressing the same invariant.",
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r 'if ((.tool_input.file_path // \"\") | test(\"workers/mta-sts/posture\\\\.ts$\")) then (.tool_input.new_string // .tool_input.content // \"\") else \"\" end' | grep -qE 'redirect:[[:space:]]*\"(error|follow)\"' && { echo 'Blocked: MTA-STS policy fetch in workers/mta-sts/posture.ts must use redirect: \"manual\" (RFC 8461 §3.3). This invariant regressed twice in the sibling dmarcheck repo (PRs #58, #92). See CLAUDE.md.' >&2; exit 2; } || exit 0",
+            "statusMessage": "Checking MTA-STS redirect mode..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "$comment": "stripDefaultEqual must guard settings-tier writes (CLAUDE.md: 'stripDefaultEqual runs on every settings-tier write'; regressed in PRs #148, #154). Coarse file-wide tripwire: a settings-write file that performs an R2/helper write but no longer references stripDefaultEqual is flagged. Heuristic by design — if a write legitimately needs no strip, route it so the file still references stripDefaultEqual or move the write out of these files.",
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path // \"\"' | { read -r f; case \"$f\" in *workers/index.ts|*workers/lib/mailbox-settings.ts|*workers/lib/domain-settings.ts|*workers/lib/org-settings.ts|*workers/security/settings.ts) if [ -f \"$f\" ] && grep -qE 'BUCKET\\.put\\(|putDomainSettings|putMailboxSettings|orgSettingsKey' \"$f\" && ! grep -q 'stripDefaultEqual' \"$f\"; then echo \"Blocked: $f performs a settings-tier write but no longer references stripDefaultEqual. Every settings-tier write (mailboxes/<id>.json, domains/<domain>.json, org/settings.json) must route through stripDefaultEqual from workers/lib/mailbox-settings.ts before BUCKET.put — see CLAUDE.md. This regressed in PRs #148 and #154.\" >&2; exit 2; fi ;; esac; }",
+            "statusMessage": "Checking stripDefaultEqual on settings-tier writes..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,7 @@ opencode.jsonc
 skills-lock.json
 .DS_Store
 worker-configuration.d.ts
-.claude/
+# Track the committed Claude Code harness (settings.json) but keep
+# local-only session state (plans, transcripts, settings.local.json) ignored.
+.claude/*
+!.claude/settings.json


### PR DESCRIPTION
Closes #278.

## What

Adds a version-controlled `.claude/settings.json` so two invariants documented in `CLAUDE.md` — but until now caught only by manual advisor review or post-hoc CodeQL — fail at edit time.

| Hook | Type | Behavior |
|---|---|---|
| MTA-STS redirect | PreToolUse `Edit\|Write` | Blocks introducing `redirect: "follow"`/`"error"` into `workers/mta-sts/posture.ts` (RFC 8461 §3.3). Presence check; mirrors the dmarcheck hook that stopped PRs #58/#92 regressing the same invariant. |
| stripDefaultEqual | PostToolUse `Edit\|Write` | Flags a settings-write file (`workers/index.ts`, `workers/lib/{mailbox,domain,org}-settings.ts`, `workers/security/settings.ts`) that performs a tier write but no longer references `stripDefaultEqual` (regressed in PRs #148, #154). |

`.gitignore` narrowed from `.claude/` to `.claude/*` + `!.claude/settings.json` so the harness is tracked while local session state (`settings.local.json`, plans, transcripts) stays ignored.

## Design notes

- **stripDefaultEqual is a coarse, file-wide tripwire**, not a per-endpoint check. PostToolUse (not PreToolUse) on full-file content was chosen deliberately: an absence-check against an Edit's partial `new_string` would misfire on every refactor that moves a `BUCKET.put` line without including the existing `stripDefaultEqual` line in the same hunk — a hook that cries wolf gets culturally bypassed. The trade-off: a brand-new endpoint added to `index.ts` alongside existing strip-guarded endpoints won't be caught (file still references `stripDefaultEqual`). The durable wins here are the committed harness, the hard MTA-STS block, and the existing CLAUDE.md prose; a precise per-endpoint check is deferred (see Follow-ups).

## Verification

10 synthetic tool-input cases, all passing — block, pass, path-scoping, and the critical no-op-on-existing-`workers/index.ts`/`mailbox-settings.ts` cases (confirms the regex is not over-aggressive). Full suite: **1043 passing, 0 failing** (81 files); config-only change, unaffected as expected.

## Follow-ups (out of scope)

- Precise per-endpoint stripDefaultEqual detection (current check is file-wide coarse).
- Per-subsystem CLAUDE.md files — #279
- Top-level codebase map — #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)