### PR TITLE
fix(security): enforce send-risk gate on MCP toolSendReply and toolSendEmail

### DIFF
--- a/tests/lib/tools-send-risk.test.ts
+++ b/tests/lib/tools-send-risk.test.ts
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Send-risk gate on toolSendReply and toolSendEmail (issue #313).
+ *
+ * Acceptance criteria tested:
+ *   1. Tier 0 send (internal recipient) proceeds without a token.
+ *   2. Tier ≥ 1 send (external recipient) without token → confirmation_required error,
+ *      no env.EMAIL send, no SENT write.
+ *   3. Tier ≥ 1 send with invalid/expired token → rejected, no send.
+ *   4. Tier ≥ 1 send with valid token → send proceeds.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// ── Mock sendEmail so no real delivery happens ───────────────────────────────
+vi.mock("../../workers/email-sender", () => ({
+	sendEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ── Mock the AI verifyDraft to return the body unchanged ──────────────────────
+vi.mock("../../workers/lib/ai", async (orig) => {
+	const original = await orig<typeof import("../../workers/lib/ai")>();
+	return {
+		...original,
+		verifyDraft: vi.fn().mockImplementation((_ai: unknown, body: string) =>
+			Promise.resolve(body),
+		),
+	};
+});
+
+// ── Mock mailbox-settings (resolveMailboxSettings) to return defaults ─────────
+vi.mock("../../workers/lib/mailbox-settings", async (orig) => {
+	const original = await orig<typeof import("../../workers/lib/mailbox-settings")>();
+	return {
+		...original,
+		resolveMailboxSettings: vi.fn().mockResolvedValue({ draftVerifierModel: undefined }),
+	};
+});
+
+import { toolSendReply, toolSendEmail } from "../../workers/lib/tools";
+import { sendEmail } from "../../workers/email-sender";
+import {
+	signConfirmationToken,
+	computePayloadHash,
+} from "../../workers/lib/confirm-token";
+import type { Env } from "../../workers/types";
+import type { EmailFull } from "../../workers/lib/schemas";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const MAILBOX_ID = "operator@internal.example";
+const ORIGINAL_ID = "orig-email-1";
+const SECRET = "test-secret-at-least-32-chars-long-for-hs256!!";
+
+const originalEmail: EmailFull = {
+	id: ORIGINAL_ID,
+	subject: "Question",
+	sender: "asker@external.com",
+	recipient: MAILBOX_ID,
+	date: new Date().toISOString(),
+	body: "Hello?",
+	folder: "inbox",
+	read: false,
+	starred: false,
+	thread_id: ORIGINAL_ID,
+	message_id: "msg-orig",
+	in_reply_to: null,
+	email_references: null,
+	cc: null,
+	bcc: null,
+	raw_headers: null,
+};
+
+// ── KV stub for token replay-protection ──────────────────────────────────────
+
+function makeKv(initial: Record<string, string> = {}) {
+	const store: Record<string, string> = { ...initial };
+	return {
+		async get(key: string) {
+			return store[key] ?? null;
+		},
+		async put(key: string, value: string, _opts?: unknown) {
+			store[key] = value;
+		},
+		async delete(key: string) {
+			delete store[key];
+		},
+		_store: store,
+	} as unknown as KVNamespace;
+}
+
+// ── DO stub factory ───────────────────────────────────────────────────────────
+
+function makeStub(opts: { sendRateLimitError?: string | null } = {}) {
+	const sentEmails: unknown[] = [];
+	return {
+		async checkSendRateLimit() {
+			return opts.sendRateLimitError ?? null;
+		},
+		async getEmail(id: string) {
+			return id === ORIGINAL_ID ? originalEmail : null;
+		},
+		async createEmail(_folder: unknown, email: unknown) {
+			sentEmails.push(email);
+			return {};
+		},
+		_sentEmails: sentEmails,
+	};
+}
+
+// ── Env factory ───────────────────────────────────────────────────────────────
+
+function makeEnv(
+	stub: ReturnType<typeof makeStub>,
+	kv?: KVNamespace,
+): Env {
+	return {
+		CONFIRMATION_TOKEN_SECRET: SECRET,
+		BLOOM_KV: kv ?? makeKv(),
+		// The DO binding — getMailboxStub calls env.MAILBOX.idFromName()
+		// and .get(). We intercept by providing a minimal stub that always
+		// returns our pre-built stub.
+		MAILBOX: {
+			idFromName: () => "id",
+			get: () => stub,
+		},
+		// Minimal stubs for other bindings that tools.ts may touch.
+		BUCKET: { get: vi.fn(), put: vi.fn(), delete: vi.fn(), list: vi.fn() } as unknown as R2Bucket,
+		AI: {} as unknown as Ai,
+		EMAIL: {} as unknown as SendEmail,
+	} as unknown as Env;
+}
+
+// ── Helper: mint a valid confirmation token ───────────────────────────────────
+
+async function mintValidToken(
+	to: string,
+	subject: string,
+	body: string,
+	mailboxId: string,
+	kv: KVNamespace,
+): Promise<string> {
+	const jti = crypto.randomUUID();
+	const payloadHash = await computePayloadHash(to, subject, body, []);
+	const token = await signConfirmationToken(
+		{ tier: 1, mailboxId, payloadHash, jti },
+		SECRET,
+	);
+	// Pre-seed KV so the verify step finds the jti.
+	await kv.put(`confirm-jti:${jti}`, "1");
+	return token;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// toolSendReply tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("toolSendReply — send-risk gate", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("tier 0 (internal recipient): sends without a confirmation token", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolSendReply(env, MAILBOX_ID, {
+			originalEmailId: ORIGINAL_ID,
+			to: "colleague@internal.example", // same domain → tier 0
+			subject: "Re: Question",
+			bodyHtml: "<p>Sure!</p>",
+		});
+		expect(result).toMatchObject({ status: "sent" });
+		expect(sendEmail).toHaveBeenCalledOnce();
+		expect(stub._sentEmails).toHaveLength(1); // SENT row written
+	});
+
+	it("tier ≥ 1 (external recipient) without token: returns confirmation_required, no send", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolSendReply(env, MAILBOX_ID, {
+			originalEmailId: ORIGINAL_ID,
+			to: "vendor@external.com", // different domain → tier 1
+			subject: "Re: Question",
+			bodyHtml: "<p>Sure!</p>",
+		});
+		expect(result).toMatchObject({
+			error: "confirmation_required",
+			confirmation_required: true,
+		});
+		expect((result as { risk?: { tier: number } }).risk?.tier).toBeGreaterThanOrEqual(1);
+		expect(sendEmail).not.toHaveBeenCalled();
+		expect(stub._sentEmails).toHaveLength(0); // no SENT write
+	});
+
+	it("tier ≥ 1 with invalid/expired token: rejected, no send", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolSendReply(env, MAILBOX_ID, {
+			originalEmailId: ORIGINAL_ID,
+			to: "vendor@external.com",
+			subject: "Re: Question",
+			bodyHtml: "<p>Sure!</p>",
+			confirmationToken: "this.is.not.a.valid.jwt",
+		});
+		expect("error" in result).toBe(true);
+		expect((result as { error: string }).error).toMatch(/invalid|expired|confirmation/i);
+		expect(sendEmail).not.toHaveBeenCalled();
+		expect(stub._sentEmails).toHaveLength(0);
+	});
+
+	it("tier ≥ 1 with valid token: send proceeds", async () => {
+		const kv = makeKv();
+		const stub = makeStub();
+		const env = makeEnv(stub, kv);
+
+		const to = "vendor@external.com";
+		const subject = "Re: Question";
+		const body = "<p>Sure!</p>";
+		const token = await mintValidToken(to, subject, body, MAILBOX_ID, kv);
+
+		const result = await toolSendReply(env, MAILBOX_ID, {
+			originalEmailId: ORIGINAL_ID,
+			to,
+			subject,
+			bodyHtml: body,
+			confirmationToken: token,
+		});
+		expect(result).toMatchObject({ status: "sent" });
+		expect(sendEmail).toHaveBeenCalledOnce();
+		expect(stub._sentEmails).toHaveLength(1);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// toolSendEmail tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("toolSendEmail — send-risk gate", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("tier 0 (internal recipient): sends without a confirmation token", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to: "colleague@internal.example", // same domain → tier 0
+			subject: "Hello",
+			bodyHtml: "<p>Hi there</p>",
+		});
+		expect(result).toMatchObject({ status: "sent" });
+		expect(sendEmail).toHaveBeenCalledOnce();
+		expect(stub._sentEmails).toHaveLength(1);
+	});
+
+	it("tier ≥ 1 (external recipient) without token: returns confirmation_required, no send", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to: "vendor@external.com",
+			subject: "Hello",
+			bodyHtml: "<p>Hi there</p>",
+		});
+		expect(result).toMatchObject({
+			error: "confirmation_required",
+			confirmation_required: true,
+		});
+		expect((result as { risk?: { tier: number } }).risk?.tier).toBeGreaterThanOrEqual(1);
+		expect(sendEmail).not.toHaveBeenCalled();
+		expect(stub._sentEmails).toHaveLength(0);
+	});
+
+	it("tier ≥ 1 with invalid/expired token: rejected, no send", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to: "vendor@external.com",
+			subject: "Hello",
+			bodyHtml: "<p>Hi there</p>",
+			confirmationToken: "bad.token.value",
+		});
+		expect("error" in result).toBe(true);
+		expect((result as { error: string }).error).toMatch(/invalid|expired|confirmation/i);
+		expect(sendEmail).not.toHaveBeenCalled();
+		expect(stub._sentEmails).toHaveLength(0);
+	});
+
+	it("tier ≥ 1 with valid token: send proceeds", async () => {
+		const kv = makeKv();
+		const stub = makeStub();
+		const env = makeEnv(stub, kv);
+
+		const to = "vendor@external.com";
+		const subject = "Hello";
+		const body = "<p>Hi there</p>";
+		const token = await mintValidToken(to, subject, body, MAILBOX_ID, kv);
+
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to,
+			subject,
+			bodyHtml: body,
+			confirmationToken: token,
+		});
+		expect(result).toMatchObject({ status: "sent" });
+		expect(sendEmail).toHaveBeenCalledOnce();
+		expect(stub._sentEmails).toHaveLength(1);
+	});
+
+	it("BEC keyword (tier 2) without token: returns confirmation_required", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to: "colleague@internal.example",
+			subject: "Urgent",
+			bodyHtml: "<p>Please wire transfer $10,000 immediately</p>",
+		});
+		expect(result).toMatchObject({
+			error: "confirmation_required",
+			confirmation_required: true,
+		});
+		expect((result as { risk?: { tier: number } }).risk?.tier).toBe(2);
+		expect(sendEmail).not.toHaveBeenCalled();
+	});
+});

--- a/workers/lib/tools.ts
+++ b/workers/lib/tools.ts
@@ -29,6 +29,7 @@ import {
 import { verifyDraft } from "./ai";
 import { resolveMailboxSettings } from "./mailbox-settings";
 import { sendEmail } from "../email-sender";
+import { enforceSendRiskConfirmation } from "./send-risk-gate";
 import { Folders } from "../../shared/folders";
 import type { Env } from "../types";
 
@@ -428,10 +429,12 @@ export async function toolSendReply(
 		to: string;
 		subject: string;
 		bodyHtml: string;
+		/** Optional step-up confirmation token required for tier ≥ 1 sends. */
+		confirmationToken?: string;
 	},
 ): Promise<
 	| { status: "sent"; messageId: string; message: string }
-	| { error: string }
+	| { error: string; confirmation_required?: true; risk?: { tier: number; reasons: string[] } }
 > {
 	const stub = getMailboxStub(env, mailboxId);
 
@@ -439,6 +442,25 @@ export async function toolSendReply(
 	const rateLimitError = await (stub as unknown as RateLimitStub).checkSendRateLimit();
 	if (rateLimitError) {
 		return { error: rateLimitError };
+	}
+
+	// Enforce send-risk step-up confirmation gate
+	const gate = await enforceSendRiskConfirmation(
+		env,
+		params.confirmationToken,
+		{
+			mailboxId,
+			to: params.to,
+			subject: params.subject,
+			body: params.bodyHtml,
+		},
+	);
+	if (!gate.ok) {
+		const body = gate.body;
+		if (body.error === "confirmation_required") {
+			return { error: body.error, confirmation_required: true, risk: body.risk };
+		}
+		return { error: body.error };
 	}
 
 	const originalEmail = (await stub.getEmail(params.originalEmailId)) as EmailFull | null;
@@ -516,10 +538,12 @@ export async function toolSendEmail(
 		subject: string;
 		bodyHtml: string;
 		attachments?: ToolAttachment[];
+		/** Optional step-up confirmation token required for tier ≥ 1 sends. */
+		confirmationToken?: string;
 	},
 ): Promise<
 	| { status: "sent"; messageId: string; message: string }
-	| { error: string }
+	| { error: string; confirmation_required?: true; risk?: { tier: number; reasons: string[] } }
 > {
 	const stub = getMailboxStub(env, mailboxId);
 
@@ -527,6 +551,26 @@ export async function toolSendEmail(
 	const rateLimitError = await (stub as unknown as RateLimitStub).checkSendRateLimit();
 	if (rateLimitError) {
 		return { error: rateLimitError };
+	}
+
+	// Enforce send-risk step-up confirmation gate
+	const gate = await enforceSendRiskConfirmation(
+		env,
+		params.confirmationToken,
+		{
+			mailboxId,
+			to: params.to,
+			subject: params.subject,
+			body: params.bodyHtml,
+			attachments: params.attachments?.map((a) => ({ filename: a.filename })),
+		},
+	);
+	if (!gate.ok) {
+		const body = gate.body;
+		if (body.error === "confirmation_required") {
+			return { error: body.error, confirmation_required: true, risk: body.risk };
+		}
+		return { error: body.error };
 	}
 
 	const fromDomain = mailboxId.split("@")[1];

--- a/workers/mcp/index.ts
+++ b/workers/mcp/index.ts
@@ -347,8 +347,12 @@ export class EmailMCP extends McpAgent<Env> {
 				to: z.string().email().describe("Recipient email address"),
 				subject: z.string().describe("Subject line"),
 				bodyHtml: z.string().describe("The HTML body of the reply"),
+				confirmationToken: z
+					.string()
+					.optional()
+					.describe("Step-up confirmation token required for tier ≥ 1 sends (external recipients, BEC keywords, etc.)"),
 			},
-			async ({ mailboxId, originalEmailId, to, subject, bodyHtml }) => {
+			async ({ mailboxId, originalEmailId, to, subject, bodyHtml, confirmationToken }) => {
 				const denied = await verifyMailbox(mailboxId);
 				if (denied) return denied;
 				const result = await toolSendReply(env, mailboxId, {
@@ -356,6 +360,7 @@ export class EmailMCP extends McpAgent<Env> {
 					to,
 					subject,
 					bodyHtml,
+					confirmationToken,
 				});
 				if ("error" in result) {
 					// Preserve the original MCP error format for send failures
@@ -400,8 +405,12 @@ export class EmailMCP extends McpAgent<Env> {
 					)
 					.optional()
 					.describe("Optional file attachments"),
+				confirmationToken: z
+					.string()
+					.optional()
+					.describe("Step-up confirmation token required for tier ≥ 1 sends (external recipients, BEC keywords, etc.)"),
 			},
-			async ({ mailboxId, to, subject, bodyHtml, attachments }) => {
+			async ({ mailboxId, to, subject, bodyHtml, attachments, confirmationToken }) => {
 				const denied = await verifyMailbox(mailboxId);
 				if (denied) return denied;
 				const result = await toolSendEmail(env, mailboxId, {
@@ -409,6 +418,7 @@ export class EmailMCP extends McpAgent<Env> {
 					subject,
 					bodyHtml,
 					...(attachments && attachments.length > 0 ? { attachments } : {}),
+					confirmationToken,
 				});
 				if ("error" in result) {
 					if (typeof result.error === "string" && result.error.startsWith("Failed to send")) {


### PR DESCRIPTION
## Summary

- Wire `enforceSendRiskConfirmation()` into `toolSendReply` and `toolSendEmail` in `workers/lib/tools.ts` so MCP agent-driven sends go through the same step-up confirmation that PR #312 enforced for the HTTP routes.
- Add optional `confirmationToken?: string` parameter to both tool functions and plumb it through the MCP server call sites in `workers/mcp/index.ts` (lines 354 and 407).
- On `ok: false` from the gate, each tool returns a structured `{ error, confirmation_required, risk }` object — no `env.EMAIL` send and no `Folders.SENT` write occurs.

**MCP tool surface decision: option (a)** — added optional `confirmationToken` parameter so agents that have obtained a step-up token can pass it through. This matches the HTTP surface (`x-confirmation-token` header) and allows automated agents to complete tier ≥ 1 sends after obtaining a token via `/api/v1/confirm`.

Closes #313

## Test plan

- [ ] `tests/lib/tools-send-risk.test.ts` — new file mirroring `tests/routes/reply-forward-send-risk.test.ts` shape:
  - `toolSendReply` tier 0 (internal recipient): sends without token ✓
  - `toolSendReply` tier ≥ 1 (external recipient) without token: returns `confirmation_required`, no send, no SENT write ✓
  - `toolSendReply` tier ≥ 1 with invalid/expired token: rejected, no send ✓
  - `toolSendReply` tier ≥ 1 with valid token: send proceeds ✓
  - `toolSendEmail` tier 0: sends without token ✓
  - `toolSendEmail` tier ≥ 1 without token: `confirmation_required` ✓
  - `toolSendEmail` tier ≥ 1 with invalid token: rejected ✓
  - `toolSendEmail` tier ≥ 1 with valid token: send proceeds ✓
  - `toolSendEmail` BEC keyword (tier 2) without token: `confirmation_required` with tier=2 ✓
- [ ] `npm test`: 88 files, 1138 tests — all passing, no regression in `tests/routes/send-email.test.ts` or `tests/routes/reply-forward-send-risk.test.ts`
- [ ] `npm run typecheck`: no errors

https://claude.ai/code/session_01HNtim6at93qANhpSLgq8pQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNtim6at93qANhpSLgq8pQ)_