### PR TITLE
feat: mailbox ACL member-management UI

### DIFF
--- a/app/components/AclMembersPanel.tsx
+++ b/app/components/AclMembersPanel.tsx
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { Button, Input, Loader } from "@cloudflare/kumo";
+import { LockIcon, UserIcon, XIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { useLockDownMailbox, useMailboxAcl, useAddAclMember, useRemoveAclMember } from "~/queries/mailboxes";
+import { ApiError } from "~/services/api";
+
+interface AclMembersPanelProps {
+	mailboxId: string;
+}
+
+export function AclMembersPanel({ mailboxId }: AclMembersPanelProps) {
+	const { data: acl, isLoading } = useMailboxAcl(mailboxId);
+	const lockDown = useLockDownMailbox();
+	const addMember = useAddAclMember(mailboxId);
+	const removeMember = useRemoveAclMember(mailboxId);
+
+	const [newEmail, setNewEmail] = useState("");
+	const [addError, setAddError] = useState<string | null>(null);
+	const [removeError, setRemoveError] = useState<string | null>(null);
+
+	if (isLoading || acl === undefined) {
+		return (
+			<div className="flex justify-center py-6">
+				<Loader size="sm" />
+			</div>
+		);
+	}
+
+	if (acl === null) {
+		return (
+			<div className="rounded-md border border-line bg-paper-2 px-4 py-3 text-sm text-ink-3">
+				<div className="flex items-center gap-2 mb-2">
+					<LockIcon size={14} weight="duotone" />
+					<span className="font-medium text-ink">Mailbox is unscoped</span>
+				</div>
+				<p className="mb-3">
+					This mailbox is accessible to anyone admitted by CF Access. Lock it
+					down first to manage individual members.
+				</p>
+				<Button
+					variant="secondary"
+					size="sm"
+					loading={lockDown.isPending}
+					onClick={() => lockDown.mutate(mailboxId)}
+					data-testid="acl-lockdown-btn"
+				>
+					Lock down
+				</Button>
+				{lockDown.isError && (
+					<p className="mt-2 text-xs text-red-600">
+						{lockDown.error instanceof ApiError ? lockDown.error.message : "Lock down failed"}
+					</p>
+				)}
+			</div>
+		);
+	}
+
+	const handleAdd = async () => {
+		setAddError(null);
+		const email = newEmail.trim().toLowerCase();
+		if (!email) return;
+		try {
+			await addMember.mutateAsync(email);
+			setNewEmail("");
+		} catch (err) {
+			setAddError(err instanceof ApiError ? err.message : "Failed to add member");
+		}
+	};
+
+	const handleRemove = async (email: string) => {
+		setRemoveError(null);
+		try {
+			await removeMember.mutateAsync(email);
+		} catch (err) {
+			setRemoveError(err instanceof ApiError ? err.message : "Failed to remove member");
+		}
+	};
+
+	return (
+		<div className="space-y-4">
+			<div>
+				<div className="text-xs text-ink-3 mb-1">Owner</div>
+				<div className="flex items-center gap-2 text-sm text-ink">
+					<UserIcon size={14} weight="duotone" className="text-ink-3 shrink-0" />
+					<span data-testid="acl-owner">{acl.owner}</span>
+				</div>
+			</div>
+
+			<div>
+				<div className="text-xs text-ink-3 mb-2">Members</div>
+				<ul className="space-y-1" data-testid="acl-members-list">
+					{acl.members.map((member) => (
+						<li key={member} className="flex items-center justify-between gap-2">
+							<span className="text-sm text-ink truncate">{member}</span>
+							{member !== acl.owner && (
+								<button
+									type="button"
+									aria-label={`Remove ${member}`}
+									data-testid={`remove-member-${member}`}
+									className="text-ink-3 hover:text-red-600 shrink-0"
+									disabled={removeMember.isPending}
+									onClick={() => handleRemove(member)}
+								>
+									<XIcon size={14} />
+								</button>
+							)}
+						</li>
+					))}
+				</ul>
+				{removeError && (
+					<p className="mt-1 text-xs text-red-600" data-testid="remove-error">{removeError}</p>
+				)}
+			</div>
+
+			<div>
+				<div className="text-xs text-ink-3 mb-2">Add member</div>
+				<div className="flex gap-2">
+					<Input
+						type="email"
+						placeholder="teammate@example.com"
+						value={newEmail}
+						onChange={(e) => setNewEmail(e.target.value)}
+						onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
+						data-testid="add-member-input"
+					/>
+					<Button
+						variant="secondary"
+						size="sm"
+						loading={addMember.isPending}
+						onClick={handleAdd}
+						data-testid="add-member-btn"
+					>
+						Add
+					</Button>
+				</div>
+				{addError && (
+					<p className="mt-1 text-xs text-red-600" data-testid="add-error">{addError}</p>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/app/queries/keys.ts
+++ b/app/queries/keys.ts
@@ -7,6 +7,7 @@ export const queryKeys = {
 	mailboxes: {
 		all: ["mailboxes"] as const,
 		detail: (id: string) => ["mailboxes", id] as const,
+		acl: (id: string) => ["mailboxes", id, "acl"] as const,
 	},
 	emails: {
 		list: (mailboxId: string, params: Record<string, string>) =>

--- a/app/queries/mailboxes.ts
+++ b/app/queries/mailboxes.ts
@@ -3,7 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import api from "~/services/api";
+import api, { ApiError } from "~/services/api";
 import type { Mailbox } from "~/types";
 import { queryKeys } from "./keys";
 
@@ -76,6 +76,41 @@ export function useLockDownAllMailboxes() {
 		mutationFn: () => api.lockDownAllMailboxes(),
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey: queryKeys.mailboxes.all });
+		},
+	});
+}
+
+export function useMailboxAcl(mailboxId: string | undefined) {
+	return useQuery<{ owner: string; members: string[] } | null>({
+		queryKey: mailboxId ? queryKeys.mailboxes.acl(mailboxId) : ["mailboxes", "_acl_disabled"],
+		queryFn: async () => {
+			try {
+				return await api.getMailboxAcl(mailboxId!) as { owner: string; members: string[] };
+			} catch (err) {
+				if (err instanceof ApiError && err.status === 404) return null;
+				throw err;
+			}
+		},
+		enabled: !!mailboxId,
+	});
+}
+
+export function useAddAclMember(mailboxId: string) {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (email: string) => api.addAclMember(mailboxId, email),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: queryKeys.mailboxes.acl(mailboxId) });
+		},
+	});
+}
+
+export function useRemoveAclMember(mailboxId: string) {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (email: string) => api.removeAclMember(mailboxId, email),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: queryKeys.mailboxes.acl(mailboxId) });
 		},
 	});
 }

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -12,6 +12,7 @@ import { useOrgSettings } from "~/queries/org-settings";
 import { useDomainSettings } from "~/queries/domain-settings";
 import { useTextModels } from "~/queries/text-models";
 import { SecuritySettingsPanel } from "~/components/SecuritySettingsPanel";
+import { AclMembersPanel } from "~/components/AclMembersPanel";
 import {
 	HubSettingsPanel,
 	normalizeHubConfig,
@@ -847,6 +848,18 @@ export default function SettingsRoute() {
 							</div>
 						)}
 					</div>
+				</div>
+
+				{/* Access / Members — per-mailbox ACL panel (#291). Not part of the
+				    settings-tier save; managed via separate ACL endpoints. */}
+				<div className="pp-card p-5">
+					<div className="text-sm font-medium text-ink mb-4">Access</div>
+					<p className="text-xs text-ink-3 mb-4">
+						Manage who can access this mailbox. Lock it down to restrict access to
+						specific members; unscoped mailboxes are visible to everyone admitted
+						by Cloudflare Access.
+					</p>
+					<AclMembersPanel mailboxId={mailboxId!} />
 				</div>
 
 				{/* Save */}

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -144,6 +144,12 @@ const api = {
 		post<{ owner: string; members: string[] }>(`/api/v1/mailboxes/${mailboxId}/acl`),
 	lockDownAllMailboxes: () =>
 		post<{ locked: number; skipped: number; errors: string[] }>("/api/v1/mailboxes/bulk-lockdown"),
+	getMailboxAcl: (mailboxId: string) =>
+		get<{ owner: string; members: string[] }>(`/api/v1/mailboxes/${mailboxId}/acl`),
+	addAclMember: (mailboxId: string, email: string) =>
+		post<{ owner: string; members: string[] }>(`/api/v1/mailboxes/${mailboxId}/acl/members`, { email }),
+	removeAclMember: (mailboxId: string, email: string) =>
+		del<{ owner: string; members: string[] }>(`/api/v1/mailboxes/${mailboxId}/acl/members/${encodeURIComponent(email)}`),
 	// Org-level settings (#106). Backed by R2 key org/settings.json behind a
 	// module-scope ETag cache; the GET returns the raw blob (or {} if missing),
 	// PUT validates through the OrgSettings Zod schema worker-side.

--- a/tests/frontend/hub-settings.test.tsx
+++ b/tests/frontend/hub-settings.test.tsx
@@ -27,6 +27,10 @@ let mailboxFixture: Mailbox;
 vi.mock("~/queries/mailboxes", () => ({
 	useMailbox: () => ({ data: mailboxFixture }),
 	useUpdateMailbox: () => updateMailboxMock,
+	useLockDownMailbox: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+	useMailboxAcl: () => ({ data: undefined, isLoading: true }),
+	useAddAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useRemoveAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 // Per-mailbox settings page now also reads org settings to drive the

--- a/tests/frontend/security-settings.test.tsx
+++ b/tests/frontend/security-settings.test.tsx
@@ -20,6 +20,10 @@ let mailboxFixture: Mailbox;
 vi.mock("~/queries/mailboxes", () => ({
 	useMailbox: () => ({ data: mailboxFixture }),
 	useUpdateMailbox: () => updateMailboxMock,
+	useLockDownMailbox: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+	useMailboxAcl: () => ({ data: undefined, isLoading: true }),
+	useAddAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useRemoveAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 // Per-mailbox settings page now also reads org settings to drive the

--- a/tests/frontend/settings-attachment-scanner.test.tsx
+++ b/tests/frontend/settings-attachment-scanner.test.tsx
@@ -23,6 +23,10 @@ let mailboxFixture: Mailbox;
 vi.mock("~/queries/mailboxes", () => ({
 	useMailbox: () => ({ data: mailboxFixture }),
 	useUpdateMailbox: () => updateMailboxMock,
+	useLockDownMailbox: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+	useMailboxAcl: () => ({ data: undefined, isLoading: true }),
+	useAddAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useRemoveAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 vi.mock("~/queries/org-settings", () => ({

--- a/tests/frontend/settings-behavior.test.tsx
+++ b/tests/frontend/settings-behavior.test.tsx
@@ -25,6 +25,10 @@ let domainSettingsFixture: { domain: string; settings: Record<string, unknown> }
 vi.mock("~/queries/mailboxes", () => ({
 	useMailbox: () => ({ data: mailboxFixture }),
 	useUpdateMailbox: () => updateMailboxMock,
+	useLockDownMailbox: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+	useMailboxAcl: () => ({ data: undefined, isLoading: true }),
+	useAddAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useRemoveAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 vi.mock("~/queries/org-settings", () => ({

--- a/tests/routes/acl-members.test.ts
+++ b/tests/routes/acl-members.test.ts
@@ -100,6 +100,53 @@ const aliceAndBobAcl: MailboxAcl = {
 };
 
 // ---------------------------------------------------------------------------
+// GET /api/v1/mailboxes/:mailboxId/acl — read ACL (#291)
+// ---------------------------------------------------------------------------
+
+describe("GET /acl — read ACL", () => {
+	it("owner gets { owner, members } with 200", async () => {
+		const { fetch } = makeApp(storeWithAcl(aliceOnlyAcl), "alice@example.com");
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl`);
+		expect(res.status).toBe(200);
+		const body = await res.json() as MailboxAcl;
+		expect(body.owner).toBe("alice@example.com");
+		expect(body.members).toContain("alice@example.com");
+	});
+
+	it("non-owner admitted member → 403", async () => {
+		const { fetch } = makeApp(storeWithAcl(aliceAndBobAcl), "bob@example.com");
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl`);
+		expect(res.status).toBe(403);
+	});
+
+	it("unscoped mailbox (no ACL blob) → 404 with { acl_status: 'unscoped' }", async () => {
+		const { fetch } = makeApp({ [mailboxKey]: "{}" }, "alice@example.com");
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl`);
+		expect(res.status).toBe(404);
+		const body = await res.json() as { acl_status: string };
+		expect(body.acl_status).toBe("unscoped");
+	});
+
+	it("dev mode (no callerEmail) → 200 when ACL exists", async () => {
+		const { fetch } = makeApp(storeWithAcl(aliceOnlyAcl), null);
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl`);
+		expect(res.status).toBe(200);
+		const body = await res.json() as MailboxAcl;
+		expect(body.owner).toBe("alice@example.com");
+	});
+
+	it("returns both owner and multi-member list", async () => {
+		const { fetch } = makeApp(storeWithAcl(aliceAndBobAcl), "alice@example.com");
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl`);
+		expect(res.status).toBe(200);
+		const body = await res.json() as MailboxAcl;
+		expect(body.owner).toBe("alice@example.com");
+		expect(body.members).toContain("alice@example.com");
+		expect(body.members).toContain("bob@example.com");
+	});
+});
+
+// ---------------------------------------------------------------------------
 // POST /api/v1/mailboxes/:mailboxId/acl/members
 // ---------------------------------------------------------------------------
 

--- a/workers/routes/acl-members.ts
+++ b/workers/routes/acl-members.ts
@@ -18,6 +18,26 @@ export const aclMemberRoutes = new Hono<MailboxContext>();
 aclMemberRoutes.use("*", requireMailbox);
 
 /**
+ * Read the ACL for a mailbox (#291). Owner-only — returns { owner, members }.
+ * Non-owner admitted callers receive 403. Unscoped mailboxes (no ACL blob)
+ * return 404 with { acl_status: "unscoped" } so the UI can prompt lock-down.
+ */
+aclMemberRoutes.get("/", async (c) => {
+	const mailboxId = c.req.param("mailboxId")!;
+	const callerEmail =
+		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+
+	const acl = await readMailboxAcl(c.env, mailboxId);
+	if (!acl) {
+		return c.json({ acl_status: "unscoped" }, 404);
+	}
+	if (callerEmail !== null && callerEmail !== acl.owner) {
+		return c.json({ error: "Forbidden" }, 403);
+	}
+	return c.json({ owner: acl.owner, members: acl.members });
+});
+
+/**
  * Lock down an unscoped (pre-#27) mailbox by creating its first ACL with the
  * caller as owner (#241). Returns 201 on success, 409 if an ACL already exists,
  * 400 when CF Access email is absent (dev mode).


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/mailboxes/:id/acl` — owner-only endpoint returning `{ owner, members }` (404 with `{ acl_status: "unscoped" }` for mailboxes not yet locked down)
- Adds `AclMembersPanel` component: shows current owner, member list with per-member remove, add-member input; shows "Lock down first" prompt for unscoped mailboxes (reuses existing lock-down flow)
- Wires the panel into the mailbox Settings page as an "Access" card; panel is independently managed via ACL endpoints and does not participate in the settings-tier save

Closes #291

## Test plan

- [ ] `GET /acl` as owner → 200 `{ owner, members }` (5 new route tests)
- [ ] `GET /acl` as non-owner admitted member → 403
- [ ] `GET /acl` on unscoped mailbox → 404 `{ acl_status: "unscoped" }`
- [ ] `GET /acl` in dev mode (no caller email) → 200
- [ ] Settings page test mocks updated for the 4 files that render SettingsRoute (hub-settings, security-settings, settings-attachment-scanner, settings-behavior)
- [ ] 81 test files, 1048 tests passing, 0 TypeScript errors

## Deferred / follow-up

- #292 (org-wide ACL overview) depends on this PR landing first — see its issue body
- #293 (ownership transfer) coordinates with the member-management panel added here

https://claude.ai/code/session_01Y2qBLjzUVCFjqTkHrg1uHD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2qBLjzUVCFjqTkHrg1uHD)_