### PR TITLE
feat: bulk lock-down for all unscoped mailboxes

### DIFF
--- a/app/queries/mailboxes.ts
+++ b/app/queries/mailboxes.ts
@@ -69,3 +69,13 @@ export function useLockDownMailbox() {
 		},
 	});
 }
+
+export function useLockDownAllMailboxes() {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: () => api.lockDownAllMailboxes(),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: queryKeys.mailboxes.all });
+		},
+	});
+}

--- a/app/routes/mailboxes.tsx
+++ b/app/routes/mailboxes.tsx
@@ -21,6 +21,7 @@ import api from "~/services/api";
 import {
 	useCreateMailbox,
 	useDeleteMailbox,
+	useLockDownAllMailboxes,
 	useLockDownMailbox,
 	useMailboxes,
 } from "~/queries/mailboxes";
@@ -36,6 +37,7 @@ export default function MailboxesRoute() {
 	const createMailbox = useCreateMailbox();
 	const deleteMailbox = useDeleteMailbox();
 	const lockDownMailbox = useLockDownMailbox();
+	const lockDownAllMailboxes = useLockDownAllMailboxes();
 
 	useAutoProvisionMailboxes();
 
@@ -60,6 +62,7 @@ export default function MailboxesRoute() {
 		email: string;
 	} | null>(null);
 	const [isDeleting, setIsDeleting] = useState(false);
+	const [isBulkLockDownOpen, setIsBulkLockDownOpen] = useState(false);
 
 	useEffect(() => {
 		if (domains.length > 0 && !selectedDomain) {
@@ -128,6 +131,26 @@ export default function MailboxesRoute() {
 		}
 	};
 
+	const unscopedCount = mailboxes.filter((m) => m.acl_status === "unscoped").length;
+
+	const handleBulkLockDown = async () => {
+		try {
+			const result = await lockDownAllMailboxes.mutateAsync();
+			const parts: string[] = [];
+			if (result.locked > 0) parts.push(`${result.locked} locked`);
+			if (result.skipped > 0) parts.push(`${result.skipped} skipped`);
+			if (result.errors.length > 0) {
+				feedback.error(`Bulk lock-down finished with errors: ${result.errors.join("; ")}`);
+			} else {
+				feedback.success(`Bulk lock-down complete — ${parts.join(", ")}`);
+			}
+		} catch {
+			feedback.error("Bulk lock-down failed");
+		} finally {
+			setIsBulkLockDownOpen(false);
+		}
+	};
+
 	const isLoading = !configData;
 
 	return (
@@ -136,15 +159,26 @@ export default function MailboxesRoute() {
 				<div className="mb-8">
 					<div className="flex items-center justify-between">
 						<h1 className="pp-serif text-[40px] leading-none text-ink">Mailboxes</h1>
-						{!isConfigured && (
-							<Button
-								variant="primary"
-								icon={<PlusIcon size={16} />}
-								onClick={() => setIsCreateOpen(true)}
-							>
-								New Mailbox
-							</Button>
-						)}
+						<div className="flex items-center gap-2">
+							{unscopedCount > 0 && (
+								<Button
+									variant="secondary"
+									size="sm"
+									onClick={() => setIsBulkLockDownOpen(true)}
+								>
+									Lock down all unscoped
+								</Button>
+							)}
+							{!isConfigured && (
+								<Button
+									variant="primary"
+									icon={<PlusIcon size={16} />}
+									onClick={() => setIsCreateOpen(true)}
+								>
+									New Mailbox
+								</Button>
+							)}
+						</div>
 					</div>
 					{domains.length > 0 && (
 						<p className="text-sm text-ink-3 mt-1">
@@ -326,6 +360,38 @@ export default function MailboxesRoute() {
 							</Button>
 						</div>
 					</form>
+				</Dialog>
+			</Dialog.Root>
+
+			{/* Bulk Lock-down Confirm Dialog */}
+			<Dialog.Root open={isBulkLockDownOpen} onOpenChange={setIsBulkLockDownOpen}>
+				<Dialog size="sm" className="p-6">
+					<Dialog.Title className="text-base font-semibold mb-2">
+						Lock down all unscoped mailboxes?
+					</Dialog.Title>
+					<Dialog.Description className="text-ink-3 text-sm mb-5">
+						Lock down{" "}
+						<strong className="text-ink">{unscopedCount}</strong>{" "}
+						unscoped{" "}
+						{unscopedCount === 1 ? "mailbox" : "mailboxes"}? You will become owner of each.
+					</Dialog.Description>
+					<div className="flex justify-end gap-2">
+						<Dialog.Close
+							render={(props) => (
+								<Button {...props} variant="secondary" size="sm">
+									Cancel
+								</Button>
+							)}
+						/>
+						<Button
+							variant="primary"
+							size="sm"
+							loading={lockDownAllMailboxes.isPending}
+							onClick={handleBulkLockDown}
+						>
+							Lock down all
+						</Button>
+					</div>
 				</Dialog>
 			</Dialog.Root>
 

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -130,6 +130,8 @@ const api = {
 		del<void>(`/api/v1/mailboxes/${mailboxId}`),
 	lockDownMailbox: (mailboxId: string) =>
 		post<{ owner: string; members: string[] }>(`/api/v1/mailboxes/${mailboxId}/acl`),
+	lockDownAllMailboxes: () =>
+		post<{ locked: number; skipped: number; errors: string[] }>("/api/v1/mailboxes/bulk-lockdown"),
 	// Org-level settings (#106). Backed by R2 key org/settings.json behind a
 	// module-scope ETag cache; the GET returns the raw blob (or {} if missing),
 	// PUT validates through the OrgSettings Zod schema worker-side.

--- a/tests/routes/mailboxes-acl-status.test.ts
+++ b/tests/routes/mailboxes-acl-status.test.ts
@@ -12,7 +12,7 @@ import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import { requireMailbox, type MailboxContext } from "../../workers/lib/mailbox";
 import { aclMemberRoutes } from "../../workers/routes/acl-members";
-import { readMailboxAcl, callerInAcl } from "../../workers/lib/mailbox-acl";
+import { readMailboxAcl, writeMailboxAcl, callerInAcl } from "../../workers/lib/mailbox-acl";
 import { listMailboxes } from "../../workers/lib/email-helpers";
 import type { MailboxAcl } from "../../workers/lib/mailbox-acl";
 
@@ -260,5 +260,174 @@ describe("POST /api/v1/mailboxes/:id/acl — lock down", () => {
 		const body = await listRes.json() as Array<{ id: string; acl_status: string }>;
 		const mailbox = body.find((m) => m.id === mailboxId);
 		expect(mailbox?.acl_status).toBe("scoped");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Bulk lock-down endpoint app (#294)
+// ---------------------------------------------------------------------------
+
+function makeBulkLockDownApp(bucketStore: Record<string, string>, callerEmail: string | null) {
+	const bucket = makeR2Stub(bucketStore);
+	const MAILBOX = { idFromName: () => "fake-id", get: () => ({}) };
+
+	const app = new Hono<{ Bindings: { BUCKET: typeof bucket; MAILBOX: typeof MAILBOX } }>();
+
+	app.post("/api/v1/mailboxes/bulk-lockdown", async (c) => {
+		const caller =
+			c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+
+		if (!caller) {
+			return c.json({ error: "CF Access email required" }, 400);
+		}
+
+		const allMailboxes = await listMailboxes(c.env.BUCKET as unknown as R2Bucket);
+		const acls = await Promise.all(
+			allMailboxes.map((m) => readMailboxAcl(c.env as unknown as { BUCKET: R2Bucket }, m.id)),
+		);
+
+		const unscoped = allMailboxes.filter((_m, i) => !acls[i]);
+
+		let locked = 0;
+		let skipped = 0;
+		const errors: string[] = [];
+
+		await Promise.all(
+			unscoped.map(async (m) => {
+				const existing = await readMailboxAcl(c.env as unknown as { BUCKET: R2Bucket }, m.id);
+				if (existing) {
+					skipped++;
+					return;
+				}
+				try {
+					const acl = { owner: caller, members: [caller] };
+					await writeMailboxAcl(c.env as unknown as { BUCKET: R2Bucket }, m.id, acl);
+					locked++;
+				} catch (err) {
+					errors.push(`${m.id}: ${(err as Error)?.message ?? "unknown error"}`);
+				}
+			}),
+		);
+
+		return c.json({ locked, skipped, errors });
+	});
+
+	return {
+		post() {
+			const hdrs: Record<string, string> = {};
+			if (callerEmail) hdrs["cf-access-authenticated-user-email"] = callerEmail;
+			return app.request(
+				"/api/v1/mailboxes/bulk-lockdown",
+				{ method: "POST", headers: hdrs },
+				{
+					BUCKET: bucket as unknown as R2Bucket,
+					MAILBOX: MAILBOX as unknown as DurableObjectNamespace,
+				},
+			);
+		},
+		bucket,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/mailboxes/bulk-lockdown (#294)
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/mailboxes/bulk-lockdown (#294)", () => {
+	const aliceKey = `mailboxes/alice@example.com.json`;
+	const aliceAclKey = `mailboxes-acl/alice@example.com.json`;
+	const bobKey = `mailboxes/bob@example.com.json`;
+	const bobAclKey = `mailboxes-acl/bob@example.com.json`;
+	const charlieKey = `mailboxes/charlie@example.com.json`;
+
+	it("locks all unscoped mailboxes in a mixed fleet", async () => {
+		// alice is already scoped; bob and charlie are unscoped
+		const aliceAcl: MailboxAcl = { owner: "alice@example.com", members: ["alice@example.com"] };
+		const store = {
+			[aliceKey]: "{}",
+			[aliceAclKey]: JSON.stringify(aliceAcl),
+			[bobKey]: "{}",
+			[charlieKey]: "{}",
+		};
+		const { post, bucket } = makeBulkLockDownApp(store, "operator@example.com");
+		const res = await post();
+		expect(res.status).toBe(200);
+		const body = await res.json() as { locked: number; skipped: number; errors: string[] };
+		expect(body.locked).toBe(2);
+		expect(body.skipped).toBe(0);
+		expect(body.errors).toHaveLength(0);
+
+		// bob and charlie now have ACLs with operator as owner
+		const storedBob = JSON.parse(bucket._store[bobAclKey]) as MailboxAcl;
+		expect(storedBob.owner).toBe("operator@example.com");
+		expect(storedBob.members).toContain("operator@example.com");
+		const charlieAclKey = `mailboxes-acl/charlie@example.com.json`;
+		const storedCharlie = JSON.parse(bucket._store[charlieAclKey]) as MailboxAcl;
+		expect(storedCharlie.owner).toBe("operator@example.com");
+	});
+
+	it("returns 0 locked, 0 skipped when all mailboxes are already scoped", async () => {
+		const aliceAcl: MailboxAcl = { owner: "alice@example.com", members: ["alice@example.com"] };
+		const store = {
+			[aliceKey]: "{}",
+			[aliceAclKey]: JSON.stringify(aliceAcl),
+		};
+		const { post } = makeBulkLockDownApp(store, "operator@example.com");
+		const res = await post();
+		expect(res.status).toBe(200);
+		const body = await res.json() as { locked: number; skipped: number; errors: string[] };
+		expect(body.locked).toBe(0);
+		expect(body.skipped).toBe(0);
+		expect(body.errors).toHaveLength(0);
+	});
+
+	it("returns 0/0 when there are no mailboxes at all", async () => {
+		const { post } = makeBulkLockDownApp({}, "operator@example.com");
+		const res = await post();
+		expect(res.status).toBe(200);
+		const body = await res.json() as { locked: number; skipped: number; errors: string[] };
+		expect(body.locked).toBe(0);
+		expect(body.skipped).toBe(0);
+		expect(body.errors).toHaveLength(0);
+	});
+
+	it("after bulk lock-down, GET /api/v1/mailboxes shows all as scoped", async () => {
+		const store: Record<string, string> = { [aliceKey]: "{}", [bobKey]: "{}" };
+		const { post, bucket } = makeBulkLockDownApp(store, "operator@example.com");
+		const lockRes = await post();
+		expect(lockRes.status).toBe(200);
+		const lockBody = await lockRes.json() as { locked: number };
+		expect(lockBody.locked).toBe(2);
+
+		const { fetch } = makeListApp(bucket._store, null);
+		const listRes = await fetch();
+		expect(listRes.status).toBe(200);
+		const listBody = await listRes.json() as Array<{ id: string; acl_status: string }>;
+		for (const m of listBody) {
+			expect(m.acl_status).toBe("scoped");
+		}
+	});
+
+	it("returns 400 when no CF Access email is present", async () => {
+		const store = { [aliceKey]: "{}" };
+		const { post } = makeBulkLockDownApp(store, null);
+		const res = await post();
+		expect(res.status).toBe(400);
+	});
+
+	it("does not abort when a mailbox is already scoped (partial-success idempotence)", async () => {
+		// alice is already scoped; only bob is unscoped → 1 locked, 0 skipped
+		const aliceAcl: MailboxAcl = { owner: "alice@example.com", members: ["alice@example.com"] };
+		const store = {
+			[aliceKey]: "{}",
+			[aliceAclKey]: JSON.stringify(aliceAcl),
+			[bobKey]: "{}",
+		};
+		const { post } = makeBulkLockDownApp(store, "operator@example.com");
+		const res = await post();
+		expect(res.status).toBe(200);
+		const body = await res.json() as { locked: number; skipped: number; errors: string[] };
+		expect(body.locked).toBe(1);
+		expect(body.errors).toHaveLength(0);
 	});
 });

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -279,6 +279,45 @@ app.get("/api/v1/mailboxes", async (c) => {
 	})));
 });
 
+// Bulk lock-down: lock every unscoped mailbox the caller can see (#294).
+app.post("/api/v1/mailboxes/bulk-lockdown", async (c) => {
+	const callerEmail =
+		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+
+	if (!callerEmail) {
+		return c.json({ error: "CF Access email required" }, 400);
+	}
+
+	const allMailboxes = await listMailboxes(c.env.BUCKET);
+	const acls = await Promise.all(allMailboxes.map((m) => readMailboxAcl(c.env, m.id)));
+
+	// Filter to unscoped mailboxes (no ACL = unscoped = visible to all).
+	const unscoped = allMailboxes.filter((_m, i) => !acls[i]);
+
+	let locked = 0;
+	let skipped = 0;
+	const errors: string[] = [];
+
+	await Promise.all(
+		unscoped.map(async (m) => {
+			const existing = await readMailboxAcl(c.env, m.id);
+			if (existing) {
+				skipped++;
+				return;
+			}
+			try {
+				const acl = { owner: callerEmail, members: [callerEmail] };
+				await writeMailboxAcl(c.env, m.id, acl);
+				locked++;
+			} catch (err) {
+				errors.push(`${m.id}: ${(err as Error)?.message ?? "unknown error"}`);
+			}
+		}),
+	);
+
+	return c.json({ locked, skipped, errors });
+});
+
 // -- Org overview ---------------------------------------------------
 
 /** Versioned KV key — bumping the prefix on schema change is a clean rename. */


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/mailboxes/bulk-lockdown` backend endpoint: iterates every unscoped mailbox visible to the caller, assigns the caller as owner (reusing the same ACL write path as the single lock-down endpoint), and returns `{ locked: N, skipped: M, errors: [...] }`. Partial failures do not abort remaining mailboxes.
- Adds a "Lock down all unscoped" button in `app/routes/mailboxes.tsx`, shown only when `unscopedCount > 0`. Clicking opens a confirm dialog ("Lock down N unscoped mailboxes? You will become owner of each.") before calling the new endpoint.
- Adds `lockDownAllMailboxes()` to `app/services/api.ts` and `useLockDownAllMailboxes()` mutation hook to `app/queries/mailboxes.ts`.
- After the action, `GET /api/v1/mailboxes` reflects `acl_status: "scoped"` for all formerly-unscoped mailboxes.

Closes #294

## Test plan

- [ ] Mixed fleet (1 scoped alice, 2 unscoped bob+charlie) → `locked: 2, skipped: 0, errors: []`
- [ ] All-scoped fleet → `locked: 0, skipped: 0, errors: []`
- [ ] Empty mailbox list → `locked: 0, skipped: 0, errors: []`
- [ ] Full round-trip: bulk lock-down then `GET /api/v1/mailboxes` → all `acl_status: "scoped"`
- [ ] No CF Access email → 400
- [ ] Partial-success: one mailbox already scoped, rest continue → correct counts, no errors

All 6 new tests pass; full suite: **81 test files, 1049 tests passed**. TypeCheck: **0 errors**.

https://claude.ai/code/session_01Y2qBLjzUVCFjqTkHrg1uHD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2qBLjzUVCFjqTkHrg1uHD)_