### PR TITLE
feat: defending-code security-review skills + initial threat model

### DIFF
--- a/.claude/skills/_lib/checkpoint.py
+++ b/.claude/skills/_lib/checkpoint.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+# Copyright 2026 Anthropic PBC
+# SPDX-License-Identifier: Apache-2.0
+"""Checkpoint helper for the runbook skills (vuln-scan, triage, threat-model).
+
+Called via Bash from within a skill so phase state and final output land on disk
+in small, atomic chunks instead of one large Write tool call.
+
+    save   <state_dir> <N> [<name>] --from F [--key K]  → <K><N>.json + progress.json
+    shard  <state_dir> <shard_id> --from F              → shard_<id>.json; shards_done += id
+    done   <state_dir> <N> [--key K]                    → progress.json status=complete
+    load   <state_dir>                                  → progress.json to stdout
+    append <output_file> --from F                       → appended (creates if absent)
+    reset  <state_dir>                                  → rm -rf state dir
+
+Payload always comes from --from <file> (written via the Write tool), never
+stdin or heredoc: target-derived strings in a heredoc could collide with the
+delimiter and break out to shell. With --from, no repo-derived bytes touch
+the Bash argv.
+
+--key defaults to "phase" (vuln-scan, triage). Pass --key stage for
+threat-model bootstrap. progress.json schema:
+    {"status": "running"|"complete", "<key>_done": N, "shards_done": [...], "updated": iso}
+
+All writes are atomic (tmp + os.replace) so a kill mid-write never leaves a
+partial file that breaks resume.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+_ROOT = Path(os.environ.get("CHECKPOINT_ROOT", ".")).resolve()
+
+
+def _confine(p: str | Path, *, must_end: str | None = None) -> Path:
+    """Resolve p and require it stays under CHECKPOINT_ROOT (default: cwd).
+
+    The Bash permission is a prefix wildcard, so a prompt-injected agent could
+    otherwise point append/reset at ~/.ssh, ~/.bashrc, etc. Confining to cwd
+    keeps the blast radius at the repo being scanned."""
+    r = Path(p).resolve()
+    if not r.is_relative_to(_ROOT):
+        print(f"checkpoint: refusing path outside {_ROOT}: {p}", file=sys.stderr)
+        raise SystemExit(2)
+    if must_end and not r.name.endswith(must_end):
+        print(f"checkpoint: refusing {p} (name must end with {must_end!r})", file=sys.stderr)
+        raise SystemExit(2)
+    return r
+
+
+def _safe_token(s: str, what: str) -> str:
+    if "/" in s or os.sep in s or ".." in s:
+        print(f"checkpoint: refusing {what} with path separators: {s!r}", file=sys.stderr)
+        raise SystemExit(2)
+    return s
+
+
+def _atomic_write(path: Path, data: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(data)
+    os.replace(tmp, path)
+
+
+def _pop_opt(argv: list[str], flag: str, default: str | None = None) -> tuple[list[str], str | None]:
+    if flag in argv:
+        i = argv.index(flag)
+        return argv[:i] + argv[i + 2:], argv[i + 1]
+    return argv, default
+
+
+def _read_payload(src: str | None) -> str:
+    """Payload comes from --from <file>, never stdin/heredoc.
+
+    Target-derived strings in a heredoc can terminate the delimiter early and
+    break out to shell. Requiring --from keeps all repo-derived bytes out of
+    the Bash argv; the file is written via the Write tool (no shell)."""
+    if src is None:
+        print("checkpoint: payload must be passed via --from <file> "
+              "(stdin/heredoc disabled to prevent shell injection)", file=sys.stderr)
+        raise SystemExit(2)
+    return _confine(src).read_text()
+
+
+def _read_json(src: str | None) -> str:
+    raw = _read_payload(src)
+    try:
+        json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"checkpoint: --from {src} is not valid JSON: {e}", file=sys.stderr)
+        raise SystemExit(1)
+    return raw
+
+
+def _write_progress(state_dir: Path, *, status: str, key: str, n: int,
+                    shards: list[str]) -> None:
+    _atomic_write(state_dir / "progress.json", json.dumps({
+        "status": status,
+        f"{key}_done": n,
+        "shards_done": shards,
+        "updated": datetime.now(timezone.utc).isoformat(),
+    }))
+
+
+def cmd_save(argv: list[str]) -> int:
+    argv, key = _pop_opt(argv, "--key", "phase")
+    assert key
+    argv, src = _pop_opt(argv, "--from")
+    if len(argv) < 2:
+        print("usage: checkpoint.py save <state_dir> <N> [<name>] --from <file> [--key K]",
+              file=sys.stderr)
+        return 2
+    state_dir = _confine(argv[0], must_end="-state")
+    n = int(argv[1])
+    key = _safe_token(key, "--key")
+    name = argv[2] if len(argv) > 2 else f"{key}{n}"
+    raw = _read_json(src)
+    _atomic_write(state_dir / f"{key}{n}.json", raw)
+    _write_progress(state_dir, status="running", key=key, n=n, shards=[])
+    print(f"checkpoint: {key} {n} ({name}) saved → {state_dir}/")
+    return 0
+
+
+def cmd_shard(argv: list[str]) -> int:
+    argv, src = _pop_opt(argv, "--from")
+    if len(argv) != 2:
+        print("usage: checkpoint.py shard <state_dir> <shard_id> --from <file>", file=sys.stderr)
+        return 2
+    state_dir = _confine(argv[0], must_end="-state")
+    shard_id = _safe_token(argv[1], "shard_id")
+    raw = _read_json(src)
+    _atomic_write(state_dir / f"shard_{shard_id}.json", raw)
+    p = state_dir / "progress.json"
+    prog: dict = json.loads(p.read_text()) if p.exists() else {"status": "running"}
+    shards: list = prog.get("shards_done", [])
+    if shard_id not in shards:
+        shards.append(shard_id)
+    prog["shards_done"] = shards
+    prog["updated"] = datetime.now(timezone.utc).isoformat()
+    _atomic_write(p, json.dumps(prog))
+    print(f"checkpoint: shard {shard_id} saved ({len(shards)} done)")
+    return 0
+
+
+def cmd_done(argv: list[str]) -> int:
+    argv, key = _pop_opt(argv, "--key", "phase")
+    assert key
+    if len(argv) != 2:
+        print("usage: checkpoint.py done <state_dir> <N> [--key K]", file=sys.stderr)
+        return 2
+    _write_progress(_confine(argv[0], must_end="-state"), status="complete",
+                    key=_safe_token(key, "--key"), n=int(argv[1]), shards=[])
+    print("checkpoint: complete")
+    return 0
+
+
+def cmd_load(argv: list[str]) -> int:
+    if len(argv) != 1:
+        print("usage: checkpoint.py load <state_dir>", file=sys.stderr)
+        return 2
+    p = _confine(argv[0], must_end="-state") / "progress.json"
+    sys.stdout.write(p.read_text() if p.exists() else '{"status": "absent"}')
+    return 0
+
+
+def cmd_append(argv: list[str]) -> int:
+    argv, src = _pop_opt(argv, "--from")
+    if len(argv) != 1:
+        print("usage: checkpoint.py append <output_file> --from <file>", file=sys.stderr)
+        return 2
+    out = _confine(argv[0])
+    out.parent.mkdir(parents=True, exist_ok=True)
+    chunk = _read_payload(src)
+    with open(out, "a") as f:
+        f.write(chunk)
+        if not chunk.endswith("\n"):
+            f.write("\n")
+    print(f"checkpoint: appended {len(chunk)} bytes → {out}")
+    return 0
+
+
+def cmd_reset(argv: list[str]) -> int:
+    if len(argv) != 1:
+        print("usage: checkpoint.py reset <state_dir>", file=sys.stderr)
+        return 2
+    d = _confine(argv[0], must_end="-state")
+    if d.exists():
+        shutil.rmtree(d)
+        print(f"checkpoint: removed {d}/")
+    return 0
+
+
+CMDS = {"save": cmd_save, "shard": cmd_shard, "done": cmd_done,
+        "load": cmd_load, "append": cmd_append, "reset": cmd_reset}
+
+
+def main(argv: list[str]) -> int:
+    if not argv or argv[0] not in CMDS:
+        print(f"usage: checkpoint.py {{{'|'.join(CMDS)}}} ...", file=sys.stderr)
+        return 2
+    return CMDS[argv[0]](argv[1:])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.claude/skills/_lib/phishsoc-rules.md
+++ b/.claude/skills/_lib/phishsoc-rules.md
@@ -1,0 +1,110 @@
+PhishSOC org-specific review calibration
+=========================================
+
+Pass this file to `/sec-vuln-scan` via `--extra` and to `/sec-triage` via
+`--fp-rules`. It encodes invariants this codebase already enforces so they are
+not re-reported as findings. Each rule names the control and WHERE it lives;
+a verifier must still confirm the control is actually present at the cited
+sink before dropping a finding — if the control is missing or bypassable on
+the path under review, the finding is REAL.
+
+Authoritative sources: `SECURITY_SPEC.md` (Rules 1-6), `.github/SECURITY.md`
+(scope + disclosure), and the repo `CLAUDE.md` conventions.
+
+
+SCOPE (from .github/SECURITY.md)
+--------------------------------
+
+In scope: `app/`, `workers/`, `hub/`, `shared/`; auth / authorization /
+tenant-isolation boundaries; the detection pipeline (SPF/DKIM/DMARC parsing,
+URL/homograph/RDAP analysis, LLM classifier); security-relevant
+`wrangler.jsonc` config.
+
+OUT OF SCOPE — treat as FALSE_POSITIVE (cite "out of scope per SECURITY.md"):
+- Vulnerabilities in upstream/third-party dependencies (handled by Dependabot).
+- Anything that requires physical access to the operator's Cloudflare account.
+- Findings that only hold if Cloudflare Access is disabled, or that require
+  running outside the documented deployment topology.
+- Self-XSS, missing security headers with no demonstrated impact, and other
+  low-severity classes major bug-bounty programs routinely reject.
+
+
+PIPELINE INVARIANTS (from SECURITY_SPEC.md) — FALSE_POSITIVE if the finding
+relies on violating one of these without showing the guard is missing
+---------------------------------------------------------------------------
+
+- Rule 1 — LLM output is NOT load-bearing. The Workers AI classifier
+  (`workers/security/classification.ts`) and the hub triage agent
+  (`hub/src/agent/triage.ts`) only influence advisory fields (tags,
+  summaries, a capped score). Therefore **prompt injection via email
+  subject/body/headers into the classifier or the EmailAgent/OrgAgent is NOT a
+  code vulnerability in this target** — it cannot move a verdict on its own.
+  Report it ONLY if you can show injected text reaches a load-bearing decision
+  (a verdict write, an auth check, an outbound send) — that would itself be a
+  Rule 1 violation and IS a real finding.
+- Rule 2 — downstream stages only TIGHTEN verdicts. Deep-scan
+  (`workers/intel/deep-scan.ts`) adds score and never downgrades. A finding
+  that an async stage "lowers" a verdict is real only if the monotonicity
+  guard is actually absent.
+- Rule 3 — Authentication-Results are trusted only from an operator-configured
+  authserv allowlist (`workers/security/auth.ts`). "We trust a spoofed
+  Authentication-Results header" is FP unless the allowlist check is missing.
+- Rule 4 — single-stage score contribution is capped (deep-scan ≤ 40, auth
+  ≤ 30, classifier ~50 with confidence scaling). "One stage dominates the
+  score" is FP unless the cap is missing.
+- Rule 5 — LLM timeouts/parse-failures are treated as no-signal / fail-closed,
+  not as a clean pass. FP unless that handling is absent.
+- Rule 6 — the agent CANNOT send email. There is no `send_email` tool in the
+  EmailAgent/OrgAgent toolset (`workers/agent/`); sending is a separate
+  auth-protected, user-initiated endpoint. "The agent autonomously sends/
+  exfiltrates" is FP unless a send-capable tool is actually wired in.
+
+
+CONTROL LOCATIONS — FALSE_POSITIVE if the control is present at the cited sink
+-----------------------------------------------------------------------------
+
+- HTML / XSS: email HTML is rendered through DOMPurify in an opaque-origin
+  iframe (`app/components/EmailIframe.tsx`); signatures are DOMPurify-sanitized
+  in `app/lib/`. XSS in rendered email/signature content is FP UNLESS the
+  sanitizer is missing or bypassable on that specific raw-HTML sink. (Stored
+  email body/subject/headers and hub event data ARE untrusted — a NEW sink
+  that bypasses DOMPurify is a real finding.)
+- SSRF / redirects: MTA-STS policy fetches use `redirect: "manual"`
+  (`workers/mta-sts/`), enforced by a hook in `.claude/settings.json`. "MTA-STS
+  follows redirects" is FP unless `redirect: "manual"` is actually absent.
+  Note: redirect-chain resolution of untrusted email URLs
+  (`workers/intel/url-resolver.ts`) and RDAP/CrowdSec/DoH lookups ARE a real
+  SSRF surface — report genuinely unguarded host/protocol control there.
+- URL host checks: the convention is to compare a parsed `new URL(u).hostname`,
+  never `startsWith`/`includes`/substring (CodeQL-gated). A substring host
+  check IS a real finding; do not flag code that already parses the hostname.
+- SQL: `MailboxDO` uses Drizzle with parameterized queries
+  (`workers/durableObject/`); the hub uses `.bind(...)`. SQLi is FP unless you
+  find string/template interpolation into a query or an unparameterized
+  `.raw()`.
+- Settings inheritance: every settings-tier write (mailbox POST/PUT, domain
+  PUT, org PUT) routes through `stripDefaultEqual(...)`
+  (`workers/lib/mailbox-settings.ts`), enforced by a hook. "Defaults shadow
+  upstream tiers" is FP unless a write path skips `stripDefaultEqual` — a write
+  path that DOES skip it is a real finding.
+- ACL back-compat: when no `mailboxes-acl/<id>.json` blob exists, anyone whom
+  Cloudflare Access already admitted is allowed (`workers/lib/mailbox-acl.ts`).
+  This is intended documented design, not a bug. A real finding is a path that
+  bypasses an ACL blob that IS present, or a route mounted before the ACL
+  middleware that should be behind it.
+- Auth front door: Cloudflare Access JWT validation in `workers/app.ts` is the
+  perimeter; per Rule from SECURITY.md, any teammate past CF Access may reach
+  all mailboxes by design. Tenant-isolation findings must show a break that
+  does not assume CF Access is disabled.
+
+
+STANDARD EXCLUSIONS (reinforce the built-in triage rules for this stack)
+------------------------------------------------------------------------
+
+- Volumetric DoS / rate-limiting / resource-exhaustion is infra-layer (FP).
+  ReDoS / algorithmic blowup driven by untrusted email content IS reportable.
+- No native memory-safety findings — this is TypeScript on Workers.
+- Operator-controlled inputs (env vars, `wrangler.jsonc` values, CLI) are
+  trusted unless an untrusted path reaches them.
+- Open redirect, log spoofing, regex injection, missing audit logs, CSRF on
+  idempotent endpoints: low-impact, FP unless chained into something real.

--- a/.claude/skills/sec-patch/SKILL.md
+++ b/.claude/skills/sec-patch/SKILL.md
@@ -1,0 +1,548 @@
+---
+name: sec-patch
+description: Generate candidate fixes for verified security findings. Consumes
+  TRIAGE.json (preferred) or VULN-FINDINGS.json. Static-analysis input gets a
+  per-finding patch subagent + independent reviewer and is written as inert
+  diffs for human review. Writes PATCHES/bug_NN/{patch.diff,patch_result.json},
+  PATCHES.md, and PATCHES.json. Use when asked to "fix the findings",
+  "patch these vulns", "generate fixes", or "close the loop on triage".
+argument-hint: "<findings-path> [--repo PATH] [--top N] [--id fNNN] [--fresh]"
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Write
+  - Task
+  - Bash(python3 .claude/skills/_lib/checkpoint.py:*)
+  - Bash(rg:*)
+  - Bash(grep:*)
+  - Bash(ls:*)
+  - Bash(wc:*)
+  - Bash(head:*)
+  - Bash(file:*)
+  - Bash(jq:*)
+---
+
+# patch
+
+Third leg of the static pipeline (`/sec-vuln-scan` → `/sec-triage` → `/sec-patch`).
+Turns a ranked list of verified findings into candidate diffs.
+
+**Static mode only.** This port targets a TypeScript / Cloudflare Workers app;
+there is no execution oracle (no ASAN binary to build, run, and re-attack), so
+the execution-verified ladder from the reference harness does not apply. Every
+diff here is authored and independently reviewed by agents reading source, then
+written as inert text. Confirm each at runtime with a human-built `vitest` case
+before upstreaming.
+
+The skill **never applies a diff** to the target repo. Output is inert text
+in `./PATCHES/` for a human to review and apply out-of-band. There is no
+`--apply` or `--approve` flag by design: the capability isn't present, so it
+can't be prompt-injected into use.
+
+Invoke with `/sec-patch <findings-path> [--repo PATH] [--top N] [--id fNNN]
+[--fresh]`.
+
+**Arguments** (parse from `$ARGUMENTS`):
+- findings path (first positional, required): `TRIAGE.json`,
+  `VULN-FINDINGS.json`, or any JSON the `/sec-triage` ingest table recognizes.
+- `--repo PATH`: target codebase, read-only (default cwd). Required; the skill
+  stops if cited files don't resolve under it.
+- `--top N`: patch only the N highest-severity true positives.
+- `--id fNNN`: patch only the finding with this id.
+- `--fresh`: ignore `./.patch-state/` checkpoint and start over.
+
+**Tools.** Prefer Read, Glob, Grep, Write, Task. Some sessions do not
+provision Glob or Grep; `allowed-tools` is a permission filter, not a loader.
+When they are unavailable, fall back to the read-only Bash commands
+whitelisted above: `rg`/`grep` for search, `ls` for enumeration,
+`head`/`file`/`wc` for sniffing, `jq` for JSON ingest. Bash is otherwise
+permitted only for `python3 .claude/skills/_lib/checkpoint.py` (state I/O).
+`find` is NOT permitted.
+
+**Write scope.** The Write tool may target ONLY paths under `./PATCHES/` and
+`./.patch-state/`. Never write into `--repo`, never `git apply`, never
+`patch`, never edit target source. If a step seems to require it, the step is
+wrong.
+
+---
+
+## Checkpointing (runs before Phase 0 and after every phase)
+
+State persists to `./.patch-state/` so a fresh `/patch` session resumes
+without re-spawning patch or reviewer subagents. All checkpoint I/O goes
+through `python3 .claude/skills/_lib/checkpoint.py` (atomic, JSON-validated).
+The Write→`--from` pattern keeps repo-derived bytes out of Bash argv; never
+pass payload via heredoc or stdin.
+
+State files: `progress.json` (single source of truth: `{"status":
+"running"|"complete", "phase_done": N, "shards_done": [...]}`),
+`phaseN.json`, `_chunk.tmp`.
+
+**Start of run.** Bash:
+`python3 .claude/skills/_lib/checkpoint.py load ./.patch-state`
+
+- `status == "absent"` OR `"complete"`, OR `--fresh` in `$ARGUMENTS` →
+  fresh start. Bash:
+  `python3 .claude/skills/_lib/checkpoint.py reset ./.patch-state`,
+  proceed to Phase 0.
+- `status == "running"` with `phase_done == N` → resume. Read
+  `phase0.json`..`phaseN.json` in order (and any `shard_*.json` listed in
+  `shards_done`), merge into working state, print
+  `Resuming from checkpoint: Phase N complete`, skip to Phase N+1. Do not
+  re-spawn any subagent whose output is already checkpointed.
+
+**End of every phase N.** Write tool → `./.patch-state/_chunk.tmp` with the
+phase's JSON, then Bash:
+`python3 .claude/skills/_lib/checkpoint.py save ./.patch-state <N> <name> --from ./.patch-state/_chunk.tmp`
+
+**End of run.** After writing `PATCHES.md` and `PATCHES.json`, Bash:
+`python3 .claude/skills/_lib/checkpoint.py done ./.patch-state 4`
+
+---
+
+## Phase 0: Parse arguments
+
+### 0a. Parse `$ARGUMENTS`
+
+Extract findings path (first positional), `--repo` (default `.`), `--top`,
+`--id`, `--fresh`. If no findings path, stop and ask.
+
+### 0b. Mode is always `static`
+
+This port has no execution oracle, so there is no execution-verified mode.
+`TRIAGE.json`, `VULN-FINDINGS.json`, generic finding JSON, and markdown are all
+handled in static mode: the oracle is a fresh-context reviewer that reads
+source (Phase 3). Record `mode: "static"` in working state and proceed.
+
+**Checkpoint:** Write tool → `./.patch-state/_chunk.tmp`:
+`{"phase": 0, "mode": "static", "args": {repo, top, id, findings_path}}`
+Then Bash:
+`python3 .claude/skills/_lib/checkpoint.py save ./.patch-state 0 mode --from ./.patch-state/_chunk.tmp`
+
+---
+
+## Phase 1: Ingest and normalize
+
+Same input contract as `/sec-triage` Phase 1. Normalize every input format to a
+flat `findings[]` of dicts. Pull what's present; never guess what's absent.
+
+### 1a. Recognized containers (priority order)
+
+1. **`TRIAGE.json`** — read `.findings[]`. **Filter to `verdict ==
+   "true_positive"`.** This is the canonical input: already verified,
+   deduped, ranked, owner-tagged.
+2. **`VULN-FINDINGS.json`** — read `.findings[]`. Unverified; print
+   `Warning: VULN-FINDINGS.json is unverified scanner output. Consider
+   /sec-triage first.` and continue.
+3. Generic `*.json` with a top-level list or a `findings`/`results`/
+   `issues`/`vulnerabilities` array.
+
+### 1b. Field aliases (canonical ← also-accept)
+
+| Canonical        | Also accept                                              |
+|------------------|----------------------------------------------------------|
+| `file`           | `path`, `location.file`, `filename`                      |
+| `line`           | `line_number`, `location.line`, `lineno`                 |
+| `category`       | `type`, `cwe`, `rule_id`, `crash_type`                   |
+| `severity`       | `severity_rating`, `level`, `priority`                   |
+| `title`          | `name`, `summary`, `message`                             |
+| `description`    | `details`, `report`, `body`, `evidence`, `rationale`     |
+| `recommendation` | `fix`, `remediation`, `mitigation`                       |
+| `owner_hint`     | `owner`, `component`                                     |
+
+Attach `id` (`f001`, `f002`, ... in ingest order; preserve existing ids from
+TRIAGE.json) and `source` (relative path of the file it came from).
+
+### 1c. Filter and order
+
+- If `--id fNNN`: keep only that finding.
+- If `--top N` (static mode): sort by `severity` HIGH > MEDIUM > LOW then
+  `confidence` desc, keep the first N.
+- Drop findings with no `file` (cannot patch what cannot be located). Record
+  them as `skipped` with reason `"no source location"`.
+
+### 1d. Locate the target codebase (static mode)
+
+Resolve `--repo`. For the first 5 findings with a `file`, check the path
+resolves under repo (try as-given, then with common prefixes stripped). If
+none resolve, **stop**: tell the user the cited files aren't reachable and
+suggest a `--repo` value.
+
+**Checkpoint:** Write tool → `./.patch-state/_chunk.tmp`:
+`{"phase": 1, "mode": ..., "findings": [...], "skipped": [...], "repo": ...}`
+Then Bash:
+`python3 .claude/skills/_lib/checkpoint.py save ./.patch-state 1 ingest --from ./.patch-state/_chunk.tmp`
+
+---
+
+## Phase 2: Generate patches (one patch subagent per finding)
+
+One Task per finding, all in a SINGLE assistant message for parallel
+execution. `subagent_type: "general-purpose"`. Never set
+`run_in_background` — you need the diff text, not an async handle.
+
+Each subagent has read-only access to `--repo`. It cannot modify the target;
+it emits the diff as text in its response. The orchestrator writes that text
+to `PATCHES/bug_NN/patch.diff`.
+
+#### Patch subagent prompt (assemble once, reuse per finding)
+
+```
+You are conducting authorized security research as part of a defensive
+assessment. Your task: write a candidate fix for ONE verified vulnerability
+finding in a codebase you have read-only access to.
+
+You may use Read, Glob, and Grep ONLY on paths inside {REPO_PATH}. You may
+NOT build, run, install, edit files on disk, or reach the network. You will
+emit the fix as a unified diff in your final response; you will NOT apply it.
+
+────────────────────────────────────────────────────────────────────────
+FINDING:
+
+  id:        {id}
+  file:      {file}
+  line:      {line}
+  category:  {category}
+  severity:  {severity}
+  title:     {title}
+
+  description:
+  {description}
+
+  recommendation:
+  {recommendation or "(none provided)"}
+
+────────────────────────────────────────────────────────────────────────
+PROCEDURE:
+
+1. READ THE CODE. Open {file} at line {line} and the surrounding function.
+   Understand what the code does — do not trust the finding's description as
+   the only source.
+
+2. ROOT CAUSE FIRST. Trace backward from the cited sink to where the bad
+   value or missing check originates. The fix usually belongs there, not at
+   the line the scanner flagged. Name the root-cause location (file:line).
+
+3. VARIANT HUNT. Grep for sibling call sites with the same pattern. Your fix
+   should cover all of them, or your rationale should say why not.
+
+4. MINIMAL DIFF. Smallest change that fixes the root cause. No refactoring,
+   no drive-by cleanup, no reformatting, no comment-only changes. Match the
+   surrounding code's style (brace placement, naming, error handling).
+
+5. ADVERSARIAL SELF-CHECK. Re-read your diff as an attacker. Name one input
+   variation that would reach the same bad state without tripping your
+   change. If you can name one, your fix is at the wrong layer — go back to
+   step 2.
+
+6. REGRESSION TEST. As part of the diff, add ONE test case that fails before
+   your change and passes after — placed wherever the project keeps its
+   tests (look for test_*/, *_test.*, tests/, spec/). If no test directory
+   exists, omit the test and say so in <test_note>.
+
+────────────────────────────────────────────────────────────────────────
+OUTPUT — your final response MUST contain exactly these tags. Emit the diff
+verbatim between the markers; do NOT wrap it in ``` fences.
+
+<patch_diff>
+--- a/path/to/file
++++ b/path/to/file
+@@ ... @@
+ context line
+-removed line
++added line
+</patch_diff>
+<rationale>what changed and why, mechanically — file:line of root cause,
+what the change enforces</rationale>
+<variants_checked>file:function pairs you grepped for the same
+pattern, and whether each needed the fix</variants_checked>
+<bypass_considered>the input variation you tried in step 5 and why it
+no longer reaches the bad state</bypass_considered>
+<test_note>where the regression test landed, or why none was
+added</test_note>
+
+If you determine the finding is NOT fixable as described (wrong file, code
+already patched, finding is a false positive), emit:
+
+<patch_diff>NONE</patch_diff>
+<rationale>why no patch is appropriate</rationale>
+```
+
+#### Spawn
+
+For each finding in `findings[]`, build a Task call with the prompt above
+(substituting `{REPO_PATH}`, `{id}`, `{file}`, `{line}`, `{category}`,
+`{severity}`, `{title}`, `{description}`, `{recommendation}`).
+`description: "patch {id}"`.
+
+If `len(findings) > ~40`, shard into sequential batches of ~40 (each batch
+one message). Per-finding shard checkpoint after each result is parsed.
+
+If any Task call returns `status: "async_launched"` instead of the
+subagent's text, the runtime backgrounded it. Pick one recovery and use it
+for the whole batch:
+  - If completion notifications arrive in your conversation: parse each
+    subagent's tagged blocks from its notification `result` as it lands. Do
+    not end your turn until every finding is accounted for.
+  - If notifications do not arrive: do NOT poll transcript files. Re-spawn
+    the missing patch subagents in a fresh Task batch (smaller shard, e.g.
+    10) and use the synchronous results.
+The same recovery applies to reviewer subagents in Phase 3.
+
+#### Parse
+
+From each Task result, extract the five tagged blocks. Tolerate leading/
+trailing whitespace, stray ``` fences, and HTML-escaped entities (`&lt;`
+`&gt;` `&amp;` — some runtimes escape angle brackets in notification
+payloads; unescape before writing the diff). If `<patch_diff>` is `NONE` or
+empty,
+mark `status: "no_patch"`. Otherwise write the diff text to
+`./PATCHES/bug_NN/patch.diff` (NN = zero-padded index in sorted order) and
+record `rationale`, `variants_checked`, `bypass_considered`, `test_note`.
+
+**Checkpoint per finding:** Write tool → `./.patch-state/_chunk.tmp` =
+`{"id": ..., "bug_nn": "NN", "status": ..., "rationale": ..., ...}`, then Bash:
+`python3 .claude/skills/_lib/checkpoint.py shard ./.patch-state <id> --from ./.patch-state/_chunk.tmp`.
+After all findings, write the consolidated phase payload to `_chunk.tmp` then:
+`python3 .claude/skills/_lib/checkpoint.py save ./.patch-state 2 generate --from ./.patch-state/_chunk.tmp`
+
+---
+
+## Phase 3: Independent review (static mode only)
+
+One reviewer subagent per generated diff, all in ONE message,
+`subagent_type: "general-purpose"`.
+
+**The reviewer never sees the finding's `description`, `recommendation`, or
+the patch author's `rationale`.** It gets only `{file, line, category}`
+plus the raw diff bytes, and re-derives whether the diff is a minimal,
+in-scope fix by reading the source itself. This keeps any instructions
+embedded in finding prose from reaching both the author and the gate.
+
+#### Reviewer prompt (assemble once, reuse per diff)
+
+```
+You are reviewing a candidate security patch as a maintainer would. You have
+read-only access to the unpatched source at {REPO_PATH}. You may use Read,
+Glob, Grep. You may NOT build, run, or apply the diff.
+
+You have NOT seen the scanner's description of the vulnerability or the
+patch author's reasoning. Work only from the location, the category, and the
+diff.
+
+LOCATION: {file}:{line}
+CATEGORY: {category}
+
+DIFF UNDER REVIEW:
+<diff>
+{diff_text — or, for diffs over ~50 lines, replace this block with:
+"Read the diff at ./PATCHES/bug_NN/patch.diff" and let the reviewer Read it}
+</diff>
+
+────────────────────────────────────────────────────────────────────────
+ANSWER FOUR QUESTIONS:
+
+1. SCOPE. Does the diff touch only files/functions on the path between
+   {file}:{line} and its callers? List any hunk that falls outside that
+   path.
+
+2. SUPPRESSION. Does the diff fix a root cause, or does it suppress the
+   symptom (try/except: pass, early-return on a magic value, deleting the
+   check that fired, lowering a log level)?
+
+3. NEW SURFACE. Does the diff add parsing, trust a new input field, weaken
+   validation elsewhere, or remove a security-relevant check?
+
+4. STYLE. 0-10: would you merge this as-is?
+   0-3 wrong layer / suppression; 4-6 correct but noisy; 7-10 minimal,
+   targeted, matches surrounding style.
+
+────────────────────────────────────────────────────────────────────────
+End your response with EXACTLY:
+
+  REVIEW: ACCEPT | REJECT
+  STYLE_SCORE: <0-10>
+  OUT_OF_SCOPE_HUNKS: <comma-separated file:line, or none>
+  REASON: <2-4 sentences citing specific diff hunks and source lines>
+
+ACCEPT requires: in-scope, root-cause fix, no new attack surface,
+style >= 5. Otherwise REJECT.
+```
+
+#### Spawn and parse
+
+One Task per finding with `status != "no_patch"`. Parse the trailing block.
+Attach `review`, `style_score`, `out_of_scope_hunks`, `review_reason` to the
+finding. Set `verified: "static_review_only"` for every static-mode result
+regardless of ACCEPT/REJECT — the label describes the verification class,
+not the outcome.
+
+**Checkpoint:** Write tool → `./.patch-state/_chunk.tmp`:
+`{"phase": 3, "findings": [...]}`
+Then Bash:
+`python3 .claude/skills/_lib/checkpoint.py save ./.patch-state 3 review --from ./.patch-state/_chunk.tmp`
+
+---
+
+## Phase 4: Output
+
+### 4a. Per-finding `patch_result.json`
+
+For each finding (both modes), Write
+`./PATCHES/bug_NN/patch_result.json`:
+
+```json
+{
+  "id": "f003",
+  "source": "TRIAGE.json#2",
+  "title": "...",
+  "file": "...",
+  "line": 0,
+  "category": "...",
+  "severity": "HIGH",
+  "owner_hint": "...",
+  "mode": "static",
+  "verified": "static_review_only",
+  "review": "ACCEPT" | "REJECT" | null,
+  "style_score": 0,
+  "out_of_scope_hunks": [],
+  "rationale": "...",
+  "variants_checked": "...",
+  "bypass_considered": "...",
+  "test_note": "...",
+  "review_reason": "..."
+}
+```
+
+### 4b. `./PATCHES.json`
+
+```json
+{
+  "patch_completed": true,
+  "mode": "static",
+  "repo": "...",
+  "summary": {
+    "input_count": 0,
+    "patched": 0,
+    "no_patch": 0,
+    "accepted": 0,
+    "rejected": 0
+  },
+  "findings": [ { ...patch_result.json shape... } ]
+}
+```
+
+### 4c. `./PATCHES.md` (incremental)
+
+**Step 1 — header.** Write tool → `./PATCHES.md` (clobbers prior):
+
+````markdown
+# Candidate Patches
+
+> **Static review only.** These diffs were authored and reviewed by
+> independent agents reading source. They were NOT compiled, run, or
+> re-attacked. Read each diff yourself and add a `vitest` case before
+> applying or upstreaming.
+
+**Input:** {findings_path} · **Repo:** {repo} · {N} findings → {M} diffs
+
+---
+````
+
+**Step 2 — per finding** (sorted: ACCEPT first, then by
+severity). Write `./.patch-state/_chunk.tmp`:
+
+````markdown
+## bug_{NN}: [{severity}] {title}  ({id})
+
+`{file}:{line}` · {category} · owner: {owner_hint or "?"}
+**Status:** {verified} · review {review or "n/a"} · style {style_score or "n/a"}/10
+**Diff:** `PATCHES/bug_{NN}/patch.diff` ({hunk count} hunks, {line count} lines)
+
+**Rationale:** {rationale}
+**Variants checked:** {variants_checked}
+**Bypass considered:** {bypass_considered}
+{if review == "REJECT":}
+> **Rejected by reviewer:** {review_reason}
+{if out_of_scope_hunks:}
+> **Out-of-scope hunks:** {out_of_scope_hunks}
+
+---
+````
+
+Then `checkpoint.py append ./PATCHES.md --from ./.patch-state/_chunk.tmp`.
+
+**Step 3 — footer.** Append a `## Skipped` table for findings with no `file`
+or `status == "no_patch"`, one line each with the reason.
+
+**Checkpoint (final):** Bash:
+`python3 .claude/skills/_lib/checkpoint.py done ./.patch-state 4`
+
+### 4d. Terminal summary
+
+Under ~10 lines:
+
+```
+Patches generated (static mode): {N} findings → {M} diffs.
+
+  Accepted:  {n}   {title of top accepted}
+  Rejected:  {n}
+  No patch:  {n}
+
+Wrote ./PATCHES/bug_NN/, ./PATCHES.md, ./PATCHES.json
+These are drafts. Review each diff and add a vitest case before applying.
+```
+
+---
+
+## Guard rails
+
+- **The skill never applies diffs.** No `git apply`, no `patch`, no Edit
+  against `--repo`. If you find yourself needing to, the design is wrong.
+- **Write only under `./PATCHES/` and `./.patch-state/`.**
+- **Reviewer isolation.** The reviewer prompt receives `{file, line,
+  category, diff}` and nothing else from the finding. Do not pass it
+  `description`, `recommendation`, `exploit_scenario`, or the patch author's
+  `rationale`.
+- **Always set `subagent_type`.** Forking would leak every finding's prose
+  into every patch subagent.
+- **All Task calls for a phase in ONE message.** Serial spawning is correct
+  but N× slower.
+- **Checkpoint before starting the next phase**, every time.
+
+---
+
+## Testing this skill
+
+Run the static chain against this repo's own findings:
+
+```
+/sec-vuln-scan workers/intel
+/sec-triage VULN-FINDINGS.json --repo . --auto
+/sec-patch TRIAGE.json --repo . --top 3
+```
+
+Expected: up to three diffs under `PATCHES/bug_00..02/`, each
+`verified: "static_review_only"` with an ACCEPT/REJECT review and a style
+score. Confirmed true-positives go to a private GitHub Security Advisory
+(`.github/SECURITY.md`), not a public issue.
+
+---
+
+## Design notes
+
+- **TRIAGE.json is canonical input** because patching unverified findings
+  wastes tokens on false positives. VULN-FINDINGS.json is accepted with a
+  warning for convenience.
+- **Static mode emits a regression test inside the diff** rather than
+  running it. The skill cannot execute target code; the test is for the
+  human who applies the diff (a `vitest` case here).
+- **Reviewer never sees finding prose.** Target source can contain
+  injected instructions that survive into a scanner's `description` field.
+  The patch author sees that prose (it has to, to know what to fix); the
+  reviewer doesn't, so injected text cannot pass its own gate.
+- **`verified` is the verification class, not pass/fail.**
+  `static_review_only` means "an agent read it" regardless of
+  ACCEPT/REJECT. Downstream tooling should branch on this field, not on
+  `review`.

--- a/.claude/skills/sec-threat-model/README.md
+++ b/.claude/skills/sec-threat-model/README.md
@@ -1,0 +1,126 @@
+# threat-model
+
+A Claude Code skill that builds a threat model for a target codebase. Two
+modes: **bootstrap** derives the threat model from the target itself (source
+tree, git history, public advisories, an optional past-vulns file);
+**interview** discovers the threat model by walking an application owner
+through the four-question framework. Both write `THREAT_MODEL.md` in a shared
+schema.
+
+## Status
+
+The skill is read-only (it does not build,
+run, or probe the target) and is safe to point at any local checkout. The
+output is a starting point for human review, not a substitute for it.
+
+## Why a threat model
+
+Vulnerability scanners find instances; a threat model is the map of where
+instances are likely to be and which ones matter. Hand `/sec-vuln-scan` a
+threat model and it knows where to look. Hand `/sec-triage` a threat model and
+it knows which findings to escalate. Use the output's focus areas to scope the
+scan and to inform how you prioritize triage results.
+
+## Model selection
+
+The skill has no `model:` frontmatter pin; it runs on whatever model your
+session uses (or `--model` if you pass one). It is designed for
+reasoning-capable Claude models — use the same model you run the rest of the
+pipeline with. If you want to lock the model regardless of session, add a
+`model:` line to `SKILL.md`; frontmatter takes precedence over `/model` and
+`--model`.
+
+## Installation
+
+Project-scoped (already done if you cloned this repo):
+
+```bash
+ls .claude/skills/sec-threat-model/
+```
+
+User-scoped:
+
+```bash
+cp -r .claude/skills/sec-threat-model ~/.claude/skills/
+```
+
+## Usage
+
+### Bootstrap (derive from target, git history, advisories)
+
+Use when no application owner is available. Point it at a checkout and,
+optionally, a list of past vulnerabilities:
+
+```
+/sec-threat-model bootstrap targets/drlibs
+/sec-threat-model bootstrap targets/drlibs --vulns targets/drlibs/vulns.txt
+```
+
+Without `--vulns` the skill mines `git log`, `CHANGELOG`, and GitHub Security
+Advisories itself; with it, it ingests your supplied list first.
+
+The skill spawns a parallel research swarm (docs reader, surface mapper, asset
+finder, git-history miner, advisory fetcher, vuln-file parser), synthesizes
+their returns into the system-context / assets / entry-points sections,
+generalizes the collected vulns into threat classes, gap-fills with STRIDE for
+surfaces the vuln history didn't cover, and writes
+`targets/drlibs/THREAT_MODEL.md`. On small targets (<50 source files) it runs
+the same briefs sequentially instead of spawning.
+
+### Interview (discover via owner conversation)
+
+Use when an application owner is in the session.
+
+```
+/sec-threat-model interview targets/alsa
+/sec-threat-model interview targets/alsa --design-doc targets/alsa/README.md
+```
+
+Without `--design-doc` the interview opens cold by asking the owner to
+describe the system; with it, the skill reads the doc first and summarizes it
+back for confirmation.
+
+The skill will walk the owner through the four questions ("what are we working
+on?", "what can go wrong?", "what are we going to do about it?", "did we do a
+good job?"), grounding answers in the code as it goes, and write
+`targets/alsa/THREAT_MODEL.md`.
+
+### Bootstrap then Interview (bootstrap a draft, then refine via interview)
+
+Use when an owner is available but their time is limited: bootstrap produces
+the draft unattended, then the interview spends owner time only on what the
+code couldn't answer.
+
+```
+/sec-threat-model bootstrap targets/drlibs/
+/sec-threat-model interview targets/drlibs/ --seed targets/drlibs/THREAT_MODEL.md
+```
+
+The interview will focus on the bootstrap's open questions instead of starting
+cold.
+
+## Checkpointing and resume (bootstrap mode)
+
+Bootstrap writes per-stage checkpoints to `./.threat-model-state/` in the
+current working directory (cwd-confined by `checkpoint.py`). If a run is
+interrupted, re-invoking `/sec-threat-model bootstrap <target-dir>` from the same
+working directory
+resumes from the last completed stage — the research swarm is not re-spawned
+if Stage 1 already landed. Pass `--fresh` to start over. The state directory
+is scratch; add it to `.gitignore`.
+
+## Output
+
+`<target-dir>/THREAT_MODEL.md` with eight sections: system context, assets,
+entry points & trust boundaries, threats (the table), deprioritized, open
+questions, provenance, recommended mitigations. See `schema.md` for the full
+contract. For PhishSOC the durable copy lives at `docs/security/THREAT_MODEL.md`.
+
+## References
+
+- Shostack, *The Four Question Framework for Threat Modeling* (2024) —
+  https://shostack.org/files/papers/The_Four_Question_Framework.pdf
+- OWASP Threat Modeling Cheat Sheet —
+  https://cheatsheetseries.owasp.org/cheatsheets/Threat_Modeling_Cheat_Sheet.html
+- `.github/SECURITY.md` (disclosure policy) and `SECURITY_SPEC.md` (pipeline invariants).
+- Adapted from Anthropic's [defending-code reference harness](https://github.com/anthropics/defending-code-reference-harness).

--- a/.claude/skills/sec-threat-model/SKILL.md
+++ b/.claude/skills/sec-threat-model/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: sec-threat-model
+description: >-
+  Build a threat model for a target codebase. Three modes: "interview" walks an
+  application owner through the four-question framework and produces a threat
+  model from their answers; "bootstrap" derives a threat model from the code
+  plus past vulnerabilities (CVEs, git history, pentest reports) when no owner
+  is available; "bootstrap-then-interview" chains the two when both owner and
+  codebase are present. All write THREAT_MODEL.md in a shared schema. Use
+  when asked to "threat
+  model", "build a threat model", "map the attack surface", or "what should we
+  be worried about in this codebase".
+argument-hint: "[bootstrap-then-interview|bootstrap|interview] <target-dir> [--vulns <file>] [--design-doc <file>] [--seed <THREAT_MODEL.md>] [--fresh]"
+allowed-tools:
+  - Read
+  - Glob
+  - Bash(python3 .claude/skills/_lib/checkpoint.py:*)
+  - Grep
+  - Write
+  - Bash(git:*)
+  - Bash(gh api:*)
+  - Bash(find:*)
+  - Bash(ls:*)
+  - Bash(cat:*)
+  - AskUserQuestion
+  - Task
+---
+
+# threat-model
+
+A threat model answers **"what could go wrong with this system, who would do
+it, and what should we do about it?"** independently of whether any specific
+bug has been found yet. It is the map; vulnerability discovery is the metal
+detector. A good threat model tells the pipeline where to look and tells triage
+which findings matter.
+
+**Litmus test:** If patching one line of code makes an entry disappear, it was
+a vulnerability, not a threat. A threat ("attacker achieves RCE via untrusted
+media parsing") still stands after every known bug is fixed; a vulnerability
+("`dr_wav.h:412` doesn't bounds-check `chunk_size`") does not. This skill
+produces threats. Vulnerabilities appear only as **evidence** that raises a
+threat's likelihood score.
+
+**Invocation:** `/sec-threat-model [bootstrap-then-interview|bootstrap|interview] <target-dir> [flags]`
+
+---
+
+## Step 0 — Safety preamble (always runs first)
+
+This skill performs **static analysis only**. It reads source, git history,
+and any vulnerability reports the user supplies, and writes a single output
+file (`<target-dir>/THREAT_MODEL.md`). It does not build, execute, fuzz, or
+modify the target, and does not make network requests against the target's
+infrastructure.
+
+Before proceeding, confirm and state in your first response:
+
+1. The target directory exists and is a local checkout you can read.
+2. You will not execute any code from the target directory.
+3. If `--vulns` points at a URL or you are asked to "fetch CVEs", you will
+   query only public advisory databases (NVD, GitHub Security Advisories, the
+   project's own issue tracker) and never the target's live deployment.
+
+If the user asks you to validate a threat by running an exploit, decline and
+recommend a human-built `vitest` case or controlled proof-of-concept instead.
+
+---
+
+## Step 1 — Route to a mode
+
+Parse `$ARGUMENTS`:
+
+| First token | Route to |
+|---|---|
+| `interview` | Read `interview.md` in this directory and follow it. |
+| `bootstrap` | Read `bootstrap.md` in this directory and follow it. |
+| `bootstrap-then-interview` | Bootstrap first, then interview seeded from the draft. See below. |
+| anything else, or empty | Ask the user: **"Is someone who owns or built this system available to answer questions in this session?"** Yes and the codebase is checked out → recommend `bootstrap-then-interview`. Yes but no codebase → `interview.md`. No → `bootstrap.md`. |
+
+All modes write the same artifact (`THREAT_MODEL.md`, schema in `schema.md`)
+so downstream consumers (pipeline `recon`/`judge`, verifier agents) do not need
+to know which mode produced it.
+
+| | `interview` | `bootstrap` |
+|---|---|---|
+| **Needs** | An application owner present in the session | A local checkout; optionally past vulns |
+| **Method** | Four-question framework: conversational walk through *what are we working on → what can go wrong → what are we going to do about it → did we do a good job* | Five stages: parallel research swarm → synthesize sections 1-3 + vuln table → generalize vulns into threat classes → STRIDE gap-fill → emit |
+| **Best for** | New systems, design reviews, systems where the risk lives in business logic the code doesn't show | Inherited systems, third-party code, OSS dependencies, anything with a CVE history |
+| **Provenance tag** | `interview` | `bootstrap` |
+
+**Context durability.** Interview mode is multi-turn; tool results from early
+reads may be evicted before you need them. To stay resilient:
+
+- Do **not** read `interview.md` or `bootstrap.md` in full up front. Read the
+  mode file (or the relevant section of it) **at the point you need it**, one
+  question or stage at a time.
+- If a re-read via the Read tool is refused as "file unchanged", the prior
+  result was evicted; reload with `cat <path>` via Bash instead.
+
+**Interview backbone** (so you can proceed even if `interview.md` is
+unavailable mid-session):
+
+| Q | Question | Fills schema sections |
+|---|---|---|
+| Q1 | What are we working on? | section 1 context, section 2 assets, section 3 entry points |
+| Q2 | What can go wrong? | section 4 threat rows (id, threat, actor, surface, asset) |
+| Q3 | What are we going to do about it? | section 4 impact/likelihood/status/controls; section 5 deprioritized; section 8 recommended mitigations |
+| Q4 | Did we do a good job? | validate ranking, coverage check, section 6 open questions |
+
+### `bootstrap-then-interview` mode
+
+When the owner is available *and* the codebase is checked out, this is the
+recommended path: the owner's time goes to refining a code-grounded draft
+instead of describing the system from scratch.
+
+1. Tell the owner: "I'll read the code first and come back with a draft
+   (about 5-10 min), then we'll walk it together. Want that, or would you
+   rather start cold?" Only proceed if they opt in; otherwise fall back to
+   `interview.md`.
+2. Read `bootstrap.md` and follow it end-to-end. Write
+   `<target-dir>/THREAT_MODEL.md`.
+3. Immediately continue into interview mode: read `interview.md` and follow
+   it with `--seed <target-dir>/THREAT_MODEL.md` in effect. The section 6 open
+   questions from bootstrap become your Q1-Q4 prompts; the owner confirms,
+   corrects, and adds rather than starting from nothing.
+4. Overwrite `<target-dir>/THREAT_MODEL.md` with the refined model. Set
+   provenance `mode: bootstrap-then-interview`.
+
+The same flow is available manually: run `bootstrap` first, then
+`interview --seed <THREAT_MODEL.md>` in a later session.
+
+---
+
+## Step 2 — Shared output contract
+
+All modes MUST emit `<target-dir>/THREAT_MODEL.md` conforming to `schema.md`
+in this directory. **Read `schema.md` immediately before you write the file**,
+not at routing time; in interview mode the gap between routing and emit can be
+many turns, and an early read will be evicted before it's used.
+
+After writing the file, print to the user:
+
+1. The path to `THREAT_MODEL.md`.
+2. The top 5 threats by likelihood × impact (id, one-line description, L×I).
+3. For `bootstrap`: any open questions the code could not answer (these seed a
+   later `interview` pass).
+4. For `interview`: any owner statements that could not be verified in code
+   (these seed follow-up code review).
+
+---
+
+## References
+
+- [`.github/SECURITY.md`](../../../.github/SECURITY.md) — PhishSOC's
+  vulnerability disclosure policy and in-scope/out-of-scope boundaries;
+  confirmed findings go to a private GitHub Security Advisory, not a public issue.
+- [`SECURITY_SPEC.md`](../../../SECURITY_SPEC.md) — the security-pipeline
+  invariants (Rules 1-6) this threat model must respect.
+- This skill is adapted from Anthropic's
+  [defending-code reference harness](https://github.com/anthropics/defending-code-reference-harness).

--- a/.claude/skills/sec-threat-model/bootstrap.md
+++ b/.claude/skills/sec-threat-model/bootstrap.md
@@ -1,0 +1,420 @@
+# /sec-threat-model bootstrap
+
+> **Re-read note:** If you need this file mid-session and the Read tool
+> reports "file unchanged", the prior result was evicted from context; reload
+> with `cat .claude/skills/sec-threat-model/bootstrap.md` via Bash.
+
+Derive a threat model from **code + past vulnerabilities** when no application
+owner is available. Five stages: spawn a parallel research swarm, synthesize
+its findings into sections 1-3 and a vuln working table, generalize vulns into threat
+classes, gap-fill with STRIDE, emit `THREAT_MODEL.md` per `schema.md`.
+
+This mode is read-only static analysis and is **language-agnostic**: the same
+stages apply whether the target is C/C++, Rust, Go, Python, Java/Kotlin,
+JavaScript/TypeScript, or polyglot. Do not build, run, or fuzz the target. The
+Bash tool is permitted **only** for `git` (history mining), `find`/`ls`
+(layout), `gh api` (public advisory lookup), and `cat` (re-reading skill
+files). Do not execute anything from inside `<target-dir>`. The same
+restriction applies to every subagent you spawn: pass it verbatim in each
+prompt.
+
+---
+
+## Inputs
+
+- `<target-dir>` (required): local checkout.
+- `--vulns <path>` (optional): past vulnerabilities. Any of:
+  - newline-separated CVE IDs (`CVE-2026-29022`)
+  - CSV with columns `id,title,component,description` (extra columns ignored)
+  - markdown pentest report (parse headings + body for finding descriptions)
+  - JSON array of objects with at least `id` and `description` keys
+- `--depth recon|full` (optional, default `full`): `recon` runs stages 1-2
+  only. Still write all eight sections (schema requires sections 1-7; section 8 optional);
+  leave section 4, section 5, and section 8 as header + empty table, and put "run with --depth full
+  to populate" in section 6.
+  Use for fast context-building before a deeper pass.
+
+If `--vulns` is absent, the Vuln-file parser agent is skipped; the History
+miner and Advisory fetcher agents in the Stage-1 swarm cover the same ground
+from `<target-dir>`'s own git history and public advisories.
+
+- `--fresh` (optional): ignore any existing checkpoint in
+  `./.threat-model-state/` and start from Stage 1.
+
+---
+
+## Checkpointing (runs before Stage 1 and after every stage)
+
+On large codebases the Stage-1 swarm can exhaust context or hit rate limits
+before Stage 5 emits `THREAT_MODEL.md`. Stage state persists to
+`./.threat-model-state/` (in the **current working directory**, not
+`<target-dir>`) so a fresh `/sec-threat-model bootstrap` session can resume
+without re-spawning the swarm. The state dir is cwd-relative because
+`checkpoint.py` confines all paths to cwd as a guard against prompt-injected
+writes outside the repo.
+
+All checkpoint I/O goes through `python3 .claude/skills/_lib/checkpoint.py`
+(atomic writes, JSON-validated). Never use the Write tool for `progress.json`
+directly. Never pass payload via heredoc or stdin; target-derived strings
+could collide with the heredoc delimiter and break out to shell. The
+Write→`--from` pattern keeps repo-derived bytes out of Bash argv.
+
+State files in `./.threat-model-state/`:
+- `progress.json` — **single source of truth** for resume position:
+  `{"status": "running"|"complete", "stage_done": N}`. Resume decisions read
+  ONLY this file.
+- `stageN.json` — data payload for stage N (schemas at the tail of each stage
+  below).
+- `_chunk.tmp` — transient payload buffer; overwritten before every
+  `save`/`append` call.
+
+**Start of run — resume check.** Bash:
+`python3 .claude/skills/_lib/checkpoint.py load ./.threat-model-state`
+
+- `status == "absent"` OR `"complete"`, OR `--fresh` in `$ARGUMENTS` →
+  **fresh start.** Bash:
+  `python3 .claude/skills/_lib/checkpoint.py reset ./.threat-model-state`,
+  then proceed to Stage 1.
+- `status == "running"` with `stage_done == N` → **resume.** Read
+  `stage1.json` through `stageN.json` **in order**, merging keys into working
+  state (later files override earlier — checkpoints may be deltas). Print
+  `Resuming from checkpoint: Stage N complete`, and **skip directly to
+  Stage N+1**.
+
+**End of every stage N.** Two tool calls:
+1. Write tool → `./.threat-model-state/_chunk.tmp` containing the
+   stage's output JSON.
+2. Bash → `python3 .claude/skills/_lib/checkpoint.py save ./.threat-model-state <N> <name> --key stage --from ./.threat-model-state/_chunk.tmp`
+
+**End of run.** After writing `<target-dir>/THREAT_MODEL.md`, Bash:
+`python3 .claude/skills/_lib/checkpoint.py done ./.threat-model-state 5 --key stage`
+
+---
+
+## Stage 1 — Research swarm
+
+Goal: gather everything needed to fill sections 1-3 and the vuln working table, in
+parallel. Spawn the agents below **in a single batch** with the Task tool so
+they run concurrently. Each agent gets a narrow brief, the absolute path to
+`<target-dir>`, and the read-only restriction verbatim. Each returns a
+structured text block; you synthesize in Stage 2.
+
+Skip the swarm and run the briefs yourself sequentially if `<target-dir>` is
+small (<50 source files) or `--depth recon` is set; the parallelism isn't
+worth the overhead there.
+
+| Agent | Brief | Returns |
+|---|---|---|
+| **Docs reader** | Read `README*`, `SECURITY.md`, `CHANGELOG*`, top-level `docs/`, and the build manifest (`setup.py` / `Cargo.toml` / `package.json` / `CMakeLists.txt`). Summarize what the project says it is, who uses it, and any security claims or fix entries it documents. | Prose system description; list of self-documented security fixes. |
+| **Surface mapper** | Grep the source tree for entry-point signatures (table below). For each hit, name the surface, the file:function, and what crosses it. Include supply-chain surfaces (lockfiles, vendored deps, `curl \| sh` in build scripts). Bound the scan: exclude `vendor/`, `node_modules/`, `third_party/`, generated code; cap at ~5 representative hits per surface row. | Candidate section 3 rows: `{entry_point, description, trust_boundary, file_refs}`. |
+| **Infra reader** | Read deploy-time config: `*.tf`/`*.tfvars`, k8s manifests (`*.yaml` under `k8s/`/`deploy/`/`manifests/`), `Dockerfile*`, CI workflows, and any IAM/service-account/dataset-ACL files. For each, name (a) the identity it runs as and what that identity can reach, (b) any access grant not managed in this tree (ad-hoc IAM, hand-created SAs, missing column/policy tags), (c) credentials or principals that survive a migration or teardown. | Candidate section 3 rows for infra surfaces + candidate section 4 rows: `{threat, surface, asset}` where the config itself is the finding. |
+| **Asset finder** | Identify what the code protects or produces: sensitive data it reads/writes (secrets, keys, user records, DBs), process integrity (always present for native code), service availability, and downstream embedder assets if it's a library. | Candidate section 2 rows: `{asset, description, sensitivity}`. |
+| **History miner** | Two steps. **(a)** Glance at the build manifest and file extensions to identify language **and domain**, then derive 6-10 commit-message keywords specific to that stack on top of the base set `CVE- security vuln fix exploit`. Derive from what the code does, not from a lookup table; the three examples below illustrate the specificity bar, not coverage: native parser → `overflow OOB UAF integer`; web service → `injection SSRF IDOR traversal`; crypto → `timing constant-time nonce`. **(b)** `git -C <target-dir> log --all -i --grep='<base ∪ derived, \|-joined>' --oneline`, then read the full message + diff of each hit. Also grep any `issues/` or `bugs/` export in-tree. | Vuln rows: `{id (commit hash), title, component, class, vector}`. |
+| **Advisory fetcher** | If `git -C <target-dir> remote get-url origin` is GitHub and `gh` is on PATH: `gh api /repos/{owner}/{repo}/security-advisories`. Otherwise return "no public advisory source". | Vuln rows: `{id (CVE/GHSA), title, component, class, vector}`. |
+| **Vuln-file parser** | Only spawn if `--vulns <path>` was provided. Parse the file (newline CVE list, CSV, markdown report, or JSON array) into normalized rows. | Vuln rows: `{id, title, component, class, vector}`. |
+
+Surface-mapper grep targets (pass this table in its prompt). Treat the
+"Look for" column as a **seed, not a checklist**: one concrete token per row
+to set the specificity bar, then extend with the idioms of whatever
+language/framework the target actually uses.
+
+| Surface | Look for |
+|---|---|
+| Network | socket `listen`/`accept`/`bind`; HTTP route definitions (e.g., `@app.route`); RPC/gRPC/GraphQL service defs |
+| File / format parsing | file-open calls (e.g., `open(`); format magic-byte checks; "parse"/"decode"/"load"/"unmarshal" function names |
+| CLI / env | argv parsers (e.g., `argparse`); env reads (e.g., `getenv`) |
+| Deserialization | language-native deserializers on external data (e.g., `pickle`, `ObjectInputStream`) |
+| DB / query | raw query-string construction; ORM `.raw()`/`.query()` escapes |
+| IPC / plugins | dynamic load (e.g., `dlopen`); subprocess spawn; `eval`/`exec` on config; dynamic import |
+| Supply chain | dependency lockfiles; vendored libs; `curl \| sh` in build scripts |
+| Infra / IAM | terraform `google_*_iam_*`/`aws_iam_*`; k8s `serviceAccountName`/WIF annotations; BigQuery dataset/table `access{}` blocks; secrets mounts |
+
+**Checkpoint:** Write tool → `./.threat-model-state/_chunk.tmp`:
+
+```json
+{
+  "stage": 1,
+  "swarm": {
+    "docs_reader": "<returned text block>",
+    "surface_mapper": [ {entry_point, description, trust_boundary, file_refs} ],
+    "infra_reader": { "surfaces": [...], "threats": [...] },
+    "asset_finder": [ {asset, description, sensitivity} ],
+    "history_miner": [ {id, title, component, class, vector} ],
+    "advisory_fetcher": [ {id, title, component, class, vector} ],
+    "vuln_file_parser": [ {id, title, component, class, vector} ]
+  }
+}
+```
+
+Then Bash:
+`python3 .claude/skills/_lib/checkpoint.py save ./.threat-model-state 1 swarm --key stage --from ./.threat-model-state/_chunk.tmp`
+
+This is the most expensive checkpoint — the swarm is the majority of the
+mode's token spend. Agents that were skipped (no `--vulns`, no GitHub remote,
+`--depth recon`) get an empty list/null. If the swarm was run inline
+(small target), populate the same keys from your own sequential passes.
+
+---
+
+## Stage 2 — Synthesize
+
+Goal: turn the swarm returns into `## 1-3` of the schema plus a vuln working
+table. This stage runs in the orchestrating agent, not a subagent; it's the
+join.
+
+**Section 1: System context.** From the Docs reader's summary plus your own glance at
+the tree layout, write 1-2 paragraphs: what it is, language, rough size, who
+would embed or deploy it, where it would run.
+
+**Section 2: Assets.** Take the Asset finder's rows. Dedupe, fill any obvious gaps
+(native code without "host process integrity" → add it), assign `sensitivity`.
+
+**Section 3: Entry points & trust boundaries.** Merge Surface mapper + Infra reader
+rows. Dedupe, name the trust boundary for each ("untrusted file → process
+memory", "unauth HTTP → application logic", "namespace workload → WIF
+identity"), and for each list which section 2 assets are reachable from it.
+Supply-chain, build-time, and infra/IAM surfaces **are** entry points even
+though no runtime input crosses them. **Every row here must get at least one
+threat in Stage 3 or 4**; that's the coverage invariant the emit-time check
+enforces.
+
+**Vuln working table.** Concatenate rows from History miner + Advisory
+fetcher + Vuln-file parser. Dedupe by `id`. For each row, decide which section 3
+entry point it traversed; read the relevant source to confirm (e.g.,
+"CVE-2026-29022 is in `drwav__read_smpl`, reached via the WAV file-parsing
+entry point"). If a vuln's entry point isn't in section 3, the Surface mapper missed
+one; add it now. Hold this table in your working notes; it does **not** go
+into `THREAT_MODEL.md` verbatim. It becomes the `evidence` column in Stage 3.
+
+**Checkpoint:** Write tool → `./.threat-model-state/_chunk.tmp`:
+
+```json
+{
+  "stage": 2,
+  "section1_context": "<markdown prose>",
+  "section2_assets": [ {asset, description, sensitivity} ],
+  "section3_entry_points": [ {entry_point, description, trust_boundary, reachable_assets} ],
+  "vuln_table": [ {id, title, component, class, vector, entry_point} ]
+}
+```
+
+Then Bash:
+`python3 .claude/skills/_lib/checkpoint.py save ./.threat-model-state 2 synthesize --key stage --from ./.threat-model-state/_chunk.tmp`
+
+---
+
+## Stage 3 — Generalize: vulns → threats
+
+Goal: cluster Stage-2 vulns into threat rows at the right abstraction level.
+
+### 3a. Cluster
+
+Group the Stage-2 vuln table by `(entry point, bug class, asset reached)`.
+Each cluster becomes **one** candidate threat. Examples:
+
+- 3 heap overflows + 1 integer overflow, all in WAV/FLAC parsers, all
+  reaching process memory → **one** threat: "Memory corruption leading to RCE
+  via untrusted audio file parsing". Evidence: all 4 IDs.
+- 2 SQL injections in different endpoints → **one** threat: "Data exfiltration
+  / tampering via SQL injection in HTTP API". Evidence: both IDs.
+
+Apply the litmus test to each cluster's threat statement: would it still be
+true after every listed evidence item is patched? If not, you're still at vuln
+level; zoom out.
+
+### 3b. Variant scan (raises likelihood)
+
+For each cluster, look for **siblings**: code paths with the same shape that
+weren't in the vuln list. Grep for the same pattern (other format parsers,
+other endpoints calling the same unsafe helper, other size fields multiplied
+without overflow checks). You are not trying to prove these are exploitable;
+you are estimating how much of the surface shares the pattern. More siblings →
+higher likelihood.
+
+Keep sibling locations in your working notes and surface them in the hand-back
+(Stage 5, item 4). Do **not** put `file:func` references in the section 4 `evidence`
+cell; evidence is for confirmed past vulns only. Sibling counts inform the
+likelihood score, not the evidence column.
+
+### 3c. Score
+
+For each cluster, assign:
+
+- `actor`: from the entry point (file parsing → whoever supplies the file;
+  network endpoint → `remote_unauth` or `remote_auth` depending on whether
+  auth precedes it).
+- `impact`: from the asset and the bug class (memory corruption on a network
+  service → `critical`; info leak of non-sensitive data → `low`).
+- `likelihood`: start from the evidence. ≥1 confirmed past vuln in this exact
+  surface → at least `likely`. Public exploit or active exploitation →
+  `almost_certain`. No evidence, but siblings found and technique is well
+  known → `possible`. Adjust down for controls.
+- `controls`: grep for mitigations relevant to the stack (size caps, input
+  validation, sandboxing/seccomp; ASLR/stack-protector/CFI in native builds;
+  parameterized queries / ORM; auth middleware / CSRF tokens / CSP; rate
+  limiting; SecurityManager/JEP-411 replacements in Java; etc.). `none` if
+  none found.
+- `status`: `unmitigated` unless you found a control that fully closes it.
+- `recommended_mitigation` (working notes, not a section 4 column): for each cluster,
+  name **one class-level control** that would close or materially shrink the
+  whole threat regardless of which instance is found next (e.g., "sandbox the
+  decoder process", "parameterized queries everywhere", "drop `pickle` for
+  `json`", "enable CSP `default-src 'self'`", "size-cap all length fields
+  before allocation"). Prefer a control that survives the next bug over a
+  patch for the last one. These become section 8 rows in Stage 5.
+
+Write each cluster as a section 4 row.
+
+**Checkpoint:** Write tool → `./.threat-model-state/_chunk.tmp`:
+
+```json
+{
+  "stage": 3,
+  "section1_context": "...",
+  "section2_assets": [...],
+  "section3_entry_points": [...],
+  "section4_threats": [ {threat, actor, surface, asset, impact, likelihood, status, controls, evidence} ],
+  "mitigation_notes": [ {cluster, recommended_mitigation} ],
+  "sibling_locations": [ {threat, locations: ["file:func", ...]} ]
+}
+```
+
+Then Bash:
+`python3 .claude/skills/_lib/checkpoint.py save ./.threat-model-state 3 generalize --key stage --from ./.threat-model-state/_chunk.tmp`
+
+---
+
+## Stage 4 — Gap-fill (the part past vulns can't give you)
+
+Past vulnerabilities are biased toward what's already been found. A threat
+model must also cover what hasn't. For **every section 3 entry point that has no section 4
+row yet**, walk STRIDE and add at least the plausible ones:
+
+| | For this entry point, could an attacker… |
+|---|---|
+| Spoofing | …pretend to be a trusted source? |
+| Tampering | …modify data in transit or at rest? |
+| Repudiation | …act without leaving attributable logs? |
+| Info disclosure | …read data they shouldn't? |
+| DoS | …exhaust a resource (CPU, memory, disk, connections)? |
+| Elevation | …end up with more privilege than they started with? |
+
+Also walk the entry points that **do** have rows: is the existing row the only
+plausible threat, or are other STRIDE categories live too? (A file parser with
+an RCE threat probably also has a DoS threat.)
+
+For **infra/IAM entry points** (from the Infra reader), STRIDE maps less
+cleanly than for code. Walk these instead:
+
+- **Over-grant**: does the identity reach more than the app needs (whole
+  dataset vs one table; project-level vs resource-level)?
+- **Lateral identity**: can a co-located workload (same namespace, same node,
+  same SA) assume this identity?
+- **Drift**: is any grant managed outside this tree (click-ops IAM, ad-hoc
+  ACL, unmanaged SA), so it won't be reviewed or torn down with the code?
+- **Residual access**: do credentials or principals from a predecessor system
+  survive the migration?
+- **Column exposure**: does a broad table read expose identity/PII columns
+  the app doesn't need?
+- **Scope enforcement**: where an automated approval, merge, or write path
+  exists, what bounds it to its intended scope (path allowlist, label,
+  reviewer set)?
+
+Threats added in this stage have empty `evidence`. That's fine; score
+`likelihood` from technique prevalence and surface reachability alone. **The
+final section 4 table must contain at least one row with empty evidence**, or this
+stage didn't run.
+
+Populate `## 5. Deprioritized` with STRIDE categories you considered and
+ruled out, with the reason ("Repudiation: not applicable, no multi-user
+actions").
+
+**Checkpoint:** Write tool → `./.threat-model-state/_chunk.tmp`:
+
+```json
+{
+  "stage": 4,
+  "section1_context": "...",
+  "section2_assets": [...],
+  "section3_entry_points": [...],
+  "section4_threats": [ {...stage3 rows + gap-fill rows with empty evidence} ],
+  "section5_deprioritized": [ {threat, reason} ],
+  "mitigation_notes": [...],
+  "sibling_locations": [...]
+}
+```
+
+Then Bash:
+`python3 .claude/skills/_lib/checkpoint.py save ./.threat-model-state 4 gap-fill --key stage --from ./.threat-model-state/_chunk.tmp`
+
+---
+
+## Stage 5 — Emit
+
+**Coverage check (do this before writing the file).** For every section 3 entry
+point, confirm at least one section 4 row names it in the `surface` column. Match on
+the entry-point's name string, not the concept; the downstream scorer is a
+text match. Any section 3 row with zero section 4 coverage means Stage 4 was incomplete; go
+back and add the missing threat now.
+
+Sort section 4 by (impact desc, likelihood desc). Assign `id` = `T1`, `T2`, … in
+sorted order.
+
+Populate `## 6. Open questions` with everything the code couldn't tell you:
+
+- Deployment context ("Is this exposed to the network or only local?")
+- Intended actors ("Who supplies the input files in practice?")
+- Controls you couldn't verify ("Is there a WAF / sandbox / size limit
+  upstream of this?")
+- Risk appetite ("Is DoS acceptable for this use case?")
+
+These seed a later `/sec-threat-model interview --seed THREAT_MODEL.md`
+pass.
+
+Populate `## 8. Recommended mitigations` from the Stage-3c working notes: one
+row per class-level `mitigation`, listing the `threat_ids` it covers, whether
+it `closes_class` (yes/partial), and a rough `effort` (S/M/L). If two
+clusters are closed by the same control, emit one row with both clusters'
+ids. Gap-fill threats from Stage 4 get rows here too where an obvious
+class-level control exists.
+
+Assemble the file **incrementally** in `./.threat-model-state/THREAT_MODEL.md`
+(one chunk per `## N.` section; a stalled chunk loses that section, not the
+file), then copy the assembled result to `<target-dir>/THREAT_MODEL.md` in
+one Write. The assembly happens in cwd because `checkpoint.py append` is
+cwd-confined; the final Write tool call is not.
+
+1. Write tool → `./.threat-model-state/THREAT_MODEL.md` (clobbers any prior
+   file) containing only the title line and `## 1. Context` section.
+2. For each remaining section (`## 2. Assets`, `## 3. Entry points`,
+   `## 4. Threats`, `## 5. Deprioritized`, `## 6. Open questions`,
+   `## 7. Provenance`, `## 8. Recommended mitigations`):
+   - Write tool → `./.threat-model-state/_chunk.tmp` containing that ONE
+     section's markdown.
+   - Bash:
+     `python3 .claude/skills/_lib/checkpoint.py append ./.threat-model-state/THREAT_MODEL.md --from ./.threat-model-state/_chunk.tmp`
+3. Read tool → `./.threat-model-state/THREAT_MODEL.md`, then Write tool →
+   `<target-dir>/THREAT_MODEL.md` with the same content.
+
+Set `## 7. Provenance`:
+
+```
+- mode: bootstrap
+- date: <today>
+- target: <target-dir> @ <git rev-parse --short HEAD or "not a git repo">
+- inputs: <--vulns path, or "git-log + CHANGELOG mined">
+- owner: unset
+```
+
+**Checkpoint (final):** After the file is on disk, Bash:
+`python3 .claude/skills/_lib/checkpoint.py done ./.threat-model-state 5 --key stage`
+
+Hand back to the user:
+
+1. Path to the file.
+2. Top 5 threats (id, threat, impact × likelihood).
+3. Count of threats with evidence vs without (shows gap-fill ran).
+4. Stage-3b sibling locations as candidate leads for `/sec-vuln-scan` or the
+   pipeline `find` stage.
+5. The section 8 recommended mitigations, top 3 by (closes_class, effort asc).
+6. The section 6 open questions, framed as "ask the owner".

--- a/.claude/skills/sec-threat-model/interview.md
+++ b/.claude/skills/sec-threat-model/interview.md
@@ -1,0 +1,203 @@
+# /sec-threat-model interview
+
+> **Re-read note:** If you need this file mid-session and the Read tool
+> reports "file unchanged", the prior result was evicted from context; reload
+> with `cat .claude/skills/sec-threat-model/interview.md` via Bash.
+
+Build a threat model by interviewing the application owner using the
+**four-question framework**. The owner is in the session; your job is to ask,
+listen, ground their answers in the code where you can, and emit
+`THREAT_MODEL.md` per `schema.md`.
+
+The four questions (use this exact wording when you introduce each phase; the
+phrasing is deliberate):
+
+1. **What are we working on?**
+2. **What can go wrong?**
+3. **What are we going to do about it?**
+4. **Did we do a good job?**
+
+Reference: Shostack, *The Four Question Framework for Threat Modeling* (2024).
+
+---
+
+## Inputs
+
+- `<target-dir>` (required): local checkout. You will read it to ground
+  answers; you will not execute it.
+- `--design-doc <path>` (optional): architecture or design document. Read it
+  before asking Q1 so you can summarize back instead of starting cold.
+- `--seed <THREAT_MODEL.md>` (optional): a prior `bootstrap` output. If
+  present, the interview focuses on its `## 6. Open questions` and any threat
+  rows with uncertain likelihood, instead of building from scratch.
+
+---
+
+## Provenance discipline
+
+Every fact you write into `THREAT_MODEL.md` carries one of two tags in your
+working notes:
+
+- `[Code-verified]` — you read the source in `<target-dir>` and confirmed it.
+- `[Owner-states]` — the owner told you and you have not (or cannot) verify it
+  in code.
+
+The final `THREAT_MODEL.md` does not include the tags inline (they would
+clutter the table), but every `[Owner-states]` fact that affects a likelihood
+or status score MUST be listed in `## 6. Open questions` as a follow-up to
+verify. This is how an interview-mode threat model stays honest about what is
+asserted versus observed.
+
+---
+
+## Method
+
+Work through the four questions in order. Within each, ask one thing at a
+time, wait for the answer, then move on. Do not dump a questionnaire.
+
+### Q1 — What are we working on?
+
+Goal: fill `## 1. System context`, `## 2. Assets`, `## 3. Entry points & trust
+boundaries`.
+
+If `--design-doc` was provided: read it, then **summarize the system back to
+the owner in 4-6 sentences** and ask "Is this right? What did I miss?" This is
+faster than asking them to describe it cold and surfaces drift between doc and
+reality.
+
+If no design doc: ask directly. Prompts, in order:
+
+- "In two or three sentences, what does this system do and who uses it?"
+- "What data does it hold or pass through that would be bad to lose, leak, or
+  tamper with?" → assets table.
+- "Where does input come from? Walk me from the outside in: network, files,
+  CLI, other services, anything a user or another system hands you." → entry
+  points.
+- "Where does privilege change? Unauth to auth, user to admin, one service
+  trusting another?" → trust boundaries.
+
+While the owner answers, **read the code** in `<target-dir>` to corroborate:
+look for `main`, route definitions, file-open calls, socket listeners,
+deserializers, `argv` parsing. Where code confirms the owner, tag
+`[Code-verified]`. Where code shows an entry point the owner did not mention,
+ask about it: "I see a `/admin/debug` route in `routes.py:88`; is that
+reachable in production?"
+
+If `--seed` was provided: read its sections 1-3, summarize back, and ask only "What's
+wrong or missing here?"
+
+### Q2 — What can go wrong?
+
+Goal: fill `## 4. Threats` rows (id, threat, actor, surface, asset).
+
+Start open: **"For each of those entry points, what can go wrong? What's the
+worst thing someone could do?"** Let the owner answer in their own words
+first. Capture each answer as a candidate threat row.
+
+When the owner stalls or stays vague, switch to structured prompts. Walk each
+entry point from section 3 through STRIDE:
+
+| | Ask |
+|---|---|
+| **S**poofing | "Could someone pretend to be a user or service they're not, here?" |
+| **T**ampering | "Could input or stored data be modified in transit or at rest?" |
+| **R**epudiation | "If someone did something bad here, would you know who?" |
+| **I**nformation disclosure | "Could this leak data it shouldn't?" |
+| **D**enial of service | "Could someone make this unavailable or too expensive to run?" |
+| **E**levation of privilege | "Could someone end up with more access than they started with?" |
+
+Then derive the domain-specific classes. From the section 1 context (stack,
+language, deployment, data flows), name the 5-8 attack classes most likely
+to matter for *this* system. Derive from what the owner described, not from
+a generic checklist. Name classes at the granularity of "IDOR on dataset
+rows" or "integer overflow on length fields", not "web vulnerabilities" or
+"memory bugs".
+
+Show the derived list to the owner: "Based on what you've described, these
+are the classes I'd focus on. Anything you'd add from incidents you've seen
+here or on similar systems?" Their additions are high-signal; weight them
+above your own. If a class you'd expect for this stack (injection,
+deserialization, auth, memory safety, crypto, supply chain, infra/IAM)
+didn't make either list, ask the owner why before dropping it.
+
+Walk each section 3 entry point through STRIDE plus the derived-and-confirmed
+classes. For each candidate threat, pin down: **actor** (who, from the enum in
+`schema.md`), **surface** (which section 3 entry point), **asset** (which section 2 row).
+Phrase the threat at the level where it survives a patch: "RCE via untrusted
+WAV parsing", not "missing bounds check at line 412".
+
+If `--seed` was provided: walk the seed's section 4 table row by row and ask "Does
+this apply? Is the actor right?" Then ask "What's missing?"
+
+### Q3 — What are we going to do about it?
+
+Goal: fill `impact`, `likelihood`, `status`, `controls` for every section 4 row, and
+fill `## 5. Deprioritized`.
+
+For each threat row, ask:
+
+- "What's in place today that stops or limits this?" → `controls`. Verify in
+  code where possible (`[Code-verified]` vs `[Owner-states]`).
+- "If it happened anyway, how bad is it?" → `impact` (read them the scale
+  from `schema.md` if needed).
+- "How likely is it that someone tries and succeeds, given the controls?" →
+  `likelihood`. If past incidents, CVEs, or pentest findings exist for this
+  surface, list them in `evidence` and weight likelihood up.
+- "Is this mitigated, partially mitigated, unmitigated, or are you accepting
+  the risk?" → `status`. **If the owner says "risk accepted", capture their
+  reason verbatim** and put the row in section 5 with that reason.
+
+The answer to Q3 is allowed to be "nothing, and we're not going to":
+deprioritized threats with a recorded reason are a valid output. "Threat
+modeling can result in knowing what we're not going to do and why."
+
+After scoring, ask one closing question per **threat class** (not per row):
+"If we could land one engineering control that makes this whole class go
+away or shrink, what would it be?" Record the answer (or your own proposal
+if the owner punts) as a section 8 row: `mitigation | threat_ids | closes_class |
+effort`. Prefer controls that survive the next bug (sandboxing, type-safe
+parsers, parameterized queries, CSP, allocation caps) over patches for the
+last one.
+
+### Q4 — Did we do a good job?
+
+Goal: validate before writing.
+
+- Read the draft section 4 table back to the owner, sorted by impact × likelihood.
+  Ask: **"Does the top of this list match your gut? Is anything ranked too
+  high or too low?"** Adjust.
+- Ask: **"Is there anything you've been worried about that isn't on this
+  list?"** Add it.
+- Check coverage yourself: for every row in section 3, the `entry_point` name must
+  appear verbatim in at least one section 4 `surface` cell, OR a section 5 row must say
+  "<entry_point>: out of scope because …". If neither, either add a threat for
+  that surface or ask the owner why it's safe and record the answer in section 5.
+- Ask: **"Would you do this again for the next service? What would make it
+  easier?"** Record the answer in your hand-back to the user (not in the
+  file); it's feedback for this skill.
+
+---
+
+## Emit
+
+Write `<target-dir>/THREAT_MODEL.md` per `schema.md`. Set `## 7. Provenance`:
+
+```
+- mode: interview
+- date: <today>
+- target: <target-dir> @ <git rev-parse HEAD if available>
+- inputs: <design-doc path or "none">; <seed path or "none">
+- owner: <name the user gave, or "present, unnamed">
+```
+
+Then hand back to the user:
+
+1. Path to the file.
+2. Top 5 threats by impact × likelihood, one line each.
+3. The section 8 recommended mitigations, top 3 by (closes_class, effort asc).
+4. Every `[Owner-states]` claim that affects a score, as a follow-up list.
+   Format each as a section 6 bullet: `- [Owner-states] <claim>. Affects: <Tn
+   field>. Verify by: <suggested check>.`
+5. If `--seed` was provided: a short diff summary ("added T7-T9, downgraded T2
+   likelihood from likely → possible because owner confirmed input is
+   size-capped").

--- a/.claude/skills/sec-threat-model/schema.md
+++ b/.claude/skills/sec-threat-model/schema.md
@@ -1,0 +1,189 @@
+# THREAT_MODEL.md schema
+
+> **Re-read note:** If you need this file mid-session and the Read tool
+> reports "file unchanged", the prior result was evicted from context; reload
+> with `cat .claude/skills/sec-threat-model/schema.md` via Bash.
+
+Both `/sec-threat-model interview` and `/sec-threat-model bootstrap` write
+this file to `<target-dir>/THREAT_MODEL.md`. The format is markdown so humans
+can read and edit it, but the section headings, table columns, and enum values
+below are a contract: keep the headings and column order exactly as shown so
+downstream tooling can parse them with regex.
+
+---
+
+## Required sections, in order
+
+```markdown
+# Threat Model: <system name>
+
+## 1. System context
+
+## 2. Assets
+
+## 3. Entry points & trust boundaries
+
+## 4. Threats
+
+## 5. Deprioritized
+
+## 6. Open questions
+
+## 7. Provenance
+
+## 8. Recommended mitigations
+```
+
+A consumer that only needs the threat table can regex for `^## 4\. Threats$`
+and read until the next `^## `. Section 8 is optional and additive: older threat
+models may omit it, and consumers must tolerate its absence.
+
+---
+
+## Section contents
+
+### 1. System context
+
+One to three paragraphs of prose: what the system is, what it does, who uses
+it, where it runs. No table. This is the answer to "what are we working on?".
+
+### 2. Assets
+
+Markdown table. One row per thing worth protecting.
+
+| asset | description | sensitivity |
+|---|---|---|
+
+`sensitivity` ∈ {`low`, `medium`, `high`, `critical`}.
+
+### 3. Entry points & trust boundaries
+
+Markdown table. One row per place untrusted input enters the system or
+privilege level changes.
+
+| entry_point | description | trust_boundary | reachable_assets |
+|---|---|---|---|
+
+`trust_boundary` is free text naming the crossing (e.g. "untrusted file →
+process memory", "unauth network → authenticated session").
+`reachable_assets` is a comma-separated list of asset names from section 2.
+
+### 4. Threats
+
+Markdown table. **This is the threat model proper.** One row per
+actor-wants-outcome pair, at the abstraction level where it survives a patch.
+
+| id | threat | actor | surface | asset | impact | likelihood | status | controls | evidence |
+|---|---|---|---|---|---|---|---|---|---|
+
+- `id`: `T1`, `T2`, … Stable across edits; do not renumber when rows are
+  removed.
+- `threat`: One sentence, active voice, names the outcome. "Remote code
+  execution via untrusted media parsing", not "buffer overflow in dr_wav".
+- `actor` ∈ {`remote_unauth`, `remote_auth`, `adjacent_network`,
+  `local_user`, `local_admin`, `supply_chain`, `insider`}.
+- `surface`: Which entry point(s) from section 3 this threat traverses.
+- `asset`: Which asset(s) from section 2 this threat compromises.
+- `impact` ∈ {`low`, `medium`, `high`, `critical`, `existential`}.
+- `likelihood` ∈ {`very_rare`, `rare`, `possible`, `likely`,
+  `almost_certain`}.
+- `status` ∈ {`unmitigated`, `partially_mitigated`, `mitigated`,
+  `risk_accepted`}.
+- `controls`: Current mitigations, or `none`.
+- `evidence`: CVE IDs, issue links, pentest finding IDs, or git commit
+  hashes that **instantiate** this threat. May be empty. **Evidence raises
+  likelihood; it is not the threat.**
+
+Sort the table by (impact, likelihood) descending so the top rows are the
+priorities.
+
+### 5. Deprioritized
+
+Markdown table. Threats considered and explicitly parked.
+
+| threat | reason |
+|---|---|
+
+Common reasons: out of scope, actor not in threat model, asset not present,
+risk accepted by owner.
+
+### 6. Open questions
+
+Bullet list. Things the mode could not determine. For `bootstrap` these are
+questions for a human owner; for `interview` these are claims the owner made
+that were not verifiable in code.
+
+### 7. Provenance
+
+```markdown
+- mode: interview | bootstrap | bootstrap-then-interview
+- date: YYYY-MM-DD
+- target: <path or repo url @ commit>
+- inputs: <design doc path | --vulns path | "none">
+- owner: <name, for interview> | <unset, for bootstrap>
+```
+
+### 8. Recommended mitigations
+
+Optional, additive: older `THREAT_MODEL.md` files may omit this section, and
+consumers must tolerate its absence. Each row is **one class-level control**,
+not a per-finding patch: a mitigation that closes or materially shrinks an
+entire threat cluster regardless of which instance is found next.
+
+```markdown
+| mitigation | threat_ids | closes_class | effort |
+|---|---|---|---|
+```
+
+- `mitigation`: imperative, one line (e.g., "sandbox the decoder process",
+  "parameterized queries everywhere", "drop pickle for json", "enable CSP
+  default-src 'self'", "size-cap all length fields before allocation").
+- `threat_ids`: comma-separated section 4 ids (e.g., `T1,T3`) this mitigation covers.
+- `closes_class`: `yes` | `partial`.
+- `effort`: `S` | `M` | `L`.
+
+---
+
+## Scoring guide
+
+### Impact
+
+| value | means |
+|---|---|
+| `low` | Nuisance; no data or availability loss. |
+| `medium` | Limited data exposure or degraded availability for some users. |
+| `high` | Significant data exposure, integrity loss, or full availability loss. |
+| `critical` | Full compromise of a primary asset (RCE, auth bypass, data exfil at scale). |
+| `existential` | Compromise threatens the organization's continued operation. |
+
+### Likelihood
+
+| value | means |
+|---|---|
+| `very_rare` | Requires nation-state resources or an unlikely chain of preconditions. |
+| `rare` | Requires significant skill and a non-default configuration. |
+| `possible` | A motivated attacker with public tooling could plausibly do this. |
+| `likely` | The attack surface is reachable and the technique is well known; prior evidence exists in this or similar systems. |
+| `almost_certain` | Actively exploited in the wild, or trivially automatable against the default configuration. |
+
+Evidence (past CVEs in the same surface, pentest findings, public exploit
+code) moves likelihood **up**. Existing controls move it **down**. Score the
+**residual** likelihood after current controls.
+
+---
+
+## Example (excerpt)
+
+```markdown
+## 4. Threats
+
+| id | threat | actor | surface | asset | impact | likelihood | status | controls | evidence |
+|---|---|---|---|---|---|---|---|---|---|
+| T1 | Memory corruption leading to RCE via untrusted audio file parsing | remote_unauth | dr_wav/dr_flac decoders | host process integrity | critical | likely | unmitigated | none | CVE-2026-29022, CVE-2025-14369 |
+| T2 | Denial of service via resource exhaustion on decode | remote_unauth | dr_flac decoder | service availability | medium | likely | unmitigated | none | CVE-2025-14369 |
+| T3 | Supply-chain compromise of vendored single-header dependency | supply_chain | build pipeline | host process integrity | critical | rare | partially_mitigated | pinned commit | |
+```
+
+T1 stays in the model after both CVEs are patched: attackers will still send
+malformed audio files. The CVEs are evidence the surface is fertile, not the
+threat itself.

--- a/.claude/skills/sec-triage/README.md
+++ b/.claude/skills/sec-triage/README.md
@@ -1,0 +1,95 @@
+# triage
+
+A Claude Code skill that triages a batch of raw security-scanner findings:
+verifies each is real, collapses duplicates, re-ranks by derived
+exploitability, and tags each survivor with a component owner. Turns a raw
+dump into a short, ranked, owned list.
+
+## Status
+
+Pairs with `/sec-vuln-scan` (which writes `VULN-FINDINGS.json`), and will also
+ingest loosely-structured JSON or markdown from other scanners.
+
+## Requirements
+
+- Claude Code CLI installed and authenticated
+- A read-only checkout of the target codebase (verification reads source;
+  it does not build or run anything)
+- A file or directory of findings to triage
+
+## Installation
+
+Project-scoped (ships with this repo — nothing to do if you cloned it):
+
+```bash
+ls .claude/skills/sec-triage/SKILL.md
+```
+
+Or user-scoped:
+
+```bash
+mkdir -p ~/.claude/skills
+cp -r .claude/skills/sec-triage ~/.claude/skills/
+```
+
+## Usage
+
+From a Claude Code session in the target repo:
+
+```
+/sec-triage path/to/findings.json
+```
+
+Interactive mode (the default) opens with a short interview about your
+environment, threat model, and preferred scoring standard — these shape how
+reachability is judged and how severity is labeled. To skip the interview
+and use defaults:
+
+```
+/sec-triage path/to/findings.json --auto
+```
+
+Common invocations:
+
+```
+/sec-triage VULN-FINDINGS.json --repo .                 # sec-vuln-scan output, repo = cwd
+/sec-triage VULN-FINDINGS.json --repo . --fp-rules .claude/skills/_lib/phishsoc-rules.md
+/sec-triage scanner_export/ --votes 5 --repo .          # high-stakes batch, 5-vote verify
+/sec-triage backlog.md --auto --votes 1 --repo .        # quick first pass on a markdown report
+```
+
+## Output
+
+- `./TRIAGE.json` — every input finding, annotated with `verdict`,
+  `verify_verdict`, recomputed `severity`, `severity_alignment` vs. the
+  scanner's claim, `preconditions`, `vote_breakdown`, `rationale` citing
+  file:line evidence, `owner_hint`, and `duplicate_of` where applicable.
+  Sorted by what to act on first.
+- `./TRIAGE.md` — reviewer-facing report: an "Act on these" section with
+  one entry per confirmed finding, then a "Dropped" table explaining every
+  rejection.
+
+A `needs_manual_test` verdict means static reasoning hit its limit on that
+finding — treat it as a recommendation for a human to build a controlled
+proof-of-concept, not as a failure.
+
+## Checkpointing and resume
+
+Per-phase state is written to `./.triage-state/`. If a run is interrupted
+(rate limit, context exhaustion, Ctrl-C), re-invoking `/sec-triage` with the same
+arguments resumes from the last completed phase — the interview is not
+re-asked and verifiers already tallied are not re-spawned. Pass `--fresh` to
+start over. `./.triage-state/` is scratch; add it to `.gitignore`.
+
+## What it does and doesn't do
+
+- **Does:** read source, grep for callers, reason about reachability and
+  protections, vote, rank, and route.
+- **Does not:** build, run, or test the target; install dependencies;
+  reach the network; write proof-of-concept exploits. All conclusions are
+  static. This is deliberate — the skill is meant to run in a review box
+  alongside a read-only checkout.
+
+## Questions
+
+Reach out to your Anthropic contact.

--- a/.claude/skills/sec-triage/SKILL.md
+++ b/.claude/skills/sec-triage/SKILL.md
@@ -1,0 +1,1000 @@
+---
+name: sec-triage
+description: Triage a batch of raw security findings. Verify each is real,
+  collapse duplicates, re-rank by derived exploitability, and tag with an
+  owner. Takes a directory or file of scanner output and writes TRIAGE.json
+  + TRIAGE.md sorted by what actually needs engineering attention. Use when
+  asked to "triage findings", "validate scanner output", "prioritize vulns",
+  or "review the backlog". Runs interactively by default; pass --auto to
+  skip the interview.
+argument-hint: "<findings-path> [--auto] [--votes N] [--repo PATH] [--fp-rules FILE] [--fresh]"
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Write
+  - Task
+  - AskUserQuestion
+  - Bash(git log:*)
+  - Bash(jq:*)
+  - Bash(find:*)
+  - Bash(ls:*)
+  - Bash(wc:*)
+  - Bash(python3 .claude/skills/_lib/checkpoint.py:*)
+---
+
+# triage
+
+Adversarial triage of raw security-scanner output. Does four jobs:
+**verify** each finding is real, **deduplicate** across runs and scanners,
+**rank** survivors by derived exploitability rather than the scanner's
+claimed severity, and **route** each to a component owner. Output is a
+short, ranked, owned list instead of a raw dump.
+
+Invoke with `/sec-triage <findings-path> [--auto] [--votes N] [--repo PATH] [--fp-rules FILE]`.
+
+**Arguments** (parse from `$ARGUMENTS`; positional `$1`/`$2` expansion is
+not stable across runtimes):
+- findings path (first positional, required): a JSON file, a directory of
+  JSON files, a `VULN-FINDINGS.json`, a pipeline `results/<target>/<ts>/`
+  directory, or a markdown report.
+- `--auto`: skip the interview and use defaults. Default mode is
+  **interactive**.
+- `--votes N`: verifier votes per finding (default 3; use 1 for a quick
+  pass, 5 for high-stakes batches).
+- `--repo PATH`: path to the target codebase, read-only (default cwd).
+  Verification needs source access; the skill stops with an error if the
+  cited files aren't reachable.
+- `--fp-rules FILE`: append the contents of FILE to the verifier's
+  exclusion-rule list (Phase 3a). Use for org-specific precedents: "we use
+  Prisma ORM everywhere — raw-query SQLi only", "k8s resource limits cover
+  DoS", etc. Plain text, one rule per line or paragraph.
+- `--fresh`: ignore any existing checkpoint in `./.triage-state/` and start
+  from Phase 0. Without this flag the skill resumes from the last completed
+  phase if a checkpoint is present.
+
+**Tools:** Read, Glob, Grep, Write, Task, AskUserQuestion. Bash is
+permitted only for `git`, `find`, `wc`, `ls`, `jq`, and
+`python3 .claude/skills/_lib/checkpoint.py` (checkpoint I/O).
+
+**Do not execute target code.** No building, running, installing
+dependencies, or sending requests. A proof-of-concept that accidentally
+works against something real is unacceptable, and "couldn't write a working
+PoC" is weak evidence of non-exploitability. Every conclusion comes from
+reading source. This applies to the orchestrator and every subagent;
+include the constraint in every Task prompt. For high-confidence HIGH
+findings, recommend a human-built PoC as a follow-up instead.
+
+**Do not reach the network.** No package-registry lookups, CVE-database
+queries, or upstream-commit fetches.
+
+---
+
+## Checkpointing (runs before Phase 0 and after every phase)
+
+On large finding batches a full run can exhaust context or hit rate limits
+mid-way — particularly Phase 3, which spawns `candidates × votes` verifiers.
+Phase state persists to `./.triage-state/` so a fresh `/sec-triage` session can
+resume without re-asking the interview or re-spawning verifiers.
+
+All checkpoint I/O goes through `python3 .claude/skills/_lib/checkpoint.py`
+(atomic writes, JSON-validated). Never use the Write tool for `progress.json`
+directly. Never pass payload via heredoc or stdin; target-derived strings
+could collide with the heredoc delimiter and break out to shell. The
+Write→`--from` pattern keeps repo-derived bytes out of Bash argv.
+
+State files in `./.triage-state/`:
+- `progress.json` — **single source of truth** for resume position:
+  `{"status": "running"|"complete", "phase_done": N, "shards_done": [...]}`.
+  Resume decisions read ONLY this file, never a glob of `phase*.json` or
+  shard files (stale files from a prior run must not be trusted).
+- `phaseN.json` — data payload for phase N (schemas at the tail of each phase
+  section below).
+- `_chunk.tmp` — transient payload buffer; overwritten before every
+  `save`/`shard`/`append` call.
+
+**Start of run — resume check.** Bash:
+`python3 .claude/skills/_lib/checkpoint.py load ./.triage-state`
+
+- `status == "absent"` OR `"complete"`, OR `--fresh` in `$ARGUMENTS` →
+  **fresh start.** Bash:
+  `python3 .claude/skills/_lib/checkpoint.py reset ./.triage-state`,
+  then proceed to Phase 0.
+- `status == "running"` with `phase_done == N` → **resume.** Read
+  `./.triage-state/phase0.json` through `phaseN.json` **in order** (and any
+  `shard_*.json` files listed in `shards_done`), merging keys into working
+  state (later files override earlier — checkpoints may be deltas). Print
+  `Resuming from checkpoint: Phase N complete (./.triage-state/phaseN.json)`,
+  and **skip directly to Phase N+1**.
+
+**End of every phase N.** Two tool calls:
+1. Write tool → `./.triage-state/_chunk.tmp` containing the phase's output
+   JSON (schema at the tail of each phase section).
+2. Bash → `python3 .claude/skills/_lib/checkpoint.py save ./.triage-state <N> <name> --from ./.triage-state/_chunk.tmp`
+
+**End of run.** After writing `TRIAGE.json` and `TRIAGE.md`, Bash:
+`python3 .claude/skills/_lib/checkpoint.py done ./.triage-state 6`
+
+---
+
+## Phase 0: Mode select and interview
+
+### 0a. Parse arguments
+
+From `$ARGUMENTS`: extract the findings path (first positional), `--auto`
+flag, `--votes N` (default 3), `--repo PATH` (default `.`), `--fp-rules
+FILE` (default none). If no findings path was given, ask for one and stop.
+If `--fp-rules` was given, Read the file now and carry its contents as
+`context.extra_fp_rules` for injection into the Phase 3a verifier prompt.
+
+### 0b. Interactive mode (default): interview the user
+
+Unless `--auto` was passed, use **AskUserQuestion** to gather context that
+shapes verification and ranking. Batch into one or two calls of up to four
+questions. Expect free-text answers via "Other"; the multiple-choice options
+are prompts, not constraints.
+
+**Round 1** (single AskUserQuestion call):
+
+1. **Environment & trust boundary** (header `Environment`, single-select)
+   `What kind of system are these findings from, and where does untrusted
+   input enter it?`
+   Options: `Internet-facing web service (HTTP is untrusted)`,
+   `Internal service (callers are authenticated peers)`,
+   `Library / SDK (caller is the trust boundary)`,
+   `CLI / batch tool (operator inputs trusted, file inputs not)`,
+   `Embedded / firmware (physical access in scope)`.
+   Reachability is judged against this boundary; "command injection from env
+   var" is a true positive in a multi-tenant web service and a rule-8 false
+   positive in an operator CLI.
+
+2. **Threat model** (header `Threat model`, multi-select)
+   `What does a worst-case attacker look like for this system, and what
+   must never happen? Free text is best.`
+   Options: `Unauthenticated remote code execution`,
+   `Tenant-to-tenant data leakage`, `Privilege escalation to admin`,
+   `Supply-chain compromise of downstream users`,
+   `Denial of service against a paid SLA`,
+   `Compliance-scoped data exposure (PII / PCI / PHI)`.
+   Phase 4 boosts findings that map onto a stated threat.
+
+3. **Scoring standard** (header `Scoring`, single-select)
+   `How should severity be expressed in the output?`
+   Options: `Derived HIGH/MEDIUM/LOW from preconditions (default)`,
+   `CVSS v3.1 vector + base score`, `CVSS v4.0 vector + base score`,
+   `OWASP Risk Rating (likelihood x impact)`,
+   `Organization bug-bar (describe in Other)`.
+   The precondition rule is always computed; this controls what
+   `severity_label` additionally shows.
+
+4. **Noise tolerance** (header `Noise tolerance`, single-select)
+   `When verifiers disagree, which way should ties break?`
+   Options:
+   `Precision: drop anything not majority-confirmed (fewer FPs, may miss real bugs)`,
+   `Recall: keep split votes as needs_manual_test (more to review, fewer misses)`,
+   `Ask me per-finding when it happens`.
+
+**Round 2** (conditional): if the threat-model answer was empty or generic,
+or the scoring answer was `Organization bug-bar`, ask one targeted follow-up.
+
+Record the answers as a `context` dict carried through every phase and
+echoed in the output under `triage_context`.
+
+### 0c. Auto mode defaults
+
+When `--auto` is set, do not call AskUserQuestion. Use:
+- Environment: `Unknown. Treat any externally-reachable entry point as
+  untrusted; flag trust-boundary assumptions explicitly in rationale.`
+- Threat model: empty (no boost).
+- Scoring: derived HIGH/MEDIUM/LOW.
+- Noise tolerance: precision.
+
+**Checkpoint:** Write tool → `./.triage-state/_chunk.tmp`:
+
+```json
+{"phase": 0, "context": {mode, environment, threat_model, scoring, noise_tolerance, votes_per_finding, repo, findings_path}}
+```
+
+Then Bash:
+`python3 .claude/skills/_lib/checkpoint.py save ./.triage-state 0 interview --from ./.triage-state/_chunk.tmp`
+On resume past Phase 0, the interview is **not** re-asked; `context` is
+restored from this file.
+
+---
+
+## Phase 1: Ingest and normalize
+
+Turn the input into a flat `findings[]` list with stable ids, regardless of
+source format.
+
+### 1a. Detect input shape
+
+Inspect the findings path:
+
+- **Directory**: Glob for `**/*.json` and `**/*.jsonl`. Recognized
+  containers, in priority order:
+  - `VULN-FINDINGS.json` (a `{findings: [...]}` container): read
+    `.findings[]`.
+  - `reports/bug_*/report.json` or `reports/manifest.jsonl` (this repo's
+    pipeline output): one finding per `bug_NN`. Map `crash.crash_type` →
+    `category`, `verdict.severity_rating` → `severity`, the prose `report` →
+    `description`, crash file from the ASAN top frame → `file`/`line`.
+  - `found_bugs.jsonl`: one finding per line.
+  - Any other `*.json` whose top level is a list of objects, or an object
+    with a `findings`/`results`/`issues`/`vulnerabilities` array: that
+    array.
+- **Single `.json` / `.jsonl` file**: same recognition as above.
+- **Markdown / text**: split on level-2/3 headings or `---` rules; for each
+  section, extract `file`, `line`, `category`, `severity`, `description` by
+  pattern (`File:`, `Line:`, `Severity:` labels or `path:NN` spans).
+  Best-effort; mark `source_format: "markdown_heuristic"`.
+
+If nothing parseable is found, stop and report what was seen.
+
+### 1b. Normalize fields
+
+For each raw record, build a finding dict. **Pull what's present; never
+guess what's absent.** Field map (source-key aliases → canonical):
+
+| Canonical       | Also accept                                              |
+|-----------------|----------------------------------------------------------|
+| `file`          | `path`, `location.file`, `filename`, ASAN top-frame file |
+| `line`          | `line_number`, `location.line`, `lineno`                 |
+| `category`      | `type`, `cwe`, `rule_id`, `crash_type`, `vulnerability_class` |
+| `severity`      | `severity_rating`, `level`, `priority`, `risk`           |
+| `title`         | `name`, `summary`, `message`                             |
+| `description`   | `details`, `report`, `body`, `evidence`                  |
+| `exploit_scenario` | `attack_scenario`, `poc`, `reproduction`              |
+| `preconditions` | `requirements`, `assumptions`                            |
+| `recommendation`| `fix`, `remediation`, `mitigation`                       |
+| `scanner_confidence` | `confidence`, `score`, `certainty` (normalize to 0.0-1.0) |
+
+Attach to every finding:
+- `id`: `f001`, `f002`, ... in ingest order. If `scanner_confidence` is
+  present on most findings, order ingest by it descending so high-signal
+  findings get verified (and surface in partial output) first; otherwise
+  keep source order. This is a scheduling prior only — it does not affect
+  verdicts.
+- `source`: relative path of the file it came from, plus source format.
+- `missing_fields`: list of canonical fields that were absent. If `file` is
+  missing or does not resolve under `--repo`, the finding is
+  **unlocatable**: it skips dedup and verification and is emitted directly
+  with `verdict: false_positive`, `verify_verdict: needs_manual_test`,
+  `confidence: 0`, `refute_reasons: ["doesnt_exist"]`, `rationale: "no
+  source location in input; cannot verify statically; human review
+  required"`. Never emit a confident verdict on a finding you could not
+  locate, and never let it absorb or be absorbed by dedup.
+
+### 1c. Locate the target codebase
+
+Resolve `--repo` (default cwd). For the first 5 findings with a `file`,
+check the path resolves under the repo. Try, in order: (a) `repo/file`
+as-given; (b) `file` as an absolute or cwd-relative path; (c) `repo/file`
+with common prefixes stripped from `file` (`src/`, `app/`, `./`, or the
+repo's own basename, e.g. `harness/grade.py` with `--repo harness`).
+Record which resolution worked and apply it to every finding. If none
+resolve, **stop**: tell the user verification needs source access and the
+cited files aren't reachable, and suggest a `--repo` value based on the
+longest common suffix you can see.
+
+**Checkpoint:** Write tool → `./.triage-state/_chunk.tmp`:
+
+```json
+{"phase": 1, "context": {...}, "findings": [ {normalized finding dicts with id/source/file/line/category/...} ], "path_resolution": "<which of a/b/c worked>"}
+```
+
+Then Bash:
+`python3 .claude/skills/_lib/checkpoint.py save ./.triage-state 1 ingest --from ./.triage-state/_chunk.tmp`
+
+---
+
+## Phase 2: Deduplicate (before verification)
+
+Collapse repeats so duplicate findings don't each burn N verifiers.
+
+### 2a. Deterministic pass (inline, no subagent)
+
+Cluster findings where all of:
+- same `file` (after path normalization), AND
+- same `category` (case-insensitive, punctuation stripped), AND
+- `line` numbers within 10 of each other. Both-missing matches; one-side-
+  missing does NOT (a line-less record must not absorb a located one).
+
+Within each cluster, the canonical is the record with the fewest
+`missing_fields`; ties break to lowest `id`. Every other member gets
+`verdict: duplicate`, `duplicate_of: <canonical id>`, and is removed from
+the working set. Record duplicate ids on the canonical as `absorbed: [...]`.
+
+### 2b. Semantic pass (one subagent, only if >1 cluster survives)
+
+Spawn ONE Task with `subagent_type: "general-purpose"` and this prompt:
+
+```
+You are deduplicating security findings before expensive verification. Two
+findings are DUPLICATES if fixing one would also fix the other. Two findings
+are DISTINCT if they have genuinely independent root causes, even if they
+share a category or file.
+
+Treat as DUPLICATE:
+- Same root cause described with different wording or by different scanners
+- A shared vulnerable helper function reported once per call site
+- A missing global protection (auth check, output encoding) reported once
+  per endpoint that lacks it
+- A cause ("missing input validation on `name`") and its consequence
+  ("SQL injection via `name`") in the same code path
+
+Treat as DISTINCT:
+- Different categories in the same file region (an "ssrf" near a
+  "buffer_overflow" is not a duplicate just because the lines are close)
+- Same file, same category, but different tainted variables reaching
+  different sinks
+- Same helper, but two independent bugs inside it
+- Two endpoints missing the same check, where the fix is per-endpoint
+  rather than a shared gate
+
+Below are the candidate findings (one per line: id | file:line | category |
+title). Group them. Respond with ONLY lines of the form:
+
+  GROUP: <canonical_id> <- <dup_id>, <dup_id>, ...
+
+One line per group that has duplicates. Omit singletons. Pick the most
+specific / best-described finding as canonical. No prose.
+
+CANDIDATES:
+{one line per surviving finding: "f003 | src/auth.py:112 | sql_injection | User lookup concatenates name into query"}
+```
+
+Parse `GROUP:` lines. For each, mark the listed dup ids with
+`verdict: duplicate`, `duplicate_of: <canonical>`, append them to the
+canonical's `absorbed`, and drop them from the working set.
+
+Carry forward `candidates[]` = the surviving canonicals.
+
+**Checkpoint:** Write tool → `./.triage-state/_chunk.tmp`:
+
+```json
+{"phase": 2, "context": {...}, "findings": [ {all findings; duplicates carry verdict/duplicate_of} ], "candidates": ["f001", "f003", "..."]}
+```
+
+Then Bash:
+`python3 .claude/skills/_lib/checkpoint.py save ./.triage-state 2 dedup --from ./.triage-state/_chunk.tmp`
+
+---
+
+## Phase 3: Verify
+
+For each candidate, N independent adversarial verifiers re-derive the claim
+from the code and vote. Each verifier's stance is "find any reason this is
+wrong." Each starts from the code at the cited location, not the scanner's
+description, and never sees the other verifiers' reasoning (shared context
+propagates blind spots).
+
+### 3a. Verifier prompt (assemble once, reuse for every spawn)
+
+```
+You are a skeptical security engineer adversarially verifying ONE finding
+from an automated scanner. Your default assumption is that the scanner is
+WRONG. Your job is to re-derive the claim from the source code yourself and
+decide TRUE_POSITIVE or FALSE_POSITIVE.
+
+You have read-only access to the target codebase at: {REPO_PATH}
+You may use Read, Glob, and Grep, but ONLY on paths inside {REPO_PATH}.
+Do NOT read, grep, or glob outside that root: anything outside it (the
+triage pipeline itself, scanner outputs, fixtures, other repos on disk) is
+out of scope and citing it contaminates your verdict. If a finding's
+`file` resolves outside {REPO_PATH}, return CANNOT_VERIFY with
+REFUTE_REASON: doesnt_exist. You may NOT build, run, or test the target,
+install dependencies, or reach the network. Every conclusion must come
+from reading source under {REPO_PATH}.
+
+ENVIRONMENT (from the operator; this defines the trust boundary):
+{context.environment or "Unknown. Treat any externally-reachable entry point as untrusted."}
+
+────────────────────────────────────────────────────────────────────────
+PROCEDURE: follow all four steps. Each exists because skipping it lets a
+specific false-positive class through.
+
+1. READ THE CODE AT THE CITED LOCATION YOURSELF.
+   Open {file} at line {line}. Understand what the code actually does. Do
+   NOT trust the scanner's description: scanners misread code surprisingly
+   often, and if you start from the summary you inherit the misreading.
+
+2. TRACE REACHABILITY BACKWARDS FROM THE SINK.
+   Grep for callers of this function/method. Follow imports. Establish
+   whether attacker-controlled input (per the ENVIRONMENT above) can
+   actually reach this line. A plausible-sounding chain is NOT enough: for
+   at least the FIRST link in the chain, READ the actual call site and
+   QUOTE the file:line in your rationale. Unreachable code is the single
+   largest false-positive source.
+
+3. HUNT FOR PROTECTIONS.
+   Actively look for reasons the finding is WRONG:
+   - Input validation / sanitization upstream of the sink
+   - Framework auto-escaping, parameterized queries, prepared statements
+   - Type constraints (the value is an int, an enum, a fixed-length token)
+   - Authentication / authorization gates before this path
+   - Configuration that limits exposure (feature flag off, debug-only)
+   - Dead code, test-only code, example/fixture code
+
+4. STRESS-TEST EACH PROTECTION.
+   For each protection you found: is it applied on EVERY path to the sink,
+   or only the one the scanner happened to trace? Are there encodings,
+   edge cases, or alternate entry points that bypass it?
+
+────────────────────────────────────────────────────────────────────────
+EXCLUSION RULES: if the finding matches any of these, it is FALSE_POSITIVE
+even if technically accurate. Cite the rule number in your verdict.
+
+  1. Volumetric DoS or missing rate-limiting (handled at infrastructure
+     layer). ReDoS, algorithmic complexity, and unbounded recursion ARE
+     still valid findings.
+  2. Test-only code, dead code, example/fixture code, or a crash with no
+     security impact.
+  3. Behavior that is the intended design (compression middleware, a
+     backward-compatible weak algorithm offered alongside a strong one).
+  4. Memory-safety concerns in memory-safe languages outside `unsafe` /
+     FFI blocks.
+  5. SSRF where the attacker controls only the path, not the host or
+     protocol.
+  6. User input flowing into an AI/LLM prompt (prompt injection is not a
+     code vulnerability in the target).
+  7. Path traversal in object storage (S3/GCS) where `../` does not escape
+     a trust boundary.
+  8. Trusted inputs used as the attack vector (env vars, CLI flags set by
+     the operator), UNLESS the ENVIRONMENT above marks them untrusted.
+  9. Client-side code flagged for server-side vulnerability classes.
+ 10. Outdated dependency versions (managed by a separate process).
+ 11. Weak random used for non-security purposes (jitter, shuffling,
+     dev-only fallbacks).
+ 12. Low-impact nuisance issues (log spoofing, CSRF on logout, self-XSS,
+     tabnabbing, open redirect, regex injection).
+ 13. Missing hardening or best-practice gap with no concrete exploit path
+     (missing security headers, no audit logging, permissive config that
+     isn't actually reached by untrusted input).
+ 14. XSS in a framework with default auto-escaping (React, Angular, Vue,
+     Jinja2 autoescape=on) UNLESS the sink is a raw-HTML escape hatch
+     (dangerouslySetInnerHTML, bypassSecurityTrustHtml, v-html, |safe).
+ 15. Identifiers that are unguessable by construction (UUIDv4, 128-bit+
+     random tokens) flagged as "predictable" or "needs validation".
+ 16. Race conditions or TOCTOU that are theoretical only — no realistic
+     window, or no security-relevant state changes between check and use.
+
+{if context.extra_fp_rules: append here verbatim under an
+ "ORG-SPECIFIC RULES:" heading}
+
+────────────────────────────────────────────────────────────────────────
+VERDICT: your response MUST end with EXACTLY this block:
+
+  VERDICT: TRUE_POSITIVE | FALSE_POSITIVE | CANNOT_VERIFY
+  CONFIDENCE: <0-10>
+  REFUTE_REASON: <one of: doesnt_exist, already_handled,
+    implausible_trigger, intentional_behavior, misread_code, duplicate,
+    not_actionable, n/a>
+  EXCLUSION_RULE: <1-16, org rule, or none>
+  FIRST_LINK: <file:line of the first call site you read, or "none found">
+  RATIONALE: <2-5 sentences citing specific file:line evidence for
+    reachability, protections found/absent, and why each held or didn't>
+
+TRUE_POSITIVE requires ALL of: path is reachable from untrusted input per
+the ENVIRONMENT; protections are insufficient or bypassable; real-world
+exploitation is feasible.
+
+FALSE_POSITIVE requires ANY of: unreachable from untrusted input;
+adequately protected on all paths; scanner misread the code; an exclusion
+rule applies.
+
+CANNOT_VERIFY: static reasoning genuinely hit its limit (e.g. behavior
+depends on runtime configuration you cannot read, or the code path crosses
+into a binary you cannot inspect). Use sparingly; it must not become the
+default.
+```
+
+### 3b. Spawn N verifiers per candidate, all in one message
+
+For each finding in `candidates[]`, build N Task calls (N = `--votes`,
+default 3) with `subagent_type: "general-purpose"` and `description:
+"verify {id} vote {k}/{N}"`.
+
+**Always set `subagent_type`; never fork.** Omitting `subagent_type` forks
+the orchestrator, and a fork inherits the full conversation context: every
+other finding's description, the scanner's prose, and any prior verifier
+results. That defeats verifier independence and re-introduces the
+inherited-framing failure mode this phase exists to prevent. Each verifier
+must start with a fresh, empty context and receive only the 3a prompt
+plus the single finding under review. The same applies to the ranking
+subagents in 4a.
+
+Each prompt is the verifier prompt from 3a with this block appended:
+
+```
+────────────────────────────────────────────────────────────────────────
+FINDING UNDER REVIEW (from the scanner; treat as a CLAIM, not a fact):
+
+  id:        {id}
+  file:      {file}
+  line:      {line}
+  category:  {category}
+  severity (claimed): {severity}
+  title:     {title}
+
+  description:
+  {description}
+
+  exploit_scenario:
+  {exploit_scenario or "(not provided)"}
+
+  preconditions (claimed):
+  {preconditions as bullets or "(not provided)"}
+
+You are vote {k} of {N}. You have NOT seen the other verifiers' reasoning
+and you must NOT try to find it. Work independently from the code.
+```
+
+**Put all verifier Task calls in a single assistant message** so they run
+concurrently. Do not set `run_in_background`; you need the final text, not
+an async handle. If `len(candidates) * N` exceeds ~40, shard into
+sequential batches of ~40, but keep each batch a single message.
+
+**Prompt size at scale.** The 3a prompt is ~1200 words. When
+`candidates * votes > ~50`, use this compact form instead (same procedure
+and output contract, prose stripped):
+
+```
+Adversarially verify ONE scanner finding. Default: scanner is WRONG.
+Read-only access scoped to {REPO_PATH} ONLY. No exec, no network.
+ENVIRONMENT: {context.environment}
+
+Steps: (1) Read {file}:{line} yourself; don't trust the description.
+(2) Trace callers backwards; quote the first call-site file:line.
+(3) Hunt for protections: validation, escaping, type bounds, auth gates,
+dead/test code. (4) Stress-test each protection on every path.
+
+Exclusion rules (FALSE_POSITIVE if matched): 1 volumetric DoS;
+2 test/dead/fixture code; 3 intended design; 4 memory-safety in safe
+lang outside unsafe/FFI; 5 SSRF path-only; 6 LLM prompt input;
+7 object-storage traversal; 8 trusted operator env/CLI inputs;
+9 client code, server vuln class; 10 outdated deps; 11 weak random
+non-security; 12 low-impact nuisance (log spoof, open redirect, regex
+inject); 13 missing-hardening-only, no concrete exploit; 14 XSS in
+auto-escape framework w/o raw-HTML escape hatch; 15 unguessable
+UUID/token flagged predictable; 16 theoretical-only race/TOCTOU.
+{+ org rules from --fp-rules if any}
+
+End with EXACTLY:
+  VERDICT: TRUE_POSITIVE | FALSE_POSITIVE | CANNOT_VERIFY
+  CONFIDENCE: <0-10>
+  REFUTE_REASON: <doesnt_exist|already_handled|implausible_trigger|
+    intentional_behavior|misread_code|duplicate|not_actionable|n/a>
+  EXCLUSION_RULE: <1-16, org rule, or none>
+  FIRST_LINK: <file:line or "none found">
+  RATIONALE: <2-5 sentences, file:line cited>
+
+FINDING: {id} {file}:{line} {category} (claimed {severity})
+{title}
+{description}
+Vote {k}/{N}. Independent; do not seek other votes.
+```
+
+Findings with a `file` but no `line` get **one** verifier vote regardless
+of `--votes` (a file-level sweep is expensive and doesn't benefit from
+voting).
+
+**If any Task call returns `status: "async_launched"` instead of the
+verifier's text**, the runtime backgrounded it (some runtimes do this
+automatically for large parallel batches). Pick one recovery and use it for
+the whole batch:
+  - If completion notifications arrive in your conversation: parse each
+    verifier's VERDICT block from its notification `result` as it lands.
+    Do not end your turn until every vote is accounted for.
+  - If notifications do not arrive: do not poll transcript files. Re-spawn
+    the missing verifiers in a fresh Task batch (smaller shard size, e.g.
+    10) and use the synchronous results.
+The same recovery applies to the dedupe subagent in 2b and the ranking
+subagents in 4a.
+
+### 3c. Tally votes
+
+For each candidate, parse the trailing block from each of its N verifiers
+(tolerate code fences and whitespace). If a verifier errored, timed out,
+or produced no parseable VERDICT block, re-spawn it once. If the retry
+also fails, count that vote as `cannot_verify` with `confidence: 0` and
+note `"verifier_error"` in `refute_reasons`. The remaining N-1 votes still
+decide.
+
+Build:
+
+- `vote_breakdown`: `{"true_positive": x, "false_positive": y,
+  "cannot_verify": z}`
+- `confidence`: mean CONFIDENCE across votes that agree with the majority,
+  rounded to one decimal.
+- `exclusion_rule`: the modal EXCLUSION_RULE among FALSE_POSITIVE votes,
+  else `null`.
+- `refute_reasons`: sorted unique REFUTE_REASON values from FALSE_POSITIVE
+  votes.
+- `first_links`: unique FIRST_LINK values across all votes (reachability
+  audit trail).
+- `rationale`: the RATIONALE from the highest-confidence vote on the
+  winning side, verbatim.
+
+**Decide `verdict`:**
+- Majority TRUE_POSITIVE → `verdict: true_positive`. Proceeds to Phase 4.
+- Majority FALSE_POSITIVE → `verdict: false_positive`. Skips Phase 4.
+- No majority (tie, or majority CANNOT_VERIFY):
+  - Noise tolerance `precision` → `verdict: false_positive`; append
+    `"(split vote, dropped under precision policy)"` to rationale.
+  - Noise tolerance `recall` → `verdict: true_positive` with
+    `verify_verdict: needs_manual_test`. Proceeds to Phase 4.
+  - Noise tolerance `ask` → collect all split findings and present them in
+    one AskUserQuestion call at the end of Phase 3 (header: id + title,
+    options: keep / drop), then apply the user's choices.
+
+Build `confirmed[]` = candidates with `verdict == true_positive`.
+
+**Checkpoint:** Write tool → `./.triage-state/_chunk.tmp`:
+
+```json
+{"phase": 3, "context": {...}, "findings": [ {all findings with verdict/vote_breakdown/confidence/refute_reasons/first_links/rationale/exclusion_rule} ], "confirmed": ["f001", "..."]}
+```
+
+Then Bash:
+`python3 .claude/skills/_lib/checkpoint.py save ./.triage-state 3 verify --from ./.triage-state/_chunk.tmp`
+
+This is the most expensive checkpoint. When `len(candidates) * votes` exceeds
+~40 and verifier spawns are sharded into sequential batches, additionally
+checkpoint **per candidate** as its votes are tallied:
+
+1. Write tool → `./.triage-state/_chunk.tmp` = that finding's post-tally dict.
+2. Bash:
+   `python3 .claude/skills/_lib/checkpoint.py shard ./.triage-state <id> --from ./.triage-state/_chunk.tmp`
+
+On resume at `phase_done == 2`, the Phase-3 entry point reads
+`progress.json:shards_done` (default `[]` — do **not** glob shard files on
+disk; stale shards from a prior run may exist), loads the corresponding
+`shard_{id}.json` files, and spawns verifiers only for `candidates[]` ids
+from `phase2.json` that are NOT in `shards_done`. Once every candidate is in
+`shards_done`, write the consolidated `phase3.json` checkpoint as above.
+
+---
+
+## Phase 4: Rank by exploitability (confirmed findings only)
+
+Recompute severity from preconditions and reachability rather than category
+name, and judge the scanner's claimed severity separately. Verification and
+severity are independent judgments; "this is real" must not inflate into
+"this is critical."
+
+### 4a. Ranking prompt
+
+Spawn one Task per confirmed finding (`subagent_type: "general-purpose"`,
+all in one message) with:
+
+```
+You are assigning severity to a CONFIRMED security finding. Verification
+already happened; assume the finding is real. Your only job is to derive
+how bad it is, independently of what the scanner claimed.
+
+You may Read/Grep the codebase at {REPO_PATH} to check preconditions. Do
+NOT execute code.
+
+ENVIRONMENT: {context.environment}
+THREAT MODEL (operator-stated, may be empty):
+{context.threat_model as bullets, or "(none provided)"}
+SCORING STANDARD: {context.scoring}
+
+FINDING:
+  id:        {id}
+  file:      {file}:{line}
+  category:  {category}
+  claimed severity: {severity}
+  reachability evidence: {first_links from Phase 3}
+  verifier rationale: {rationale from Phase 3}
+
+────────────────────────────────────────────────────────────────────────
+STEP 1: Enumerate EVERY precondition that must hold for exploitation.
+Be concrete: required auth state, configuration, prior request, race
+window, attacker position. Then state the minimum ACCESS LEVEL required
+(unauthenticated remote / authenticated / local / physical).
+
+STEP 2: Derive severity from the precondition count and access level:
+
+  | Preconditions | Access required          | Severity |
+  |---------------|--------------------------|----------|
+  | 0             | Unauthenticated remote   | HIGH     |
+  | 1-2           | Authenticated            | MEDIUM   |
+  | 3+            | Local-only / no demo path| LOW      |
+
+  Evaluate each column independently and take the LOWER result. Example:
+  0 preconditions but authenticated-only is MEDIUM, not HIGH; 1
+  precondition but local-only is LOW. Cross-check: if your preconditions
+  list has 3+ items, HIGH is almost certainly wrong.
+
+STEP 3: Threat-model match. If the THREAT MODEL is non-empty and this
+finding maps onto one of its entries, note which one. A match may raise
+severity by ONE step (LOW to MEDIUM or MEDIUM to HIGH), never two. If the
+threat model is empty, skip this step.
+
+STEP 4: Judge the scanner's claimed severity. From the perspective of an
+engineer who has reviewed two hundred scanner findings this week and is
+allergic to inflation: would the CLAIMED severity contribute to alert
+fatigue? Is it comparable to a real CVE at that level? Is the code in test
+fixtures or dev-only config? Score in -5..+5:
+  +3..+5  claimed severity is justified or understated
+   0..+2  roughly right
+  -1..-3  inflated by one level
+  -4..-5  badly inflated (LOW dressed as HIGH)
+
+STEP 5: verify_verdict. Exactly one of:
+  exploitable        preconditions are realistically satisfiable
+  mitigated          real, but a deployed control reduces it below the
+                     derived severity (name the control)
+  needs_manual_test  severity hinges on something only a runtime test can
+                     settle; recommend a human build a PoC
+
+STEP 6: If SCORING STANDARD is a CVSS or OWASP variant, emit a
+`severity_label` in that format (vector string + base score for CVSS;
+likelihood x impact for OWASP). Otherwise set it equal to the derived
+HIGH/MEDIUM/LOW.
+
+────────────────────────────────────────────────────────────────────────
+Respond with ONLY this block:
+
+  PRECONDITIONS:
+  - <one per line>
+  ACCESS_LEVEL: <unauthenticated_remote|authenticated|local|physical>
+  SEVERITY: <HIGH|MEDIUM|LOW>
+  SEVERITY_LABEL: <per scoring standard>
+  THREAT_MATCH: <matched threat-model entry, or none>
+  SEVERITY_ALIGNMENT: <-5..+5>
+  VERIFY_VERDICT: <exploitable|mitigated|needs_manual_test>
+  RANK_RATIONALE: <2-4 sentences>
+```
+
+### 4b. Merge
+
+For each confirmed finding, parse the block and attach `preconditions`
+(replacing any scanner-supplied list), `access_level`, `severity`
+(recomputed), `severity_label`, `threat_match`, `severity_alignment`,
+`verify_verdict`, and append RANK_RATIONALE to `rationale` (separated by a
+blank line from the Phase-3 rationale).
+
+For findings that did NOT reach Phase 4 (`false_positive`, `duplicate`,
+unlocatable): set `severity: null`, `verify_verdict: null`,
+`severity_alignment: null`, `preconditions: []`.
+
+**Checkpoint:** Write tool → `./.triage-state/_chunk.tmp`:
+
+```json
+{"phase": 4, "context": {...}, "findings": [ {all findings with severity/severity_label/preconditions/access_level/threat_match/severity_alignment/verify_verdict} ]}
+```
+
+Then Bash:
+`python3 .claude/skills/_lib/checkpoint.py save ./.triage-state 4 rank --from ./.triage-state/_chunk.tmp`
+
+---
+
+## Phase 5: Route
+
+Tag each confirmed true-positive with the most specific component or owner
+inferable. For each finding in `confirmed[]`, stop at the first hit:
+
+1. **CODEOWNERS / OWNERS.** Grep `--repo` for `CODEOWNERS`, `OWNERS`,
+   `.github/CODEOWNERS`, `docs/CODEOWNERS`. If found, match the finding's
+   `file` against its patterns (last match wins). Hint:
+   `"CODEOWNERS: <pattern> -> <owner(s)>"`.
+2. **git log.** If `--repo` is a git checkout, run
+   `git -C {REPO} log --format='%an' -n 50 -- "{file}" | sort | uniq -c | sort -rn | head -3`.
+   Hint: `"top committer: <name> (<n>/<total> recent commits); no
+   CODEOWNERS entry"`.
+3. **Module fallback.** Hint: `"component: <top-level dir of file>/; no
+   CODEOWNERS or git history"`.
+
+Attach as `owner_hint`. State the source so confidence is clear; a bare
+username is less useful than `"component: auth/; no CODEOWNERS entry; top
+committer jsmith (14/20 recent commits)"`. For non-true-positive findings,
+set `owner_hint: null`.
+
+**Checkpoint:** Write tool → `./.triage-state/_chunk.tmp`:
+
+```json
+{"phase": 5, "context": {...}, "findings": [ {all findings with owner_hint} ]}
+```
+
+Then Bash:
+`python3 .claude/skills/_lib/checkpoint.py save ./.triage-state 5 route --from ./.triage-state/_chunk.tmp`
+
+---
+
+## Phase 6: Output
+
+### 6a. Sort
+
+Order all findings by:
+1. `verdict`: `true_positive`, then `duplicate`, then `false_positive`.
+2. Within true positives: `severity` HIGH > MEDIUM > LOW, then `confidence`
+   descending, then `severity_alignment` descending.
+3. Within others: original `id`.
+
+### 6b. Write `./TRIAGE.json`
+
+```json
+{
+  "triage_completed": true,
+  "triage_context": {
+    "mode": "interactive|auto",
+    "environment": "...",
+    "threat_model": ["..."],
+    "scoring": "...",
+    "noise_tolerance": "...",
+    "votes_per_finding": 3,
+    "repo": "..."
+  },
+  "summary": {
+    "input_count": 0,
+    "duplicates": 0,
+    "false_positives": 0,
+    "true_positives": 0,
+    "needs_manual_test": 0,
+    "by_severity": {"HIGH": 0, "MEDIUM": 0, "LOW": 0}
+  },
+  "findings": [
+    {
+      "id": "f001",
+      "source": "VULN-FINDINGS.json#0",
+      "title": "...",
+      "file": "...",
+      "line": 0,
+      "category": "...",
+      "claimed_severity": "HIGH",
+      "verdict": "true_positive|false_positive|duplicate",
+      "verify_verdict": "exploitable|mitigated|needs_manual_test|null",
+      "confidence": 0.0,
+      "severity": "HIGH|MEDIUM|LOW|null",
+      "severity_label": "...",
+      "severity_alignment": 0,
+      "preconditions": ["..."],
+      "access_level": "...",
+      "threat_match": "...|null",
+      "rationale": "file:line-cited prose: reachability, protections, why each held or didn't; then ranking rationale",
+      "vote_breakdown": {"true_positive": 0, "false_positive": 0, "cannot_verify": 0},
+      "refute_reasons": ["..."],
+      "exclusion_rule": null,
+      "first_links": ["file:line", "..."],
+      "duplicate_of": null,
+      "absorbed": ["..."],
+      "owner_hint": "...",
+      "missing_fields": ["..."]
+    }
+  ]
+}
+```
+
+Every input finding appears exactly once (duplicates reference their
+canonical via `duplicate_of`). Do not silently drop anything. Do not print
+this JSON to the terminal; write to file only.
+
+### 6c. Write `./TRIAGE.md`
+
+Reviewer-facing report. Build it **incrementally**. Do NOT emit the whole
+file in one Write. One chunk per finding; a stalled chunk loses that one
+section, not the file.
+
+**Step 1 — header.** Write tool → `./TRIAGE.md` (clobbers any prior file)
+containing only the title block, summary, and `## Act on these` heading:
+
+```
+# Triage Report
+
+{summary line: N in -> D duplicates, F false positives, T confirmed (H high / M med / L low), X need manual test}
+
+Context: {mode}; environment = {environment}; scoring = {scoring}; {votes}-vote verification.
+
+## Act on these
+```
+
+**Step 2 — per finding.** For each true_positive in severity order:
+1. Write tool → `./.triage-state/_chunk.tmp` containing ONE finding's section:
+
+```
+### [{severity}] {title}  ({id})
+`{file}:{line}` | {category} | claimed {claimed_severity} (alignment {severity_alignment:+d}) | confidence {confidence}/10
+**Owner:** {owner_hint}
+**Verdict:** {verify_verdict}, votes {vote_breakdown}
+**Preconditions ({n}):** {bulleted}
+**Threat-model match:** {threat_match or "none"}
+**Why:** {rationale}
+**Reachability evidence:** {first_links}
+{if verify_verdict == needs_manual_test:}
+> Recommend a human build a PoC; static reasoning hit its limit.
+```
+
+2. Bash:
+   `python3 .claude/skills/_lib/checkpoint.py append ./TRIAGE.md --from ./.triage-state/_chunk.tmp`
+
+Repeat for each true_positive.
+
+**Step 3 — footer.** Write tool → `./.triage-state/_chunk.tmp` containing the
+Dropped table, then `checkpoint.py append` it the same way:
+
+```
+## Dropped
+
+| id | title | file:line | why dropped |
+{false_positives: refute_reasons + exclusion_rule}
+{duplicates: "duplicate of {duplicate_of}"}
+{unlocatable: "no source location in input"}
+```
+
+**Checkpoint (final):** Bash:
+`python3 .claude/skills/_lib/checkpoint.py done ./.triage-state 6`
+The next invocation's resume check sees `status == "complete"` and starts
+fresh.
+
+### 6d. Terminal summary
+
+Under ~12 lines:
+
+```
+Triage complete: {N} findings -> {T} confirmed, {F} false positives, {D} duplicates.
+
+  HIGH:   {n}   {title of top HIGH, owner_hint}
+  MEDIUM: {n}
+  LOW:    {n}
+  Needs manual test: {n}
+
+  Top refute reasons: {top 3 refute_reasons with counts}
+
+Wrote ./TRIAGE.md and ./TRIAGE.json
+```
+
+---
+
+## Testing this skill
+
+Run it on this repo's own scan output, with the project FP rules loaded:
+
+```
+/sec-vuln-scan workers/intel --extra .claude/skills/_lib/phishsoc-rules.md
+/sec-triage VULN-FINDINGS.json --repo . --auto --fp-rules .claude/skills/_lib/phishsoc-rules.md
+```
+
+Hand-check a sample of TRUE_POSITIVE/HIGH results (the `first_links` should
+point at real call sites under `workers/` or `app/`) and a sample of
+FALSE_POSITIVE rejects (the `exclusion_rule` or `refute_reasons` should be
+defensible — e.g. prompt-injection findings should be dropped because
+SECURITY_SPEC Rule 1 makes LLM output non-load-bearing).
+
+---
+
+## Design notes
+
+- **Checkpoints are per-phase JSON**, not conversation state. The pipeline's
+  `--resume <session_id>` (docs/pipeline.md) restores transcript history but
+  doesn't help when the orchestrator's context window itself fills;
+  file-backed checkpoints let a brand-new session pick up from the last
+  completed phase. `./.triage-state/` is scratch — add to `.gitignore`.
+- **Dedupe runs before verify** to cut verifier spend by the duplication
+  factor (often 2-4x on multi-scanner input) at the cost of one cheap
+  subagent.
+- **Semantic dedupe is one agent**, given only id/file/line/category/title:
+  enough to cluster, not enough to leak one scanner's reasoning into
+  another finding's verification.
+- **Bash is allowed narrowly** for `git log` (owner hints), `jq`/`find`
+  (ingest), and `python3 .claude/skills/_lib/checkpoint.py` (state I/O).
+  The actual safety property is "no execution of target code," which is
+  preserved.
+- **`CANNOT_VERIFY`** exists so verifiers aren't forced into a false
+  binary. It maps to `needs_manual_test` under recall policy and to a drop
+  under precision policy.
+- **Threat-model boost is capped at one step** so a stated threat can't
+  re-inflate a LOW back to HIGH and defeat the precondition rule.
+- **`severity_label` is separate from `severity`.** Sorting always uses the
+  precondition-derived HIGH/MEDIUM/LOW; the label is presentation-layer for
+  whatever standard the reviewer's tooling expects.
+- **Pipeline `report.json` ingest is best-effort.** Those reports describe
+  ASAN crashes with prose exploitability analysis rather than the
+  file/line/category shape static verifiers expect. Expect more
+  `needs_manual_test` verdicts on that input than on static-scanner JSON.
+- **Sharding at ~40 parallel Tasks** is a conservative ceiling for typical
+  agent-spawn limits; tune up if your runtime allows.
+- **No network**, deliberately. CVE-database enrichment and upstream-fix
+  checks would help ranking but break the air-gapped-review property.

--- a/.claude/skills/sec-vuln-scan/SKILL.md
+++ b/.claude/skills/sec-vuln-scan/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: sec-vuln-scan
+description: >-
+  Static source-code vulnerability scan. Reads a target directory (and
+  THREAT_MODEL.md if present), spawns parallel review subagents per focus
+  area, and writes VULN-FINDINGS.json + .md for /sec-triage to consume. Read-only
+  — no building, running, or network. Use when asked to "scan for vulns", "review
+  this code for security issues", "find bugs in <dir>", or as the step between
+  /sec-threat-model and /sec-triage.
+argument-hint: "<target-dir> [--focus <area>] [--single] [--extra <file>] [--no-score]"
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Write
+  - Task
+  - Bash(rg:*)
+  - Bash(grep:*)
+  - Bash(ls:*)
+  - Bash(wc:*)
+  - Bash(head:*)
+  - Bash(file:*)
+---
+
+# /sec-vuln-scan
+
+Static vulnerability review of a source tree. Produces `VULN-FINDINGS.json`
+(+ a human-readable `.md`) that `/sec-triage` ingests directly.
+
+**This skill does not execute code.** It reads source and reasons about it.
+There is no execution oracle in this port (it's a Cloudflare Workers app, not
+a fuzzable binary). To confirm a finding at runtime, recommend a human write a
+focused `vitest` case or a controlled proof-of-concept; do not run one here.
+
+**Tool fallbacks.** Prefer the dedicated Glob and Grep tools. Some sessions
+do not provision them — `allowed-tools` is a permission filter, not a loader,
+so listing them here does not make them appear. When Glob/Grep are
+unavailable, fall back to the read-only Bash commands whitelisted above:
+`rg --files <scope>` / `ls -R` for enumeration, `rg -n` / `grep -rn` for
+search, `wc` / `head` / `file` for sniffing. These are the ONLY permitted
+Bash commands; do not write helper scripts or pipe target content into a
+shell interpreter.
+
+## Arguments
+
+- `<target-dir>` (required) — directory to scan. Relative or absolute.
+- `--focus <area>` — scan only this focus area (repeatable). Skips recon.
+- `--single` — no subagent fan-out; one sequential pass. Use on tiny targets
+  or when debugging the prompt.
+- `--extra <file>` — append the contents of `<file>` to the review brief
+  (after the category list). Use to add org-specific vulnerability classes,
+  compliance checks, or stack-specific patterns. Plain text; same shape as
+  the category blocks below.
+- `--no-score` — skip the Step 3b confidence pass (saves a round of
+  subagents). Findings keep the scanner's self-reported confidence only.
+
+## Step 1 — Scope
+
+1. Resolve `<target-dir>`. If it doesn't exist or has no source files, stop
+   with an error.
+2. Look for `<target-dir>/THREAT_MODEL.md`. If present, parse its section 3 "Entry
+   points & trust boundaries" table and section 4 "Threats" table for focus areas
+   and threat classes. This is the preferred scoping input.
+3. If no THREAT_MODEL.md and no `--focus`: do a **quick recon** — list the
+   source tree, read entry points and dispatch code, and propose 3-10 focus
+   areas using the pattern `<subsystem> (<function/file>) — <key operations>`.
+   Same shape as `harness/prompts/recon_prompt.py`.
+4. If `--focus` was given, use exactly those.
+
+Tell the user the focus areas you'll scan and the source-file count before
+fanning out.
+
+## Step 2 — Fan out
+
+Unless `--single`, spawn **one Task subagent per focus area** in parallel.
+Cap at 10 concurrent. Each subagent gets the review brief below with its
+focus area filled in. On tiny targets (<15 source files), fall through to
+`--single` automatically.
+
+### Review brief (per subagent)
+
+```
+You are conducting authorized static security review of source code. Your
+focus area: **{focus_area}**. Other agents cover other areas; duplication
+is wasted effort.
+
+TARGET: {target_dir}
+TRUST BOUNDARY: {from THREAT_MODEL.md section 3, or "untrusted input → process memory"}
+
+TASK: read the source in your focus area and identify candidate
+vulnerabilities. This is static review — do NOT build, run, or probe
+anything. Reason from the code.
+
+REPORTING BAR: report anything with a plausible exploit path. Skip style
+concerns, best-practice gaps, and purely theoretical issues with no attack
+story at all — but if you're unsure whether something is real, REPORT IT
+with a low confidence score rather than dropping it. A downstream triage
+step does the rigorous verification; your job is to not miss things.
+
+WHAT TO LOOK FOR (this is a TypeScript / Cloudflare Workers codebase — web
+and serverless classes are HIGH VALUE; native memory-corruption bugs do not
+apply and should not be reported):
+
+  SSRF & OUTBOUND FETCH — HIGH VALUE:
+  - server-side request forgery: attacker-controlled host/protocol reaching
+    fetch()/DoH/RDAP/redirect resolution; reaching internal or metadata hosts
+  - redirect-following without redirect:"manual" (this app fetches MTA-STS
+    policies and resolves redirect chains from untrusted email URLs)
+  - URL host checks done by substring/startsWith/includes instead of a parsed
+    URL().hostname comparison (redirect/allowlist bypass)
+
+  INJECTION & CODE EXECUTION — HIGH VALUE:
+  - SQL injection in SQLite/Drizzle (string-built queries, .raw(), unparam'd
+    .bind, template-literal interpolation into SQL)
+  - command / header / template injection; unsafe deserialization; eval/Function
+  - prototype pollution via attacker-controlled JSON merge/Object.assign/spread
+
+  XSS & HTML RENDERING — HIGH VALUE:
+  - untrusted content (email body/subject/headers, scan input, hub event data)
+    rendered into HTML without escaping; dangerouslySetInnerHTML / innerHTML /
+    raw template interpolation; a missing or bypassable sanitizer on a raw-HTML sink
+
+  AUTH, ACL, CRYPTO, DATA — HIGH VALUE:
+  - authentication or authorization bypass, mailbox/tenant isolation break,
+    privilege escalation; a route mounted BEFORE the auth/ACL middleware
+  - hand-rolled JWT/HMAC/signature verification; timing-unsafe secret compares;
+    broken cert/JWKS validation; predictable or guessable tokens
+  - secrets/PII in logs or error responses; secret material returned to client
+
+  SECURITY-PIPELINE INTEGRITY (this app's verdict engine) — HIGH VALUE:
+  - a crafted email that evades verdict-tightening, downgrades a verdict, or
+    makes LLM/classifier output load-bearing (violating the SECURITY_SPEC rules)
+  - a settings-tier write that persists rendered defaults as explicit overrides
+    (missing stripDefaultEqual), silently shadowing upstream inheritance
+
+  LOW VALUE — note briefly, keep looking:
+  - clean error returns / thrown-and-handled exceptions (correct handling, not a bug)
+  - missing defense-in-depth with no concrete attacker-reachable path
+
+DO NOT REPORT (common false positives — skip even if technically present):
+  - volumetric DoS / rate-limiting / resource-exhaustion — BUT unbounded
+    recursion, algorithmic-complexity blowup, or ReDoS driven by untrusted
+    input ARE reportable
+  - memory-safety findings in memory-safe languages outside unsafe/FFI
+  - XSS in React/Angular/Vue unless via dangerouslySetInnerHTML,
+    bypassSecurityTrustHtml, v-html, or equivalent raw-HTML escape hatch
+  - findings in test files, fixtures, build scripts, docs, or .ipynb
+  - missing hardening / best-practice gaps with no concrete exploit
+  - env vars and CLI flags as the attack vector (operator-controlled)
+  - regex injection, log spoofing, open redirect, missing audit logs
+  - outdated third-party dependency versions
+
+{if --extra <file> was given: append its contents here verbatim}
+
+For each finding you DO report, trace: where does the untrusted input
+enter, what path reaches the sink, and what condition triggers it.
+
+OUTPUT — one block per finding, nothing else:
+
+<finding>
+<id>F-{focus_idx:02d}-{n:02d}</id>
+<file>{relative/path}</file>
+<line>{line_number}</line>
+<category>{ssrf | xss | sql-injection | command-injection | header-injection | deserialization | prototype-pollution | auth-bypass | acl-bypass | broken-crypto | secret-exposure | pipeline-bypass | settings-shadowing | ...}</category>
+<severity>{HIGH | MEDIUM | LOW}</severity>
+<confidence>{0.0-1.0}</confidence>
+<title>{one line}</title>
+<description>{root cause, attacker control, trigger condition, data flow from entry to sink. Cite line numbers.}</description>
+<exploit_scenario>{concrete attack: what input, from where, causing what outcome}</exploit_scenario>
+<recommendation>{specific fix: parameterize the query, parse URL().hostname instead of substring, escape before HTML, add the auth/ACL gate, etc.}</recommendation>
+</finding>
+
+SEVERITY: HIGH = directly exploitable → RCE, data breach, auth bypass.
+MEDIUM = significant impact under specific conditions. LOW = defense-in-
+depth.
+
+If you find nothing reportable in your area after a thorough read, emit a
+single <finding> with category=none and a one-line note of what you covered.
+```
+
+## Step 3 — Collate
+
+1. Collect `<finding>` blocks from all subagents. Drop `category=none`
+   placeholders.
+2. **Light dedupe** — if two findings cite the same `file:line` with the
+   same category, keep the one with the longer description and note the
+   duplicate id. (Heavy dedupe is `/sec-triage`'s job; don't over-engineer here.)
+3. Assign stable ids `F-001`, `F-002`, ... in (severity desc, file, line)
+   order.
+
+## Step 3b — Confidence pass (skip if `--no-score`)
+
+A cheap second-opinion read that **ranks** findings by signal quality.
+**Nothing is dropped** — this pass calibrates `confidence` so humans and
+`/sec-triage` see high-signal findings first. Spawn **one Task subagent per
+finding** in parallel with the brief below. Shallow: re-read and score, not
+a full reachability trace.
+
+### Scoring brief (per finding)
+
+```
+You are giving ONE candidate security finding an independent confidence
+score. You are NOT deciding whether to keep it — every finding is kept.
+You are deciding how likely it is to survive rigorous triage.
+
+FINDING:
+{the full <finding> block}
+
+TARGET: {target_dir} (you may Read/Grep inside it; do NOT execute)
+
+STEP 1 — Re-read the cited code. Open {file} around line {line}. Does the
+code actually do what the description claims?
+
+STEP 2 — Check against common false-positive patterns (volumetric DoS,
+memory-safe language, test/fixture/doc file, framework auto-escape, env-var
+vector, missing-hardening-only, regex/log injection, outdated dep). A match
+lowers confidence sharply but does not auto-zero it.
+
+STEP 3 — Score 1-10 that this is a real, actionable vulnerability:
+  1-3  likely false positive or noise
+  4-5  plausible but speculative
+  6-7  credible, needs investigation
+  8-10 high confidence, clear pattern
+
+OUTPUT (exactly this, nothing else):
+  CONFIDENCE: <1-10>
+  REASON: <one line>
+```
+
+**Resolve:** overwrite each finding's `confidence` with the score
+(normalized to 0.0-1.0) and attach `confidence_reason`. Re-sort findings
+by (`confidence` desc, `severity` desc, `file`, `line`) and reassign ids
+`F-001..` in that order. Compute `low_confidence_count` = findings with
+confidence < 0.4, for the summary line.
+
+## Step 4 — Write output
+
+Write **both** files to `<target-dir>/`:
+
+**`VULN-FINDINGS.json`** — the `/sec-triage` ingest shape:
+
+```json
+{
+  "target": "<target-dir>",
+  "scanned_at": "<iso8601>",
+  "focus_areas": ["..."],
+  "findings": [
+    {
+      "id": "F-001",
+      "file": "relative/path.c",
+      "line": 123,
+      "category": "heap-buffer-overflow",
+      "severity": "HIGH",
+      "confidence": 0.9,
+      "title": "...",
+      "description": "...",
+      "exploit_scenario": "...",
+      "recommendation": "...",
+      "confidence_reason": "..."
+    }
+  ],
+  "summary": {"total": 0, "high": 0, "medium": 0, "low": 0, "low_confidence": 0}
+}
+```
+
+Findings are sorted by `confidence` desc (then severity, file, line), so
+the top of the file is the highest-signal material.
+
+**`VULN-FINDINGS.md`** — human-readable: a summary table (id | severity |
+category | file:line | title), then one `### F-NNN` section per finding with
+the full description.
+
+## Step 5 — Hand back
+
+Tell the user:
+
+1. Counts: N findings (H/M/L split, X low-confidence), across K focus
+   areas, from M source files.
+2. Top 3 by confidence, one line each.
+3. Next step: `> /sec-triage <target-dir>/VULN-FINDINGS.json --repo <target-dir>`
+4. Remind: these are **static candidates**, not verified. `/sec-triage` does the
+   adversarial verification; for runtime confirmation recommend a human-built
+   `vitest` case or controlled PoC.
+
+## Constraints
+
+- **Never execute target code.** No Bash, no builds, no `docker`, no network.
+  If the user asks you to "reproduce" or "confirm with a PoC," decline and
+  recommend a human-built `vitest` case instead.
+- **Don't fabricate line numbers.** Every `file:line` you emit must be
+  something you Read or Grep'd. If unsure of the exact line, cite the
+  function and say so in the description.
+- **Stay in `<target-dir>`.** Don't follow symlinks or `..` out of it.
+- Findings are candidates for `/sec-triage`, not final verdicts. **This skill
+  never drops a finding** — Step 3b only ranks. `/sec-triage` does the rigorous
+  N-vote verification and is where false positives actually get removed.
+
+## Provenance
+
+The focus-area recon pattern and memory-safety quality tiers are lifted
+from this repo's own `harness/prompts/find_prompt.py` and
+`harness/prompts/recon_prompt.py` — the same logic the autonomous pipeline
+uses, applied statically. The broader category menu, DO-NOT-REPORT
+exclusions, per-finding confidence pass, and
+`exploit_scenario`/`recommendation` output fields are adapted from
+[`anthropics/claude-code-security-review`](https://github.com/anthropics/claude-code-security-review)'s
+`/security-review` command.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,18 @@ worker-configuration.d.ts
 # local-only session state (plans, transcripts, settings.local.json) ignored.
 .claude/*
 !.claude/settings.json
+# Track the committed security-review skills (sec-* + shared _lib).
+!.claude/skills/
+
+# Security-review scratch state and raw outputs (ephemeral; not committed —
+# confirmed findings go to GitHub Security Advisories per .github/SECURITY.md).
+.threat-model-state/
+.triage-state/
+.patch-state/
+/VULN-FINDINGS.json
+/VULN-FINDINGS.md
+/TRIAGE.json
+/TRIAGE.md
+/PATCHES/
+/PATCHES.json
+/PATCHES.md

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -1,0 +1,98 @@
+# Threat Model: PhishSOC
+
+## 1. System context
+
+PhishSOC is a phishing-triage SOC mailbox application built on Cloudflare
+Workers (TypeScript) with a React 19 / React Router v7 single-page frontend.
+Inbound email is delivered via the Cloudflare Email binding, parsed, and run
+through a synchronous security pipeline (SPF/DKIM/DMARC, URL/homograph
+heuristics, an LLM classifier, sender reputation, off-hours scoring) that
+produces a verdict, followed by an asynchronous deep-scan stage
+(redirect-chain resolution, RDAP domain age, CrowdSec CTI, Spamhaus DROP,
+attachment heuristics). Per-mailbox state lives in a `MailboxDO` Durable
+Object (SQLite + R2 attachments). AI chat agents (`EmailAgent`, `OrgAgent`
+Durable Objects) and an MCP server expose mailbox tools to operators and
+external AI clients. A MISP-compatible threat-intel `hub` exposes a
+destroylist feed and admin UI. The app is deployed behind Cloudflare Access;
+operators are authenticated teammates. It is the kind of system a small
+security team self-hosts to triage a shared phishing inbox.
+
+## 2. Assets
+
+| asset | description | sensitivity |
+|---|---|---|
+| Mailbox contents | Stored emails, headers, bodies, attachments, drafts per mailbox | high |
+| Cross-mailbox / tenant isolation | The boundary that keeps one mailbox's data from another | high |
+| Detection integrity | Correctness of the phishing verdict (a bypass lets phishing through; a flood causes alert fatigue) | high |
+| Operator session | The authenticated Cloudflare Access session and its UI context | high |
+| Service credentials | API keys/secrets in `Env` (CrowdSec, send-email, hub admin key, JWKS config) | critical |
+| Internal/Cloudflare network reachability | What the Worker can reach via outbound fetch (internal hosts, metadata) | high |
+| Service availability | The Worker staying responsive under crafted input | medium |
+| Hub feed integrity | Correctness of the corroborated-phishing destroylist served to the community | medium |
+
+## 3. Entry points & trust boundaries
+
+| entry_point | description | trust_boundary | reachable_assets |
+|---|---|---|---|
+| Inbound email pipeline | `workers/index.ts` `receiveEmail` — raw MIME via the Email binding, parsed by `postal-mime`; subject/body/headers/attachments are fully attacker-controlled | untrusted email → process + stored mailbox data | Mailbox contents, Detection integrity, Service availability, Internal network reachability |
+| Authenticated HTTP API | `workers/app.ts` + `workers/index.ts` + `workers/routes/*` — mailbox CRUD, settings, send, cases, dmarc/tlsrpt ingest, behind Cloudflare Access | unauth network → CF-Access-authenticated session | Mailbox contents, Cross-mailbox isolation, Operator session, Service credentials |
+| Routes mounted before auth/ACL | `/api/v1/confirm` step-up (own JWT) and the yaramail HMAC callback are mounted before the mailbox-ACL middleware | unauthenticated network → privileged action gated by a separate secret | Mailbox contents, Cross-mailbox isolation |
+| Outbound deep-scan fetches | `workers/intel/*` — redirect resolution of URLs extracted from email, RDAP, CrowdSec, DoH; `workers/mta-sts` policy fetch | server → arbitrary/attacker-named hosts | Internal network reachability, Service availability, Service credentials |
+| Email rendering in UI | `app/components/EmailIframe.tsx` and signature rendering — stored untrusted email HTML projected into the operator's browser | stored untrusted content → operator browser | Operator session, Mailbox contents |
+| AI agents & MCP server | `workers/agent/*`, `workers/mcp/*` — email content becomes LLM context; 9 mailbox tools exposed to operators and external AI clients | untrusted email content → LLM context → tool actions | Mailbox contents, Detection integrity |
+| Hub feed & admin | `hub/*` — MISP event ingest/triage and the community destroylist feed; admin gated by `HUB_ADMIN_KEY`, per-org by bearer tokens | untrusted report submitters / unauth feed readers → hub state | Hub feed integrity, Service credentials |
+| Settings-tier writes | mailbox POST/PUT, domain PUT, org PUT writing `*.json` to R2 (`workers/lib/mailbox-settings.ts`) | authenticated operator → multi-tier config inheritance | Detection integrity, Mailbox contents |
+
+## 4. Threats
+
+| id | threat | actor | surface | asset | impact | likelihood | status | controls | evidence |
+|---|---|---|---|---|---|---|---|---|---|
+| T1 | SSRF / internal-resource access by crafting email URLs that the deep-scan stage resolves and fetches | remote_unauth | Outbound deep-scan fetches | Internal network reachability, Service availability | high | possible | partially_mitigated | MTA-STS uses `redirect:"manual"`; URL host checks parse `URL().hostname` (CodeQL-gated); no internal-range denylist on data-driven fetch | CLAUDE.md MTA-STS regression history (PRs #58/#92); CodeQL `js/incomplete-url-substring-sanitization` gate (PR #130) |
+| T2 | Stored XSS via attacker-supplied email HTML/headers rendered in the operator's browser | remote_unauth | Email rendering in UI | Operator session, Mailbox contents | high | possible | partially_mitigated | DOMPurify sanitization + opaque-origin sandboxed iframe in `EmailIframe.tsx`; DOMPurify on signatures | |
+| T3 | Cross-mailbox / tenant authorization bypass via a route reachable without the ACL gate or an ACL-blob bypass | remote_auth | Authenticated HTTP API; Routes mounted before auth/ACL | Cross-mailbox isolation, Mailbox contents | high | possible | partially_mitigated | Cloudflare Access perimeter; per-mailbox ACL blobs; HMAC on yaramail callback; step-up JWT on `/confirm` | |
+| T4 | Detection-integrity manipulation: a crafted email evades verdict-tightening, makes LLM output load-bearing, or bypasses a score cap so phishing is scored clean | remote_unauth | Inbound email pipeline | Detection integrity | high | possible | partially_mitigated | SECURITY_SPEC Rules 1-6 (LLM advisory-only, monotonic tightening, score caps, fail-closed timeouts, no agent send) | SECURITY_SPEC.md Rules 1-6 exist precisely to bound this threat |
+| T5 | SQL injection / unsafe query construction in the mailbox Durable Object or hub triage reaching stored data | remote_auth | Authenticated HTTP API; Hub feed & admin | Mailbox contents, Hub feed integrity | critical | rare | mitigated | Drizzle parameterized queries in `MailboxDO`; `.bind(...)` in hub triage; static migrations | |
+| T6 | Disclosure of secrets / PII via error responses, logs, or over-broad API payloads | remote_auth | Authenticated HTTP API; Outbound deep-scan fetches | Service credentials, Mailbox contents | high | possible | partially_mitigated | Convention: secrets not logged; deep-scan logs error message only | |
+| T7 | Settings-inheritance shadowing: a tier write persists rendered defaults as explicit overrides, silently masking upstream config | remote_auth | Settings-tier writes | Detection integrity, Mailbox contents | medium | possible | mitigated | `stripDefaultEqual(...)` on every write path, enforced by a `.claude/settings.json` hook | CLAUDE.md `stripDefaultEqual` convention (PRs #148/#154) |
+| T8 | Sender / authentication-results spoofing: a forged `Authentication-Results` header is trusted, inflating sender legitimacy | remote_unauth | Inbound email pipeline | Detection integrity | medium | likely | partially_mitigated | Rule 3 trusted-authserv allowlist (default empty; operator must configure) | |
+| T9 | Algorithmic-complexity / ReDoS denial of service via crafted email headers or body in a parser or heuristic | remote_unauth | Inbound email pipeline | Service availability | medium | possible | unmitigated | none specific (volumetric DoS is infra-layer; algorithmic blowup is not) | |
+| T10 | Hub feed poisoning: a submitter corroborates a benign domain onto the community destroylist | remote_auth | Hub feed & admin | Hub feed integrity | medium | possible | partially_mitigated | corroboration threshold before promotion; admin/org token gating | |
+
+## 5. Deprioritized
+
+| threat | reason |
+|---|---|
+| Prompt injection from email content into the LLM classifier or EmailAgent/OrgAgent | Contained by SECURITY_SPEC Rules 1 & 6: LLM output is advisory-only and the agent has no send capability, so injection cannot move a verdict or take an action on its own. Re-promote only if injected text is shown to reach a load-bearing decision. |
+| Volumetric DoS / request flooding | Handled at the Cloudflare infrastructure layer; out of application scope per `.github/SECURITY.md`. |
+| Vulnerabilities in upstream dependencies (`postal-mime`, DOMPurify, etc.) | Out of scope per `.github/SECURITY.md`; tracked via Dependabot. |
+| Attacks requiring Cloudflare Access to be disabled or physical CF-account access | Explicitly out of scope per `.github/SECURITY.md`. |
+| Self-XSS, missing security headers without demonstrated impact | Low-severity classes excluded per `.github/SECURITY.md`. |
+
+## 6. Open questions
+
+- Does any data-driven outbound fetch (`workers/intel/url-resolver.ts`, RDAP, CrowdSec, DoH) restrict the destination host to public ranges, or can it reach `127.0.0.0/8`, `169.254.169.254`, or RFC-1918 hosts? (T1)
+- Is DOMPurify applied on **every** path that renders email-derived HTML, including drafts, quoted replies, and any hub UI projection — or only the primary iframe? (T2)
+- Are there any HTTP routes mounted before the mailbox-ACL middleware besides `/confirm` and the yaramail callback, and is each one independently authenticated? (T3)
+- Is the HMAC verification on the yaramail callback constant-time, and is the secret compared with a timing-safe primitive? (T3)
+- Can any email-controlled field reach a verdict write or a score that is not capped per Rule 4 — i.e., is the Rule 1/2/4 boundary enforced on every aggregation path? (T4)
+- Are there parsers/heuristics that run unbounded regex or recursion over attacker-sized email fields without a size/time cap? (T9)
+- What is the corroboration threshold and who can submit to the hub feed before a domain is promoted to the destroylist? (T10)
+
+## 7. Provenance
+
+- mode: bootstrap
+- date: 2026-05-28
+- target: /Users/cory/PhishSOC @ d2714eb
+- inputs: code + CLAUDE.md + SECURITY_SPEC.md + .github/SECURITY.md (git-log/advisories not mined separately)
+- owner: unset
+
+## 8. Recommended mitigations
+
+| mitigation | threat_ids | closes_class | effort |
+|---|---|---|---|
+| Add an SSRF guard to every data-driven outbound fetch: resolve and reject private/link-local/metadata ranges before the request, on each redirect hop | T1 | yes | M |
+| Enforce a Content-Security-Policy on the app and assert DOMPurify on every raw-HTML sink that renders email-derived content (test coverage per sink) | T2 | partial | M |
+| Centralize the mailbox-ACL gate and add a test asserting no route is mounted before it without its own authentication | T3 | yes | M |
+| Property/fuzz-test verdict aggregation against crafted emails to prove Rules 1/2/4 hold on every path (LLM advisory-only, monotonic, capped) | T4, T8 | partial | M |
+| Apply size and time caps to all email-field parsers and regex heuristics; prefer linear-time matchers on attacker-controlled input | T9 | partial | S |
+| Keep `stripDefaultEqual` on every settings-write path; the existing hook is the enforcement — extend it if a new write endpoint is added | T7 | yes | S |


### PR DESCRIPTION
## Summary

Implements the [defending-code reference harness](https://github.com/anthropics/defending-code-reference-harness) methodology for this repo as a set of **file-only, read-only** Claude Code skills plus a first threat model.

- **`.claude/skills/sec-{threat-model,vuln-scan,triage,patch}`** — the interactive find→triage→patch loop, namespaced `sec-*` to avoid colliding with the existing `/triage` skill. Adapted for TypeScript/Workers: the scan brief leads with web/serverless vuln classes (SSRF, XSS, injection, auth/ACL, **pipeline bypass**) rather than native memory corruption; `sec-patch` is **static-only** (no ASAN execution ladder); a shared `_lib/phishsoc-rules.md` encodes SECURITY_SPEC Rules 1–6 and repo conventions as scan/triage calibration so known invariants aren't re-litigated as findings.
- **`docs/security/THREAT_MODEL.md`** — output of a first `bootstrap` pass (10 threats T1–T10, 6 class-level mitigations).
- **`.gitignore`** — tracks `.claude/skills/` while keeping review scratch (`.triage-state/`, `VULN-FINDINGS.*`, `TRIAGE.*`, `PATCHES/`) ignored.

The C/C++ autonomous pipeline (`harness/`), `/customize`, and `/quickstart` were intentionally **not** ported — there's no fuzzable binary in a Workers app; the test suite is the only execution oracle.

## First review (driven through these skills)

The first pass surfaced 5 candidates; 3-vote adversarial triage confirmed **3 true-positives** (2 dropped as false positives). Remediations and tests are in a follow-up PR; two confirmed findings are tracked as **draft GitHub Security Advisories** (per `.github/SECURITY.md`), not public issues.

## Test plan

- [ ] Skills are file-only/read-only; no runtime behavior changes in this PR
- [ ] `.claude/skills/_lib/checkpoint.py` runs (`python3 … ` prints usage)
- [ ] Skills load in a fresh Claude Code session (`/sec-threat-model`, `/sec-vuln-scan`, `/sec-triage`, `/sec-patch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)