### PR TITLE
feat: active DKIM selector probing for send-only domains

### DIFF
--- a/app/routes/domain-detail.tsx
+++ b/app/routes/domain-detail.tsx
@@ -420,6 +420,16 @@ function TlsRptPostureCard({
 	);
 }
 
+function DkimSourceBadge({ source }: { source?: "observed" | "probed" | "both" }) {
+	if (!source || source === "observed") return null;
+	const label = source === "both" ? "observed+probed" : "probed";
+	return (
+		<span className="ml-1.5 inline-block text-[10px] px-1.5 py-0.5 rounded bg-surface-2 text-ink-3 pp-mono leading-none">
+			{label}
+		</span>
+	);
+}
+
 function DkimPostureCard({
 	posture,
 }: { posture: DomainStats["dkimPosture"] }) {
@@ -445,11 +455,15 @@ function DkimPostureCard({
 			) : (
 				<dl className="space-y-1.5 text-[12.5px]">
 					{selectors.map((s) => (
-						<PostureRow
-							key={s.selector}
-							label={s.selector}
-							value={s.published === true ? "published" : "missing"}
-						/>
+						<div key={s.selector} className="flex items-baseline justify-between gap-3">
+							<dt className="text-ink-3 flex items-center">
+								{s.selector}
+								<DkimSourceBadge source={s.source} />
+							</dt>
+							<dd className="pp-mono text-ink-2 tabular-nums">
+								{s.published === true ? "published" : "missing"}
+							</dd>
+						</div>
 					))}
 				</dl>
 			)}

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -327,18 +327,21 @@ export interface TlsRptPosture {
 	endpoints: readonly string[] | null;
 }
 
-/** DKIM published-record posture (#170). Per-selector list of selectors
- * observed over a 30-day inbound-mail window, each with current
- * `<selector>._domainkey.<domain>` published-yes/no/unavailable status.
+/** DKIM published-record posture (#170, #358). Per-selector list from the
+ * 30-day inbound-mail observation window AND/OR the active well-known-selector
+ * probe, each with published status and provenance.
  *
- * Empty `selectors` is the natural state for a domain that's never sent
- * inbound DKIM-signed mail. `published: null` is the transient "lookup
- * unavailable" sentinel; the UI renders it identically to `false` (per
- * #170 Constraints) but the cache layer keeps them separate. */
+ * `published: null` is the transient "lookup unavailable" sentinel; the UI
+ * renders it identically to `false` but the cache layer keeps them separate.
+ *
+ * `source` (#358): `"observed"` — from inbound mail headers; `"probed"` —
+ * found by active probe; `"both"` — observed and probed; absent — treat as
+ * `"observed"` (pre-#358 payload). */
 export interface DkimPosture {
 	selectors: ReadonlyArray<{
 		selector: string;
 		published: boolean | null;
+		source?: "observed" | "probed" | "both";
 	}>;
 }
 

--- a/tests/dkim/posture.test.ts
+++ b/tests/dkim/posture.test.ts
@@ -3,12 +3,15 @@
 import { describe, expect, it } from "vitest";
 import {
 	DKIM_OBSERVATION_WINDOW_DAYS,
+	DKIM_PROBE_SELECTORS,
 	dkimObservationCutoffIso,
 	emptyDkimPosture,
 	fetchDkimPosture,
 	isAnyPublished,
 	isPublishedDkimRecord,
+	mergeDkimPosture,
 	normalizeDohTxtData,
+	probeDkimSelectors,
 	type DkimPostureKv,
 } from "../../workers/dkim/posture";
 
@@ -385,5 +388,191 @@ describe("fetchDkimPosture", () => {
 		expect(u.pathname).toBe("/dns-query");
 		expect(u.searchParams.get("name")).toBe("googleapis._domainkey.acme.com");
 		expect(u.searchParams.get("type")).toBe("TXT");
+	});
+});
+
+// ── probeDkimSelectors (#358) ─────────────────────────────────────────
+
+describe("DKIM_PROBE_SELECTORS", () => {
+	it("contains the expected well-known names", () => {
+		expect(DKIM_PROBE_SELECTORS).toContain("google");
+		expect(DKIM_PROBE_SELECTORS).toContain("selector1");
+		expect(DKIM_PROBE_SELECTORS).toContain("selector2");
+		expect(DKIM_PROBE_SELECTORS).toContain("mail");
+	});
+
+	it("has no duplicates", () => {
+		const unique = new Set(DKIM_PROBE_SELECTORS);
+		expect(unique.size).toBe(DKIM_PROBE_SELECTORS.length);
+	});
+});
+
+describe("probeDkimSelectors", () => {
+	it("returns only published selectors tagged source:'probed'", async () => {
+		const fetchImpl = async (url: string) => {
+			const name = new URL(url).searchParams.get("name") ?? "";
+			if (name === "google._domainkey.send-only.example") {
+				return dohTxtResponse(['"v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQ"']);
+			}
+			return dohNxdomainResponse();
+		};
+		const result = await probeDkimSelectors("send-only.example", { fetchImpl });
+		expect(result.selectors).toHaveLength(1);
+		expect(result.selectors[0]).toEqual({
+			selector: "google",
+			published: true,
+			source: "probed",
+		});
+	});
+
+	it("returns empty posture when no well-known selectors are published", async () => {
+		const fetchImpl = async () => dohNxdomainResponse();
+		const result = await probeDkimSelectors("no-dkim.example", { fetchImpl });
+		expect(result).toEqual(emptyDkimPosture());
+	});
+
+	it("silently drops absent selectors (no false positives in the output)", async () => {
+		const fetchImpl = async (url: string) => {
+			const name = new URL(url).searchParams.get("name") ?? "";
+			// selector1 is published; all others are NXDOMAIN
+			if (name === "selector1._domainkey.acme.com") {
+				return dohTxtResponse(['"v=DKIM1; p=AAA"']);
+			}
+			return dohNxdomainResponse();
+		};
+		const result = await probeDkimSelectors("acme.com", { fetchImpl });
+		// Only the published selector should appear; absent probes are dropped.
+		expect(result.selectors.every((s) => s.published === true)).toBe(true);
+		expect(result.selectors.every((s) => s.source === "probed")).toBe(true);
+	});
+
+	it("degrades to emptyDkimPosture when DoH times out (probe failure → not probed, not absent)", async () => {
+		const fetchImpl = async (): Promise<Response> => {
+			throw new Error("AbortError: signal timed out");
+		};
+		const result = await probeDkimSelectors("timeout.example", { fetchImpl });
+		// Timeout should produce published:null for each selector but probeDkimSelectors
+		// filters to published===true only, so the result is empty — not an error.
+		expect(result).toEqual(emptyDkimPosture());
+	});
+
+	it("does not include published:null (transient unavailable) selectors in output", async () => {
+		// SERVFAIL returns published:null — should not appear as a published selector.
+		const fetchImpl = async () =>
+			new Response(JSON.stringify({ Status: 2 }), { status: 200 });
+		const result = await probeDkimSelectors("servfail.example", { fetchImpl });
+		expect(result.selectors).toHaveLength(0);
+	});
+
+	it("probes against the well-known candidate list, not observed selectors", async () => {
+		const probed: string[] = [];
+		const fetchImpl = async (url: string) => {
+			const name = new URL(url).searchParams.get("name") ?? "";
+			probed.push(name.split("._domainkey.")[0] ?? "");
+			return dohNxdomainResponse();
+		};
+		await probeDkimSelectors("acme.com", { fetchImpl });
+		// Every probed selector should be in the well-known list.
+		for (const sel of probed) {
+			expect(DKIM_PROBE_SELECTORS).toContain(sel);
+		}
+		expect(probed).toHaveLength(DKIM_PROBE_SELECTORS.length);
+	});
+});
+
+// ── mergeDkimPosture (#358) ─────────────────────────────────────────
+
+describe("mergeDkimPosture", () => {
+	it("tags observed-only selectors as source:'observed'", () => {
+		const observed = {
+			selectors: [{ selector: "s1", published: true }],
+		};
+		const probed = emptyDkimPosture();
+		const result = mergeDkimPosture(observed, probed);
+		expect(result.selectors).toEqual([
+			{ selector: "s1", published: true, source: "observed" },
+		]);
+	});
+
+	it("tags probed-only selectors as source:'probed'", () => {
+		const probed = {
+			selectors: [{ selector: "google", published: true, source: "probed" as const }],
+		};
+		const result = mergeDkimPosture(emptyDkimPosture(), probed);
+		expect(result.selectors).toEqual([
+			{ selector: "google", published: true, source: "probed" },
+		]);
+	});
+
+	it("tags selectors present in both as source:'both' without duplication", () => {
+		const observed = {
+			selectors: [{ selector: "google", published: true }],
+		};
+		const probed = {
+			selectors: [{ selector: "google", published: true, source: "probed" as const }],
+		};
+		const result = mergeDkimPosture(observed, probed);
+		expect(result.selectors).toHaveLength(1);
+		expect(result.selectors[0]).toEqual({
+			selector: "google",
+			published: true,
+			source: "both",
+		});
+	});
+
+	it("uses observed published status for overlap (observed is authoritative)", () => {
+		// Observed has published:false (revoked key), probe has published:true.
+		// The observed value should win.
+		const observed = {
+			selectors: [{ selector: "old", published: false }],
+		};
+		const probed = {
+			selectors: [{ selector: "old", published: true, source: "probed" as const }],
+		};
+		const result = mergeDkimPosture(observed, probed);
+		expect(result.selectors[0]).toEqual({
+			selector: "old",
+			published: false,
+			source: "both",
+		});
+	});
+
+	it("merges multiple selectors with correct provenance", () => {
+		const observed = {
+			selectors: [
+				{ selector: "custom-sel", published: true },
+				{ selector: "google", published: true },
+			],
+		};
+		const probed = {
+			selectors: [
+				{ selector: "google", published: true, source: "probed" as const },
+				{ selector: "selector1", published: true, source: "probed" as const },
+			],
+		};
+		const result = mergeDkimPosture(observed, probed);
+		// Alphabetical order: custom-sel, google, selector1
+		expect(result.selectors).toEqual([
+			{ selector: "custom-sel", published: true, source: "observed" },
+			{ selector: "google", published: true, source: "both" },
+			{ selector: "selector1", published: true, source: "probed" },
+		]);
+	});
+
+	it("returns empty posture when both inputs are empty", () => {
+		expect(mergeDkimPosture(emptyDkimPosture(), emptyDkimPosture())).toEqual(
+			emptyDkimPosture(),
+		);
+	});
+
+	it("output is alphabetically sorted for stable rendering", () => {
+		const observed = {
+			selectors: [
+				{ selector: "zebra", published: true },
+				{ selector: "alpha", published: true },
+			],
+		};
+		const result = mergeDkimPosture(observed, emptyDkimPosture());
+		expect(result.selectors.map((s) => s.selector)).toEqual(["alpha", "zebra"]);
 	});
 });

--- a/workers/dkim/posture.ts
+++ b/workers/dkim/posture.ts
@@ -30,10 +30,17 @@
  * returned non-200, or returned malformed JSON. The dashboard renders this
  * with the same affordance as `false` (per Constraints in #170) but the
  * cache layer keeps them separate so a transient blip doesn't poison the
- * cache for an hour. */
+ * cache for an hour.
+ *
+ * `source` is present on results from `mergeDkimPosture` (#358):
+ *   - `"observed"` — selector lifted from inbound `Authentication-Results` headers.
+ *   - `"probed"` — found by the active well-known-selector probe with `published=true`.
+ *   - `"both"` — observed inbound AND confirmed by the active probe.
+ */
 export interface DkimSelectorPosture {
 	selector: string;
 	published: boolean | null;
+	source?: "observed" | "probed" | "both";
 }
 
 /** Whole-domain DKIM posture surface — the list of observed selectors with
@@ -47,6 +54,98 @@ export interface DkimPosture {
 /** Sentinel for "no observations yet" — same shape as a degenerate result. */
 export function emptyDkimPosture(): DkimPosture {
 	return { selectors: [] };
+}
+
+/**
+ * Well-known DKIM selector names used by the active probe (#358). Keeping
+ * this list in one place ensures callers share the same candidate set.
+ *
+ * The list covers the most widely deployed ESPs and mail platforms. Per-domain
+ * custom selectors remain out of scope for now.
+ */
+export const DKIM_PROBE_SELECTORS: ReadonlyArray<string> = [
+	"google",
+	"selector1",
+	"selector2",
+	"k1",
+	"k2",
+	"default",
+	"mandrill",
+	"s1",
+	"s2",
+	"dkim",
+	"mail",
+	"smtp",
+];
+
+/**
+ * Actively probe `DKIM_PROBE_SELECTORS` against `domain` and return only the
+ * selectors confirmed as published (i.e. `published === true`). Each returned
+ * row is tagged `source: "probed"`.
+ *
+ * Absent selectors (`published === false`) are silently dropped — surfacing
+ * them would flood the card with 12 "missing" entries for a domain that
+ * happens not to use any well-known name. Transient failures (`published ===
+ * null`) are also dropped; the caller receives `emptyDkimPosture()` on any
+ * uncaught error from the underlying resolver.
+ */
+export async function probeDkimSelectors(
+	domain: string,
+	options: {
+		kv?: DkimPostureKv | null;
+		fetchImpl?: DkimPostureFetch;
+	} = {},
+): Promise<DkimPosture> {
+	let result: DkimPosture;
+	try {
+		result = await fetchDkimPosture(domain, DKIM_PROBE_SELECTORS, options);
+	} catch {
+		return emptyDkimPosture();
+	}
+	return {
+		selectors: result.selectors
+			.filter((s) => s.published === true)
+			.map((s) => ({ selector: s.selector, published: true, source: "probed" as const })),
+	};
+}
+
+/**
+ * Merge an observed posture (from per-mailbox `getDkimSelectorsObserved`
+ * fan-out + `fetchDkimPosture`) with a probed posture (from
+ * `probeDkimSelectors`).
+ *
+ * Rules:
+ *   - Observed-only selectors keep their `published` status and get
+ *     `source: "observed"`.
+ *   - Probed-only selectors (always `published: true`) get `source: "probed"`.
+ *   - Selectors present in both get the observed `published` value (the
+ *     inbound observation is authoritative for whether the record is still
+ *     live) and `source: "both"`.
+ *
+ * Output is alphabetically sorted for stable UI rendering.
+ */
+export function mergeDkimPosture(
+	observed: DkimPosture,
+	probed: DkimPosture,
+): DkimPosture {
+	const out = new Map<string, DkimSelectorPosture>();
+
+	for (const s of observed.selectors) {
+		out.set(s.selector, { selector: s.selector, published: s.published, source: "observed" });
+	}
+
+	for (const s of probed.selectors) {
+		const existing = out.get(s.selector);
+		if (existing) {
+			out.set(s.selector, { selector: s.selector, published: existing.published, source: "both" });
+		} else {
+			out.set(s.selector, { selector: s.selector, published: s.published, source: "probed" });
+		}
+	}
+
+	const rows = [...out.values()];
+	rows.sort((a, b) => a.selector.localeCompare(b.selector));
+	return { selectors: rows };
 }
 
 /** Number of days an observed selector remains in the rollup before the

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -60,7 +60,7 @@ import { emptyMtaStsPosture, fetchMtaStsPosture } from "./mta-sts/posture";
 import { emptyBimiPosture, fetchBimiPosture } from "./dmarc/bimi";
 import { emptySpfPosture, fetchSpfPosture } from "./spf/posture";
 import { emptyTlsRptPosture, fetchTlsRptPosture } from "./tlsrpt/posture";
-import { emptyDkimPosture, fetchDkimPosture } from "./dkim/posture";
+import { emptyDkimPosture, fetchDkimPosture, mergeDkimPosture, probeDkimSelectors } from "./dkim/posture";
 import { emptyDnssecPosture, fetchDnssecPosture } from "./dnssec/posture";
 import { listTextModels } from "./lib/text-models";
 import { fetchHubCorroborationCount } from "./intel/hub-corroboration";
@@ -573,6 +573,11 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 	const dnssecPromise = fetchDnssecPosture(domain, {
 		kv: c.env.BLOOM_KV ?? null,
 	});
+	// Active DKIM probe (#358): probe well-known selectors concurrently with
+	// the rest of the posture fan-out so it doesn't add sequential latency.
+	const dkimProbePromise = probeDkimSelectors(domain, {
+		kv: c.env.BLOOM_KV ?? null,
+	});
 
 	const [
 		settledSummaries,
@@ -584,6 +589,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		settledSpf,
 		settledTlsRpt,
 		settledDnssec,
+		settledDkimProbe,
 	] = await Promise.all([
 		Promise.allSettled(summaryPromises),
 		Promise.allSettled(alignmentPromises),
@@ -594,6 +600,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		Promise.allSettled([spfPromise]),
 		Promise.allSettled([tlsRptPromise]),
 		Promise.allSettled([dnssecPromise]),
+		Promise.allSettled([dkimProbePromise]),
 	]);
 
 	const summaries: Array<DomainMailboxSummary | null> = settledSummaries.map((r) => {
@@ -670,7 +677,7 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 		}
 	}
 
-	const dkimPosture = observedSelectors.size === 0
+	const observedDkimPosture = observedSelectors.size === 0
 		? emptyDkimPosture()
 		: await fetchDkimPosture(domain, [...observedSelectors], {
 			kv: c.env.BLOOM_KV ?? null,
@@ -681,6 +688,13 @@ app.get("/api/v1/domains/:domain/stats", async (c) => {
 			);
 			return emptyDkimPosture();
 		});
+
+	const probedDkimPosture =
+		settledDkimProbe[0]?.status === "fulfilled"
+			? settledDkimProbe[0].value
+			: emptyDkimPosture();
+
+	const dkimPosture = mergeDkimPosture(observedDkimPosture, probedDkimPosture);
 
 	const mailboxRefs: DomainMailboxRef[] = scoped.map((m) => ({
 		id: m.id,

--- a/workers/lib/dashboard-aggregation.ts
+++ b/workers/lib/dashboard-aggregation.ts
@@ -467,9 +467,10 @@ export interface TlsRptPostureView {
 	endpoints: readonly string[] | null;
 }
 
-/** DKIM published-record posture (#170). Per-selector list of selectors
- * observed over the last 30 days on inbound mail to this domain, each with
- * its current published-at-`<selector>._domainkey.<domain>` status.
+/** DKIM published-record posture (#170, #358). Per-selector list of selectors
+ * observed over the last 30 days on inbound mail to this domain OR found by
+ * the active well-known-selector probe, each with its published status and
+ * provenance.
  *
  * `published: true` — DoH returned a TXT entry that's a valid DKIM record.
  * `published: false` — durable "no record" (NXDOMAIN, NOERROR-no-data, or
@@ -479,12 +480,20 @@ export interface TlsRptPostureView {
  *   affordance as `false` per the #170 Constraints, but the cache layer
  *   keeps them separate.
  *
+ * `source` (#358) records how the selector was discovered:
+ *   - `"observed"` — lifted from inbound `Authentication-Results` headers.
+ *   - `"probed"` — found by the active well-known-selector probe (always `published=true`).
+ *   - `"both"` — observed inbound AND confirmed by the active probe.
+ *   - absent (legacy / pre-#358 payloads) — treat as `"observed"`.
+ *
  * Empty `selectors` is the natural state for a domain that's never sent
- * inbound DKIM-signed mail; the UI shows the empty-state affordance. */
+ * inbound DKIM-signed mail AND none of the well-known selectors are published;
+ * the UI shows the empty-state affordance. */
 export interface DkimPostureView {
 	selectors: ReadonlyArray<{
 		selector: string;
 		published: boolean | null;
+		source?: "observed" | "probed" | "both";
 	}>;
 }
 


### PR DESCRIPTION
## Summary

- Adds `DKIM_PROBE_SELECTORS` (12 well-known names: `google`, `selector1`, `selector2`, `k1`, `k2`, `default`, `mandrill`, `s1`, `s2`, `dkim`, `mail`, `smtp`) to `workers/dkim/posture.ts`, plus two new exports: `probeDkimSelectors()` and `mergeDkimPosture()`.
- Wires the probe into the `domain-stats` handler concurrently with SPF/MTA-STS/BIMI/TLS-RPT/DNSSEC (all inside `Promise.allSettled`). A send-only domain publishing `google._domainkey.<domain>` now shows that selector on the DKIM card with zero observed inbound mail.
- Merges observed and probed results without duplication; a selector present in both carries `source: "both"`. Adds optional `source` field (`"observed"` | `"probed"` | `"both"`) to `DkimSelectorPosture`, `DkimPostureView`, and the frontend `DkimPosture` type. `DkimPostureCard` renders a small provenance badge ("probed" / "observed+probed") next to selector names discovered by the active probe.

Closes #358.

## Test plan

- [x] `npm test` — 1170 passing, 0 failing
- [x] `npm run typecheck` — clean (0 errors)

New test coverage in `tests/dkim/posture.test.ts`:
- `probeDkimSelectors`: probe finds published selector → `source: "probed"`; probe finds nothing (all NXDOMAIN) → empty result, no false positives; DoH times out → `emptyDkimPosture()` (graceful degrade); transient SERVFAIL → no selectors surfaced; probed names match the well-known list.
- `mergeDkimPosture`: observed-only → `"observed"`; probed-only → `"probed"`; overlap → `"both"` without duplication; observed `published` status wins on overlap (authoritative); multi-selector merge with correct ordering; empty × empty → empty; alphabetical sort invariant.

## Choices made

- Absent probed selectors (`published: false`) are silently dropped from the merged output — surfacing 12 "missing" entries for selectors a domain simply doesn't use would flood the card with false negatives. Only `published === true` probed results are forwarded. The `DkimSelectorPosture.source` field documents this distinction at the type level.
- `source` is optional on the interface (absent = treat as `"observed"`) for forward-compatibility with cached payloads written before this PR.
- `DkimSourceBadge` renders nothing for `source === "observed"` (the original state of the card) so existing UI for fully-observed domains is unchanged.

_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNr61CLm9LY8M48bKgByPt)_