### PR TITLE
feat: DNSSEC posture lookup on /domains/:domain (#324)

### DIFF
--- a/app/routes/domain-detail.tsx
+++ b/app/routes/domain-detail.tsx
@@ -12,6 +12,7 @@ import Shell from "~/components/phishsoc/Shell";
 import { useDomainStats, useRufRecords } from "~/queries/domains";
 import type {
 	DmarcRufRecord,
+	DnssecPosture,
 	DomainStats,
 	OrgVerdictMix,
 } from "~/types";
@@ -107,6 +108,7 @@ function DomainBody({ data, rufData }: { data: DomainStats; rufData: import("~/q
 			<div className="grid gap-4 lg:grid-cols-3">
 				<TlsRptPostureCard posture={data.tlsRptPosture} />
 				<DkimPostureCard posture={data.dkimPosture} />
+				<DnssecPostureCard posture={data.dnssec} />
 			</div>
 			<MailboxList mailboxes={data.mailboxes} />
 			{data.recentCases.length > 0 && <RecentCasesList cases={data.recentCases} />}
@@ -503,6 +505,28 @@ function RufFailuresTable({ records }: { records: DmarcRufRecord[] }) {
 					</tbody>
 				</table>
 			</div>
+		</div>
+	);
+}
+
+function DnssecPostureCard({ posture }: { posture: DnssecPosture }) {
+	let statusText: string;
+	if (!posture.signed) {
+		statusText = "not signed";
+	} else if (posture.hasDsAtParent) {
+		statusText = "signed (DS at parent)";
+	} else {
+		statusText = "signed (no DS at parent — broken chain)";
+	}
+	return (
+		<div className="pp-card p-5">
+			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-3 flex items-center gap-1.5">
+				<ShieldCheckIcon size={12} />
+				DNSSEC
+			</div>
+			<p className={`text-[12.5px] ${posture.signed ? "text-ink" : "text-ink-3"}`}>
+				{statusText}
+			</p>
 		</div>
 	);
 }

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -342,6 +342,14 @@ export interface DkimPosture {
 	}>;
 }
 
+/** DNSSEC posture (#324, part of #156).
+ * `{ signed: false }` — unsigned or lookup unavailable.
+ * `{ signed: true, hasDsAtParent: boolean }` — resolver AD-bit set;
+ * `hasDsAtParent` reflects whether a DS record exists at the parent zone. */
+export type DnssecPosture =
+	| { signed: false }
+	| { signed: true; hasDsAtParent: boolean };
+
 /** One row in the `/api/v1/domains` list. */
 export interface DomainListEntry {
 	domain: string;
@@ -373,6 +381,7 @@ export interface DomainStats {
 	spfPosture: SpfPosture;
 	tlsRptPosture: TlsRptPosture;
 	dkimPosture: DkimPosture;
+	dnssec: DnssecPosture;
 	recentCases: DashboardCase[];
 }
 

--- a/tests/dnssec/posture.test.ts
+++ b/tests/dnssec/posture.test.ts
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, expect, it } from "vitest";
+import {
+	emptyDnssecPosture,
+	fetchDnssecPosture,
+	type DnssecKv,
+} from "../../workers/dnssec/posture";
+
+function fakeKv(initial: Record<string, unknown> = {}): DnssecKv & {
+	store: Map<string, string>;
+} {
+	const store = new Map<string, string>();
+	for (const [k, v] of Object.entries(initial)) {
+		store.set(k, JSON.stringify(v));
+	}
+	return {
+		store,
+		async get(key: string, _type: "json") {
+			const raw = store.get(key);
+			return raw ? (JSON.parse(raw) as unknown) : null;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+	};
+}
+
+function adResponse(ad: boolean, answers: Array<{ type: number }> = []): Response {
+	return new Response(
+		JSON.stringify({
+			Status: 0,
+			AD: ad,
+			Answer: answers,
+		}),
+		{ status: 200, headers: { "content-type": "application/dns-json" } },
+	);
+}
+
+function dsResponse(dsRecords: number): Response {
+	const Answer = Array.from({ length: dsRecords }, (_, i) => ({
+		name: "example.com",
+		type: 43,
+		TTL: 3600,
+		data: `${257 + i} 13 2 abc123`,
+	}));
+	return new Response(
+		JSON.stringify({ Status: 0, AD: true, Answer }),
+		{ status: 200, headers: { "content-type": "application/dns-json" } },
+	);
+}
+
+describe("fetchDnssecPosture", () => {
+	it("AD=true with DS present → signed: true, hasDsAtParent: true", async () => {
+		// Hostname-based dispatch — substring matching on URLs is a CodeQL
+		// `js/incomplete-url-substring-sanitization` trip wire (repo CLAUDE.md).
+		let calls = 0;
+		const fetchImpl = async (url: string) => {
+			const u = new URL(url);
+			expect(u.hostname).toBe("cloudflare-dns.com");
+			expect(u.pathname).toBe("/dns-query");
+			calls += 1;
+			if (u.searchParams.get("type") === "A") {
+				expect(u.searchParams.get("name")).toBe("example.com");
+				expect(u.searchParams.get("cd")).toBe("0");
+				return adResponse(true);
+			}
+			if (u.searchParams.get("type") === "DS") {
+				expect(u.searchParams.get("name")).toBe("example.com");
+				return dsResponse(1);
+			}
+			throw new Error(`unexpected type: ${u.searchParams.get("type")}`);
+		};
+		const r = await fetchDnssecPosture("example.com", { fetchImpl });
+		expect(r).toEqual({ signed: true, hasDsAtParent: true });
+		expect(calls).toBe(2);
+	});
+
+	it("AD=true with DS absent → signed: true, hasDsAtParent: false", async () => {
+		const fetchImpl = async (url: string) => {
+			const u = new URL(url);
+			if (u.searchParams.get("type") === "A") return adResponse(true);
+			// No DS records in the Answer section.
+			return new Response(
+				JSON.stringify({ Status: 0, AD: true, Answer: [] }),
+				{ status: 200, headers: { "content-type": "application/dns-json" } },
+			);
+		};
+		const r = await fetchDnssecPosture("example.com", { fetchImpl });
+		expect(r).toEqual({ signed: true, hasDsAtParent: false });
+	});
+
+	it("AD=false (unsigned domain) → signed: false, no DS query", async () => {
+		let dsCalls = 0;
+		const fetchImpl = async (url: string) => {
+			const u = new URL(url);
+			if (u.searchParams.get("type") === "DS") dsCalls += 1;
+			return adResponse(false);
+		};
+		const r = await fetchDnssecPosture("unsigned.example.com", { fetchImpl });
+		expect(r).toEqual({ signed: false });
+		expect(r).toEqual(emptyDnssecPosture());
+		// Short-circuits after the A query — no DS lookup on unsigned domains.
+		expect(dsCalls).toBe(0);
+	});
+
+	it("DoH timeout on A query → signed: false", async () => {
+		const fetchImpl = async () => {
+			throw new Error("timeout");
+		};
+		const r = await fetchDnssecPosture("example.com", { fetchImpl });
+		expect(r).toEqual(emptyDnssecPosture());
+	});
+
+	it("DoH timeout on DS query when AD=true → signed: true, hasDsAtParent: false", async () => {
+		const fetchImpl = async (url: string) => {
+			const u = new URL(url);
+			if (u.searchParams.get("type") === "A") return adResponse(true);
+			throw new Error("timeout");
+		};
+		const r = await fetchDnssecPosture("example.com", { fetchImpl });
+		expect(r).toEqual({ signed: true, hasDsAtParent: false });
+	});
+
+	it("non-200 A query → signed: false", async () => {
+		const fetchImpl = async () =>
+			new Response("server error", { status: 503 });
+		const r = await fetchDnssecPosture("example.com", { fetchImpl });
+		expect(r).toEqual(emptyDnssecPosture());
+	});
+
+	it("reads from KV cache on hit", async () => {
+		const cached = { signed: true, hasDsAtParent: true };
+		const kv = fakeKv({ "dmarc-dnssec:v1:example.com": cached });
+		let httpCalls = 0;
+		const fetchImpl = async () => {
+			httpCalls += 1;
+			return adResponse(false);
+		};
+		const r = await fetchDnssecPosture("example.com", { fetchImpl, kv });
+		expect(httpCalls).toBe(0);
+		expect(r).toEqual(cached);
+	});
+
+	it("writes result to KV on cache miss", async () => {
+		const kv = fakeKv();
+		const fetchImpl = async (url: string) => {
+			const u = new URL(url);
+			if (u.searchParams.get("type") === "A") return adResponse(true);
+			return dsResponse(1);
+		};
+		await fetchDnssecPosture("example.com", { fetchImpl, kv });
+		// Allow the fire-and-forget put to settle.
+		await new Promise((r) => setTimeout(r, 0));
+		expect(kv.store.get("dmarc-dnssec:v1:example.com")).toBeDefined();
+		const stored = JSON.parse(kv.store.get("dmarc-dnssec:v1:example.com")!);
+		expect(stored).toEqual({ signed: true, hasDsAtParent: true });
+	});
+
+	it("queries the apex domain for both A and DS records", async () => {
+		const names: string[] = [];
+		const fetchImpl = async (url: string) => {
+			const u = new URL(url);
+			names.push(`${u.searchParams.get("type")}:${u.searchParams.get("name")}`);
+			if (u.searchParams.get("type") === "A") return adResponse(true);
+			return dsResponse(0);
+		};
+		await fetchDnssecPosture("acme.com", { fetchImpl });
+		expect(names).toContain("A:acme.com");
+		expect(names).toContain("DS:acme.com");
+	});
+
+	it("returns empty sentinel for empty domain string", async () => {
+		const fetchImpl = async () => adResponse(true);
+		expect(await fetchDnssecPosture("", { fetchImpl })).toEqual(
+			emptyDnssecPosture(),
+		);
+	});
+});

--- a/tests/frontend/domain-detail.test.tsx
+++ b/tests/frontend/domain-detail.test.tsx
@@ -92,6 +92,9 @@ const populated: DomainStats = {
 	dkimPosture: {
 		selectors: [],
 	},
+	dnssec: {
+		signed: false as const,
+	},
 	recentCases: [
 		{
 			id: "C1",

--- a/tests/frontend/shell-domain-nav.test.tsx
+++ b/tests/frontend/shell-domain-nav.test.tsx
@@ -86,6 +86,9 @@ const populated: DomainStats = {
 	dkimPosture: {
 		selectors: [],
 	},
+	dnssec: {
+		signed: false as const,
+	},
 	recentCases: [],
 };
 

--- a/workers/dnssec/posture.ts
+++ b/workers/dnssec/posture.ts
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * DNSSEC posture lookup.
+ *
+ * Resolves whether a domain is DNSSEC-signed by trusting the upstream
+ * resolver's AD (Authenticated Data) bit on a standard A-record query.
+ * No local chain walking — posture only, per issue #324 constraints.
+ *
+ * Two DoH queries per cache miss:
+ *   1. A-record at apex with cd=0 → read the AD bit.
+ *   2. DS-record at apex → check whether a delegation-signer record
+ *      exists at the parent zone (type=43).
+ *
+ * Mirrors the DoH + KV + 1500ms-cap pattern from `workers/dmarc/bimi.ts`
+ * verbatim: same resolver host, same AbortSignal.timeout cap, same
+ * fire-and-forget KV write, same empty-sentinel on any failure path.
+ *
+ * SECURITY_SPEC.md Rule 5: any failure (timeout, NXDOMAIN, SERVFAIL,
+ * non-200) returns `emptyDnssecPosture()` and never throws.
+ *
+ * Issue: #324 (part of #156).
+ */
+
+/**
+ * DNSSEC posture returned by `fetchDnssecPosture`.
+ *
+ * `{ signed: false }` — resolver did not set AD=true on the apex A query,
+ * or any lookup failed. Covers unsigned domains, NXDOMAIN, timeout, etc.
+ *
+ * `{ signed: true, hasDsAtParent: boolean }` — resolver confirmed DNSSEC
+ * validation (AD=true). `hasDsAtParent` is true when a DS record (type=43)
+ * exists at the apex label in the parent zone, false when the DS query
+ * returned no DS records (broken chain or DS query failure).
+ */
+export type DnssecPosture =
+	| { signed: false }
+	| { signed: true; hasDsAtParent: boolean };
+
+/** Sentinel returned when DNSSEC is not configured or any failure occurred. */
+export function emptyDnssecPosture(): DnssecPosture {
+	return { signed: false };
+}
+
+const KV_PREFIX = "dmarc-dnssec:v1:";
+/** 1h TTL — matches the apex-DMARC KV TTL and the BIMI/TLS-RPT pattern. */
+const KV_TTL_S = 60 * 60;
+/** DoH resolver host. Hostname-based mock matching is required by repo CLAUDE.md. */
+const DOH_HOST = "cloudflare-dns.com";
+const DOH_URL = `https://${DOH_HOST}/dns-query`;
+/** Hard-cap the upstream — slow lookup must not block dashboard rendering.
+ * Matches the 1500ms cap in `workers/dmarc/bimi.ts`. */
+const DOH_TIMEOUT_MS = 1500;
+
+/** Minimal `KVNamespace` view we depend on; lets tests pass a fake. */
+export interface DnssecKv {
+	get(key: string, type: "json"): Promise<unknown>;
+	put(
+		key: string,
+		value: string,
+		options?: { expirationTtl?: number },
+	): Promise<void>;
+}
+
+/** Minimal `fetch` view we depend on; lets tests inject a stub. */
+export type DnssecFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Fetch and parse the DNSSEC posture for `<domain>`, with KV caching.
+ *
+ * Two sequential DoH queries on cache miss: an A-record query to read the
+ * resolver's AD bit, then a DS-record query to confirm the delegation signer.
+ * Any failure at either step degrades gracefully — see type docs above.
+ *
+ * Per SECURITY_SPEC.md Rule 5, no error is ever thrown.
+ */
+export async function fetchDnssecPosture(
+	domain: string,
+	options: {
+		kv?: DnssecKv | null;
+		fetchImpl?: DnssecFetch;
+	} = {},
+): Promise<DnssecPosture> {
+	if (!domain || typeof domain !== "string") return emptyDnssecPosture();
+	const fetchImpl = options.fetchImpl ?? (globalThis.fetch as DnssecFetch);
+	const kv = options.kv ?? null;
+	const cacheKey = `${KV_PREFIX}${domain}`;
+
+	if (kv) {
+		try {
+			const cached = (await kv.get(cacheKey, "json")) as DnssecPosture | null;
+			if (cached && typeof cached === "object" && "signed" in cached) {
+				if (cached.signed === false) return { signed: false };
+				if (cached.signed === true) {
+					const hasDsAtParent =
+						typeof (cached as { signed: true; hasDsAtParent?: unknown })
+							.hasDsAtParent === "boolean"
+							? (cached as { signed: true; hasDsAtParent: boolean }).hasDsAtParent
+							: false;
+					return { signed: true, hasDsAtParent };
+				}
+			}
+		} catch {
+			// KV read failure is non-fatal; fall through to DoH.
+		}
+	}
+
+	const posture = await resolveDnssecPosture(domain, fetchImpl);
+
+	if (kv) {
+		// Fire-and-forget — matches the bimi.ts pattern.
+		void kv
+			.put(cacheKey, JSON.stringify(posture), { expirationTtl: KV_TTL_S })
+			.catch(() => {});
+	}
+
+	return posture;
+}
+
+async function resolveDnssecPosture(
+	domain: string,
+	fetchImpl: DnssecFetch,
+): Promise<DnssecPosture> {
+	// Step 1: A-record query at apex with cd=0 (DNSSEC checking enabled by
+	// default; cd=0 is explicit for clarity). Read the AD bit from the response.
+	let adRes: Response;
+	try {
+		adRes = await fetchImpl(
+			`${DOH_URL}?name=${encodeURIComponent(domain)}&type=A&cd=0`,
+			{
+				headers: { accept: "application/dns-json" },
+				signal: AbortSignal.timeout(DOH_TIMEOUT_MS),
+			},
+		);
+	} catch {
+		// Timeout or network error → not-signed sentinel (Rule 5).
+		return emptyDnssecPosture();
+	}
+	if (!adRes.ok) return emptyDnssecPosture();
+
+	let adBody: unknown;
+	try {
+		adBody = await adRes.json();
+	} catch {
+		return emptyDnssecPosture();
+	}
+
+	const adBit = (adBody as { AD?: boolean }).AD === true;
+	if (!adBit) return { signed: false };
+
+	// Step 2: DS-record query to check for a delegation signer at the parent.
+	// Failure here degrades to hasDsAtParent=false — we know the domain is
+	// signed but can't confirm the parent delegation.
+	let dsRes: Response;
+	try {
+		dsRes = await fetchImpl(
+			`${DOH_URL}?name=${encodeURIComponent(domain)}&type=DS`,
+			{
+				headers: { accept: "application/dns-json" },
+				signal: AbortSignal.timeout(DOH_TIMEOUT_MS),
+			},
+		);
+	} catch {
+		return { signed: true, hasDsAtParent: false };
+	}
+	if (!dsRes.ok) return { signed: true, hasDsAtParent: false };
+
+	let dsBody: unknown;
+	try {
+		dsBody = await dsRes.json();
+	} catch {
+		return { signed: true, hasDsAtParent: false };
+	}
+
+	const answer = (dsBody as { Answer?: Array<{ type?: number }> }).Answer;
+	// DS records are type=43 in DoH JSON (RFC 4034 §5).
+	const hasDsAtParent =
+		Array.isArray(answer) && answer.some((a) => a.type === 43);
+
+	return { signed: true, hasDsAtParent };
+}

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -61,6 +61,7 @@ import { emptyBimiPosture, fetchBimiPosture } from "./dmarc/bimi";
 import { emptySpfPosture, fetchSpfPosture } from "./spf/posture";
 import { emptyTlsRptPosture, fetchTlsRptPosture } from "./tlsrpt/posture";
 import { emptyDkimPosture, fetchDkimPosture } from "./dkim/posture";
+import { emptyDnssecPosture, fetchDnssecPosture } from "./dnssec/posture";
 import { listTextModels } from "./lib/text-models";
 import { fetchHubCorroborationCount } from "./intel/hub-corroboration";
 import { loadHubCredentials } from "./lib/hub-config";
@@ -569,6 +570,9 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 	const tlsRptPromise = fetchTlsRptPosture(domain, {
 		kv: c.env.BLOOM_KV ?? null,
 	});
+	const dnssecPromise = fetchDnssecPosture(domain, {
+		kv: c.env.BLOOM_KV ?? null,
+	});
 
 	const [
 		settledSummaries,
@@ -579,6 +583,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		settledBimi,
 		settledSpf,
 		settledTlsRpt,
+		settledDnssec,
 	] = await Promise.all([
 		Promise.allSettled(summaryPromises),
 		Promise.allSettled(alignmentPromises),
@@ -588,6 +593,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		Promise.allSettled([bimiPromise]),
 		Promise.allSettled([spfPromise]),
 		Promise.allSettled([tlsRptPromise]),
+		Promise.allSettled([dnssecPromise]),
 	]);
 
 	const summaries: Array<DomainMailboxSummary | null> = settledSummaries.map((r) => {
@@ -642,6 +648,11 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 			? settledTlsRpt[0].value
 			: emptyTlsRptPosture();
 
+	const dnssecPosture =
+		settledDnssec[0].status === "fulfilled"
+			? settledDnssec[0].value
+			: emptyDnssecPosture();
+
 	// Union the per-mailbox selector lists. A failed DO call contributes
 	// nothing rather than blocking the whole DKIM tile — same degradation
 	// model as `getDmarcAlignmentTotals`.
@@ -687,6 +698,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		spfPosture,
 		tlsRptPosture,
 		dkimPosture,
+		dnssec: dnssecPosture,
 	});
 	// `aggregateDomainStats` only returns null when `mailboxes.length === 0`,
 	// which we already guarded above with the 404 — but narrow the type

--- a/workers/lib/dashboard-aggregation.ts
+++ b/workers/lib/dashboard-aggregation.ts
@@ -488,6 +488,15 @@ export interface DkimPostureView {
 	}>;
 }
 
+/** DNSSEC posture (#324, part of #156).
+ *
+ * `{ signed: false }` — resolver did not set AD=true, or any lookup failed.
+ * `{ signed: true, hasDsAtParent: boolean }` — AD=true; hasDsAtParent
+ *   reflects whether a DS record (type=43) exists at the apex label. */
+export type DnssecPostureView =
+	| { signed: false }
+	| { signed: true; hasDsAtParent: boolean };
+
 export interface DomainListEntry {
 	domain: string;
 	mailboxesCount: number;
@@ -527,6 +536,9 @@ export interface DomainStats {
 	 * 30-day inbound-mail observation window. Empty `selectors` is the natural
 	 * state for a domain that's never received DKIM-signed inbound mail. */
 	dkimPosture: DkimPostureView;
+	/** DNSSEC posture (#324). `signed: false` when unsigned or lookup failed;
+	 * `signed: true` when the resolver's AD bit is set, with DS-at-parent. */
+	dnssec: DnssecPostureView;
 	recentCases: DomainRecentCase[];
 }
 
@@ -600,6 +612,13 @@ export function emptyTlsRptPostureView(): TlsRptPostureView {
  * as "no DKIM selectors observed in the last 30 days". */
 export function emptyDkimPostureView(): DkimPostureView {
 	return { selectors: [] };
+}
+
+/** Empty DNSSEC posture sentinel — `signed: false` surfaces the same
+ * "not configured" affordance whether the lookup failed or the domain is
+ * genuinely unsigned. */
+export function emptyDnssecPostureView(): DnssecPostureView {
+	return { signed: false };
 }
 
 /** Per-mailbox alignment totals harvested from `dmarc_records` by the DO.
@@ -748,6 +767,11 @@ interface AggregateDomainStatsInput {
 	 * sentinel (no selectors observed).
 	 */
 	dkimPosture?: DkimPostureView;
+	/**
+	 * DNSSEC posture (#324) from the resolver AD-bit query plus DS-record
+	 * check. Omitted defaults to the not-signed sentinel.
+	 */
+	dnssec?: DnssecPostureView;
 }
 
 /**
@@ -810,6 +834,7 @@ export function aggregateDomainStats(
 		spfPosture: input.spfPosture ?? emptySpfPostureView(),
 		tlsRptPosture: input.tlsRptPosture ?? emptyTlsRptPostureView(),
 		dkimPosture: input.dkimPosture ?? emptyDkimPostureView(),
+		dnssec: input.dnssec ?? emptyDnssecPostureView(),
 		recentCases: recentCases.slice(0, 5),
 	};
 }


### PR DESCRIPTION
## Summary

- Adds `workers/dnssec/posture.ts` — new DNSSEC posture module mirroring the BIMI/TLS-RPT pattern (DoH + KV + 1500ms hard cap + empty-sentinel). Two DoH queries per cache miss: (1) A-record at apex with `cd=0` to read the resolver's AD bit; (2) DS-record at apex (type=43) to check for a delegation-signer at the parent. Return type `DnssecPosture = { signed: false } | { signed: true, hasDsAtParent: boolean }`. KV prefix `dmarc-dnssec:v1:`, 1h TTL.
- Wires `dnssecPromise` into the existing `Promise.allSettled` fan-out in `workers/index.ts` and surfaces it as `dnssec: DnssecPosture` on the `/api/v1/domains/:domain/stats` response.
- Adds a "DNSSEC" posture tile to `app/routes/domain-detail.tsx` showing "signed (DS at parent)", "signed (no DS at parent — broken chain)", or "not signed".

Closes #324.

## Test plan

- [x] `npm test` — 1148 passing, 0 failing (10 new DNSSEC tests under `tests/dnssec/posture.test.ts`)
- [x] `npm run typecheck` — clean (0 errors)
- Existing posture tests under `tests/{mta-sts,spf,dkim,tlsrpt,bimi}/` all green

## Choices made

- Field name is `dnssec` on the API response (per issue spec), not `dnssecPosture` — consistent with the issue's Acceptance wording and the explicit mention in `app/types/index.ts` pointer.
- DS timeout/failure when AD=true degrades to `{ signed: true, hasDsAtParent: false }` rather than `{ signed: false }` — the domain is provably signed; only the parent delegation confirmation is uncertain. This matches the principle of not discarding information we already have.
- `DnssecPostureView` type in `dashboard-aggregation.ts` is identical to `DnssecPosture` in `app/types/index.ts` (same discriminated union) — no coercion needed on the response path.

## Deferred

- SECURITY_SPEC.md Rule 5 behavioral note: DNSSEC timeout → not-signed sentinel is consistent with Rule 5. Spec edit deferred per CLAUDE.md convention (do not edit SECURITY_SPEC.md from a code PR).

_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATRYc4UR7B5mVg499MVpSU)_