### PR TITLE
feat: surface 'policy file unreachable' in MTA-STS card when TXT id present but policy absent

### DIFF
--- a/app/routes/domain-detail.tsx
+++ b/app/routes/domain-detail.tsx
@@ -100,7 +100,7 @@ function DomainBody({ data, rufData }: { data: DomainStats; rufData: import("~/q
 				<DmarcPostureCard posture={data.dmarcPosture} />
 			</div>
 			<div className="grid gap-4 lg:grid-cols-3">
-				<MtaStsPostureCard posture={data.mtaStsPosture} />
+				<MtaStsPostureCard posture={data.mtaStsPosture} domain={data.domain} />
 				<BimiPostureCard posture={data.bimiPosture} />
 				<SpfPostureCard posture={data.spfPosture} />
 			</div>
@@ -256,12 +256,18 @@ function DmarcPostureCard({
 
 function MtaStsPostureCard({
 	posture,
-}: { posture: DomainStats["mtaStsPosture"] }) {
+	domain,
+}: { posture: DomainStats["mtaStsPosture"]; domain: string }) {
 	const allNull =
 		posture.mode === null &&
 		posture.mx === null &&
 		posture.maxAge === null &&
 		posture.id === null;
+	const txtPublishedPolicyAbsent =
+		posture.id !== null &&
+		posture.mode === null &&
+		posture.mx === null &&
+		posture.maxAge === null;
 	return (
 		<div className="pp-card p-5">
 			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-3 flex items-center gap-1.5">
@@ -273,6 +279,15 @@ function MtaStsPostureCard({
 					MTA-STS isn't published for this domain (or the lookup failed). Operators
 					configure it by publishing a `_mta-sts` TXT record plus a policy file at
 					`mta-sts.&lt;domain&gt;/.well-known/mta-sts.txt`.
+				</p>
+			) : txtPublishedPolicyAbsent ? (
+				<p className="text-[12.5px] text-ink-3">
+					TXT record present (id: <span className="pp-mono">{posture.id}</span>) but
+					policy file unreachable — check that{" "}
+					<span className="pp-mono">
+						mta-sts.{domain}/.well-known/mta-sts.txt
+					</span>{" "}
+					resolves and returns 200.
 				</p>
 			) : (
 				<dl className="space-y-1.5 text-[12.5px]">

--- a/tests/frontend/domain-detail.test.tsx
+++ b/tests/frontend/domain-detail.test.tsx
@@ -229,7 +229,7 @@ describe("DomainDetailRoute", () => {
 		).toBeInTheDocument();
 		expect(within(mtaCard).getByText("20260331")).toBeInTheDocument();
 		expect(
-			within(mtaCard).getByText(/mta-sts\.acme\.com\/.well-known\/mta-sts\.txt/),
+			within(mtaCard).getByText("mta-sts.acme.com/.well-known/mta-sts.txt"),
 		).toBeInTheDocument();
 		// Must not render bare dashes for the missing fields.
 		expect(within(mtaCard).queryByText("—")).not.toBeInTheDocument();

--- a/tests/frontend/domain-detail.test.tsx
+++ b/tests/frontend/domain-detail.test.tsx
@@ -206,6 +206,82 @@ describe("DomainDetailRoute", () => {
 		expect(within(dkimCard).getAllByText("missing")).toHaveLength(2);
 	});
 
+	it("renders 'policy file unreachable' when _mta-sts TXT id is present but policy fields are null (#359)", () => {
+		queryState = {
+			data: {
+				...populated,
+				mtaStsPosture: {
+					mode: null,
+					mx: null,
+					maxAge: null,
+					id: "20260331",
+				},
+			},
+			isLoading: false,
+			isError: false,
+		};
+		renderDomainDetail("acme.com");
+		const mtaCard = screen
+			.getByText(/mta-sts posture/i)
+			.closest(".pp-card") as HTMLElement;
+		expect(
+			within(mtaCard).getByText(/policy file unreachable/i),
+		).toBeInTheDocument();
+		expect(within(mtaCard).getByText("20260331")).toBeInTheDocument();
+		expect(
+			within(mtaCard).getByText(/mta-sts\.acme\.com\/.well-known\/mta-sts\.txt/),
+		).toBeInTheDocument();
+		// Must not render bare dashes for the missing fields.
+		expect(within(mtaCard).queryByText("—")).not.toBeInTheDocument();
+	});
+
+	it("renders 'isn't published' empty state when MTA-STS posture is all-null (#359)", () => {
+		queryState = {
+			data: {
+				...populated,
+				mtaStsPosture: { mode: null, mx: null, maxAge: null, id: null },
+			},
+			isLoading: false,
+			isError: false,
+		};
+		renderDomainDetail("acme.com");
+		const mtaCard = screen
+			.getByText(/mta-sts posture/i)
+			.closest(".pp-card") as HTMLElement;
+		expect(
+			within(mtaCard).getByText(/mta-sts isn't published/i),
+		).toBeInTheDocument();
+		expect(
+			within(mtaCard).queryByText(/policy file unreachable/i),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders the MTA-STS dl rows when fully configured (#359)", () => {
+		queryState = {
+			data: {
+				...populated,
+				mtaStsPosture: {
+					mode: "enforce",
+					mx: ["mail.acme.com"],
+					maxAge: 604800,
+					id: "20260101",
+				},
+			},
+			isLoading: false,
+			isError: false,
+		};
+		renderDomainDetail("acme.com");
+		const mtaCard = screen
+			.getByText(/mta-sts posture/i)
+			.closest(".pp-card") as HTMLElement;
+		expect(within(mtaCard).getByText("enforce")).toBeInTheDocument();
+		expect(within(mtaCard).getByText("604800s")).toBeInTheDocument();
+		expect(within(mtaCard).getByText("mail.acme.com")).toBeInTheDocument();
+		expect(
+			within(mtaCard).queryByText(/policy file unreachable/i),
+		).not.toBeInTheDocument();
+	});
+
 	it("renders the DMARC fields when posture data is present (forward-compatible)", () => {
 		queryState = {
 			data: {


### PR DESCRIPTION
## Summary

- Added an `id-present / policy-absent` branch to `MtaStsPostureCard` that fires when `id !== null && mode === null && mx === null && maxAge === null`, rendering "TXT record present (id: …) but policy file unreachable — check that `mta-sts.<domain>/.well-known/mta-sts.txt` resolves and returns 200."
- The backend (`workers/mta-sts/posture.ts:249-252`) already produces this shape; no backend or aggregation changes needed.
- The existing all-null empty state ("MTA-STS isn't published…") and fully-configured dl rows are untouched.

Closes #359.

## Test plan

- [x] `npm test` — 1085 passing, 0 failing
- [x] `npm run typecheck` — clean

## Choices made

- Passed `domain` as a prop to `MtaStsPostureCard` (from `data.domain` in `DomainBody`) so the well-known URI in the error message names the actual domain rather than a placeholder.
- Copy style matches sibling cards: terse, inline `pp-mono` for the URI and id value.


---
_Generated by [Claude Code](https://claude.ai/code/session_018qd4uW9Bhu2kZfH1KMj6r6)_