### PR TITLE
docs: update yaramail-signal.ts module header to reflect completed wiring

### DIFF
--- a/workers/security/yaramail-signal.ts
+++ b/workers/security/yaramail-signal.ts
@@ -14,9 +14,12 @@
  *   - `fireYaraScan` fires the fire-and-forget enrichment request via
  *     ctx.waitUntil when the mailbox has the scanner enabled.
  *
- * Wiring `fireYaraScan` into the email-receive pipeline, the callback route
- * that accepts sidecar responses, and the DO methods for storing results are
- * tracked in the follow-up issue filed against #256.
+ * All three wiring points are in place: `fireYaraScan` is called from
+ * `receiveEmail` at `workers/index.ts:1464`; the callback route is mounted at
+ * `workers/index.ts:140` and handled by `workers/routes/yaramail-callback.ts`;
+ * the DO methods `MailboxDO.insertYaraScanResult` (line 1928) and
+ * `MailboxDO.applyYaraSignal` (line 1955) live in
+ * `workers/durableObject/index.ts`.
  */
 
 import { resolveMailboxSettings } from "../lib/mailbox-settings";


### PR DESCRIPTION
## Summary

- Removes the stale paragraph pointing at closed follow-up issue #257 (filed against #256).
- Replaces it with accurate file paths for all three wiring points that are now in place: the `receiveEmail` call site, the callback route mount, and the two DO methods (`insertYaraScanResult`, `applyYaraSignal`).

Closes #330.

## Test plan

- [x] `npm test` — 1150 passing, 0 failing (89 test files)
- [x] `npm run typecheck` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_019QpTc5jDN9fT8r2Zq8fU2J)_