### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The threat intel hub allows configuring an inbound peer via an API endpoint that takes an `api_key_secret_name` parameter. This parameter dynamically accesses an environment variable to retrieve a secret. Without restriction, an operator could inadvertently or maliciously exfiltrate unrelated system secrets (like `HUB_ADMIN_KEY` or AWS keys) by sending requests to a malicious upstream server they control.
 **Learning:** Dynamic access to environment variables based on user input or API parameters represents a Confused Deputy / Secret Exfiltration vulnerability. Validating these inputs strictly, especially enforcing mandatory prefixes (like `PEER_SECRET_`), restricts access purely to intended credentials and ensures safe behavior.
 **Prevention:** Always validate dynamic secret names against an explicit prefix or denylist before accessing them from the environment or secret manager.
+
+## 2024-05-30 - Add missing security headers to hub application
+**Vulnerability:** Missing security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and `Strict-Transport-Security`) in the `hub/src/index.ts` Hono application initialization.
+**Learning:** Hono applications in this codebase do not add security headers out-of-the-box. When provisioning a new application or sub-application, they must be added manually. The root application `workers/app.ts` had them, but the `hub` application did not.
+**Prevention:** Whenever provisioning a new entrypoint or Hono application, ensure `c.header` or `secureHeaders()` is implemented immediately.

--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -33,7 +33,20 @@ import type { Env, TriageMessage } from "./types";
 
 const app = new Hono<{ Bindings: Env }>();
 
-app.get("/", (c) => c.text("AIS Hub — MISP-compatible threat-intel sharing. See /events, /feeds/destroylist.txt, /orgs."));
+// Global security headers
+app.use("*", async (c, next) => {
+	await next();
+	c.header("X-Frame-Options", "DENY");
+	c.header("X-Content-Type-Options", "nosniff");
+	c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+	c.header("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+});
+
+app.get("/", (c) =>
+	c.text(
+		"AIS Hub — MISP-compatible threat-intel sharing. See /events, /feeds/destroylist.txt, /orgs.",
+	),
+);
 
 app.route("/events", eventRoutes);
 // Public (unauthenticated) feeds must be mounted before the authenticated
@@ -42,7 +55,7 @@ app.route("/events", eventRoutes);
 app.route("/feeds/public", publicFeedRoutes);
 app.route("/feeds", feedRoutes);
 app.route("/orgs", orgAcceptApp); // public /orgs/accept
-app.route("/orgs", orgRoutes);    // authed /orgs/me, /orgs/invite
+app.route("/orgs", orgRoutes); // authed /orgs/me, /orgs/invite
 app.route("/sharing_groups", sharingGroupRoutes);
 app.route("/admin", adminRoutes);
 app.route("/admin", adminStatsRoutes);
@@ -53,7 +66,11 @@ export default {
 	async queue(batch: MessageBatch<TriageMessage>, env: Env) {
 		await consumeTriageBatch(batch, env);
 	},
-	async scheduled(_event: ScheduledController, env: Env, ctx: ExecutionContext) {
+	async scheduled(
+		_event: ScheduledController,
+		env: Env,
+		ctx: ExecutionContext,
+	) {
 		ctx.waitUntil(runInboundSync(env));
 	},
 };


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `hub` Hono application was missing standard security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and `Strict-Transport-Security`), leaving it potentially vulnerable to basic attacks like clickjacking and MIME-type sniffing.
🎯 **Impact:** If exploited, attackers could potentially mount clickjacking or content-sniffing attacks on the hub UI or endpoints.
🔧 **Fix:** Added a global middleware to `hub/src/index.ts` that enforces these headers on all routes.
✅ **Verification:** Verified by checking that `app.use("*")` was added securely and tests pass in the `hub/` directory.

---
*PR created automatically by Jules for task [14540685472180028996](https://jules.google.com/task/14540685472180028996) started by @schmug*