### PR TITLE
🛡️ Sentinel: [security improvement] Enforce PEER_SECRET_ prefix for peer secrets

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The application was missing basic security headers globally across the entire API and web interface, making it susceptible to MIME sniffing and clickjacking, and lacking strict HSTS enforcement.
 **Learning:** Hono does not add security headers out-of-the-box in its routing, even if it runs securely on Cloudflare. We need to explicitly attach these headers in a global middleware (`app.use('*', ...)`).
 **Prevention:** Whenever provisioning a new entrypoint or Hono application, ensure `c.header` or `secureHeaders()` is implemented immediately.
+## 2026-05-24 - [Enforce Dynamic Secret Prefix]
+**Vulnerability:** The threat intel hub allows configuring an inbound peer via an API endpoint that takes an `api_key_secret_name` parameter. This parameter dynamically accesses an environment variable to retrieve a secret. Without restriction, an operator could inadvertently or maliciously exfiltrate unrelated system secrets (like `HUB_ADMIN_KEY` or AWS keys) by sending requests to a malicious upstream server they control.
+**Learning:** Dynamic access to environment variables based on user input or API parameters represents a Confused Deputy / Secret Exfiltration vulnerability. Validating these inputs strictly, especially enforcing mandatory prefixes (like `PEER_SECRET_`), restricts access purely to intended credentials and ensures safe behavior.
+**Prevention:** Always validate dynamic secret names against an explicit prefix or denylist before accessing them from the environment or secret manager.

--- a/hub/src/routes/admin.ts
+++ b/hub/src/routes/admin.ts
@@ -25,7 +25,7 @@ const CreatePeerSchema = z.object({
 	name: z.string().min(1).max(200),
 	contact: z.string().max(500).optional(),
 	base_url: z.string().url().max(2000),
-	api_key_secret_name: z.string().min(1).max(200),
+	api_key_secret_name: z.string().min(1).max(200).startsWith("PEER_SECRET_", { message: "Secret name must start with PEER_SECRET_" }),
 	// Required non-NULL: pulled events default to this group's visibility.
 	default_sharing_group_uuid: z.string().uuid(),
 	default_trust: z.number().min(0).max(10).default(0.5),

--- a/hub/tests/routes/admin.test.ts
+++ b/hub/tests/routes/admin.test.ts
@@ -35,7 +35,7 @@ describe("POST /admin/peers", () => {
 		const res = await appReq("/peers", {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ name: "x", base_url: "https://x", default_sharing_group_uuid: "sg-1", api_key_secret_name: "K" }),
+			body: JSON.stringify({ name: "x", base_url: "https://x", default_sharing_group_uuid: "sg-1", api_key_secret_name: "PEER_SECRET_K" }),
 		});
 		expect(res.status).toBe(401);
 	});
@@ -44,7 +44,7 @@ describe("POST /admin/peers", () => {
 		const res = await appReq("/peers", {
 			method: "POST",
 			headers: { ...adminAuth, "Content-Type": "application/json" },
-			body: JSON.stringify({ name: "x", base_url: "https://x.example", api_key_secret_name: "K" }),
+			body: JSON.stringify({ name: "x", base_url: "https://x.example", api_key_secret_name: "PEER_SECRET_K" }),
 		});
 		expect(res.status).toBe(400);
 	});
@@ -54,11 +54,26 @@ describe("POST /admin/peers", () => {
 			method: "POST",
 			headers: { ...adminAuth, "Content-Type": "application/json" },
 			body: JSON.stringify({
-				name: "x", base_url: "https://x.example", api_key_secret_name: "K",
+				name: "x", base_url: "https://x.example", api_key_secret_name: "PEER_SECRET_K",
 				default_sharing_group_uuid: "00000000-0000-0000-0000-000000000099",
 			}),
 		});
 		expect(res.status).toBe(400);
+	});
+
+	it("rejects api_key_secret_name without the PEER_SECRET_ prefix", async () => {
+		const res = await appReq("/peers", {
+			method: "POST",
+			headers: { ...adminAuth, "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: "x", base_url: "https://x.example", api_key_secret_name: "HUB_ADMIN_KEY",
+				default_sharing_group_uuid: "00000000-0000-0000-0000-000000000001",
+			}),
+		});
+		expect(res.status).toBe(400);
+		// Confused-deputy guard: arbitrary env secrets cannot be selected as peer credentials.
+		const peerCount = db.raw.prepare(`SELECT count(*) as n FROM peers`).get() as { n: number };
+		expect(peerCount.n).toBe(0);
 	});
 
 	it("creates peer + inbound_peer + synthetic org atomically", async () => {
@@ -73,7 +88,7 @@ describe("POST /admin/peers", () => {
 			body: JSON.stringify({
 				name: "CIRCL", contact: "noc@circl.lu",
 				base_url: "https://misp.circl.lu",
-				api_key_secret_name: "PEER_CIRCL_KEY",
+				api_key_secret_name: "PEER_SECRET_CIRCL_KEY",
 				default_sharing_group_uuid: "00000000-0000-0000-0000-000000000001",
 				default_trust: 0.5,
 				tag_include: "tlp:white\ntlp:green",
@@ -106,7 +121,7 @@ describe("POST /admin/peers", () => {
 			method: "POST",
 			headers: { ...adminAuth, "Content-Type": "application/json" },
 			body: JSON.stringify({
-				name: "x", base_url: "https://nope.example", api_key_secret_name: "MISSING_SECRET",
+				name: "x", base_url: "https://nope.example", api_key_secret_name: "PEER_SECRET_MISSING",
 				default_sharing_group_uuid: "00000000-0000-0000-0000-000000000001",
 			}),
 		});
@@ -114,7 +129,7 @@ describe("POST /admin/peers", () => {
 		const body = await res.json() as { error: string; probe: { stage: string; error: string; hint: string } };
 		expect(body.error).toBe("preflight_failed");
 		expect(body.probe.stage).toBe("secret");
-		expect(body.probe.hint).toContain("wrangler secret put MISSING_SECRET");
+		expect(body.probe.hint).toContain("wrangler secret put PEER_SECRET_MISSING");
 
 		// Inserts must NOT have happened.
 		const peerCount = db.raw.prepare(`SELECT count(*) as n FROM peers`).get() as { n: number };
@@ -129,14 +144,14 @@ describe("POST /admin/peers", () => {
 		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
 			new Response("error code: 526", { status: 526, statusText: "" }),
 		);
-		(env as unknown as Record<string, string>).PEER_FAKE_KEY = "fake";
+		(env as unknown as Record<string, string>).PEER_SECRET_FAKE_KEY = "fake";
 
 		const res = await appReq("/peers", {
 			method: "POST",
 			headers: { ...adminAuth, "Content-Type": "application/json" },
 			body: JSON.stringify({
 				name: "broken", base_url: "https://broken-chain.example",
-				api_key_secret_name: "PEER_FAKE_KEY",
+				api_key_secret_name: "PEER_SECRET_FAKE_KEY",
 				default_sharing_group_uuid: "00000000-0000-0000-0000-000000000001",
 			}),
 		});
@@ -160,7 +175,7 @@ describe("GET /admin/peers", () => {
 			method: "POST",
 			headers: { ...adminAuth, "Content-Type": "application/json" },
 			body: JSON.stringify({
-				name: "p1", base_url: "https://p1.example", api_key_secret_name: "K1",
+				name: "p1", base_url: "https://p1.example", api_key_secret_name: "PEER_SECRET_K1",
 				default_sharing_group_uuid: "00000000-0000-0000-0000-000000000001",
 				skip_probe: true,
 			}),
@@ -184,7 +199,7 @@ describe("DELETE /admin/peers/:uuid", () => {
 			method: "POST",
 			headers: { ...adminAuth, "Content-Type": "application/json" },
 			body: JSON.stringify({
-				name: "p1", base_url: "https://p1.example", api_key_secret_name: "K1",
+				name: "p1", base_url: "https://p1.example", api_key_secret_name: "PEER_SECRET_K1",
 				default_sharing_group_uuid: "00000000-0000-0000-0000-000000000001",
 				skip_probe: true,
 			}),


### PR DESCRIPTION
This PR enforces a mandatory `PEER_SECRET_` prefix on the `api_key_secret_name` field for inbound peer configuration in the threat intel hub.

**Context:**
The `/peers` API endpoint dynamically accesses environment variables using the `api_key_secret_name` parameter to retrieve a secret for authentication with an upstream peer.

**Vulnerability:**
Without restriction, an operator could inadvertently or maliciously configure a peer to exfiltrate unrelated system secrets (e.g., `HUB_ADMIN_KEY` or `AWS_SECRET_ACCESS_KEY`) by setting this parameter to the target secret and configuring the `base_url` to point to a server they control.

**Fix:**
By strictly enforcing the `PEER_SECRET_` prefix during Zod schema validation, access is restricted purely to intended credentials designed for peering, preventing the Confused Deputy / Secret Exfiltration vulnerability.

---
*PR created automatically by Jules for task [14674672735932999887](https://jules.google.com/task/14674672735932999887) started by @schmug*