### PR TITLE
feat: per-mailbox sender-graph BEC detector (closes #26)

### DIFF
--- a/test/security/fakes.ts
+++ b/test/security/fakes.ts
@@ -40,6 +40,11 @@ export interface IntelFeedStateRow {
 	bloom_kv_key: string;
 }
 
+export interface FakeSenderGraphRecord {
+	sender_address: string;
+	message_count: number;
+}
+
 /**
  * Minimal subset of `MailboxDO` methods the security pipeline calls. Widened
  * to include the feed-state methods so the pipeline's intel lookup doesn't
@@ -58,6 +63,8 @@ export interface FakeMailboxStub {
 		feedId: string,
 		data: Omit<IntelFeedStateRow, "feed_id">,
 	): Promise<void>;
+	getSenderGraphByName(senderName: string): Promise<FakeSenderGraphRecord[]>;
+	upsertSenderGraph(senderName: string, senderAddress: string): Promise<void>;
 }
 
 export function createFakeMailboxStub(): {
@@ -67,12 +74,14 @@ export function createFakeMailboxStub(): {
 	urls: Map<string, FakeUrlRow[]>;
 	moves: Array<{ id: string; folderId: string }>;
 	feedState: Map<string, IntelFeedStateRow>;
+	senderGraph: Map<string, FakeSenderGraphRecord[]>;
 } {
 	const reputation = new Map<string, SenderReputation>();
 	const verdicts = new Map<string, FakeVerdictRow>();
 	const urls = new Map<string, FakeUrlRow[]>();
 	const moves: Array<{ id: string; folderId: string }> = [];
 	const feedState = new Map<string, IntelFeedStateRow>();
+	const senderGraph = new Map<string, FakeSenderGraphRecord[]>();
 
 	const stub: FakeMailboxStub = {
 		async getSenderReputation(sender) {
@@ -121,9 +130,23 @@ export function createFakeMailboxStub(): {
 		async upsertIntelFeedState(feedId, data) {
 			feedState.set(feedId, { feed_id: feedId, ...data });
 		},
+		async getSenderGraphByName(name) {
+			return senderGraph.get(name) ?? [];
+		},
+		async upsertSenderGraph(name, address) {
+			const existing = senderGraph.get(name) ?? [];
+			const idx = existing.findIndex((r) => r.sender_address === address);
+			if (idx === -1) {
+				senderGraph.set(name, [...existing, { sender_address: address, message_count: 1 }]);
+			} else {
+				const updated = [...existing];
+				updated[idx] = { ...updated[idx], message_count: updated[idx].message_count + 1 };
+				senderGraph.set(name, updated);
+			}
+		},
 	};
 
-	return { stub, reputation, verdicts, urls, moves, feedState };
+	return { stub, reputation, verdicts, urls, moves, feedState, senderGraph };
 }
 
 export interface FakeEnvParts {

--- a/test/security/sender-graph-detector.test.ts
+++ b/test/security/sender-graph-detector.test.ts
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { SenderGraphDetector } from "../../workers/security/detectors";
+import { runSecurityPipeline } from "../../workers/security/index";
+import { __setClassifier } from "../../workers/security/classification";
+import { createFakeMailboxStub, makeFakeEnv } from "./fakes";
+
+afterEach(() => {
+	__setClassifier(null);
+});
+
+// ── SenderGraphDetector unit tests ────────────────────────────────────────────
+
+describe("SenderGraphDetector.score", () => {
+	it("returns 0 for empty sender name", async () => {
+		const det = new SenderGraphDetector();
+		const result = await det.score(
+			{ senderAddress: "attacker@evil.com", senderName: "" },
+			{ async getSenderGraphByName() { return []; } },
+		);
+		expect(result.score).toBe(0);
+	});
+
+	it("returns 0 when display name has no history (fresh mailbox)", async () => {
+		const det = new SenderGraphDetector();
+		const result = await det.score(
+			{ senderAddress: "attacker@evil.com", senderName: "john smith" },
+			{ async getSenderGraphByName() { return []; } },
+		);
+		expect(result.score).toBe(0);
+	});
+
+	it("returns 0 when sender address is already known for this display name", async () => {
+		const det = new SenderGraphDetector();
+		const result = await det.score(
+			{ senderAddress: "boss@company.com", senderName: "john smith" },
+			{
+				async getSenderGraphByName(name) {
+					if (name === "john smith") return [{ sender_address: "boss@company.com", message_count: 5 }];
+					return [];
+				},
+			},
+		);
+		expect(result.score).toBe(0);
+	});
+
+	it("BEC hit: new address claiming a known display name scores > 0 and ≤ 30", async () => {
+		const det = new SenderGraphDetector();
+		const result = await det.score(
+			{ senderAddress: "attacker@gmail.com", senderName: "john smith" },
+			{
+				async getSenderGraphByName(name) {
+					if (name === "john smith") return [{ sender_address: "boss@company.com", message_count: 5 }];
+					return [];
+				},
+			},
+		);
+		expect(result.score).toBeGreaterThan(0);
+		expect(result.score).toBeLessThanOrEqual(30);
+		expect(result.reason).toBeTruthy();
+	});
+
+	it("score is 10 for 1 prior message (low confidence)", async () => {
+		const det = new SenderGraphDetector();
+		const result = await det.score(
+			{ senderAddress: "attacker@gmail.com", senderName: "alice" },
+			{ async getSenderGraphByName() { return [{ sender_address: "alice@real.com", message_count: 1 }]; } },
+		);
+		expect(result.score).toBe(10);
+	});
+
+	it("score is 15 for 2–4 prior messages", async () => {
+		const det = new SenderGraphDetector();
+		const result = await det.score(
+			{ senderAddress: "attacker@gmail.com", senderName: "alice" },
+			{ async getSenderGraphByName() { return [{ sender_address: "alice@real.com", message_count: 3 }]; } },
+		);
+		expect(result.score).toBe(15);
+	});
+
+	it("score is 25 for ≥5 prior messages (high confidence)", async () => {
+		const det = new SenderGraphDetector();
+		const result = await det.score(
+			{ senderAddress: "attacker@gmail.com", senderName: "alice" },
+			{ async getSenderGraphByName() { return [{ sender_address: "alice@real.com", message_count: 10 }]; } },
+		);
+		expect(result.score).toBe(25);
+	});
+
+	it("history aggregates across multiple known addresses", async () => {
+		const det = new SenderGraphDetector();
+		const result = await det.score(
+			{ senderAddress: "new@attacker.com", senderName: "bob" },
+			{
+				async getSenderGraphByName() {
+					return [
+						{ sender_address: "bob@work.com", message_count: 2 },
+						{ sender_address: "bob@personal.com", message_count: 2 },
+					];
+				},
+			},
+		);
+		// totalHistory=4 → score 15; result.reason mentions 2 known addresses
+		expect(result.score).toBe(15);
+		expect(result.reason).toMatch(/2 known address/);
+	});
+});
+
+// ── Pipeline integration tests ────────────────────────────────────────────────
+
+const MAILBOX = "test@example.com";
+
+function safeClassifier() {
+	return { label: "safe" as const, confidence: 0.9, reasoning: "stubbed" };
+}
+
+/** Build a minimal parsed email with the given from field. */
+function makeEmail(from: { address: string; name: string }) {
+	return {
+		subject: "Urgent: wire transfer needed",
+		from,
+		html: "<p>Please approve the transfer.</p>",
+		headers: {},
+		attachments: [],
+	};
+}
+
+describe("runSecurityPipeline — sender graph integration", () => {
+	it("fresh mailbox: BEC impersonation email does not trigger detector (no history)", async () => {
+		__setClassifier(async () => safeClassifier());
+		const { stub } = createFakeMailboxStub();
+		const env = makeFakeEnv({
+			mailboxId: MAILBOX,
+			stub,
+			settings: { enabled: true, detectors: { sender_graph: { enabled: true } } },
+		});
+
+		const result = await runSecurityPipeline({
+			env, mailboxId: MAILBOX, messageId: "m-bec-fresh",
+			targetFolder: "inbox",
+			parsedEmail: makeEmail({ address: "attacker@evil.com", name: "John Smith" }),
+		});
+
+		// No sender graph history → detector contributes 0
+		expect(result.verdict?.signals.join(" ")).not.toMatch(/BEC signal/i);
+	});
+
+	it("mailbox with history: impersonating known sender triggers detector", async () => {
+		__setClassifier(async () => safeClassifier());
+		const { stub, senderGraph } = createFakeMailboxStub();
+		// Seed 5 prior messages from the real "John Smith" address
+		senderGraph.set("john smith", [
+			{ sender_address: "jsmith@company.com", message_count: 5 },
+		]);
+
+		const env = makeFakeEnv({
+			mailboxId: MAILBOX,
+			stub,
+			settings: { enabled: true, detectors: { sender_graph: { enabled: true } } },
+		});
+
+		const result = await runSecurityPipeline({
+			env, mailboxId: MAILBOX, messageId: "m-bec-known",
+			targetFolder: "inbox",
+			parsedEmail: makeEmail({ address: "attacker@evil.com", name: "John Smith" }),
+		});
+
+		expect(result.verdict?.signals.join(" ")).toMatch(/BEC signal/i);
+		expect(result.verdict?.score ?? 0).toBeGreaterThan(0);
+	});
+
+	it("known sender emailing again does not trigger detector", async () => {
+		__setClassifier(async () => safeClassifier());
+		const { stub, senderGraph } = createFakeMailboxStub();
+		senderGraph.set("john smith", [
+			{ sender_address: "jsmith@company.com", message_count: 5 },
+		]);
+
+		const env = makeFakeEnv({
+			mailboxId: MAILBOX,
+			stub,
+			settings: { enabled: true, detectors: { sender_graph: { enabled: true } } },
+		});
+
+		const result = await runSecurityPipeline({
+			env, mailboxId: MAILBOX, messageId: "m-bec-legit",
+			targetFolder: "inbox",
+			parsedEmail: makeEmail({ address: "jsmith@company.com", name: "John Smith" }),
+		});
+
+		expect(result.verdict?.signals.join(" ")).not.toMatch(/BEC signal/i);
+	});
+
+	it("detector disabled: impersonation email does not add BEC signal", async () => {
+		__setClassifier(async () => safeClassifier());
+		const { stub, senderGraph } = createFakeMailboxStub();
+		senderGraph.set("john smith", [
+			{ sender_address: "jsmith@company.com", message_count: 10 },
+		]);
+
+		const env = makeFakeEnv({
+			mailboxId: MAILBOX,
+			stub,
+			settings: { enabled: true, detectors: { sender_graph: { enabled: false } } },
+		});
+
+		const result = await runSecurityPipeline({
+			env, mailboxId: MAILBOX, messageId: "m-bec-disabled",
+			targetFolder: "inbox",
+			parsedEmail: makeEmail({ address: "attacker@evil.com", name: "John Smith" }),
+		});
+
+		expect(result.verdict?.signals.join(" ")).not.toMatch(/BEC signal/i);
+	});
+
+	it("upsertSenderGraph is called after pipeline run (sender graph is updated)", async () => {
+		__setClassifier(async () => safeClassifier());
+		const { stub, senderGraph } = createFakeMailboxStub();
+
+		const env = makeFakeEnv({
+			mailboxId: MAILBOX,
+			stub,
+			settings: { enabled: true },
+		});
+
+		await runSecurityPipeline({
+			env, mailboxId: MAILBOX, messageId: "m-graph-update",
+			targetFolder: "inbox",
+			parsedEmail: makeEmail({ address: "boss@company.com", name: "Alice Boss" }),
+		});
+
+		const records = senderGraph.get("alice boss") ?? [];
+		expect(records.some((r) => r.sender_address === "boss@company.com")).toBe(true);
+	});
+});

--- a/workers/db/schema.ts
+++ b/workers/db/schema.ts
@@ -102,6 +102,25 @@ export const senderReputation = sqliteTable("sender_reputation", {
 	flagged: integer("flagged").notNull().default(0),
 });
 
+// Per-mailbox sender graph for BEC / display-name impersonation detection
+// (issue #26). Each row records how many times a given display name was
+// seen arriving from a particular email address. The detector flags when a
+// new address claims a display name that already has history from different
+// addresses.
+export const senderGraph = sqliteTable(
+	"sender_graph",
+	{
+		sender_name: text("sender_name").notNull(),
+		sender_address: text("sender_address").notNull(),
+		message_count: integer("message_count").notNull().default(1),
+		first_seen: text("first_seen").notNull(),
+		last_seen: text("last_seen").notNull(),
+	},
+	(t) => ({
+		pk: primaryKey({ columns: [t.sender_name, t.sender_address] }),
+	}),
+);
+
 // ── Threat intel ─────────────────────────────────────────────────
 
 export const intelFeedState = sqliteTable("intel_feed_state", {

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -1189,6 +1189,52 @@ export class MailboxDO extends DurableObject<Env> {
 			.run();
 	}
 
+	// ── Sender graph (issue #26) ──────────────────────────────────
+
+	async getSenderGraphByName(senderName: string): Promise<Array<{ sender_address: string; message_count: number }>> {
+		if (!senderName) return [];
+		return this.db
+			.select({
+				sender_address: schema.senderGraph.sender_address,
+				message_count: schema.senderGraph.message_count,
+			})
+			.from(schema.senderGraph)
+			.where(eq(schema.senderGraph.sender_name, senderName))
+			.all();
+	}
+
+	async upsertSenderGraph(senderName: string, senderAddress: string): Promise<void> {
+		if (!senderName || !senderAddress) return;
+		const now = new Date().toISOString();
+		const existing = this.db
+			.select({ message_count: schema.senderGraph.message_count })
+			.from(schema.senderGraph)
+			.where(
+				and(
+					eq(schema.senderGraph.sender_name, senderName),
+					eq(schema.senderGraph.sender_address, senderAddress),
+				),
+			)
+			.get();
+		if (!existing) {
+			this.db
+				.insert(schema.senderGraph)
+				.values({ sender_name: senderName, sender_address: senderAddress, message_count: 1, first_seen: now, last_seen: now })
+				.run();
+		} else {
+			this.db
+				.update(schema.senderGraph)
+				.set({ message_count: existing.message_count + 1, last_seen: now })
+				.where(
+					and(
+						eq(schema.senderGraph.sender_name, senderName),
+						eq(schema.senderGraph.sender_address, senderAddress),
+					),
+				)
+				.run();
+		}
+	}
+
 	// ── Threat intel feed state ────────────────────────────────────
 
 	async getIntelFeedState(feedId: string) {

--- a/workers/durableObject/migrations.ts
+++ b/workers/durableObject/migrations.ts
@@ -479,4 +479,23 @@ export const mailboxMigrations: Migration[] = [
 		name: "21_emails_created_by",
 		sql: `ALTER TABLE emails ADD COLUMN created_by TEXT DEFAULT 'user';`,
 	},
+	{
+		// Per-mailbox sender graph for BEC / display-name impersonation
+		// detection (issue #26). Tracks (display_name, sender_address) pairs
+		// so the SenderGraphDetector can flag new addresses claiming a display
+		// name already associated with a different address in this mailbox.
+		// Per-DO scope keeps tenant isolation intact.
+		name: "22_sender_graph",
+		sql: `
+            CREATE TABLE IF NOT EXISTS sender_graph (
+                sender_name TEXT NOT NULL,
+                sender_address TEXT NOT NULL,
+                message_count INTEGER NOT NULL DEFAULT 1,
+                first_seen TEXT NOT NULL,
+                last_seen TEXT NOT NULL,
+                PRIMARY KEY (sender_name, sender_address)
+            );
+            CREATE INDEX IF NOT EXISTS idx_sender_graph_name ON sender_graph(sender_name);
+        `,
+	},
 ];

--- a/workers/lib/mailbox-settings.ts
+++ b/workers/lib/mailbox-settings.ts
@@ -16,6 +16,7 @@ import { getOrgSettings } from "./org-settings";
 import type { DomainSettings } from "../../shared/domain-settings";
 import { domainFromMailboxId, getDomainSettings } from "./domain-settings";
 import {
+	DEFAULT_DETECTOR_SETTINGS,
 	DEFAULT_SECURITY_SETTINGS,
 	type BusinessHours,
 	type MailboxSecuritySettings,
@@ -254,6 +255,14 @@ function mergeSecurityWithDefault(value: unknown): MailboxSecuritySettings {
 		ruf_ingestion: {
 			...DEFAULT_SECURITY_SETTINGS.ruf_ingestion,
 			...(partial.ruf_ingestion ?? {}),
+		},
+		detectors: {
+			...DEFAULT_DETECTOR_SETTINGS,
+			...(partial.detectors ?? {}),
+			sender_graph: {
+				...DEFAULT_DETECTOR_SETTINGS.sender_graph,
+				...(partial.detectors?.sender_graph ?? {}),
+			},
 		},
 	};
 }

--- a/workers/security/defaults.ts
+++ b/workers/security/defaults.ts
@@ -62,6 +62,19 @@ export interface FolderPolicy {
 	treat_as_verified?: boolean;
 }
 
+/**
+ * Per-detector enable/disable controls (issue #26). Absent key = enabled
+ * (matches the absent-key-inherits convention for security features whose
+ * default is "on" for new mailboxes where false-positive risk is low).
+ */
+export interface DetectorSettings {
+	sender_graph?: {
+		/** When false, the BEC / display-name impersonation detector is
+		 *  disabled for this mailbox. Defaults to true. */
+		enabled?: boolean;
+	};
+}
+
 export interface MailboxSecuritySettings {
 	enabled: boolean;
 	thresholds: VerdictThresholds;
@@ -119,6 +132,8 @@ export interface MailboxSecuritySettings {
 	 * mailbox never silently ingests forensic reports.
 	 */
 	ruf_ingestion: RufIngestionSettings;
+	/** Issue #26: per-mailbox detector on/off controls. */
+	detectors: DetectorSettings;
 }
 
 /**
@@ -153,6 +168,10 @@ export const DEFAULT_RUF_INGESTION_SETTINGS: RufIngestionSettings = {
 	retain_raw: false,
 };
 
+export const DEFAULT_DETECTOR_SETTINGS: DetectorSettings = {
+	sender_graph: { enabled: true },
+};
+
 export const DEFAULT_SECURITY_SETTINGS: MailboxSecuritySettings = {
 	enabled: false, // opt-in — existing mailboxes are unaffected until the user flips this
 	thresholds: DEFAULT_THRESHOLDS,
@@ -169,4 +188,5 @@ export const DEFAULT_SECURITY_SETTINGS: MailboxSecuritySettings = {
 	min_confidence_for_quarantine: 0.6,
 	mitigations: DEFAULT_MITIGATION_CONFIG,
 	ruf_ingestion: DEFAULT_RUF_INGESTION_SETTINGS,
+	detectors: DEFAULT_DETECTOR_SETTINGS,
 };

--- a/workers/security/detectors.ts
+++ b/workers/security/detectors.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Pluggable per-mailbox detector interface (issue #26).
+ *
+ * Each detector receives the incoming email's sender data and a narrow
+ * stub for reading per-mailbox DO state. Detectors are expected to run
+ * within the synchronous security pipeline and must not perform unbounded
+ * work. Each detector's score contribution is capped at +30 by the caller
+ * (mirrors the YARA async deep-scan cap).
+ */
+
+export interface DetectorInput {
+	/** Sender email address, already lowercased. */
+	senderAddress: string;
+	/** Sender display name, already lowercased and trimmed. */
+	senderName: string;
+}
+
+export interface SenderGraphRecord {
+	sender_address: string;
+	message_count: number;
+}
+
+export interface SenderGraphStub {
+	getSenderGraphByName(senderName: string): Promise<SenderGraphRecord[]>;
+}
+
+export interface Detector {
+	score(input: DetectorInput, stub: SenderGraphStub): Promise<{ score: number; reason?: string }>;
+}
+
+/**
+ * BEC / display-name impersonation detector.
+ *
+ * Queries the per-mailbox sender graph for the email's display name. If
+ * the name has prior history from one or more known addresses and the
+ * current sender address is NOT among them, this is a candidate BEC
+ * signal: someone is claiming a familiar identity from a new address.
+ *
+ * Score ramps with history depth (more prior messages = higher confidence
+ * the known-name is real, so the impersonation is more suspicious):
+ *   - 1 prior message    → +10 (low confidence — name may be common)
+ *   - 2–4 prior messages → +15
+ *   - ≥5 prior messages  → +25
+ *
+ * Returns 0 when:
+ *   - The display name is absent or empty
+ *   - No prior messages used this display name (no history to impersonate)
+ *   - The current sender address is already in the known-address set
+ */
+export class SenderGraphDetector implements Detector {
+	async score(
+		input: DetectorInput,
+		stub: SenderGraphStub,
+	): Promise<{ score: number; reason?: string }> {
+		const { senderName, senderAddress } = input;
+		if (!senderName) return { score: 0 };
+
+		const records = await stub.getSenderGraphByName(senderName);
+		if (records.length === 0) return { score: 0 };
+
+		const knownAddresses = new Set(records.map((r) => r.sender_address));
+		if (knownAddresses.has(senderAddress)) return { score: 0 };
+
+		const totalHistory = records.reduce((sum, r) => sum + r.message_count, 0);
+		const score = totalHistory >= 5 ? 25 : totalHistory >= 2 ? 15 : 10;
+		return {
+			score,
+			reason: `display name "${senderName}" previously seen from ${knownAddresses.size} known address(es), new sender (BEC signal)`,
+		};
+	}
+}

--- a/workers/security/index.ts
+++ b/workers/security/index.ts
@@ -39,6 +39,7 @@ import {
 } from "./reputation";
 import { lookupIp } from "../intel/crowdsec-cti";
 import type { StageId, StageRecord, StageStatus } from "./stage-trace";
+import { SenderGraphDetector } from "./detectors";
 
 /**
  * Apply a post-aggregation score bump and recompute the action tier and
@@ -74,7 +75,7 @@ export interface RunPipelineInput {
 	targetFolder: string;
 	parsedEmail: {
 		subject?: string;
-		from?: { address?: string };
+		from?: { address?: string; name?: string };
 		html?: string;
 		text?: string;
 		headers?: unknown;
@@ -103,6 +104,7 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 	if (!settings.enabled) return { verdict: null, skipped: true, stageTrace: [] };
 
 	const sender = (parsedEmail.from?.address || "").toLowerCase();
+	const senderName = (parsedEmail.from?.name || "").toLowerCase().trim();
 	const bodyHtml = parsedEmail.html || parsedEmail.text || "";
 	const subject = parsedEmail.subject || "";
 	const attachments = parsedEmail.attachments ?? [];
@@ -187,6 +189,22 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 	const repContrib = scoreReputation(reputation, firstTimeSenderPrior);
 	tracer.setContrib("reputation", repContrib.score, repContrib.reasons[0]);
 
+	// ── Sender-graph detector (issue #26) ──────────────────────────
+	// BEC / display-name impersonation signal. Folded into the reputation
+	// stage's wall-clock time (it's another per-mailbox DO read) so the
+	// trace stays at 7 rows. Score is applied as a post-aggregation boost
+	// in the verdict stage, bounded at +30.
+	let detectorBoost = 0;
+	let detectorReason: string | undefined;
+	if (settings.detectors?.sender_graph?.enabled !== false && senderName) {
+		await tracer.extend("reputation", async () => {
+			const detector = new SenderGraphDetector();
+			const result = await detector.score({ senderAddress: sender, senderName }, stub).catch(() => ({ score: 0, reason: undefined }));
+			detectorBoost = Math.min(30, result.score);
+			detectorReason = result.reason;
+		});
+	}
+
 	// ── Stage 5: triage ────────────────────────────────────────────
 	const triaged = tracer.measure("triage", () =>
 		evaluateTriage({
@@ -227,7 +245,7 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 			);
 		}
 		tracer.completeVerdict(verdict.score);
-		await persistAll(env, mailboxId, messageId, sender, verdict, urls, tracer.snapshot());
+		await persistAll(env, mailboxId, messageId, sender, senderName, verdict, urls, tracer.snapshot());
 		return { verdict, skipped: false, stageTrace: tracer.snapshot() };
 	}
 
@@ -287,6 +305,10 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 		if (offHours.score > 0) {
 			v = applyBoost(v, offHours.score, offHours.reasons[0], settings.thresholds);
 		}
+		// Sender-graph detector boost (issue #26). Capped at +30 by construction.
+		if (detectorBoost > 0 && detectorReason) {
+			v = applyBoost(v, detectorBoost, detectorReason, settings.thresholds);
+		}
 		// Learning mode never quarantines/blocks — cap at "tag".
 		if (settings.learning_mode && (v.action === "quarantine" || v.action === "block")) {
 			v = { ...v, action: "tag" };
@@ -315,7 +337,7 @@ export async function runSecurityPipeline(input: RunPipelineInput): Promise<Pipe
 	tracer.completeVerdict(verdict.score);
 
 	const stageTrace = tracer.snapshot();
-	await persistAll(env, mailboxId, messageId, sender, verdict, urls, stageTrace);
+	await persistAll(env, mailboxId, messageId, sender, senderName, verdict, urls, stageTrace);
 	return { verdict, skipped: false, stageTrace };
 }
 
@@ -462,6 +484,7 @@ async function persistAll(
 	mailboxId: string,
 	messageId: string,
 	sender: string,
+	senderName: string,
 	verdict: FinalVerdict,
 	urls: ReturnType<typeof extractUrls>,
 	stageTrace: StageRecord[],
@@ -499,6 +522,14 @@ async function persistAll(
 			await stub.upsertSenderReputation(sender, verdict.score);
 		} catch (e) {
 			console.error("upsertSenderReputation failed:", (e as Error).message);
+		}
+	}
+
+	if (senderName && sender) {
+		try {
+			await stub.upsertSenderGraph(senderName, sender);
+		} catch (e) {
+			console.error("upsertSenderGraph failed:", (e as Error).message);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a `sender_graph` SQLite table to the per-mailbox Durable Object tracking `(display_name, sender_address)` history, seeded on every inbound email.
- Introduces a `Detector` interface (`workers/security/detectors.ts`) and `SenderGraphDetector` implementing BEC / display-name impersonation detection: flags when a new sender address claims a display name previously seen from a different address in that mailbox.
- Wires the detector score (+10–25, capped at +30) as a post-aggregation boost in the verdict stage alongside the existing intel-feed and off-hours boosts.
- Adds `detectors.sender_graph.enabled` to `MailboxSecuritySettings` (default: `true`); setting to `false` disables the signal and returns scoring to baseline.

Closes #26

## Authz / false-positive design

Fresh mailboxes produce zero detector contribution — the table starts empty, so there is no history to trigger on. The +30 cap and the graduated scoring (1 message → +10, 2–4 → +15, ≥5 → +25) ensure the detector can only tilt borderline verdicts until the mailbox has built real sender history.

## Size note

9 files touched, ~480 lines. All 9 files are tightly coupled to deliver a single atomic feature (schema → migration → DO methods → detector → settings → pipeline integration → tests). They cannot be split into two independently useful PRs.

## Test plan

- [x] `npm test` passes — 1092 tests (84 files), including 13 new tests in `test/security/sender-graph-detector.test.ts`
- [x] `npm run typecheck` passes — 0 errors
- [x] BEC scenario: mailbox with sender history → impersonation email → `BEC signal` in verdict signals
- [x] Fresh mailbox: impersonation email → no BEC signal (no history to compare)
- [x] Known sender re-emailing → no BEC signal
- [x] `detectors.sender_graph.enabled: false` → no BEC signal regardless of history
- [x] `upsertSenderGraph` called after pipeline run (sender graph updated on every inbound)
- [x] Detector score bounded at +30 by construction (`Math.min(30, result.score)`)

## Acceptance shipped

- ✅ Per-mailbox sender graph tracking display name + address + message count
- ✅ `Detector` interface for pluggable future detectors
- ✅ `SenderGraphDetector` BEC signal
- ✅ Per-mailbox enable/disable (`detectors.sender_graph.enabled`)
- ✅ Bounded contribution (+30 max)
- ✅ BEC scenario: impersonation flagged, fresh mailbox not flagged, disabling returns to baseline

## Acceptance deferred

- UI toggle in Settings → Security for the `detectors.sender_graph.enabled` knob (the setting is writable via the settings API; a dedicated UI surface is a follow-up)
- v2 trainable classifiers and embedding-based writing-style detection (as noted in issue #26 v2 section)

## Spec follow-up needed

No — this feature adds a new scoring component and does not change or contradict any existing rule in SECURITY_SPEC.md.

https://claude.ai/code/session_01BDrRMH9q5V7G3V1ruLns6J

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDrRMH9q5V7G3V1ruLns6J)_