### PR TITLE
security: harden auth-results trust, send-gate, org settings strip

### DIFF
--- a/test/security/run-pipeline.test.ts
+++ b/test/security/run-pipeline.test.ts
@@ -171,6 +171,11 @@ describe("triage short-circuits", () => {
 			settings: settings({
 				allowlist_senders: ["newsletter@acme-example.com"],
 				trusted_auto_allow: true,
+				// Hard-allow requires a DMARC pass from a TRUSTED authserv-id
+				// (F-004). The benign-newsletter fixture's Authentication-Results
+				// authserv-id is mx.example.com; trust it so the verdict is marked
+				// trusted and the short-circuit fires.
+				trusted_authserv_ids: ["mx.example.com"],
 			}),
 		});
 		const parsed = await loadFixture("benign-newsletter.eml");

--- a/tests/lib/send-risk-gate.test.ts
+++ b/tests/lib/send-risk-gate.test.ts
@@ -108,3 +108,45 @@ describe("enforceSendRiskConfirmation — agent tier and tier downgrade", () => 
 		expect(result.body.risk?.tier).toBe(2);
 	});
 });
+
+describe("enforceSendRiskConfirmation — fail closed on missing bindings", () => {
+	const SECRET = "test-confirm-secret";
+	const MAILBOX_ID = "operator@internal.example";
+	type GateEnv = Parameters<typeof enforceSendRiskConfirmation>[0];
+
+	// A high-risk send must NOT be accepted when the step-up verification
+	// primitives are unavailable. Previously, a falsy BLOOM_KV (or secret)
+	// skipped verification and returned ok:true, accepting any token.
+	it("rejects a tier >= 1 send when BLOOM_KV is unconfigured", async () => {
+		const result = await enforceSendRiskConfirmation(
+			{ CONFIRMATION_TOKEN_SECRET: SECRET, BLOOM_KV: undefined } as unknown as GateEnv,
+			"any-token-value",
+			{
+				mailboxId: MAILBOX_ID,
+				to: "vendor@external.com",
+				subject: "Please wire transfer $10,000",
+				body: "Urgent.",
+			},
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.status).toBe(401);
+		expect(result.body.error).toBe("confirmation_unavailable");
+	});
+
+	it("rejects a tier >= 1 send when CONFIRMATION_TOKEN_SECRET is unconfigured", async () => {
+		const result = await enforceSendRiskConfirmation(
+			{ CONFIRMATION_TOKEN_SECRET: undefined, BLOOM_KV: makeKv() } as unknown as GateEnv,
+			"any-token-value",
+			{
+				mailboxId: MAILBOX_ID,
+				to: "vendor@external.com",
+				subject: "Please wire transfer $10,000",
+				body: "Urgent.",
+			},
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.body.error).toBe("confirmation_unavailable");
+	});
+});

--- a/tests/routes/config.test.ts
+++ b/tests/routes/config.test.ts
@@ -111,6 +111,16 @@ function makeApp(seedDomains: string, orgStore: ReturnType<typeof makeR2Stub>) {
 		return c.json({ domains: (stripped.domains as string[] | undefined) ?? [] });
 	});
 
+	// Mirror of PUT /api/v1/org/settings — must strip default-equal fields
+	// before persisting (F-001), the same as the domain and mailbox PUT paths.
+	app.put("/api/v1/org/settings", async (c) => {
+		const body = (await c.req.json().catch(() => ({}))) as { settings?: unknown };
+		const incoming = (body.settings ?? {}) as Record<string, unknown>;
+		const stripped = stripDefaultEqual(incoming);
+		await (c.env.BUCKET as typeof orgStore).put("org/settings.json", JSON.stringify(stripped));
+		return c.json({ settings: stripped });
+	});
+
 	return app;
 }
 
@@ -231,5 +241,28 @@ describe("stripDefaultEqual — domains field (#181)", () => {
 		const stored = bucket._read("org/settings.json");
 		const parsed = JSON.parse(stored) as Record<string, unknown>;
 		expect(parsed).not.toHaveProperty("domains");
+	});
+});
+
+describe("PUT /api/v1/org/settings — strips rendered defaults before persist (F-001)", () => {
+	it("does not persist a default-equal field as an explicit org-tier override", async () => {
+		const bucket = makeR2Stub();
+		const app = makeApp("", bucket);
+		const res = await app.request(
+			"/api/v1/org/settings",
+			{
+				method: "PUT",
+				headers: { "content-type": "application/json" },
+				// `domains: []` equals the system default; a real save with rendered
+				// defaults must not pin it as an explicit override that shadows
+				// inheritance. A genuine non-default value is preserved.
+				body: JSON.stringify({ settings: { domains: [], agentModel: "custom-model" } }),
+			},
+			{ DOMAINS: "", BUCKET: bucket },
+		);
+		expect(res.status).toBe(200);
+		const stored = JSON.parse(bucket._read("org/settings.json")) as Record<string, unknown>;
+		expect(stored).not.toHaveProperty("domains");
+		expect(stored.agentModel).toBe("custom-model");
 	});
 });

--- a/tests/security/auth.test.ts
+++ b/tests/security/auth.test.ts
@@ -109,12 +109,17 @@ describe("parseAuthResults — authserv-id gating", () => {
 		expect(v).toEqual(emptyVerdict());
 	});
 
-	it("treats an empty trusted list as 'trust any' (back-compat)", () => {
+	it("parses results with an empty trusted list but does NOT mark them trusted", () => {
+		// Back-compat: with no allowlist configured we still parse spf/dkim/dmarc
+		// so scoring keeps working. But verdict.trusted stays falsy (F-004): a
+		// forged header on an unconfigured deployment must not be treated as
+		// authserv-trusted, so it cannot reach the hard-allow short-circuit.
 		const v = parseAuthResults(
 			[header("Authentication-Results", "anywhere; spf=pass; dkim=pass; dmarc=pass")],
 			{ trustedAuthservIds: [] },
 		);
 		expect(v).toMatchObject({ spf: "pass", dkim: "pass", dmarc: "pass" });
+		expect(v.trusted).toBeFalsy();
 	});
 
 	it("preserves 'first set wins' — legitimate dkim=none is not overwritten by later headers", () => {

--- a/tests/security/triage.test.ts
+++ b/tests/security/triage.test.ts
@@ -3,7 +3,13 @@ import { evaluateTriage } from "../../workers/security/triage";
 import { DEFAULT_SECURITY_SETTINGS } from "../../workers/security/settings";
 import type { AuthVerdict } from "../../workers/security/auth";
 
-const dmarcPass: AuthVerdict = { spf: "pass", dkim: "pass", dmarc: "pass" };
+// A DMARC pass from a trusted authserv-id (verdict.trusted set by
+// parseAuthResults when a configured allowlist matched). Hard-allow requires
+// this; see the F-004 regression test below.
+const dmarcPass: AuthVerdict = { spf: "pass", dkim: "pass", dmarc: "pass", trusted: true };
+// A DMARC pass that is NOT from a trusted authserv-id (e.g. a forged header on
+// a deployment with no trustedAuthservIds configured).
+const dmarcPassUntrusted: AuthVerdict = { spf: "pass", dkim: "pass", dmarc: "pass" };
 const dmarcFail: AuthVerdict = { spf: "fail", dkim: "fail", dmarc: "fail" };
 
 const baseSettings = {
@@ -103,6 +109,21 @@ describe("evaluateTriage — hard allow", () => {
 		});
 		expect(r.shortcircuit?.tier).toBe("hard_allow");
 		expect(r.shortcircuit?.verdict.action).toBe("allow");
+	});
+
+	it("does NOT hard-allow a forged/untrusted DMARC pass, even with an allowlist match", () => {
+		// F-004: with no trustedAuthservIds configured, parseAuthResults leaves
+		// verdict.trusted falsy. A forged Authentication-Results header claiming
+		// dmarc=pass must not reach hard-allow and skip the rest of the pipeline.
+		const r = evaluateTriage({
+			...baseInputs,
+			sender: "ceo@trusted.com",
+			auth: dmarcPassUntrusted,
+			reputation: null,
+			intelMatch: null,
+			settings: { ...baseSettings, allowlist_senders: ["ceo@trusted.com"] },
+		});
+		expect(r.shortcircuit).toBeUndefined();
 	});
 
 	it("allows on explicit domain allowlist + DMARC pass (exact)", () => {

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -763,7 +763,12 @@ app.put("/api/v1/org/settings", async (c) => {
 	if (!parsed.success) {
 		return c.json({ error: "Invalid org settings", issues: parsed.error.issues }, 400);
 	}
-	const written = await putOrgSettings(c.env, parsed.data);
+	// Symmetry with the domain (below) and mailbox PUT/POST paths: drop fields
+	// equal to the system default before persisting so a fresh form save with
+	// rendered defaults doesn't pin them as explicit org-tier overrides that
+	// shadow a future default change for every inheriting domain/mailbox.
+	const stripped = stripDefaultEqual(parsed.data);
+	const written = await putOrgSettings(c.env, stripped);
 	return c.json({ settings: written });
 });
 

--- a/workers/lib/send-risk-gate.ts
+++ b/workers/lib/send-risk-gate.ts
@@ -51,35 +51,40 @@ export async function enforceSendRiskConfirmation(
 	}
 
 	const { CONFIRMATION_TOKEN_SECRET, BLOOM_KV } = env;
-	if (CONFIRMATION_TOKEN_SECRET && BLOOM_KV) {
-		const attachmentIds = (input.attachments ?? [])
-			.map((a) => a.filename?.trim() ?? "")
-			.filter(Boolean);
-		const payloadHash = await computePayloadHash(
-			input.to,
-			input.subject,
-			input.body,
-			attachmentIds,
-			input.cc,
-			input.bcc,
-		);
-		const verified = await verifyConfirmationToken(
-			confirmationToken,
-			CONFIRMATION_TOKEN_SECRET,
-			input.mailboxId,
-			payloadHash,
-			BLOOM_KV,
-		);
-		if (!verified) {
-			return { ok: false, status: 401, body: { error: "invalid or expired confirmation token" } };
-		}
-		if (verified.tier < risk.tier) {
-			return {
-				ok: false,
-				status: 401,
-				body: { error: "confirmation_required", risk },
-			};
-		}
+	// Fail closed: a tier >= 1 send must never proceed when the step-up
+	// verification primitives are unavailable. Skipping verification here (the
+	// previous behaviour when either binding was missing) accepted any token —
+	// including a forged or replayed one — for a high-risk send.
+	if (!CONFIRMATION_TOKEN_SECRET || !BLOOM_KV) {
+		return { ok: false, status: 401, body: { error: "confirmation_unavailable", risk } };
+	}
+	const attachmentIds = (input.attachments ?? [])
+		.map((a) => a.filename?.trim() ?? "")
+		.filter(Boolean);
+	const payloadHash = await computePayloadHash(
+		input.to,
+		input.subject,
+		input.body,
+		attachmentIds,
+		input.cc,
+		input.bcc,
+	);
+	const verified = await verifyConfirmationToken(
+		confirmationToken,
+		CONFIRMATION_TOKEN_SECRET,
+		input.mailboxId,
+		payloadHash,
+		BLOOM_KV,
+	);
+	if (!verified) {
+		return { ok: false, status: 401, body: { error: "invalid or expired confirmation token" } };
+	}
+	if (verified.tier < risk.tier) {
+		return {
+			ok: false,
+			status: 401,
+			body: { error: "confirmation_required", risk },
+		};
 	}
 
 	return { ok: true, risk };

--- a/workers/security/auth.ts
+++ b/workers/security/auth.ts
@@ -153,7 +153,12 @@ export function parseAuthResults(rawHeaders: unknown, options: ParseAuthOptions 
 			if (!matchesTrusted(authservId, trusted)) continue;
 		}
 		if (!verdict.authservId && authservId) verdict.authservId = authservId;
-		if (!verdict.trusted) verdict.trusted = true;
+		// Only mark the verdict trusted when an operator-configured authserv-id
+		// actually matched (gating === true). With no allowlist configured we
+		// still parse results so scoring keeps working, but `trusted` stays
+		// false — so a forged Authentication-Results header on a default
+		// deployment cannot satisfy the hard-allow short-circuit downstream.
+		if (gating && !verdict.trusted) verdict.trusted = true;
 
 		for (const match of raw.matchAll(RESULT_RE)) {
 			const method = match[1].toLowerCase() as "spf" | "dkim" | "dmarc";

--- a/workers/security/triage.ts
+++ b/workers/security/triage.ts
@@ -190,6 +190,12 @@ function evaluateHardAllow(inputs: TriageInputs): TriageShortCircuit | null {
 	// CRITICAL INVARIANT: require DMARC pass. Without it, anyone can spoof
 	// the From: address of a trusted domain.
 	if (inputs.auth.dmarc !== "pass") return null;
+	// CRITICAL INVARIANT: the DMARC pass must come from a trusted authserv-id.
+	// `auth.trusted` is only set when an operator-configured allowlist matched
+	// (see parseAuthResults). Without this, a forged Authentication-Results
+	// header would trigger hard-allow and skip the whole pipeline on any
+	// deployment that has not configured trustedAuthservIds.
+	if (!inputs.auth.trusted) return null;
 
 	const senderMatch = inputs.settings.allowlist_senders.includes(inputs.sender);
 	const domain = inputs.sender.split("@")[1] ?? "";


### PR DESCRIPTION
## Summary

Three remediations from the first defending-code security-review pass (see the skills + threat model in #368). Each was confirmed by 3-vote adversarial triage and ships with a regression test.

- **Authentication-Results / hard-allow (HIGH)** — `workers/security/auth.ts` now only marks a verdict `trusted` when an operator-configured authserv-id matches, and `workers/security/triage.ts`'s `evaluateHardAllow` requires `auth.trusted` in addition to `dmarc === "pass"`. Previously, on a deployment with no `trusted_authserv_ids` configured (the default), a forged `Authentication-Results: …; dmarc=pass` header could trigger the hard-allow short-circuit and skip the classifier + all downstream intel.
  - **Behavioral change to note:** deployments without a configured `trusted_authserv_ids` will no longer hard-allow (they fall through to full scoring) and auth confidence drops accordingly. Configure `trusted_authserv_ids` to restore hard-allow.
- **send-risk-gate fail-closed (MEDIUM)** — `workers/lib/send-risk-gate.ts` now rejects a tier≥1 send when `CONFIRMATION_TOKEN_SECRET` or `BLOOM_KV` is unavailable, instead of skipping token verification and returning `ok:true`.
- **org settings strip (MEDIUM)** — `workers/index.ts` PUT `/api/v1/org/settings` now routes the payload through `stripDefaultEqual` before persisting, matching the domain and mailbox write paths, so rendered defaults aren't pinned as explicit org-tier overrides.

Relates to draft advisories `GHSA-j644-r34r-2m9j` (HIGH) and `GHSA-p66j-vjpx-rgpg` (MEDIUM).

## Test plan

- [x] `npm test` — 1190 passing, 0 failing (added 4 regression tests; updated 2 existing tests that encoded the pre-fix hard-allow behavior)
- [x] `npm run typecheck` / `tsc -b` — clean
- [ ] Operator note: set `trusted_authserv_ids` to your inbound relay's authserv-id(s) so hard-allow continues to fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)