### PR TITLE
docs: add MAINTAINERS.md with solo-maintainer waiver (OSPS-GV-01.01, OSPS-GV-01.02, OSPS-QA-07.01)

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,29 @@
+# Maintainers
+
+## Active maintainers
+
+| GitHub handle | Role | Responsibilities |
+|---|---|---|
+| [@schmug](https://github.com/schmug) | Primary maintainer | Code review, merge authority, release tagging, security-disclosure triage |
+
+### Contact
+
+For security vulnerabilities, use the private reporting path described in [SECURITY.md](.github/SECURITY.md). For general questions, open an issue.
+
+## Roles and authorities
+
+**Primary maintainer** — holds merge rights on `main`, release authority, and security-triage responsibility. Receives all CODEOWNERS review requests. Handles private vulnerability disclosures within the SLA documented in SECURITY.md (3 business days acknowledgement / 30 days for high-severity fixes).
+
+## Solo-maintainer review waiver (OSPS-QA-07.01)
+
+This project is currently solo-maintained. OSPS Baseline L3 control OSPS-QA-07.01 asks for ≥1 non-author approving review before merge. Meeting that requirement with a single active maintainer would block all progress on self-authored PRs.
+
+**Waiver rationale:** The following compensating controls replace the peer-review gate:
+
+- **CodeQL (SAST)** — required status check on every PR; high-severity alerts block merge.
+- **Typecheck & Test** — required status checks on every PR (root workspace + hub workspace); red CI blocks merge.
+- **Secret scanning + push protection** — GitHub-native; prevents accidental credential commits.
+- **`enforce_admins: true`** — the maintainer cannot bypass status checks even on self-authored merges.
+- **`allow_force_pushes: false`** — history on `main` is append-only.
+
+This waiver is revisited whenever a second active maintainer joins the project, at which point the branch-protection rule will be updated to require ≥1 non-author approval.

--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ The per-domain page (`/domains/:domain`) surfaces published email-auth posture a
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the fork→branch→PR flow, how to run tests, commit-format rules, and DCO sign-off requirement.
 
+For project governance, maintainer contacts, and the solo-maintainer review waiver, see [MAINTAINERS.md](MAINTAINERS.md).
+
 ## License
 
 Apache 2.0 -- see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- Adds `MAINTAINERS.md` listing @schmug as primary maintainer with role and responsibilities
- Includes a solo-maintainer review waiver paragraph (Path B for OSPS-QA-07.01) documenting the compensating controls (CodeQL, status checks, secret scanning, enforce_admins, no force-push)
- Links MAINTAINERS.md from the README Contributing section
- Maintainer contact path is consistent with `.github/SECURITY.md`
- Closes OSPS Baseline L2 OSPS-GV-01.01 (member list), OSPS-GV-01.02 (roles & responsibilities), and L3 OSPS-QA-07.01 (solo-maintainer waiver path)

Closes #342
Closes #343

## Test plan
- [ ] `MAINTAINERS.md` exists at repo root
- [ ] Lists @schmug with role description
- [ ] README Contributing section links `MAINTAINERS.md`
- [ ] Solo-maintainer waiver paragraph explains compensating controls
- [ ] Contact path is consistent with `.github/SECURITY.md`

https://claude.ai/code/session_015tVQHZoR4CZx8VtC2sRt3d

---
_Generated by [Claude Code](https://claude.ai/code/session_015tVQHZoR4CZx8VtC2sRt3d)_