### PR TITLE
feat: org-level ACL audit overview (#292)

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -12,6 +12,7 @@ export default [
 	index("routes/home.tsx"),
 	route("mailboxes", "routes/mailboxes.tsx"),
 	route("settings", "routes/org-settings.tsx"),
+	route("acl-overview", "routes/org-acl-overview.tsx"),
 	route("domains", "routes/domains-list.tsx"),
 	route("domains/:domain", "routes/domain-detail.tsx"),
 	route("domains/:domain/settings", "routes/domain-settings.tsx"),

--- a/app/routes/org-acl-overview.tsx
+++ b/app/routes/org-acl-overview.tsx
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { Loader } from "@cloudflare/kumo";
+import { useQuery } from "@tanstack/react-query";
+import Shell from "~/components/phishsoc/Shell";
+import api from "~/services/api";
+
+export function meta() {
+	return [{ title: "ACL Overview · PhishSOC" }];
+}
+
+type AclOverviewEntry = {
+	email: string;
+	acl_status: "scoped" | "unscoped";
+	owner: string | null;
+	members: string[];
+};
+
+export default function AclOverviewRoute() {
+	const { data: entries = [], isLoading } = useQuery<AclOverviewEntry[]>({
+		queryKey: ["org", "acl-overview"],
+		queryFn: () => api.getAclOverview(),
+	});
+
+	// Group by domain (the part after @).
+	const byDomain = new Map<string, AclOverviewEntry[]>();
+	for (const entry of entries) {
+		const domain = entry.email.split("@")[1] ?? entry.email;
+		if (!byDomain.has(domain)) byDomain.set(domain, []);
+		byDomain.get(domain)!.push(entry);
+	}
+
+	const unscopedCount = entries.filter((e) => e.acl_status === "unscoped").length;
+
+	return (
+		<Shell>
+			<div className="mx-auto max-w-4xl px-4 py-8 md:px-6 md:py-16">
+				<div className="mb-8">
+					<h1 className="pp-serif text-[40px] leading-none text-ink">ACL Overview</h1>
+					<p className="text-sm text-ink-3 mt-1">
+						Who can access which mailboxes across your org.
+						{unscopedCount > 0 && (
+							<>
+								{" "}
+								<span className="text-amber-600 font-medium">{unscopedCount} unscoped</span>
+								{" "}— visible to all admitted users.
+							</>
+						)}
+					</p>
+				</div>
+
+				{isLoading ? (
+					<div className="flex justify-center py-20">
+						<Loader size="lg" />
+					</div>
+				) : entries.length === 0 ? (
+					<p className="text-ink-3 text-sm">No mailboxes found.</p>
+				) : (
+					<div className="space-y-8">
+						{[...byDomain.entries()].map(([domain, mailboxes]) => (
+							<div key={domain}>
+								<h2 className="text-xs font-semibold text-ink-3 uppercase tracking-wide mb-2">
+									{domain}
+								</h2>
+								<div className="pp-card overflow-hidden">
+									<table className="w-full text-sm">
+										<thead>
+											<tr className="border-b border-line text-xs text-ink-3">
+												<th className="px-4 py-2 text-left font-medium">Mailbox</th>
+												<th className="px-4 py-2 text-left font-medium">Status</th>
+												<th className="px-4 py-2 text-left font-medium">Owner</th>
+												<th className="px-4 py-2 text-left font-medium">Members</th>
+											</tr>
+										</thead>
+										<tbody>
+											{mailboxes.map((entry, idx) => (
+												<tr
+													key={entry.email}
+													className={idx > 0 ? "border-t border-line" : ""}
+												>
+													<td className="px-4 py-3 font-mono text-xs text-ink">
+														{entry.email}
+													</td>
+													<td className="px-4 py-3">
+														{entry.acl_status === "unscoped" ? (
+															<span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10.5px] font-medium bg-amber-50 text-amber-700 border border-amber-200">
+																Unscoped
+															</span>
+														) : (
+															<span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10.5px] font-medium bg-green-50 text-green-700 border border-green-200">
+																Scoped
+															</span>
+														)}
+													</td>
+													<td className="px-4 py-3 text-ink-3 text-xs">
+														{entry.owner ?? <span className="opacity-40">—</span>}
+													</td>
+													<td className="px-4 py-3 text-ink-3 text-xs">
+														{entry.members.length === 0 ? (
+															<span className="opacity-40">—</span>
+														) : (
+															entry.members.join(", ")
+														)}
+													</td>
+												</tr>
+											))}
+										</tbody>
+									</table>
+								</div>
+							</div>
+						))}
+					</div>
+				)}
+			</div>
+		</Shell>
+	);
+}

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -155,6 +155,10 @@ const api = {
 	// Org-level settings (#106). Backed by R2 key org/settings.json behind a
 	// module-scope ETag cache; the GET returns the raw blob (or {} if missing),
 	// PUT validates through the OrgSettings Zod schema worker-side.
+	getAclOverview: () =>
+		get<Array<{ email: string; acl_status: "scoped" | "unscoped"; owner: string | null; members: string[] }>>(
+			"/api/v1/org/acl-overview",
+		),
 	getOrgSettings: () =>
 		get<{ settings: Record<string, unknown> }>("/api/v1/org/settings"),
 	updateOrgSettings: (settings: unknown) =>

--- a/tests/routes/org-acl-overview.test.ts
+++ b/tests/routes/org-acl-overview.test.ts
@@ -1,0 +1,250 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Tests for issue #292: GET /api/v1/org/acl-overview.
+ *
+ * Uses in-memory R2 stubs and a minimal Hono app — same pattern as
+ * tests/routes/mailboxes-acl-status.test.ts.
+ */
+
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { readMailboxAcl } from "../../workers/lib/mailbox-acl";
+import { listMailboxes } from "../../workers/lib/email-helpers";
+import type { MailboxAcl } from "../../workers/lib/mailbox-acl";
+
+// ---------------------------------------------------------------------------
+// In-memory R2 stub (supports head / get / put / delete / list)
+// ---------------------------------------------------------------------------
+
+function makeR2Stub(initial: Record<string, string> = {}) {
+	const store = { ...initial };
+	return {
+		async head(key: string) {
+			return store[key] !== undefined ? { key } : null;
+		},
+		async get(key: string) {
+			const val = store[key];
+			if (!val) return null;
+			return { json: async <T>() => JSON.parse(val) as T };
+		},
+		async put(key: string, value: string) {
+			store[key] = value;
+		},
+		async delete(key: string) {
+			delete store[key];
+		},
+		async list({ prefix }: { prefix: string }) {
+			const objects = Object.keys(store)
+				.filter((k) => k.startsWith(prefix))
+				.map((key) => ({ key }));
+			return { objects };
+		},
+		_store: store,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Minimal Hono app replicating GET /api/v1/org/acl-overview from index.ts
+// ---------------------------------------------------------------------------
+
+type AclOverviewEntry = {
+	email: string;
+	acl_status: "scoped" | "unscoped";
+	owner: string | null;
+	members: string[];
+};
+
+function makeOverviewApp(bucketStore: Record<string, string>) {
+	const bucket = makeR2Stub(bucketStore);
+
+	const app = new Hono<{ Bindings: { BUCKET: typeof bucket } }>();
+
+	app.get("/api/v1/org/acl-overview", async (c) => {
+		const allMailboxes = await listMailboxes(c.env.BUCKET as unknown as R2Bucket);
+		const acls = await Promise.all(
+			allMailboxes.map((m) => readMailboxAcl(c.env as unknown as { BUCKET: R2Bucket }, m.id)),
+		);
+
+		return c.json(
+			allMailboxes.map((m, i) => {
+				const acl = acls[i];
+				return {
+					email: m.id,
+					acl_status: acl ? "scoped" : "unscoped",
+					owner: acl?.owner ?? null,
+					members: acl?.members ?? [],
+				};
+			}),
+		);
+	});
+
+	return {
+		fetch() {
+			return app.request(
+				"/api/v1/org/acl-overview",
+				{},
+				{ BUCKET: bucket as unknown as R2Bucket },
+			);
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const aliceId = "alice@example.com";
+const aliceKey = `mailboxes/${aliceId}.json`;
+const aliceAclKey = `mailboxes-acl/${aliceId}.json`;
+
+const bobId = "bob@example.com";
+const bobKey = `mailboxes/${bobId}.json`;
+const bobAclKey = `mailboxes-acl/${bobId}.json`;
+
+const charlieId = "charlie@other.com";
+const charlieKey = `mailboxes/${charlieId}.json`;
+
+const aliceAcl: MailboxAcl = {
+	owner: "alice@example.com",
+	members: ["alice@example.com", "bob@example.com"],
+};
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/org/acl-overview
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/org/acl-overview (#292)", () => {
+	it("returns an empty array when there are no mailboxes", async () => {
+		const { fetch } = makeOverviewApp({});
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as AclOverviewEntry[];
+		expect(body).toHaveLength(0);
+	});
+
+	it("returns acl_status: unscoped with null owner and empty members for a mailbox with no ACL", async () => {
+		const { fetch } = makeOverviewApp({ [aliceKey]: "{}" });
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as AclOverviewEntry[];
+		expect(body).toHaveLength(1);
+		expect(body[0]).toEqual({
+			email: aliceId,
+			acl_status: "unscoped",
+			owner: null,
+			members: [],
+		});
+	});
+
+	it("returns acl_status: scoped with owner and members for a mailbox that has an ACL", async () => {
+		const store = {
+			[aliceKey]: "{}",
+			[aliceAclKey]: JSON.stringify(aliceAcl),
+		};
+		const { fetch } = makeOverviewApp(store);
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as AclOverviewEntry[];
+		expect(body).toHaveLength(1);
+		expect(body[0]).toEqual({
+			email: aliceId,
+			acl_status: "scoped",
+			owner: "alice@example.com",
+			members: ["alice@example.com", "bob@example.com"],
+		});
+	});
+
+	it("returns correct mixed fleet: scoped and unscoped mailboxes side by side", async () => {
+		const store = {
+			[aliceKey]: "{}",
+			[aliceAclKey]: JSON.stringify(aliceAcl),
+			[bobKey]: "{}",
+			// bob has no ACL → unscoped
+		};
+		const { fetch } = makeOverviewApp(store);
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as AclOverviewEntry[];
+		expect(body).toHaveLength(2);
+
+		const alice = body.find((e) => e.email === aliceId);
+		expect(alice?.acl_status).toBe("scoped");
+		expect(alice?.owner).toBe("alice@example.com");
+		expect(alice?.members).toContain("bob@example.com");
+
+		const bob = body.find((e) => e.email === bobId);
+		expect(bob?.acl_status).toBe("unscoped");
+		expect(bob?.owner).toBeNull();
+		expect(bob?.members).toHaveLength(0);
+	});
+
+	it("returns all mailboxes regardless of caller email (any admitted caller sees the full fleet)", async () => {
+		// Endpoint has no per-caller filter — scoped mailboxes appear for everyone.
+		const store = {
+			[aliceKey]: "{}",
+			[aliceAclKey]: JSON.stringify(aliceAcl),
+			[charlieKey]: "{}",
+		};
+		const { fetch } = makeOverviewApp(store);
+		// No CF-Access header — simulates dev mode
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as AclOverviewEntry[];
+		expect(body).toHaveLength(2);
+		// Both alice (scoped) and charlie (unscoped) appear
+		const emails = body.map((e) => e.email).sort();
+		expect(emails).toEqual([aliceId, charlieId].sort());
+	});
+
+	it("includes multiple members correctly", async () => {
+		const multiAcl: MailboxAcl = {
+			owner: "alice@example.com",
+			members: ["alice@example.com", "bob@example.com", "carol@example.com"],
+		};
+		const store = {
+			[aliceKey]: "{}",
+			[aliceAclKey]: JSON.stringify(multiAcl),
+		};
+		const { fetch } = makeOverviewApp(store);
+		const res = await fetch();
+		const body = await res.json() as AclOverviewEntry[];
+		expect(body[0].members).toHaveLength(3);
+		expect(body[0].members).toContain("carol@example.com");
+	});
+
+	it("backwards-compat: a mailbox added before #27 (no ACL blob) always appears as unscoped", async () => {
+		// Three pre-#27 mailboxes, no ACL blobs written for any of them.
+		const store = {
+			[aliceKey]: "{}",
+			[bobKey]: "{}",
+			[charlieKey]: "{}",
+		};
+		const { fetch } = makeOverviewApp(store);
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as AclOverviewEntry[];
+		expect(body).toHaveLength(3);
+		for (const entry of body) {
+			expect(entry.acl_status).toBe("unscoped");
+			expect(entry.owner).toBeNull();
+			expect(entry.members).toHaveLength(0);
+		}
+	});
+
+	// Suppress unused-import warning for bobAclKey (used implicitly via bucket state).
+	it("does not include mailboxes-acl/ keys as mailboxes in the listing", async () => {
+		// The R2 prefix scan for mailboxes uses `mailboxes/` prefix, so ACL blobs
+		// stored at `mailboxes-acl/` must not appear in the output.
+		const store = {
+			[aliceKey]: "{}",
+			[aliceAclKey]: JSON.stringify(aliceAcl),
+		};
+		const { fetch } = makeOverviewApp(store);
+		const res = await fetch();
+		const body = await res.json() as AclOverviewEntry[];
+		// Only one mailbox entry, not two (the ACL blob must not leak as a mailbox).
+		expect(body).toHaveLength(1);
+		void bobAclKey;
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -365,6 +365,36 @@ app.get("/api/v1/org/overview", async (c) => {
 	return c.json(overview);
 });
 
+// -- Org ACL overview (#292) ----------------------------------------
+
+/**
+ * Org-level ACL audit surface (#292). Returns every mailbox with its
+ * acl_status, owner, and member list so operators can audit who can access
+ * what across the fleet without inspecting R2 blobs by hand.
+ *
+ * Authz: any CF-Access-admitted caller. No org-admin role exists today, so the
+ * policy is identical to GET /api/v1/org/overview — all callers admitted past
+ * the main CF Access policy may view the overview. In dev mode (no callerEmail)
+ * the endpoint is also accessible. Owner and member emails of scoped mailboxes
+ * are visible to all admitted callers — this is an operator audit surface.
+ */
+app.get("/api/v1/org/acl-overview", async (c) => {
+	const allMailboxes = await listMailboxes(c.env.BUCKET);
+	const acls = await Promise.all(allMailboxes.map((m) => readMailboxAcl(c.env, m.id)));
+
+	return c.json(
+		allMailboxes.map((m, i) => {
+			const acl = acls[i];
+			return {
+				email: m.id,
+				acl_status: acl ? "scoped" : "unscoped",
+				owner: acl?.owner ?? null,
+				members: acl?.members ?? [],
+			};
+		}),
+	);
+});
+
 // -- Org-scope search (#197) ----------------------------------------
 
 /** Per-mailbox cap for org-search fan-out. We pull at most this many rows


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/org/acl-overview` — returns every mailbox with `{ email, acl_status, owner|null, members[] }` so operators can audit fleet-wide access without inspecting R2 blobs by hand
- Adds a UI route at `/acl-overview` that groups mailboxes by domain, flags unscoped mailboxes with an amber badge (consistent with the `/mailboxes` page), and shows owner + member lists per mailbox
- 8 new tests cover scoped, unscoped, mixed fleets, backwards-compat (pre-#27 no-ACL mailboxes), multiple members, and ACL-blob isolation

Closes #292

## Authz model

**Any CF-Access-admitted caller** may call this endpoint — no org-admin role exists today. This is documented in the endpoint code comment and matches the existing `GET /api/v1/org/overview` policy. Consequence: owner and member emails of scoped mailboxes are visible to all admitted callers — acknowledged as an operator-oriented audit surface, not an end-user surface. A future RBAC/org-admin issue could narrow this.

## Test plan

- [ ] `node_modules/.bin/vitest run tests/routes/org-acl-overview.test.ts` — 8 tests pass
- [ ] `npm run typecheck` — exit 0
- [ ] Full suite: `node_modules/.bin/vitest run` — 1087 passing, 0 failing (all pre-existing tests continue to pass)
- [ ] Navigate to `/acl-overview` in the SPA — table renders grouped by domain, unscoped mailboxes show amber "Unscoped" badge, scoped mailboxes show green "Scoped" badge with owner and members listed

## Files changed (5)

| File | Change |
|---|---|
| `workers/index.ts` | New `GET /api/v1/org/acl-overview` endpoint (30 lines) |
| `app/services/api.ts` | Add `getAclOverview()` typed API client method |
| `app/routes.ts` | Register `/acl-overview` route |
| `app/routes/org-acl-overview.tsx` | New UI route — table grouped by domain |
| `tests/routes/org-acl-overview.test.ts` | 8 tests using in-memory R2 stub |

## Deferred

- Navigation link in Shell sidebar (not required by acceptance; avoids touching a 6th file beyond the auto-decompose threshold; easy follow-up)
- Future: narrow authz to an org-admin role once RBAC exists

https://claude.ai/code/session_0158NZ9vuCtZ8vUC627Ubm3a

---
_Generated by [Claude Code](https://claude.ai/code/session_0158NZ9vuCtZ8vUC627Ubm3a)_