### PR TITLE
chore: allowlist read-only git fetch / gh search code / pnpm lint

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,13 @@
 {
   "$comment": "Committed harness for PhishSOC. Enforces invariants documented in CLAUDE.md so they fail at edit time instead of in advisor review / CodeQL. See issue #278.",
+  "permissions": {
+    "allow": [
+      "Bash(git fetch)",
+      "Bash(git fetch *)",
+      "Bash(gh search code *)",
+      "Bash(pnpm lint)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## What

Adds a `permissions.allow` block to the committed `.claude/settings.json` covering the three most-frequent **read-only** commands that were still prompting:

| Pattern | Observed count |
|---|---|
| `Bash(git fetch)` + `Bash(git fetch *)` | 10 |
| `Bash(gh search code *)` | 8 |
| `Bash(pnpm lint)` | 4 |

## Why

Generated by `/fewer-permission-prompts` after scanning the 50 most-recently-modified session transcripts across all projects. The overwhelming majority of observed commands (`grep`, `gh pr/issue view`, `git status/log/show`, `ls`/`cat`/`tail`/`find`/`sed`, `gh api` GET) are already auto-allowed by Claude Code and need no entry. Mutating or arbitrary-exec commands (`curl`, `cloudflared access`, `npm test`, `python3 …`, `git add/push`) were deliberately excluded.

These three are genuinely read-only but **not** in the built-in auto-allow set:
- `git fetch` only updates remote-tracking refs (no worktree change).
- `gh search code` is a read-only GitHub query.
- `pnpm lint` is pinned to the exact form — intentionally **not** widened to `pnpm lint *`, so `pnpm lint --fix` would still prompt.

## Reviewer notes

- Purely additive: the file had no `permissions` key before this change.
- The existing `PreToolUse` / `PostToolUse` invariant hooks (MTA-STS redirect mode, `stripDefaultEqual`) are untouched — verified intact via `jq` post-edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)