### PR TITLE
fix: guard confirm endpoint against unconfigured BLOOM_KV binding

### DIFF
--- a/tests/routes/confirm.test.ts
+++ b/tests/routes/confirm.test.ts
@@ -115,6 +115,23 @@ describe("POST /api/v1/confirm — configuration guard", () => {
 		const res = await fetch("/api/v1/confirm", { method: "POST" });
 		expect(res.status).toBe(503);
 	});
+
+	it("returns a clean 503 (not a 500) when BLOOM_KV is not bound", async () => {
+		// Without the guard, a valid step-up JWT would proceed to BLOOM_KV.put
+		// on an undefined binding and throw an unhandled TypeError → 500.
+		const { fetch } = makeApp(FULL_ENV);
+		const res = await fetch("/api/v1/confirm", {
+			method: "POST",
+			headers: {
+				"cf-access-jwt-assertion": "valid-step-up-token",
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(VALID_BODY),
+		});
+		expect(res.status).toBe(503);
+		const body = await res.json() as { error: string };
+		expect(body.error).toContain("not configured");
+	});
 });
 
 describe("POST /api/v1/confirm — JWT validation", () => {

--- a/workers/routes/confirm.ts
+++ b/workers/routes/confirm.ts
@@ -100,7 +100,7 @@ confirmRoute.get("/", (c) =>
 confirmRoute.post("/", async (c) => {
 	const { STEP_UP_AUD, TEAM_DOMAIN, CONFIRMATION_TOKEN_SECRET, BLOOM_KV } = c.env;
 
-	if (!STEP_UP_AUD || !CONFIRMATION_TOKEN_SECRET || !TEAM_DOMAIN) {
+	if (!STEP_UP_AUD || !CONFIRMATION_TOKEN_SECRET || !TEAM_DOMAIN || !BLOOM_KV) {
 		return c.json({ error: "step-up auth not configured" }, 503);
 	}
 


### PR DESCRIPTION
## Summary

`POST /api/v1/confirm` (`workers/routes/confirm.ts`) destructured `BLOOM_KV` and called `await BLOOM_KV.put(...)` after signing the confirmation token, but its early configuration guard only checked `STEP_UP_AUD`, `CONFIRMATION_TOKEN_SECRET`, and `TEAM_DOMAIN`. When the `BLOOM_KV` namespace binding is unconfigured, a valid step-up request reached `BLOOM_KV.put` on an undefined binding and threw an unhandled `TypeError` → **500** instead of a clean precondition error.

This fix adds `BLOOM_KV` to the early guard so a missing binding returns the same **503 "step-up auth not configured"** response as the other missing bindings.

## Scope / risk

- **Not a security advisory** — robustness/availability hardening only. The step-up JWT validation at `confirm.ts:113` still runs; the crash occurred *after* token signing, so this is not an auth bypass. Tracked separately from the security-fix PR (#369).

## Changes

- `workers/routes/confirm.ts` — add `!BLOOM_KV` to the configuration guard.
- `tests/routes/confirm.test.ts` — new test asserting an unconfigured `BLOOM_KV` (valid JWT, full env minus the binding) yields a clean **503** rather than a 500.

## Test plan

- [x] `npm test` — 1191 passing (92 files), including the new guard test
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)