### PR TITLE
🎨 Palette: Add ARIA attributes to collapsible email panels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-21 - Add aria-expanded and aria-controls to collapsibles
+**Learning:** Collapsible regions (like the thread message or security verdict panels) in this application were missing ARIA roles for screen reader state mapping. The buttons needed `aria-expanded` and `aria-controls`.
+**Action:** When implementing or modifying expand/collapse UI patterns, ensure that toggle buttons are wired up with `aria-expanded` representing the boolean state, and `aria-controls` correctly tied to an explicit `id` on the content wrapper.

--- a/app/components/email-panel/SecurityVerdictPanel.tsx
+++ b/app/components/email-panel/SecurityVerdictPanel.tsx
@@ -2,15 +2,15 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { useState } from "react";
 import {
 	CaretDownIcon,
 	CaretUpIcon,
 	ShieldCheckIcon,
-	ShieldWarningIcon,
 	ShieldIcon,
+	ShieldWarningIcon,
 } from "@phosphor-icons/react";
-import { parseVerdict, type Email } from "~/types";
+import { useState } from "react";
+import { type Email, parseVerdict } from "~/types";
 
 /**
  * Renders the security pipeline's verdict for an email: action, score, auth
@@ -24,18 +24,26 @@ export default function SecurityVerdictPanel({ email }: { email: Email }) {
 	// Quiet path for the normal allow case, but surface hard-block /
 	// attachment-block explicitly even when the user is reading the
 	// quarantined message.
-	if (verdict.action === "allow"
-		&& verdict.triage !== "hard_block"
-		&& verdict.triage !== "attachment_block") return null;
+	if (
+		verdict.action === "allow" &&
+		verdict.triage !== "hard_block" &&
+		verdict.triage !== "attachment_block"
+	)
+		return null;
 
-	const { borderClass, bgClass, iconColorClass, icon, headline } = ui(verdict.action);
-	const triageTag = verdict.triage === "hard_allow"
-		? "allowlist fast-path"
-		: verdict.triage === "hard_block"
-			? "triage hard-block"
-			: verdict.triage === "attachment_block"
-				? "blocked attachment type"
-				: null;
+	const { borderClass, bgClass, iconColorClass, icon, headline } = ui(
+		verdict.action,
+	);
+	const triageTag =
+		verdict.triage === "hard_allow"
+			? "allowlist fast-path"
+			: verdict.triage === "hard_block"
+				? "triage hard-block"
+				: verdict.triage === "attachment_block"
+					? "blocked attachment type"
+					: null;
+
+	const contentId = `security-verdict-content-${email.id}`;
 
 	return (
 		<div className={`px-4 md:px-6 pt-3`}>
@@ -44,6 +52,8 @@ export default function SecurityVerdictPanel({ email }: { email: Email }) {
 					type="button"
 					className="w-full flex items-center gap-2 px-3 py-2 text-left"
 					onClick={() => setExpanded((e) => !e)}
+					aria-expanded={expanded}
+					aria-controls={contentId}
 				>
 					<span className={iconColorClass}>{icon}</span>
 					<span className="font-medium text-ink">{headline}</span>
@@ -52,21 +62,26 @@ export default function SecurityVerdictPanel({ email }: { email: Email }) {
 							{triageTag}
 						</span>
 					)}
-					<span className="text-xs text-ink-3 ml-1">score {verdict.score}/100</span>
+					<span className="text-xs text-ink-3 ml-1">
+						score {verdict.score}/100
+					</span>
 					<ConfidenceChip confidence={verdict.confidence} />
 					<span className="ml-auto text-ink-3">
 						{expanded ? <CaretUpIcon size={16} /> : <CaretDownIcon size={16} />}
 					</span>
 				</button>
 				{expanded && (
-					<div className="px-3 pb-3 pt-0 space-y-2">
+					<div id={contentId} className="px-3 pb-3 pt-0 space-y-2">
 						<div className="text-ink">{verdict.explanation}</div>
 
 						<div className="flex flex-wrap gap-1.5">
 							<AuthChip label="SPF" value={verdict.auth.spf} />
 							<AuthChip label="DKIM" value={verdict.auth.dkim} />
 							<AuthChip label="DMARC" value={verdict.auth.dmarc} />
-							<ClassifierChip label={verdict.classification.label} confidence={verdict.classification.confidence} />
+							<ClassifierChip
+								label={verdict.classification.label}
+								confidence={verdict.classification.confidence}
+							/>
 						</div>
 
 						{verdict.classification.reasoning && (
@@ -77,9 +92,13 @@ export default function SecurityVerdictPanel({ email }: { email: Email }) {
 
 						{verdict.signals.length > 0 && (
 							<div>
-								<div className="text-xs font-medium text-ink-3 mb-1">Contributing signals</div>
+								<div className="text-xs font-medium text-ink-3 mb-1">
+									Contributing signals
+								</div>
 								<ul className="text-xs text-ink list-disc ml-4 space-y-0.5">
-									{verdict.signals.map((s, i) => <li key={i}>{s}</li>)}
+									{verdict.signals.map((s, i) => (
+										<li key={i}>{s}</li>
+									))}
 								</ul>
 							</div>
 						)}
@@ -99,7 +118,10 @@ function ui(action: string) {
 				bgClass: "bg-paper-3",
 				iconColorClass: "text-danger",
 				icon: <ShieldWarningIcon size={16} weight="fill" />,
-				headline: action === "block" ? "Blocked by security pipeline" : "Quarantined by security pipeline",
+				headline:
+					action === "block"
+						? "Blocked by security pipeline"
+						: "Quarantined by security pipeline",
 			};
 		case "tag":
 			return {
@@ -122,9 +144,11 @@ function ui(action: string) {
 
 function AuthChip({ label, value }: { label: string; value: string }) {
 	const color =
-		value === "pass" ? "text-safe" :
-		value === "fail" || value === "softfail" ? "text-danger" :
-		"text-ink-3";
+		value === "pass"
+			? "text-safe"
+			: value === "fail" || value === "softfail"
+				? "text-danger"
+				: "text-ink-3";
 	return (
 		<span className="text-xs rounded border border-line px-1.5 py-0.5 bg-paper-3">
 			<span className="text-ink-3">{label} </span>
@@ -151,12 +175,21 @@ function ConfidenceChip({ confidence }: { confidence?: number }) {
 	);
 }
 
-function ClassifierChip({ label, confidence }: { label: string; confidence: number }) {
+function ClassifierChip({
+	label,
+	confidence,
+}: {
+	label: string;
+	confidence: number;
+}) {
 	const color =
-		label === "phishing" || label === "bec" ? "text-danger" :
-		label === "suspicious" ? "text-suspect" :
-		label === "spam" ? "text-ink-3" :
-		"text-safe";
+		label === "phishing" || label === "bec"
+			? "text-danger"
+			: label === "suspicious"
+				? "text-suspect"
+				: label === "spam"
+					? "text-ink-3"
+					: "text-safe";
 	return (
 		<span className="text-xs rounded border border-line px-1.5 py-0.5 bg-paper-3">
 			<span className="text-ink-3">LLM </span>

--- a/app/components/email-panel/ThreadMessage.tsx
+++ b/app/components/email-panel/ThreadMessage.tsx
@@ -37,7 +37,15 @@ interface ThreadMessageProps {
 	onPreviewImage?: (url: string, filename: string) => void;
 }
 
-function Avatar({ isDraft, isSelf, sender }: { isDraft?: boolean; isSelf: boolean; sender: string }) {
+function Avatar({
+	isDraft,
+	isSelf,
+	sender,
+}: {
+	isDraft?: boolean;
+	isSelf: boolean;
+	sender: string;
+}) {
 	return (
 		<div
 			className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
@@ -71,6 +79,7 @@ export default function ThreadMessage({
 	const isSelf = email.sender === mailboxEmail;
 	const containerClassName = `${!isLast ? "border-b border-line" : ""} ${isDraft ? "border-l-2 border-l-suspect bg-suspect/[0.02]" : ""}`;
 	const senderLabel = isDraft ? "Draft reply" : isSelf ? "You" : email.sender;
+	const contentId = `thread-message-content-${email.id}`;
 
 	if (!isExpanded) {
 		return (
@@ -79,6 +88,8 @@ export default function ThreadMessage({
 					type="button"
 					onClick={onToggleExpand}
 					className="w-full flex items-center gap-3 px-4 py-3 hover:bg-paper-2 rounded-lg text-left"
+					aria-expanded={isExpanded}
+					aria-controls={contentId}
 				>
 					<Avatar isDraft={isDraft} isSelf={isSelf} sender={email.sender} />
 					<div className="flex-1 min-w-0">
@@ -110,9 +121,15 @@ export default function ThreadMessage({
 							onClick={onToggleExpand}
 							className="shrink-0"
 							aria-label="Collapse message"
+							aria-expanded={isExpanded}
+							aria-controls={contentId}
 						>
 							<div className="cursor-pointer hover:ring-2 hover:ring-accent/30 transition-shadow rounded-full">
-								<Avatar isDraft={isDraft} isSelf={isSelf} sender={email.sender} />
+								<Avatar
+									isDraft={isDraft}
+									isSelf={isSelf}
+									sender={email.sender}
+								/>
 							</div>
 						</button>
 						<div className="min-w-0">
@@ -147,6 +164,8 @@ export default function ThreadMessage({
 							onClick={onToggleExpand}
 							className="ml-1"
 							aria-label="Collapse message"
+							aria-expanded={isExpanded}
+							aria-controls={contentId}
 						>
 							<CaretUpIcon
 								size={14}
@@ -156,7 +175,7 @@ export default function ThreadMessage({
 					</div>
 				</div>
 
-				<div className="md:ml-[42px]">
+				<div id={contentId} className="md:ml-[42px]">
 					<EmailIframe
 						body={rewriteInlineImages(
 							email.body || "",


### PR DESCRIPTION
💡 **What**: Added `aria-expanded` and `aria-controls` attributes to the buttons responsible for expanding and collapsing the `SecurityVerdictPanel` and `ThreadMessage` components. Also assigned an explicit `id` to the corresponding collapsible content wrappers.
🎯 **Why**: To improve accessibility for screen readers, allowing users to understand the current expansion state and linking the toggle control to the specific content region.
♿ **Accessibility**: Implements standard WAI-ARIA collapsible pattern.

---
*PR created automatically by Jules for task [7291009029056155849](https://jules.google.com/task/7291009029056155849) started by @schmug*