### PR TITLE
docs: fix stale LLM classifier timeout description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Weekends: flagged when weekdays_only is on
 | Sender reputation | ms | Rolling avg score per mailbox; flagged-sender fast path |
 | Threat-intel bloom lookup | ms | Against [workers/intel/feeds.ts](workers/intel/feeds.ts) (URLhaus, PhishDestroy, configurable; Spamhaus DROP/EDROP CIDR feeds consumed in deep-scan) |
 | Triage short-circuits | µs | Hard-block on confirmed intel / flagged sender; hard-allow on DMARC pass + allowlist or trusted history |
-| LLM classifier | seconds (5s cap) | Workers AI; fail-closed to `suspicious` on timeout |
+| LLM classifier | seconds (5s cap) | Workers AI; timeout → contributes 0 to score (skipped); parse/other error → fail-closed to `suspicious` (see [SECURITY_SPEC.md Rule 5](SECURITY_SPEC.md)) |
 | Verdict aggregation | µs | Pure scoring function; thresholds configurable per mailbox |
 | Off-hours boost | µs | Optional, scoring-only |
 | **Async deep-scan** | seconds–tens-of-seconds | `ctx.waitUntil`; see below |


### PR DESCRIPTION
## Summary

- README pipeline-stages row for "LLM classifier" previously said "fail-closed to `suspicious` on timeout" — stale since PR #132 narrowed Rule 5.
- New wording: timeout → contributes 0 to score (skipped); parse/other error → fail-closed to `suspicious`, with a link to SECURITY_SPEC.md Rule 5.

Closes #328.

## Test plan

- [ ] No code changes; docs-only diff.
- [ ] Wording verified against `workers/security/classification.ts:145-155` (timeout returns `unavailable`) and `SECURITY_SPEC.md` Rule 5 (no contradiction).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNPtyyUT799oc8oxJw476B)_