### PR TITLE
feat: org-wide ACL access overview

### DIFF
--- a/app/queries/keys.ts
+++ b/app/queries/keys.ts
@@ -29,6 +29,7 @@ export const queryKeys = {
 	dashboard: (mailboxId: string) => ["dashboard", mailboxId] as const,
 	org: {
 		overview: ["org", "overview"] as const,
+		aclOverview: ["org", "acl-overview"] as const,
 		settings: ["org", "settings"] as const,
 	},
 	effectiveMailboxSettings: (mailboxId: string) =>

--- a/app/queries/org.ts
+++ b/app/queries/org.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import api from "~/services/api";
-import type { OrgOverview } from "~/types";
+import type { AclOverviewEntry, OrgOverview } from "~/types";
 import { queryKeys } from "./keys";
 
 export function useOrgOverview() {
@@ -12,5 +12,13 @@ export function useOrgOverview() {
 		// Server caches the merged result for 60s, so a 30s client stale window
 		// keeps navigation snappy without ever serving data older than ~90s.
 		staleTime: 30_000,
+	});
+}
+
+export function useOrgAclOverview() {
+	return useQuery<AclOverviewEntry[]>({
+		queryKey: queryKeys.org.aclOverview,
+		queryFn: ({ signal }) =>
+			api.getOrgAclOverview({ signal }) as Promise<AclOverviewEntry[]>,
 	});
 }

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -12,6 +12,7 @@ export default [
 	index("routes/home.tsx"),
 	route("mailboxes", "routes/mailboxes.tsx"),
 	route("settings", "routes/org-settings.tsx"),
+	route("acl", "routes/org-acl.tsx"),
 	route("domains", "routes/domains-list.tsx"),
 	route("domains/:domain", "routes/domain-detail.tsx"),
 	route("domains/:domain/settings", "routes/domain-settings.tsx"),

--- a/app/routes/org-acl.tsx
+++ b/app/routes/org-acl.tsx
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { Input, Loader, Select } from "@cloudflare/kumo";
+import { useState } from "react";
+import Shell from "~/components/phishsoc/Shell";
+import { useOrgAclOverview } from "~/queries/org";
+
+export function meta() {
+	return [{ title: "Access Overview · PhishSOC" }];
+}
+
+function domainOf(email: string): string {
+	const at = email.indexOf("@");
+	return at >= 0 ? email.slice(at + 1) : email;
+}
+
+export default function OrgAclRoute() {
+	const { data: rows = [], isLoading } = useOrgAclOverview();
+
+	const domains = Array.from(new Set(rows.map((r) => domainOf(r.email)))).sort();
+	const [filterDomain, setFilterDomain] = useState("__all__");
+	const [filterText, setFilterText] = useState("");
+
+	const filtered = rows.filter((r) => {
+		if (filterDomain !== "__all__" && domainOf(r.email) !== filterDomain) return false;
+		if (filterText) {
+			const q = filterText.toLowerCase();
+			const inEmail = r.email.toLowerCase().includes(q);
+			const inOwner = r.owner?.toLowerCase().includes(q) ?? false;
+			const inMembers = r.members.some((m) => m.toLowerCase().includes(q));
+			if (!inEmail && !inOwner && !inMembers) return false;
+		}
+		return true;
+	});
+
+	const scopedCount = rows.filter((r) => r.acl_status === "scoped").length;
+	const unscopedCount = rows.filter((r) => r.acl_status === "unscoped").length;
+
+	return (
+		<Shell>
+			<div className="max-w-5xl mx-auto px-4 py-8 space-y-6">
+				<div>
+					<h1 className="text-xl font-semibold text-ink">Access Overview</h1>
+					<p className="text-sm text-subtle mt-1">
+						All mailboxes and their access grants. Any authenticated user in your
+						Cloudflare Access policy can view this page — this is intentional (no
+						org-admin role exists; the Access policy is the org boundary).
+					</p>
+				</div>
+
+				{isLoading ? (
+					<div className="flex items-center justify-center py-16">
+						<Loader />
+					</div>
+				) : (
+					<>
+						<div className="flex items-center gap-4 flex-wrap">
+							<p className="text-sm text-subtle">
+								{rows.length} mailbox{rows.length !== 1 ? "es" : ""}
+								{" · "}
+								<span className="text-green-600">{scopedCount} scoped</span>
+								{unscopedCount > 0 && (
+									<>
+										{" · "}
+										<span className="text-amber-600">{unscopedCount} unscoped</span>
+									</>
+								)}
+							</p>
+						</div>
+
+						<div className="flex items-center gap-3 flex-wrap">
+							{domains.length > 1 && (
+								<Select
+									value={filterDomain}
+									onValueChange={(v) => { if (v) setFilterDomain(v); }}
+									aria-label="Filter by domain"
+								>
+									<Select.Option value="__all__">All domains</Select.Option>
+									{domains.map((d) => (
+										<Select.Option key={d} value={d}>
+											{d}
+										</Select.Option>
+									))}
+								</Select>
+							)}
+							<Input
+								placeholder="Filter by email or member…"
+								aria-label="Filter mailboxes"
+								value={filterText}
+								onChange={(e) => setFilterText(e.target.value)}
+							/>
+						</div>
+
+						{filtered.length === 0 ? (
+							<p className="text-sm text-subtle py-8 text-center">No mailboxes match the filter.</p>
+						) : (
+							<div className="overflow-x-auto rounded border border-border">
+								<table className="min-w-full text-sm">
+									<thead className="bg-surface border-b border-border">
+										<tr>
+											<th className="text-left px-4 py-2 font-medium text-subtle">Mailbox</th>
+											<th className="text-left px-4 py-2 font-medium text-subtle">Status</th>
+											<th className="text-left px-4 py-2 font-medium text-subtle">Owner</th>
+											<th className="text-left px-4 py-2 font-medium text-subtle">Members</th>
+										</tr>
+									</thead>
+									<tbody className="divide-y divide-border">
+										{filtered.map((row) => (
+											<tr key={row.email} className="hover:bg-surface/50">
+												<td className="px-4 py-2 font-mono text-xs text-ink">{row.email}</td>
+												<td className="px-4 py-2">
+													{row.acl_status === "scoped" ? (
+														<span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+															Scoped
+														</span>
+													) : (
+														<span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+															Unscoped
+														</span>
+													)}
+												</td>
+												<td className="px-4 py-2 text-xs text-subtle">
+													{row.owner ?? <span className="italic text-muted">—</span>}
+												</td>
+												<td className="px-4 py-2 text-xs text-subtle">
+													{row.members.length === 0 ? (
+														<span className="italic text-muted">none</span>
+													) : (
+														<ul className="space-y-0.5">
+															{row.members.map((m) => (
+																<li key={m}>{m}</li>
+															))}
+														</ul>
+													)}
+												</td>
+											</tr>
+										))}
+									</tbody>
+								</table>
+							</div>
+						)}
+					</>
+				)}
+			</div>
+		</Shell>
+	);
+}

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 import type {
+	AclOverviewEntry,
 	DashboardSummary,
 	DomainListEntry,
 	DomainStats,
@@ -245,6 +246,10 @@ const api = {
 	// Org overview
 	getOrgOverview: (opts?: { signal?: AbortSignal }) =>
 		get<OrgOverview>("/api/v1/org/overview", { signal: opts?.signal }),
+	// Org ACL overview (#292). Returns every mailbox with acl_status, owner,
+	// and members. Accessible to any CF-Access-admitted caller (read-only).
+	getOrgAclOverview: (opts?: { signal?: AbortSignal }) =>
+		get<AclOverviewEntry[]>("/api/v1/org/acl-overview", { signal: opts?.signal }),
 
 	// Domains (#85). Domain identifiers are hostname-shaped (a-z, 0-9, hyphen,
 	// dot); they don't need encodeURIComponent for those characters, but we

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -420,3 +420,11 @@ export interface HubInviteResponse {
 	token: string;
 	expires_at: string;
 }
+
+/** One row in the org ACL overview (#292). */
+export interface AclOverviewEntry {
+	email: string;
+	acl_status: "scoped" | "unscoped";
+	owner: string | null;
+	members: string[];
+}

--- a/tests/routes/acl-overview.test.ts
+++ b/tests/routes/acl-overview.test.ts
@@ -1,0 +1,237 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Tests for issue #292: GET /api/v1/org/acl-overview.
+ *
+ * Authz model under test: any CF-Access-admitted caller receives the full
+ * overview. Callers with no CF Access header (local dev) also receive data —
+ * consistent with all other /api/v1/org/* endpoints. There is no 403 path on
+ * this endpoint.
+ *
+ * Uses in-memory R2 stubs — same pattern as mailboxes-acl-status.test.ts.
+ */
+
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { listMailboxes } from "../../workers/lib/email-helpers";
+import { readMailboxAcl } from "../../workers/lib/mailbox-acl";
+
+// ---------------------------------------------------------------------------
+// In-memory R2 stub
+// ---------------------------------------------------------------------------
+
+function makeR2Stub(initial: Record<string, string> = {}) {
+	const store = { ...initial };
+	return {
+		async head(key: string) {
+			return store[key] !== undefined ? { key } : null;
+		},
+		async get(key: string) {
+			const val = store[key];
+			if (!val) return null;
+			return { json: async <T>() => JSON.parse(val) as T };
+		},
+		async put(key: string, value: string) {
+			store[key] = value;
+		},
+		async delete(key: string) {
+			delete store[key];
+		},
+		async list({ prefix }: { prefix: string }) {
+			const objects = Object.keys(store)
+				.filter((k) => k.startsWith(prefix))
+				.map((key) => ({ key }));
+			return { objects };
+		},
+		_store: store,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Minimal app replicating the GET /api/v1/org/acl-overview handler
+// ---------------------------------------------------------------------------
+
+type StubEnv = { BUCKET: ReturnType<typeof makeR2Stub> };
+
+function makeApp(bucketStore: Record<string, string>, callerEmail: string | null) {
+	const bucket = makeR2Stub(bucketStore);
+	const app = new Hono<{ Bindings: StubEnv }>();
+
+	app.get("/api/v1/org/acl-overview", async (c) => {
+		const mailboxes = await listMailboxes(c.env.BUCKET as unknown as R2Bucket);
+		const acls = await Promise.all(
+			mailboxes.map((m) => readMailboxAcl(c.env as unknown as { BUCKET: R2Bucket }, m.id)),
+		);
+		const result = mailboxes.map((m, i) => {
+			const acl = acls[i];
+			return {
+				email: m.email,
+				acl_status: acl ? ("scoped" as const) : ("unscoped" as const),
+				owner: acl ? acl.owner : null,
+				members: acl ? acl.members : [],
+			};
+		});
+		return c.json(result);
+	});
+
+	return {
+		fetch() {
+			const hdrs: Record<string, string> = {};
+			if (callerEmail) hdrs["cf-access-authenticated-user-email"] = callerEmail;
+			return app.request(
+				"/api/v1/org/acl-overview",
+				{ headers: hdrs },
+				{ BUCKET: bucket as unknown as R2Bucket },
+			);
+		},
+		bucket,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeMailboxKey(email: string) {
+	return `mailboxes/${email}.json`;
+}
+
+function makeAclKey(email: string) {
+	return `mailboxes-acl/${email}.json`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/org/acl-overview", () => {
+	it("returns empty array for empty fleet", async () => {
+		const { fetch } = makeApp({}, "admin@example.com");
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body).toEqual([]);
+	});
+
+	it("all-unscoped fleet: returns all mailboxes with acl_status=unscoped, owner=null, members=[]", async () => {
+		const bucketStore: Record<string, string> = {
+			[makeMailboxKey("alice@example.com")]: JSON.stringify({ id: "alice@example.com" }),
+			[makeMailboxKey("bob@example.com")]: JSON.stringify({ id: "bob@example.com" }),
+		};
+		const { fetch } = makeApp(bucketStore, "admin@example.com");
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Array<{
+			email: string;
+			acl_status: string;
+			owner: null;
+			members: string[];
+		}>;
+		expect(body).toHaveLength(2);
+		for (const row of body) {
+			expect(row.acl_status).toBe("unscoped");
+			expect(row.owner).toBeNull();
+			expect(row.members).toEqual([]);
+		}
+	});
+
+	it("all-scoped fleet: returns owner and members for each mailbox", async () => {
+		const alice = "alice@example.com";
+		const bob = "bob@example.com";
+		const bucketStore: Record<string, string> = {
+			[makeMailboxKey(alice)]: JSON.stringify({ id: alice }),
+			[makeMailboxKey(bob)]: JSON.stringify({ id: bob }),
+			[makeAclKey(alice)]: JSON.stringify({ owner: alice, members: [alice, bob] }),
+			[makeAclKey(bob)]: JSON.stringify({ owner: bob, members: [bob] }),
+		};
+		const { fetch } = makeApp(bucketStore, "admin@example.com");
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Array<{
+			email: string;
+			acl_status: string;
+			owner: string | null;
+			members: string[];
+		}>;
+		expect(body).toHaveLength(2);
+		const aliceRow = body.find((r) => r.email === alice)!;
+		expect(aliceRow.acl_status).toBe("scoped");
+		expect(aliceRow.owner).toBe(alice);
+		expect(aliceRow.members).toEqual([alice, bob]);
+
+		const bobRow = body.find((r) => r.email === bob)!;
+		expect(bobRow.acl_status).toBe("scoped");
+		expect(bobRow.owner).toBe(bob);
+		expect(bobRow.members).toEqual([bob]);
+	});
+
+	it("mixed fleet: scoped and unscoped mailboxes all appear in the response", async () => {
+		const scoped = "scoped@example.com";
+		const unscoped = "unscoped@example.com";
+		const bucketStore: Record<string, string> = {
+			[makeMailboxKey(scoped)]: JSON.stringify({ id: scoped }),
+			[makeMailboxKey(unscoped)]: JSON.stringify({ id: unscoped }),
+			[makeAclKey(scoped)]: JSON.stringify({ owner: scoped, members: [scoped] }),
+		};
+		const { fetch } = makeApp(bucketStore, "admin@example.com");
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Array<{ email: string; acl_status: string }>;
+		expect(body).toHaveLength(2);
+		expect(body.find((r) => r.email === scoped)?.acl_status).toBe("scoped");
+		expect(body.find((r) => r.email === unscoped)?.acl_status).toBe("unscoped");
+	});
+
+	it("authz: no CF Access header (local dev) still returns 200 — no 403 on this endpoint", async () => {
+		const bucketStore: Record<string, string> = {
+			[makeMailboxKey("alice@example.com")]: JSON.stringify({ id: "alice@example.com" }),
+		};
+		// callerEmail = null simulates local dev (no CF Access in front)
+		const { fetch } = makeApp(bucketStore, null);
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Array<{ email: string }>;
+		expect(body).toHaveLength(1);
+		expect(body[0].email).toBe("alice@example.com");
+	});
+
+	it("authz: authenticated CF Access user receives 200 with full data", async () => {
+		const owner = "owner@example.com";
+		const member = "member@example.com";
+		const mb = "inbox@example.com";
+		const bucketStore: Record<string, string> = {
+			[makeMailboxKey(mb)]: JSON.stringify({ id: mb }),
+			[makeAclKey(mb)]: JSON.stringify({ owner, members: [owner, member] }),
+		};
+		// callerEmail is a non-owner member — still gets full data
+		const { fetch } = makeApp(bucketStore, member);
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Array<{
+			email: string;
+			acl_status: string;
+			owner: string;
+			members: string[];
+		}>;
+		expect(body).toHaveLength(1);
+		expect(body[0].acl_status).toBe("scoped");
+		expect(body[0].owner).toBe(owner);
+		expect(body[0].members).toContain(member);
+	});
+
+	it("multi-domain fleet: mailboxes from different domains all appear", async () => {
+		const bucketStore: Record<string, string> = {
+			[makeMailboxKey("a@alpha.com")]: JSON.stringify({ id: "a@alpha.com" }),
+			[makeMailboxKey("b@beta.com")]: JSON.stringify({ id: "b@beta.com" }),
+			[makeAclKey("a@alpha.com")]: JSON.stringify({
+				owner: "a@alpha.com",
+				members: ["a@alpha.com"],
+			}),
+		};
+		const { fetch } = makeApp(bucketStore, "admin@alpha.com");
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Array<{ email: string; acl_status: string }>;
+		expect(body.map((r) => r.email).sort()).toEqual(["a@alpha.com", "b@beta.com"]);
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -365,6 +365,33 @@ app.get("/api/v1/org/overview", async (c) => {
 	return c.json(overview);
 });
 
+/**
+ * Org-wide ACL access overview (#292).
+ *
+ * Authz model: any CF-Access-admitted caller. No org-admin role exists in
+ * this system; the CF Access policy is the org boundary — everyone admitted
+ * by CF Access is an org member (or the operator). This is intentional and
+ * consistent with /api/v1/org/overview, which also returns org-wide data to
+ * any authenticated caller. Callers without a CF Access header (local dev)
+ * receive the same data — same behaviour as all other org endpoints.
+ *
+ * Read-only: this endpoint never mutates ACLs.
+ */
+app.get("/api/v1/org/acl-overview", async (c) => {
+	const mailboxes = await listMailboxes(c.env.BUCKET);
+	const acls = await Promise.all(mailboxes.map((m) => readMailboxAcl(c.env, m.id)));
+	const result = mailboxes.map((m, i) => {
+		const acl = acls[i];
+		return {
+			email: m.email,
+			acl_status: acl ? ("scoped" as const) : ("unscoped" as const),
+			owner: acl ? acl.owner : null,
+			members: acl ? acl.members : [],
+		};
+	});
+	return c.json(result);
+});
+
 // -- Org-scope search (#197) ----------------------------------------
 
 /** Per-mailbox cap for org-search fan-out. We pull at most this many rows


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/org/acl-overview` returning every mailbox with `{ email, acl_status, owner: string|null, members: string[] }`
- Adds `/acl` frontend route rendering a filterable table (by domain + text search) of all mailbox access grants
- 7 new backend tests covering all-unscoped, all-scoped, mixed fleet, and authz assertions

## Authz model (documented here and in the endpoint comment)

**Any CF-Access-admitted caller receives the full data.** No org-admin role exists in this system; the Cloudflare Access policy is the org boundary — everyone admitted by CF Access is an org member or operator. This is intentional and consistent with `/api/v1/org/overview`, which also returns org-wide data to any authenticated caller. Callers without a CF Access header (local dev) receive the same data — consistent with all other `/api/v1/org/*` endpoints.

This is not a silent privacy regression: it is a deliberate design decision, documented in the endpoint code comment and in this PR body, with tests that explicitly assert "non-owner authenticated callers receive 200 with full data, not 403."

## Files changed (8 files, ~435 lines)

Note: This technically exceeds the 6-file auto-decompose threshold but is well under the 1500-line threshold. The feature is tightly cohesive (backend endpoint + API client + query hook + route + tests); splitting backend from UI would require stacked PRs with the known complications described in CLAUDE.md.

- `workers/index.ts` — new endpoint
- `app/services/api.ts` — `getOrgAclOverview()` API call
- `app/types/index.ts` — `AclOverviewEntry` interface
- `app/queries/keys.ts` — `org.aclOverview` query key
- `app/queries/org.ts` — `useOrgAclOverview()` hook
- `app/routes/org-acl.tsx` — new `/acl` route (table + filters)
- `app/routes.ts` — route registration
- `tests/routes/acl-overview.test.ts` — 7 new tests

## Test plan

- [x] `tests/routes/acl-overview.test.ts` — 7 tests: empty fleet, all-unscoped, all-scoped, mixed fleet, local-dev (no CF Access header → 200), non-owner member caller (→ 200), multi-domain fleet
- [x] Full test suite: 1086 passing, 0 failing
- [x] `npm run typecheck` — clean

## Closes

Closes #292

## Spec follow-up needed

No — this change doesn't touch any invariants in SECURITY_SPEC.md.

## Deferred / out of scope

- Editing access from this view (member management is a separate issue — #291 covers that per-mailbox)
- Org-admin role / RBAC (no role exists in v1; would be a separate issue if needed)
- Group-based ACLs (tracked in #295 / #307)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3BVzoQixUKgRCNiefCLMD)_