### PR TITLE
feat: add org-wide ACL access-overview endpoint and UI

### DIFF
--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -7,6 +7,7 @@ import {
 	GlobeIcon,
 	GraphIcon,
 	ListIcon,
+	LockKeyIcon,
 	MagnifyingGlassIcon,
 	MoonIcon,
 	SparkleIcon,
@@ -207,6 +208,11 @@ function NavContents({
 					end
 					icon={<GearSixIcon size={16} />}
 					label="Org settings"
+				/>
+				<NavItem
+					to="/acl-overview"
+					icon={<LockKeyIcon size={16} />}
+					label="Access overview"
 				/>
 				{mailboxId && (
 					<>

--- a/app/queries/keys.ts
+++ b/app/queries/keys.ts
@@ -30,6 +30,7 @@ export const queryKeys = {
 	org: {
 		overview: ["org", "overview"] as const,
 		settings: ["org", "settings"] as const,
+		aclOverview: ["org", "acl-overview"] as const,
 	},
 	effectiveMailboxSettings: (mailboxId: string) =>
 		["mailboxes", mailboxId, "settings", "effective"] as const,

--- a/app/queries/mailboxes.ts
+++ b/app/queries/mailboxes.ts
@@ -124,3 +124,17 @@ export function useTransferAclOwnership(mailboxId: string) {
 		},
 	});
 }
+
+export function useOrgAclOverview() {
+	return useQuery<{
+		mailboxes: Array<{
+			email: string;
+			acl_status: "scoped" | "unscoped";
+			owner: string | null;
+			members: string[];
+		}>;
+	}>({
+		queryKey: queryKeys.org.aclOverview,
+		queryFn: () => api.getOrgAclOverview(),
+	});
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -16,6 +16,7 @@ export default [
 	route("domains/:domain", "routes/domain-detail.tsx"),
 	route("domains/:domain/settings", "routes/domain-settings.tsx"),
 	route("search", "routes/search-results-org.tsx"),
+	route("acl-overview", "routes/org-acl-overview.tsx"),
 	route("mailbox/:mailboxId", "routes/mailbox.tsx", [
 		index("routes/mailbox-index.tsx"),
 		route("dashboard", "routes/dashboard.tsx"),

--- a/app/routes/org-acl-overview.tsx
+++ b/app/routes/org-acl-overview.tsx
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { Badge, Input, Loader } from "@cloudflare/kumo";
+import { WarningIcon } from "@phosphor-icons/react";
+import { useMemo, useState } from "react";
+import Shell from "~/components/phishsoc/Shell";
+import { useOrgAclOverview } from "~/queries/mailboxes";
+
+export function meta() {
+	return [{ title: "Access overview · PhishSOC" }];
+}
+
+type AclEntry = {
+	email: string;
+	acl_status: "scoped" | "unscoped";
+	owner: string | null;
+	members: string[];
+};
+
+function domainOf(email: string): string {
+	const at = email.indexOf("@");
+	return at >= 0 ? email.slice(at + 1) : email;
+}
+
+export default function OrgAclOverviewRoute() {
+	const { data, isLoading, isError } = useOrgAclOverview();
+	const [filter, setFilter] = useState("");
+
+	const entries: AclEntry[] = data?.mailboxes ?? [];
+
+	const visible = useMemo(() => {
+		const q = filter.trim().toLowerCase();
+		if (!q) return entries;
+		return entries.filter(
+			(e) =>
+				e.email.toLowerCase().includes(q) ||
+				(e.owner ?? "").toLowerCase().includes(q) ||
+				e.members.some((m) => m.toLowerCase().includes(q)),
+		);
+	}, [entries, filter]);
+
+	const grouped = useMemo(() => {
+		const map = new Map<string, AclEntry[]>();
+		for (const entry of visible) {
+			const d = domainOf(entry.email);
+			const bucket = map.get(d) ?? [];
+			bucket.push(entry);
+			map.set(d, bucket);
+		}
+		return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b));
+	}, [visible]);
+
+	const unscopedCount = entries.filter((e) => e.acl_status === "unscoped").length;
+
+	return (
+		<Shell>
+			<div className="p-6 max-w-5xl mx-auto">
+				<div className="flex items-center justify-between mb-4 gap-4">
+					<div>
+						<h1 className="text-xl font-semibold">Access overview</h1>
+						<p className="text-sm text-gray-500 mt-1">
+							Who can access which mailboxes across the org.
+						</p>
+					</div>
+					{!isLoading && unscopedCount > 0 && (
+						<div className="flex items-center gap-1.5 text-amber-600 text-sm">
+							<WarningIcon size={16} />
+							<span>{unscopedCount} unscoped {unscopedCount === 1 ? "mailbox" : "mailboxes"}</span>
+						</div>
+					)}
+				</div>
+
+				<div className="mb-4 max-w-xs">
+					<Input
+						type="text"
+						placeholder="Filter by mailbox, owner, or member…"
+						value={filter}
+						onChange={(e) => setFilter(e.target.value)}
+					/>
+				</div>
+
+				{isLoading && (
+					<div className="flex justify-center py-12">
+						<Loader />
+					</div>
+				)}
+
+				{isError && (
+					<p className="text-red-500 text-sm py-4">Failed to load access overview.</p>
+				)}
+
+				{!isLoading && !isError && grouped.length === 0 && (
+					<p className="text-gray-500 text-sm py-4">
+						{filter ? "No mailboxes match the filter." : "No mailboxes found."}
+					</p>
+				)}
+
+				{!isLoading && !isError && grouped.map(([domain, domainEntries]) => (
+					<div key={domain} className="mb-6">
+						<h2 className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">
+							{domain}
+						</h2>
+						<table className="w-full text-sm border-collapse">
+							<thead>
+								<tr className="border-b border-gray-200">
+									<th className="text-left py-2 pr-4 font-medium text-gray-600 w-1/3">Mailbox</th>
+									<th className="text-left py-2 pr-4 font-medium text-gray-600 w-20">Access</th>
+									<th className="text-left py-2 pr-4 font-medium text-gray-600 w-1/4">Owner</th>
+									<th className="text-left py-2 font-medium text-gray-600">Members</th>
+								</tr>
+							</thead>
+							<tbody>
+								{domainEntries.map((entry) => (
+									<tr key={entry.email} className="border-b border-gray-100 hover:bg-gray-50">
+										<td className="py-2 pr-4 font-mono text-xs">{entry.email}</td>
+										<td className="py-2 pr-4">
+											{entry.acl_status === "unscoped" ? (
+												<Badge variant="destructive">Unscoped</Badge>
+											) : (
+												<Badge variant="success">Scoped</Badge>
+											)}
+										</td>
+										<td className="py-2 pr-4 text-gray-700">
+											{entry.owner
+												? entry.owner
+												: <span className="text-gray-400 italic">—</span>}
+										</td>
+										<td className="py-2 text-gray-600">
+											{entry.members.length === 0 ? (
+												<span className="text-gray-400 italic">—</span>
+											) : (
+												entry.members.join(", ")
+											)}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				))}
+			</div>
+		</Shell>
+	);
+}

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -246,6 +246,10 @@ const api = {
 	getOrgOverview: (opts?: { signal?: AbortSignal }) =>
 		get<OrgOverview>("/api/v1/org/overview", { signal: opts?.signal }),
 
+	// Org ACL overview (#292)
+	getOrgAclOverview: () =>
+		get<{ mailboxes: Array<{ email: string; acl_status: "scoped" | "unscoped"; owner: string | null; members: string[] }> }>("/api/v1/org/acl-overview"),
+
 	// Domains (#85). Domain identifiers are hostname-shaped (a-z, 0-9, hyphen,
 	// dot); they don't need encodeURIComponent for those characters, but we
 	// still encode defensively in case future IDN handling lands.

--- a/tests/routes/org-acl-overview.test.ts
+++ b/tests/routes/org-acl-overview.test.ts
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Tests for GET /api/v1/org/acl-overview (#292).
+ *
+ * Uses in-memory R2 stubs and a minimal Hono app — same pattern as
+ * tests/routes/mailboxes-acl-status.test.ts.
+ */
+
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { readMailboxAcl, writeMailboxAcl } from "../../workers/lib/mailbox-acl";
+import { listMailboxes } from "../../workers/lib/email-helpers";
+import type { MailboxAcl } from "../../workers/lib/mailbox-acl";
+
+// ---------------------------------------------------------------------------
+// In-memory R2 stub
+// ---------------------------------------------------------------------------
+
+function makeR2Stub(initial: Record<string, string> = {}) {
+	const store = { ...initial };
+	return {
+		async head(key: string) {
+			return store[key] !== undefined ? { key } : null;
+		},
+		async get(key: string) {
+			const val = store[key];
+			if (!val) return null;
+			return { json: async <T>() => JSON.parse(val) as T };
+		},
+		async put(key: string, value: string) {
+			store[key] = value;
+		},
+		async delete(key: string) {
+			delete store[key];
+		},
+		async list({ prefix }: { prefix: string }) {
+			const objects = Object.keys(store)
+				.filter((k) => k.startsWith(prefix))
+				.map((key) => ({ key }));
+			return { objects };
+		},
+		_store: store,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Minimal org/acl-overview app
+// ---------------------------------------------------------------------------
+
+function makeAclOverviewApp(bucketStore: Record<string, string>) {
+	const bucket = makeR2Stub(bucketStore);
+
+	const app = new Hono<{ Bindings: { BUCKET: typeof bucket } }>();
+
+	app.get("/api/v1/org/acl-overview", async (c) => {
+		const allMailboxes = await listMailboxes(c.env.BUCKET as unknown as R2Bucket);
+		const acls = await Promise.all(
+			allMailboxes.map((m) => readMailboxAcl(c.env as unknown as { BUCKET: R2Bucket }, m.id)),
+		);
+
+		return c.json({
+			mailboxes: allMailboxes.map((m, i) => {
+				const acl = acls[i];
+				return {
+					email: m.id,
+					acl_status: (acl ? "scoped" : "unscoped") as "scoped" | "unscoped",
+					owner: acl?.owner ?? null,
+					members: acl?.members ?? [],
+				};
+			}),
+		});
+	});
+
+	return {
+		fetch() {
+			return app.request(
+				"/api/v1/org/acl-overview",
+				{},
+				{ BUCKET: bucket as unknown as R2Bucket },
+			);
+		},
+		bucket,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const aliceId = "alice@example.com";
+const aliceKey = `mailboxes/${aliceId}.json`;
+const aliceAclKey = `mailboxes-acl/${aliceId}.json`;
+
+const bobId = "bob@example.com";
+const bobKey = `mailboxes/${bobId}.json`;
+
+const aliceAcl: MailboxAcl = {
+	owner: "alice@example.com",
+	members: ["alice@example.com", "carol@example.com"],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/org/acl-overview", () => {
+	it("returns an empty mailboxes array when there are no mailboxes", async () => {
+		const { fetch } = makeAclOverviewApp({});
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as { mailboxes: unknown[] };
+		expect(body.mailboxes).toHaveLength(0);
+	});
+
+	it("returns unscoped for a mailbox with no ACL blob", async () => {
+		const { fetch } = makeAclOverviewApp({ [aliceKey]: "{}" });
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as { mailboxes: Array<{ email: string; acl_status: string; owner: string | null; members: string[] }> };
+		expect(body.mailboxes).toHaveLength(1);
+		const entry = body.mailboxes[0];
+		expect(entry.email).toBe(aliceId);
+		expect(entry.acl_status).toBe("unscoped");
+		expect(entry.owner).toBeNull();
+		expect(entry.members).toHaveLength(0);
+	});
+
+	it("returns scoped with owner and members for a mailbox with an ACL", async () => {
+		const store = {
+			[aliceKey]: "{}",
+			[aliceAclKey]: JSON.stringify(aliceAcl),
+		};
+		const { fetch } = makeAclOverviewApp(store);
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as { mailboxes: Array<{ email: string; acl_status: string; owner: string | null; members: string[] }> };
+		const entry = body.mailboxes.find((e) => e.email === aliceId);
+		expect(entry).toBeDefined();
+		expect(entry?.acl_status).toBe("scoped");
+		expect(entry?.owner).toBe("alice@example.com");
+		expect(entry?.members).toContain("carol@example.com");
+	});
+
+	it("returns all mailboxes in a mixed fleet (scoped and unscoped)", async () => {
+		const store = {
+			[aliceKey]: "{}",
+			[aliceAclKey]: JSON.stringify(aliceAcl),
+			[bobKey]: "{}",
+			// no ACL for bob → unscoped
+		};
+		const { fetch } = makeAclOverviewApp(store);
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as { mailboxes: Array<{ email: string; acl_status: string }> };
+		expect(body.mailboxes).toHaveLength(2);
+		const aliceEntry = body.mailboxes.find((e) => e.email === aliceId);
+		const bobEntry = body.mailboxes.find((e) => e.email === bobId);
+		expect(aliceEntry?.acl_status).toBe("scoped");
+		expect(bobEntry?.acl_status).toBe("unscoped");
+	});
+
+	it("returns all-scoped fleet correctly", async () => {
+		const bobAcl: MailboxAcl = { owner: "bob@example.com", members: ["bob@example.com"] };
+		const store = {
+			[aliceKey]: "{}",
+			[aliceAclKey]: JSON.stringify(aliceAcl),
+			[bobKey]: "{}",
+			[`mailboxes-acl/${bobId}.json`]: JSON.stringify(bobAcl),
+		};
+		const { fetch } = makeAclOverviewApp(store);
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as { mailboxes: Array<{ email: string; acl_status: string }> };
+		expect(body.mailboxes).toHaveLength(2);
+		for (const entry of body.mailboxes) {
+			expect(entry.acl_status).toBe("scoped");
+		}
+	});
+
+	it("returns all-unscoped fleet correctly", async () => {
+		const store = { [aliceKey]: "{}", [bobKey]: "{}" };
+		const { fetch } = makeAclOverviewApp(store);
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as { mailboxes: Array<{ email: string; acl_status: string; owner: string | null }> };
+		expect(body.mailboxes).toHaveLength(2);
+		for (const entry of body.mailboxes) {
+			expect(entry.acl_status).toBe("unscoped");
+			expect(entry.owner).toBeNull();
+		}
+	});
+
+	it("reflects ACL written by writeMailboxAcl", async () => {
+		const store: Record<string, string> = { [aliceKey]: "{}" };
+		const bucket = makeR2Stub(store);
+		await writeMailboxAcl(
+			{ BUCKET: bucket as unknown as R2Bucket },
+			aliceId,
+			{ owner: "alice@example.com", members: ["alice@example.com"] },
+		);
+
+		const { fetch } = makeAclOverviewApp(bucket._store);
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as { mailboxes: Array<{ email: string; acl_status: string }> };
+		const entry = body.mailboxes.find((e) => e.email === aliceId);
+		expect(entry?.acl_status).toBe("scoped");
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -365,6 +365,28 @@ app.get("/api/v1/org/overview", async (c) => {
 	return c.json(overview);
 });
 
+// -- Org ACL overview (#292) ----------------------------------------
+
+// Authz: any CF-Access-admitted caller. No org-admin role exists yet;
+// all CF-Access-admitted users can read the org access list.
+// Tighten when a RBAC / org-admin role is introduced.
+app.get("/api/v1/org/acl-overview", async (c) => {
+	const allMailboxes = await listMailboxes(c.env.BUCKET);
+	const acls = await Promise.all(allMailboxes.map((m) => readMailboxAcl(c.env, m.id)));
+
+	return c.json({
+		mailboxes: allMailboxes.map((m, i) => {
+			const acl = acls[i];
+			return {
+				email: m.id,
+				acl_status: (acl ? "scoped" : "unscoped") as "scoped" | "unscoped",
+				owner: acl?.owner ?? null,
+				members: acl?.members ?? [],
+			};
+		}),
+	});
+});
+
 // -- Org-scope search (#197) ----------------------------------------
 
 /** Per-mailbox cap for org-search fan-out. We pull at most this many rows


### PR DESCRIPTION
## Summary

- New `GET /api/v1/org/acl-overview` endpoint returns every mailbox with `{ email, acl_status, owner|null, members[] }` so operators can audit access across the fleet
- New UI route at `/acl-overview` renders a domain-grouped table with Scoped/Unscoped badges and a real-time text filter (by mailbox email, owner, or member)
- "Access overview" nav entry added to Shell sidebar (org-level section)

**Authz model (documented in endpoint comment):** any CF-Access-admitted caller. No org-admin role exists yet. If/when a RBAC role is introduced, tighten the guard at that point.

## Test plan

- [x] 7 new unit tests in `tests/routes/org-acl-overview.test.ts` covering: empty fleet, single unscoped mailbox, single scoped mailbox with owner+members, mixed fleet, all-scoped fleet, all-unscoped fleet, and `writeMailboxAcl` round-trip
- [x] Full test suite: **1086 passing, 0 failing** (84 test files)
- [x] Typecheck: clean

## Deferred / follow-up

- Authz tightening to org-admin role when RBAC is introduced (no issue filed yet; note intentional per current no-RBAC state)
- Group-based ACL rendering once #295 lands

Closes #292

https://claude.ai/code/session_012fRNnTpAKXJtJYzHAkTtzZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012fRNnTpAKXJtJYzHAkTtzZ)_