### PR TITLE
fix(ui): correct DKIM posture card empty-state copy

### DIFF
--- a/app/routes/domain-detail.tsx
+++ b/app/routes/domain-detail.tsx
@@ -436,9 +436,11 @@ function DkimPostureCard({
 			</div>
 			{selectors.length === 0 ? (
 				<p className="text-[12.5px] text-ink-3">
-					No DKIM selectors observed on inbound mail in the last 30 days.
-					Selectors are lifted from `Authentication-Results.dkim header.s=`
-					on inbound messages, then resolved at
+					No DKIM selectors observed signing as this domain (`d=`) in the
+					last 30 days. Selectors are lifted from messages where
+					`header.d=` matches this domain — mail your mailboxes receive
+					from other senders is signed under their own `d=`, so those
+					selectors don't appear here. Each selector is resolved at
 					`&lt;selector&gt;._domainkey.&lt;domain&gt;` to confirm the
 					record is still published.
 				</p>

--- a/tests/frontend/domain-detail.test.tsx
+++ b/tests/frontend/domain-detail.test.tsx
@@ -175,7 +175,7 @@ describe("DomainDetailRoute", () => {
 			.getByText(/dkim posture/i)
 			.closest(".pp-card") as HTMLElement;
 		expect(
-			within(dkimCard).getByText(/no dkim selectors observed on inbound mail/i),
+			within(dkimCard).getByText(/no dkim selectors observed signing as this domain/i),
 		).toBeInTheDocument();
 	});
 


### PR DESCRIPTION
## Summary

- Rewrites the DKIM posture card empty-state text to make clear it tracks selectors for mail **signed as this domain** (`header.d=`), not arbitrary inbound mail the domain receives.
- Adds an explicit sentence explaining that mail from external senders is signed under their own `d=`, so those selectors don't appear here — directly addressing the operator confusion documented in the issue.
- Updates the matching test assertion to match the new copy.

Closes #357.

## Test plan

- [x] `vitest run` — 1155 passing, 0 failing
- [x] `npm run typecheck` — clean (0 errors)

## Choices made

- Kept the `<selector>._domainkey.<domain>` resolution sentence verbatim per the constraint to preserve the "how selectors are resolved" explanation.
- Kept `d=` in backtick code style to mirror the technical precision in sibling card copy (e.g. SPF's `` `v=spf1` ``).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FA8wh5UhkvQngz846vLxcK)_