### PR TITLE
docs: link SECURITY.md from README Security section (OSPS-VM-02.01)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Any user who passes the shared Cloudflare Access policy can access all mailboxes
 
 See also: [SECURITY_SPEC.md](./SECURITY_SPEC.md) — "Rules for Agent-Safe Email Pipelines", a vendor-neutral codification of the prompt-injection and async-pipeline invariants this codebase ships.
 
+To report a vulnerability or review the disclosure policy, see [SECURITY.md](.github/SECURITY.md).
+
 [Security Policies](./docs/security-policies.md) — SCA (Dependabot) and SAST (CodeQL) remediation SLAs, merge-gate policies, and waiver processes (OSPS-VM-05.01, VM-05.02, VM-06.01).
 
 The security pipeline is **opt-in per mailbox** — existing mailboxes are unaffected until you flip the toggle in **Settings → Security**. When enabled, every inbound email runs through a synchronous scoring pipeline (SPF/DKIM/DMARC parse → URL heuristics → LLM classifier → sender reputation → threat-intel feed match → aggregate verdict), then an async deep-scan stage layered on top.


### PR DESCRIPTION
## Summary
- Adds a one-line link to `.github/SECURITY.md` in the README Security section so users can reach vulnerability-reporting instructions in one click
- Closes OSPS Baseline L1 OSPS-VM-02.01 (security contacts in project documentation)

Closes #340

## Test plan
- [ ] README Security section contains an explicit link to `.github/SECURITY.md`
- [ ] Clicking the link from the rendered README lands on the SECURITY policy
- [ ] No content from SECURITY.md is copy-pasted into README

https://claude.ai/code/session_015tVQHZoR4CZx8VtC2sRt3d

---
_Generated by [Claude Code](https://claude.ai/code/session_015tVQHZoR4CZx8VtC2sRt3d)_