### PR TITLE
feat: add persistent Compose button to email-list header

### DIFF
--- a/app/routes/email-list.tsx
+++ b/app/routes/email-list.tsx
@@ -220,6 +220,7 @@ export default function EmailListRoute() {
 	}, [folders, folder]);
 
 	const isPanelOpen = selectedEmailId !== null || isComposing;
+	const showCompose = !!(folder && FOLDER_EMPTY_STATES[folder]?.showCompose);
 
 	// Track folder identity to detect folder changes vs page changes
 	const prevFolderRef = useRef<string | undefined>(undefined);
@@ -318,6 +319,18 @@ export default function EmailListRoute() {
 							<span className="text-sm text-ink-3 mr-2 hidden sm:inline">
 								{totalCount} conversation{totalCount !== 1 ? "s" : ""}
 							</span>
+						)}
+						{showCompose && (
+							<Tooltip content="Compose" side="bottom" asChild>
+								<Button
+									variant="ghost"
+									shape="square"
+									size="sm"
+									icon={<PencilSimpleIcon size={18} />}
+									onClick={() => startCompose()}
+									aria-label="Compose"
+								/>
+							</Tooltip>
 						)}
 						<Tooltip
 							content={isRefreshing ? "Refreshing..." : "Refresh"}

--- a/tests/frontend/email-list-compose-button.test.tsx
+++ b/tests/frontend/email-list-compose-button.test.tsx
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+//
+// Tests for the persistent Compose button in the email-list header (#348).
+// Covers: button renders when folder has messages (G1), clicking calls
+// startCompose (G2), button suppressed in non-compose folders (G3).
+
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+import { renderWithProviders } from "./test-utils";
+
+const startCompose = vi.fn();
+
+// Mock the full UIStore shape consumed by both EmailListRoute and the
+// MailboxSplitView it renders.
+vi.mock("~/hooks/useUIStore", () => ({
+	useUIStore: () => ({
+		selectedEmailId: null,
+		isComposing: false,
+		selectEmail: vi.fn(),
+		closePanel: vi.fn(),
+		closeCompose: vi.fn(),
+		startCompose,
+	}),
+}));
+
+const INBOX_EMAIL = {
+	id: "e1",
+	subject: "Test email",
+	sender: "sender@example.com",
+	recipient: "me@example.com",
+	date: "2026-05-01T12:00:00Z",
+	read: true,
+	starred: false,
+	folder_id: "inbox",
+	snippet: "Hello",
+	has_draft: false,
+	needs_reply: false,
+};
+
+vi.mock("~/queries/emails", () => ({
+	useEmails: () => ({
+		data: { emails: [INBOX_EMAIL], totalCount: 1 },
+		isFetching: false,
+	}),
+	useMarkThreadRead: () => ({ mutate: vi.fn() }),
+	useDeleteEmail: () => ({ mutate: vi.fn() }),
+	useUpdateEmail: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("~/queries/folders", () => ({
+	useFolders: () => ({ data: [] }),
+}));
+
+vi.mock("~/lib/feedback", () => ({
+	useFeedback: () => ({ error: vi.fn(), info: vi.fn(), success: vi.fn() }),
+}));
+
+import EmailListRoute from "~/routes/email-list";
+
+function renderEmailList(folder: string) {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/mailbox/:mailboxId/emails/:folder"
+				element={<EmailListRoute />}
+			/>
+		</Routes>,
+		{ initialEntries: [`/mailbox/mb1/emails/${folder}`] },
+	);
+}
+
+describe("EmailListRoute — persistent Compose button", () => {
+	beforeEach(() => {
+		startCompose.mockReset();
+	});
+
+	it("renders Compose button in Inbox when emails are present", () => {
+		renderEmailList("inbox");
+		expect(screen.getByRole("button", { name: "Compose" })).toBeInTheDocument();
+	});
+
+	it("calls startCompose when the Compose button is clicked", async () => {
+		const user = userEvent.setup();
+		renderEmailList("inbox");
+		await user.click(screen.getByRole("button", { name: "Compose" }));
+		expect(startCompose).toHaveBeenCalledOnce();
+	});
+
+	it("does not render Compose button in Trash", () => {
+		renderEmailList("trash");
+		expect(
+			screen.queryByRole("button", { name: "Compose" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("does not render Compose button in Archive", () => {
+		renderEmailList("archive");
+		expect(
+			screen.queryByRole("button", { name: "Compose" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("does not render Compose button in Quarantine", () => {
+		renderEmailList("quarantine");
+		expect(
+			screen.queryByRole("button", { name: "Compose" }),
+		).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a ghost `Button` with `PencilSimpleIcon` in the folder-header right-side control group of `EmailListRoute`, immediately before the Refresh button
- Button is shown only when `FOLDER_EMPTY_STATES[folder]?.showCompose` is true (Inbox / Sent / Draft); suppressed for Trash, Archive, Quarantine — matching the existing allowlist
- Clicking calls `startCompose()` (no args → `mode: "new"`) which opens `ComposePanel`; no new state plumbing needed

Closes #348.

## Test plan

- [x] `npm test` — 1155 passing, 0 failing
- [x] `npm run typecheck` — clean
- [x] New `tests/frontend/email-list-compose-button.test.tsx` with 5 cases:
  - Compose button renders in Inbox when emails are present
  - Clicking it calls `startCompose`
  - Absent in Trash, Archive, Quarantine

## Choices made

- Icon-only ghost button with `aria-label="Compose"` and tooltip: matches the adjacent Refresh button's pattern and avoids crowding the header on narrow viewports. The empty-state Compose button retains its text label as the onboarding affordance.

https://claude.ai/code/session_01Dh7HEYxC88P916TTkAR9Uk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dh7HEYxC88P916TTkAR9Uk)_