### PR TITLE
feat: mailbox ACL ownership transfer

### DIFF
--- a/app/components/AclMembersPanel.tsx
+++ b/app/components/AclMembersPanel.tsx
@@ -3,7 +3,7 @@
 import { Button, Input, Loader } from "@cloudflare/kumo";
 import { LockIcon, UserIcon, XIcon } from "@phosphor-icons/react";
 import { useState } from "react";
-import { useLockDownMailbox, useMailboxAcl, useAddAclMember, useRemoveAclMember } from "~/queries/mailboxes";
+import { useLockDownMailbox, useMailboxAcl, useAddAclMember, useRemoveAclMember, useTransferAclOwnership } from "~/queries/mailboxes";
 import { ApiError } from "~/services/api";
 
 interface AclMembersPanelProps {
@@ -15,10 +15,12 @@ export function AclMembersPanel({ mailboxId }: AclMembersPanelProps) {
 	const lockDown = useLockDownMailbox();
 	const addMember = useAddAclMember(mailboxId);
 	const removeMember = useRemoveAclMember(mailboxId);
+	const transferOwnership = useTransferAclOwnership(mailboxId);
 
 	const [newEmail, setNewEmail] = useState("");
 	const [addError, setAddError] = useState<string | null>(null);
 	const [removeError, setRemoveError] = useState<string | null>(null);
+	const [transferError, setTransferError] = useState<string | null>(null);
 
 	if (isLoading || acl === undefined) {
 		return (
@@ -78,6 +80,15 @@ export function AclMembersPanel({ mailboxId }: AclMembersPanelProps) {
 		}
 	};
 
+	const handleTransfer = async (email: string) => {
+		setTransferError(null);
+		try {
+			await transferOwnership.mutateAsync(email);
+		} catch (err) {
+			setTransferError(err instanceof ApiError ? err.message : "Failed to transfer ownership");
+		}
+	};
+
 	return (
 		<div className="space-y-4">
 			<div>
@@ -95,22 +106,37 @@ export function AclMembersPanel({ mailboxId }: AclMembersPanelProps) {
 						<li key={member} className="flex items-center justify-between gap-2">
 							<span className="text-sm text-ink truncate">{member}</span>
 							{member !== acl.owner && (
-								<button
-									type="button"
-									aria-label={`Remove ${member}`}
-									data-testid={`remove-member-${member}`}
-									className="text-ink-3 hover:text-red-600 shrink-0"
-									disabled={removeMember.isPending}
-									onClick={() => handleRemove(member)}
-								>
-									<XIcon size={14} />
-								</button>
+								<div className="flex items-center gap-1 shrink-0">
+									<button
+										type="button"
+										aria-label={`Make ${member} owner`}
+										data-testid={`transfer-to-${member}`}
+										className="text-xs text-ink-3 hover:text-amber-600 px-1"
+										disabled={transferOwnership.isPending}
+										onClick={() => handleTransfer(member)}
+									>
+										Make owner
+									</button>
+									<button
+										type="button"
+										aria-label={`Remove ${member}`}
+										data-testid={`remove-member-${member}`}
+										className="text-ink-3 hover:text-red-600"
+										disabled={removeMember.isPending}
+										onClick={() => handleRemove(member)}
+									>
+										<XIcon size={14} />
+									</button>
+								</div>
 							)}
 						</li>
 					))}
 				</ul>
 				{removeError && (
 					<p className="mt-1 text-xs text-red-600" data-testid="remove-error">{removeError}</p>
+				)}
+				{transferError && (
+					<p className="mt-1 text-xs text-red-600" data-testid="transfer-error">{transferError}</p>
 				)}
 			</div>
 

--- a/app/queries/mailboxes.ts
+++ b/app/queries/mailboxes.ts
@@ -114,3 +114,13 @@ export function useRemoveAclMember(mailboxId: string) {
 		},
 	});
 }
+
+export function useTransferAclOwnership(mailboxId: string) {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (email: string) => api.transferAclOwnership(mailboxId, email),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: queryKeys.mailboxes.acl(mailboxId) });
+		},
+	});
+}

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -150,6 +150,8 @@ const api = {
 		post<{ owner: string; members: string[] }>(`/api/v1/mailboxes/${mailboxId}/acl/members`, { email }),
 	removeAclMember: (mailboxId: string, email: string) =>
 		del<{ owner: string; members: string[] }>(`/api/v1/mailboxes/${mailboxId}/acl/members/${encodeURIComponent(email)}`),
+	transferAclOwnership: (mailboxId: string, email: string) =>
+		post<{ owner: string; members: string[] }>(`/api/v1/mailboxes/${mailboxId}/acl/transfer`, { email }),
 	// Org-level settings (#106). Backed by R2 key org/settings.json behind a
 	// module-scope ETag cache; the GET returns the raw blob (or {} if missing),
 	// PUT validates through the OrgSettings Zod schema worker-side.

--- a/tests/frontend/hub-settings.test.tsx
+++ b/tests/frontend/hub-settings.test.tsx
@@ -31,6 +31,7 @@ vi.mock("~/queries/mailboxes", () => ({
 	useMailboxAcl: () => ({ data: undefined, isLoading: true }),
 	useAddAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
 	useRemoveAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useTransferAclOwnership: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 // Per-mailbox settings page now also reads org settings to drive the

--- a/tests/frontend/security-settings.test.tsx
+++ b/tests/frontend/security-settings.test.tsx
@@ -24,6 +24,7 @@ vi.mock("~/queries/mailboxes", () => ({
 	useMailboxAcl: () => ({ data: undefined, isLoading: true }),
 	useAddAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
 	useRemoveAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useTransferAclOwnership: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 // Per-mailbox settings page now also reads org settings to drive the

--- a/tests/frontend/settings-attachment-scanner.test.tsx
+++ b/tests/frontend/settings-attachment-scanner.test.tsx
@@ -27,6 +27,7 @@ vi.mock("~/queries/mailboxes", () => ({
 	useMailboxAcl: () => ({ data: undefined, isLoading: true }),
 	useAddAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
 	useRemoveAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useTransferAclOwnership: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 vi.mock("~/queries/org-settings", () => ({

--- a/tests/frontend/settings-behavior.test.tsx
+++ b/tests/frontend/settings-behavior.test.tsx
@@ -29,6 +29,7 @@ vi.mock("~/queries/mailboxes", () => ({
 	useMailboxAcl: () => ({ data: undefined, isLoading: true }),
 	useAddAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
 	useRemoveAclMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useTransferAclOwnership: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 vi.mock("~/queries/org-settings", () => ({

--- a/tests/routes/acl-members.test.ts
+++ b/tests/routes/acl-members.test.ts
@@ -261,3 +261,76 @@ describe("DELETE /acl/members/:memberEmail — remove member", () => {
 		expect(stored.members).not.toContain("bob@example.com");
 	});
 });
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/mailboxes/:mailboxId/acl/transfer — ownership transfer (#293)
+// ---------------------------------------------------------------------------
+
+describe("POST /acl/transfer — ownership transfer", () => {
+	it("owner transfers to an existing member → 200, new owner set, old owner stays in members", async () => {
+		const { fetch, bucket } = makeApp(storeWithAcl(aliceAndBobAcl), "alice@example.com");
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl/transfer`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "bob@example.com" }),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json() as MailboxAcl;
+		expect(body.owner).toBe("bob@example.com");
+		expect(body.members).toContain("alice@example.com");
+		expect(body.members).toContain("bob@example.com");
+		const stored = JSON.parse(bucket._store[aclKey]) as MailboxAcl;
+		expect(stored.owner).toBe("bob@example.com");
+	});
+
+	it("non-owner admitted caller → 403", async () => {
+		const { fetch } = makeApp(storeWithAcl(aliceAndBobAcl), "bob@example.com");
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl/transfer`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "alice@example.com" }),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it("target email not in members → 400 with clear message", async () => {
+		const { fetch } = makeApp(storeWithAcl(aliceOnlyAcl), "alice@example.com");
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl/transfer`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "carol@example.com" }),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json() as { error: string };
+		expect(body.error).toMatch(/member/i);
+	});
+
+	it("after transfer, old owner loses owner-only access", async () => {
+		const { fetch } = makeApp(storeWithAcl(aliceAndBobAcl), "alice@example.com");
+		// Transfer alice → bob
+		await fetch(`/api/v1/mailboxes/${mailboxId}/acl/transfer`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "bob@example.com" }),
+		});
+		// Alice tries to add a member — should now be 403
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl/members`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "carol@example.com" }),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it("email is normalised to lower-case before lookup and write", async () => {
+		const { fetch, bucket } = makeApp(storeWithAcl(aliceAndBobAcl), "alice@example.com");
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl/transfer`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "BOB@EXAMPLE.COM" }),
+		});
+		expect(res.status).toBe(200);
+		const stored = JSON.parse(bucket._store[aclKey]) as MailboxAcl;
+		expect(stored.owner).toBe("bob@example.com");
+	});
+});

--- a/workers/routes/acl-members.ts
+++ b/workers/routes/acl-members.ts
@@ -86,6 +86,35 @@ aclMemberRoutes.post("/members", async (c) => {
 	return c.json({ owner: updated.owner, members: updated.members });
 });
 
+/**
+ * Transfer ACL ownership to an existing member (#293).
+ * Only the current owner may call this. The target must already be in
+ * `acl.members`; the old owner stays as a member after the transfer.
+ */
+aclMemberRoutes.post("/transfer", async (c) => {
+	const mailboxId = c.req.param("mailboxId")!;
+	const callerEmail =
+		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+
+	const acl = await readMailboxAcl(c.env, mailboxId);
+	if (!acl || callerEmail !== acl.owner) {
+		return c.json({ error: "Forbidden" }, 403);
+	}
+
+	const body = (await c.req.json().catch(() => ({}))) as { email?: unknown };
+	const rawEmail = typeof body.email === "string" ? body.email.trim() : "";
+	if (!rawEmail) return c.json({ error: "Email required" }, 400);
+
+	const targetEmail = rawEmail.toLowerCase();
+	if (!acl.members.includes(targetEmail)) {
+		return c.json({ error: "Target must already be a member" }, 400);
+	}
+
+	const updated = { owner: targetEmail, members: acl.members };
+	await writeMailboxAcl(c.env, mailboxId, updated);
+	return c.json({ owner: updated.owner, members: updated.members });
+});
+
 /** Remove a member from the mailbox ACL. The owner cannot remove themselves. */
 aclMemberRoutes.delete("/members/:memberEmail", async (c) => {
 	const mailboxId = c.req.param("mailboxId")!;


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/mailboxes/:id/acl/transfer` (owner-only): transfers ACL ownership to an existing member; old owner stays in `members`; target not in members → 400; non-owner caller → 403
- Adds `transferAclOwnership()` to `app/services/api.ts` and `useTransferAclOwnership()` mutation hook to `app/queries/mailboxes.ts`
- Adds a "Make owner" button per non-owner member row in `AclMembersPanel` (gated to owner context); transfer error displayed inline beneath the member list

Closes #293

**Design choice (documented here per issue constraint):** target email must already be in `acl.members` — add-then-promote atomically was not chosen. The "Make owner" button only appears on existing members, so the UI enforces this invariant naturally. After transfer the old owner remains a member; they can be removed separately via the existing remove flow.

## Test plan

- [ ] Owner transfers to existing member → 200, `owner` updated, old owner stays in `members`, R2 persisted
- [ ] Non-owner admitted caller → 403
- [ ] Target not in members → 400 with `"member"` in error message
- [ ] After transfer, old owner loses owner-only access (POST /members → 403)
- [ ] Email normalized to lowercase before lookup and write
- [ ] Frontend mock stubs (`hub-settings`, `security-settings`, `settings-attachment-scanner`, `settings-behavior`) updated for new hook

**83 test files, 1073 tests passing, 0 TypeScript errors.**

## Deferred / follow-up

- #292 (org-wide ACL overview) depends on #291 landing first — unchanged
- Org-admin force-transfer and bulk transfer are explicitly out of scope per #293

## Stacking note

This PR is based on `claude/issue-291-acl-member-ui` (PR #298). When #298 merges with `--delete-branch`, flip this PR's base to `main` before merging, then rebase with `--onto origin/main <291-pre-squash-sha>` to drop the duplicated commit cleanly (per CLAUDE.md stacked-PR guidance).

https://claude.ai/code/session_01TRDTn3Q8JfPeAM7ZDXXwzW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRDTn3Q8JfPeAM7ZDXXwzW)_