### PR TITLE
fix(security): enforce send-risk gate on MCP toolSendReply and toolSendEmail

### DIFF
--- a/tests/mcp/mcp-send-risk.test.ts
+++ b/tests/mcp/mcp-send-risk.test.ts
@@ -1,0 +1,289 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Send-risk gate on MCP toolSendReply and toolSendEmail — regression for
+ * bypass where MCP tool sends could proceed without step-up confirmation
+ * even for tier ≥ 1 payloads (issue #313).
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// ── module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("../../workers/email-sender", () => ({
+	sendEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+// resolveMailboxSettings reads R2/DO — return minimal settings.
+vi.mock("../../workers/lib/mailbox-settings", () => ({
+	resolveMailboxSettings: vi.fn().mockResolvedValue({ draftVerifierModel: undefined }),
+}));
+
+// verifyDraft calls the AI binding — return the body unchanged.
+vi.mock("../../workers/lib/ai", () => ({
+	verifyDraft: vi.fn().mockImplementation((_ai: unknown, body: string) =>
+		Promise.resolve(body),
+	),
+}));
+
+// getMailboxStub returns a DO stub — return a fake one.
+vi.mock("../../workers/lib/email-helpers", async (orig) => {
+	const original = await orig<typeof import("../../workers/lib/email-helpers")>();
+	return {
+		...original,
+		getMailboxStub: vi.fn(() => fakeStub),
+	};
+});
+
+import { toolSendReply, toolSendEmail } from "../../workers/lib/tools";
+import {
+	signConfirmationToken,
+	computePayloadHash,
+} from "../../workers/lib/confirm-token";
+import type { Env } from "../../workers/types";
+
+// ── shared constants ──────────────────────────────────────────────────────────
+
+const MAILBOX_ID = "operator@internal.example";
+const ORIGINAL_ID = "orig-email-1";
+const SECRET = "test-secret-at-least-32-chars-long-for-hs256!!";
+
+// ── fake DO stub ──────────────────────────────────────────────────────────────
+
+const fakeStub = {
+	async checkSendRateLimit() {
+		return null;
+	},
+	async getEmail(id: string) {
+		if (id !== ORIGINAL_ID) return null;
+		return {
+			id: ORIGINAL_ID,
+			subject: "Question",
+			sender: "asker@external.com",
+			recipient: MAILBOX_ID,
+			date: new Date().toISOString(),
+			body: "Hello?",
+			folder: "inbox",
+			read: false,
+			starred: false,
+			thread_id: ORIGINAL_ID,
+			message_id: "msg-orig",
+			in_reply_to: null,
+			email_references: null,
+			cc: null,
+			bcc: null,
+			raw_headers: null,
+		};
+	},
+	async createEmail() {
+		return {};
+	},
+};
+
+// ── fake KV ───────────────────────────────────────────────────────────────────
+
+function makeKv(initial: Record<string, string> = {}) {
+	const store: Record<string, string> = { ...initial };
+	return {
+		async get(key: string) {
+			return store[key] ?? null;
+		},
+		async put(key: string, value: string) {
+			store[key] = value;
+		},
+		async delete(key: string) {
+			delete store[key];
+		},
+	} as unknown as KVNamespace;
+}
+
+// ── env factory ───────────────────────────────────────────────────────────────
+
+function makeEnv(overrides: Partial<Record<string, unknown>> = {}): Env {
+	return {
+		BLOOM_KV: makeKv(),
+		...overrides,
+	} as unknown as Env;
+}
+
+// ── token helper ──────────────────────────────────────────────────────────────
+
+async function makeValidToken(
+	to: string,
+	subject: string,
+	body: string,
+	kv: KVNamespace,
+): Promise<string> {
+	const payloadHash = await computePayloadHash(to, subject, body, []);
+	const jti = crypto.randomUUID();
+	// Pre-populate KV so verifyConfirmationToken finds the jti.
+	await kv.put(`confirm-jti:${jti}`, "1");
+	return signConfirmationToken(
+		{ tier: 2, mailboxId: MAILBOX_ID, payloadHash, jti },
+		SECRET,
+	);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// toolSendReply
+// ─────────────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("toolSendReply — send-risk gate", () => {
+	it("tier 0 (internal recipient) sends without a token", async () => {
+		const env = makeEnv();
+		const result = await toolSendReply(env, MAILBOX_ID, {
+			originalEmailId: ORIGINAL_ID,
+			to: "colleague@internal.example",
+			subject: "Re: Question",
+			bodyHtml: "<p>Sure!</p>",
+		});
+		expect("error" in result).toBe(false);
+		expect((result as { status: string }).status).toBe("sent");
+	});
+
+	it("tier ≥ 1 (external recipient) without token returns confirmation_required", async () => {
+		const env = makeEnv();
+		const result = await toolSendReply(env, MAILBOX_ID, {
+			originalEmailId: ORIGINAL_ID,
+			to: "vendor@external.com",
+			subject: "Re: Question",
+			bodyHtml: "<p>Sure!</p>",
+		});
+		expect("error" in result).toBe(true);
+		const err = result as { error: string; risk: { tier: number } };
+		expect(err.error).toBe("confirmation_required");
+		expect(err.risk.tier).toBeGreaterThanOrEqual(1);
+	});
+
+	it("tier ≥ 1 with an invalid token returns invalid or expired", async () => {
+		const env = makeEnv({ CONFIRMATION_TOKEN_SECRET: SECRET });
+		const result = await toolSendReply(env, MAILBOX_ID, {
+			originalEmailId: ORIGINAL_ID,
+			to: "vendor@external.com",
+			subject: "Re: Question",
+			bodyHtml: "<p>Sure!</p>",
+			confirmationToken: "not.a.valid.jwt",
+		});
+		expect("error" in result).toBe(true);
+		expect((result as { error: string }).error).toBe(
+			"invalid or expired confirmation token",
+		);
+	});
+
+	it("tier ≥ 1 with a valid token sends successfully", async () => {
+		const kv = makeKv();
+		const env = makeEnv({ CONFIRMATION_TOKEN_SECRET: SECRET, BLOOM_KV: kv });
+		const to = "vendor@external.com";
+		const subject = "Re: Question";
+		const bodyHtml = "<p>Sure!</p>";
+		const token = await makeValidToken(to, subject, bodyHtml, kv);
+
+		const result = await toolSendReply(env, MAILBOX_ID, {
+			originalEmailId: ORIGINAL_ID,
+			to,
+			subject,
+			bodyHtml,
+			confirmationToken: token,
+		});
+		expect("error" in result).toBe(false);
+		expect((result as { status: string }).status).toBe("sent");
+	});
+
+	it("does not write to SENT or call sendEmail when gate rejects", async () => {
+		const { sendEmail } = await import("../../workers/email-sender");
+		const env = makeEnv();
+		await toolSendReply(env, MAILBOX_ID, {
+			originalEmailId: ORIGINAL_ID,
+			to: "vendor@external.com",
+			subject: "Re: Question",
+			bodyHtml: "<p>Wire me funds</p>",
+		});
+		expect(sendEmail).not.toHaveBeenCalled();
+		// fakeStub.createEmail would be called on a SENT write; verify it was not.
+		const createCalls: unknown[] = [];
+		const origCreate = fakeStub.createEmail;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(fakeStub as any).createEmail = async (...args: unknown[]) => {
+			createCalls.push(args);
+			return origCreate.apply(fakeStub);
+		};
+		expect(createCalls).toHaveLength(0);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// toolSendEmail
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("toolSendEmail — send-risk gate", () => {
+	it("tier 0 (internal recipient) sends without a token", async () => {
+		const env = makeEnv();
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to: "colleague@internal.example",
+			subject: "Hello",
+			bodyHtml: "<p>How are you?</p>",
+		});
+		expect("error" in result).toBe(false);
+		expect((result as { status: string }).status).toBe("sent");
+	});
+
+	it("tier ≥ 1 (external recipient) without token returns confirmation_required", async () => {
+		const env = makeEnv();
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to: "vendor@external.com",
+			subject: "Hello",
+			bodyHtml: "<p>How are you?</p>",
+		});
+		expect("error" in result).toBe(true);
+		const err = result as { error: string; risk: { tier: number } };
+		expect(err.error).toBe("confirmation_required");
+		expect(err.risk.tier).toBeGreaterThanOrEqual(1);
+	});
+
+	it("tier ≥ 1 with an invalid token returns invalid or expired", async () => {
+		const env = makeEnv({ CONFIRMATION_TOKEN_SECRET: SECRET });
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to: "vendor@external.com",
+			subject: "Hello",
+			bodyHtml: "<p>How are you?</p>",
+			confirmationToken: "not.a.valid.jwt",
+		});
+		expect("error" in result).toBe(true);
+		expect((result as { error: string }).error).toBe(
+			"invalid or expired confirmation token",
+		);
+	});
+
+	it("tier ≥ 1 with a valid token sends successfully", async () => {
+		const kv = makeKv();
+		const env = makeEnv({ CONFIRMATION_TOKEN_SECRET: SECRET, BLOOM_KV: kv });
+		const to = "vendor@external.com";
+		const subject = "Hello";
+		const bodyHtml = "<p>How are you?</p>";
+		const token = await makeValidToken(to, subject, bodyHtml, kv);
+
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to,
+			subject,
+			bodyHtml,
+			confirmationToken: token,
+		});
+		expect("error" in result).toBe(false);
+		expect((result as { status: string }).status).toBe("sent");
+	});
+
+	it("does not call sendEmail when gate rejects", async () => {
+		const { sendEmail } = await import("../../workers/email-sender");
+		const env = makeEnv();
+		await toolSendEmail(env, MAILBOX_ID, {
+			to: "vendor@external.com",
+			subject: "Hello",
+			bodyHtml: "<p>How are you?</p>",
+		});
+		expect(sendEmail).not.toHaveBeenCalled();
+	});
+});

--- a/workers/lib/send-risk-gate.ts
+++ b/workers/lib/send-risk-gate.ts
@@ -12,6 +12,8 @@ export type SendRiskGateInput = {
 	subject: string;
 	body: string;
 	attachments?: Array<{ filename?: string | null }>;
+	/** Passed through to classifySend for the agent-authored tier bump (#266). */
+	createdBy?: "agent" | "user";
 };
 
 type GateEnv = Pick<Env, "CONFIRMATION_TOKEN_SECRET" | "BLOOM_KV">;
@@ -37,6 +39,7 @@ export async function enforceSendRiskConfirmation(
 		body: input.body,
 		attachments: input.attachments,
 		mailboxId: input.mailboxId,
+		createdBy: input.createdBy,
 	});
 
 	if (risk.tier < 1) {

--- a/workers/lib/tools.ts
+++ b/workers/lib/tools.ts
@@ -29,6 +29,8 @@ import {
 import { verifyDraft } from "./ai";
 import { resolveMailboxSettings } from "./mailbox-settings";
 import { sendEmail } from "../email-sender";
+import { enforceSendRiskConfirmation } from "./send-risk-gate";
+import type { SendRisk } from "../security/send-risk";
 import { Folders } from "../../shared/folders";
 import type { Env } from "../types";
 
@@ -428,11 +430,21 @@ export async function toolSendReply(
 		to: string;
 		subject: string;
 		bodyHtml: string;
+		confirmationToken?: string;
 	},
 ): Promise<
 	| { status: "sent"; messageId: string; message: string }
-	| { error: string }
+	| { error: string; risk?: SendRisk }
 > {
+	const gate = await enforceSendRiskConfirmation(env, params.confirmationToken, {
+		mailboxId,
+		to: params.to,
+		subject: params.subject,
+		body: params.bodyHtml,
+		createdBy: "agent",
+	});
+	if (!gate.ok) return gate.body;
+
 	const stub = getMailboxStub(env, mailboxId);
 
 	// Check send rate limit
@@ -516,11 +528,22 @@ export async function toolSendEmail(
 		subject: string;
 		bodyHtml: string;
 		attachments?: ToolAttachment[];
+		confirmationToken?: string;
 	},
 ): Promise<
 	| { status: "sent"; messageId: string; message: string }
-	| { error: string }
+	| { error: string; risk?: SendRisk }
 > {
+	const gate = await enforceSendRiskConfirmation(env, params.confirmationToken, {
+		mailboxId,
+		to: params.to,
+		subject: params.subject,
+		body: params.bodyHtml,
+		attachments: params.attachments?.map((a) => ({ filename: a.filename })),
+		createdBy: "agent",
+	});
+	if (!gate.ok) return gate.body;
+
 	const stub = getMailboxStub(env, mailboxId);
 
 	// Check send rate limit

--- a/workers/mcp/index.ts
+++ b/workers/mcp/index.ts
@@ -347,8 +347,12 @@ export class EmailMCP extends McpAgent<Env> {
 				to: z.string().email().describe("Recipient email address"),
 				subject: z.string().describe("Subject line"),
 				bodyHtml: z.string().describe("The HTML body of the reply"),
+				confirmationToken: z
+					.string()
+					.optional()
+					.describe("Step-up confirmation token required for tier ≥ 1 sends (external recipients, BEC keywords, etc.)"),
 			},
-			async ({ mailboxId, originalEmailId, to, subject, bodyHtml }) => {
+			async ({ mailboxId, originalEmailId, to, subject, bodyHtml, confirmationToken }) => {
 				const denied = await verifyMailbox(mailboxId);
 				if (denied) return denied;
 				const result = await toolSendReply(env, mailboxId, {
@@ -356,6 +360,7 @@ export class EmailMCP extends McpAgent<Env> {
 					to,
 					subject,
 					bodyHtml,
+					confirmationToken,
 				});
 				if ("error" in result) {
 					// Preserve the original MCP error format for send failures
@@ -400,8 +405,12 @@ export class EmailMCP extends McpAgent<Env> {
 					)
 					.optional()
 					.describe("Optional file attachments"),
+				confirmationToken: z
+					.string()
+					.optional()
+					.describe("Step-up confirmation token required for tier ≥ 1 sends (external recipients, BEC keywords, etc.)"),
 			},
-			async ({ mailboxId, to, subject, bodyHtml, attachments }) => {
+			async ({ mailboxId, to, subject, bodyHtml, attachments, confirmationToken }) => {
 				const denied = await verifyMailbox(mailboxId);
 				if (denied) return denied;
 				const result = await toolSendEmail(env, mailboxId, {
@@ -409,6 +418,7 @@ export class EmailMCP extends McpAgent<Env> {
 					subject,
 					bodyHtml,
 					...(attachments && attachments.length > 0 ? { attachments } : {}),
+					confirmationToken,
 				});
 				if ("error" in result) {
 					if (typeof result.error === "string" && result.error.startsWith("Failed to send")) {


### PR DESCRIPTION
## Summary

- Wires `enforceSendRiskConfirmation()` into `toolSendReply` and `toolSendEmail` in `workers/lib/tools.ts` as the first check, blocking tier ≥ 1 sends without a valid step-up token — matching the protection PR #312 added to the REST reply/forward/email routes.
- Adds optional `confirmationToken` parameter to both tool functions and to the MCP `send_reply` / `send_email` tool schemas (option a from the issue: agents that have already obtained a token can pass it through).
- Passes `createdBy: "agent"` so the tier bump from #266 applies: external-recipient sends from the MCP surface now classify as tier 2 (not tier 1), requiring full step-up confirmation.
- Extends `SendRiskGateInput` with `createdBy?: "agent" | "user"` so the bump threads correctly through `classifySend`.

Closes #313

## Test plan

- [x] `tests/mcp/mcp-send-risk.test.ts` — 10 new tests covering: tier 0 (internal) sends without a token, tier ≥ 1 rejection without token (`confirmation_required`), tier ≥ 1 rejection with invalid token, tier ≥ 1 success with valid token — for both `toolSendReply` and `toolSendEmail`, plus `sendEmail` is not called when the gate rejects.
- [x] No regression in `tests/routes/send-email.test.ts` (6 tests pass)
- [x] No regression in `tests/routes/reply-forward-send-risk.test.ts` (3 tests pass)
- [x] Full suite: **1139 passing, 0 failing**
- [x] `npm run typecheck` clean

## Acceptance deferred

None — all acceptance criteria from issue #313 are shipped in this PR.

## Spec follow-up

No SECURITY_SPEC.md edits needed — this is enforcement of an existing rule, not a narrowing of one.

https://claude.ai/code/session_01TVvztd7gRuKwyo8rCf1ny4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVvztd7gRuKwyo8rCf1ny4)_