### PR TITLE
feat: DMARC dashboard date-range selector (7d/30d/90d)

### DIFF
--- a/app/routes/dmarc.tsx
+++ b/app/routes/dmarc.tsx
@@ -26,15 +26,19 @@ interface DmarcSource {
 	last_seen: string;
 }
 
+const RANGE_PRESETS = [7, 30, 90] as const;
+type RangeDays = (typeof RANGE_PRESETS)[number];
+
 /**
  * DMARC aggregate-report dashboard. Shows legitimate vs forged sending
- * sources for a domain over the last 90 days of ingested reports.
+ * sources for a domain over the selected date window.
  */
 export default function DmarcRoute() {
 	const { mailboxId } = useParams<{ mailboxId: string }>();
 	const [reports, setReports] = useState<DmarcReport[] | null>(null);
 	const [domain, setDomain] = useState<string | null>(null);
 	const [sources, setSources] = useState<DmarcSource[] | null>(null);
+	const [days, setDays] = useState<RangeDays>(90);
 
 	useEffect(() => {
 		if (!mailboxId) return;
@@ -49,11 +53,12 @@ export default function DmarcRoute() {
 
 	useEffect(() => {
 		if (!mailboxId || !domain) return;
-		fetch(`/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/dmarc/summary?domain=${encodeURIComponent(domain)}`)
+		setSources(null);
+		fetch(`/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/dmarc/summary?domain=${encodeURIComponent(domain)}&days=${days}`)
 			.then((r) => r.json() as Promise<{ sources: DmarcSource[] }>)
 			.then((r) => setSources(r.sources))
 			.catch((e) => console.error("dmarc summary fetch failed", e));
-	}, [mailboxId, domain]);
+	}, [mailboxId, domain, days]);
 
 	const domains = useMemo(() => {
 		if (!reports) return [];
@@ -81,15 +86,32 @@ export default function DmarcRoute() {
 		<div className="max-w-5xl px-4 py-6 md:px-8 h-full overflow-y-auto">
 			<h1 className="pp-serif text-ink mb-4">DMARC Reports</h1>
 
-			<div className="mb-6 flex items-center gap-3">
-				<label className="text-sm text-ink-3">Domain:</label>
-				<select
-					value={domain ?? ""}
-					onChange={(e) => setDomain(e.target.value)}
-					className="rounded border border-line bg-paper-3 px-2 py-1 text-sm"
-				>
-					{domains.map((d) => <option key={d} value={d}>{d}</option>)}
-				</select>
+			<div className="mb-6 flex items-center gap-4 flex-wrap">
+				<div className="flex items-center gap-2">
+					<label className="text-sm text-ink-3">Domain:</label>
+					<select
+						value={domain ?? ""}
+						onChange={(e) => setDomain(e.target.value)}
+						className="rounded border border-line bg-paper-3 px-2 py-1 text-sm"
+					>
+						{domains.map((d) => <option key={d} value={d}>{d}</option>)}
+					</select>
+				</div>
+				<div className="flex items-center gap-2">
+					<label className="text-sm text-ink-3">Range:</label>
+					<div className="flex rounded border border-line overflow-hidden text-sm">
+						{RANGE_PRESETS.map((d) => (
+							<button
+								key={d}
+								type="button"
+								onClick={() => setDays(d)}
+								className={`px-3 py-1 ${days === d ? "bg-accent text-white" : "bg-paper-3 text-ink hover:bg-paper-2"}`}
+							>
+								{d}d
+							</button>
+						))}
+					</div>
+				</div>
 			</div>
 
 			<section className="mb-8">

--- a/tests/routes/dmarc.test.ts
+++ b/tests/routes/dmarc.test.ts
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { Hono } from "hono";
+import { createMiddleware } from "hono/factory";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../workers/lib/mailbox", async (orig) => {
+	const original = await orig<typeof import("../../workers/lib/mailbox")>();
+	return {
+		...original,
+		requireMailbox: createMiddleware(async (_c, next) => {
+			await next();
+		}),
+	};
+});
+
+import { dmarcRoutes } from "../../workers/routes/dmarc";
+import type { MailboxContext } from "../../workers/lib/mailbox";
+
+const fakeEnv = {
+	BUCKET: {
+		async get() { return null; },
+		async head() { return { key: "mailboxes/m1.json" }; },
+		async put() {},
+	},
+	MAILBOX: {
+		idFromName() { return {}; },
+		get() { return {}; },
+	},
+} as unknown as Parameters<Hono["request"]>[2];
+
+const fakeCtx = {
+	waitUntil: () => {},
+	passThroughOnException: () => {},
+} as unknown as ExecutionContext;
+
+interface SummaryCall { domain: string; sinceIso: string }
+
+function makeApp(summaryCalls: SummaryCall[]) {
+	const stub = {
+		async getDmarcSummary(domain: string, sinceIso: string) {
+			summaryCalls.push({ domain, sinceIso });
+			return [];
+		},
+	};
+	const app = new Hono<MailboxContext>();
+	app.use("*", async (c, next) => {
+		c.set("mailboxStub", stub as unknown as DurableObjectStub<never>);
+		await next();
+	});
+	app.route("/api/v1/mailboxes/:mailboxId/dmarc", dmarcRoutes);
+	return app;
+}
+
+describe("workers/routes/dmarc — /summary date windowing (#382)", () => {
+	it("defaults to 90 days when days param is omitted", async () => {
+		const calls: SummaryCall[] = [];
+		const app = makeApp(calls);
+		const before = Date.now();
+		const res = await app.request(
+			"/api/v1/mailboxes/m1/dmarc/summary?domain=example.com",
+			{},
+			fakeEnv,
+			fakeCtx,
+		);
+		const after = Date.now();
+		expect(res.status).toBe(200);
+		expect(calls).toHaveLength(1);
+		expect(calls[0].domain).toBe("example.com");
+		const sinceMs = new Date(calls[0].sinceIso).getTime();
+		const expectedMs90 = before - 90 * 24 * 60 * 60 * 1000;
+		const expectedMs7 = before - 7 * 24 * 60 * 60 * 1000;
+		expect(sinceMs).toBeGreaterThanOrEqual(expectedMs90 - 1000);
+		expect(sinceMs).toBeLessThan(expectedMs7);
+		void after;
+	});
+
+	it("passes the requested days window to getDmarcSummary", async () => {
+		const calls: SummaryCall[] = [];
+		const app = makeApp(calls);
+		const before = Date.now();
+		const res = await app.request(
+			"/api/v1/mailboxes/m1/dmarc/summary?domain=example.com&days=30",
+			{},
+			fakeEnv,
+			fakeCtx,
+		);
+		expect(res.status).toBe(200);
+		expect(calls).toHaveLength(1);
+		const sinceMs = new Date(calls[0].sinceIso).getTime();
+		const expected30 = before - 30 * 24 * 60 * 60 * 1000;
+		const expected7 = before - 7 * 24 * 60 * 60 * 1000;
+		expect(sinceMs).toBeGreaterThanOrEqual(expected30 - 1000);
+		expect(sinceMs).toBeLessThan(expected7);
+	});
+
+	it("clamps days=0 up to 1", async () => {
+		const calls: SummaryCall[] = [];
+		const app = makeApp(calls);
+		const before = Date.now();
+		await app.request(
+			"/api/v1/mailboxes/m1/dmarc/summary?domain=example.com&days=0",
+			{},
+			fakeEnv,
+			fakeCtx,
+		);
+		expect(calls).toHaveLength(1);
+		const sinceMs = new Date(calls[0].sinceIso).getTime();
+		const expected1 = before - 1 * 24 * 60 * 60 * 1000;
+		expect(sinceMs).toBeGreaterThanOrEqual(expected1 - 1000);
+		expect(sinceMs).toBeLessThanOrEqual(before);
+	});
+
+	it("clamps days=999 down to 365", async () => {
+		const calls: SummaryCall[] = [];
+		const app = makeApp(calls);
+		const before = Date.now();
+		await app.request(
+			"/api/v1/mailboxes/m1/dmarc/summary?domain=example.com&days=999",
+			{},
+			fakeEnv,
+			fakeCtx,
+		);
+		expect(calls).toHaveLength(1);
+		const sinceMs = new Date(calls[0].sinceIso).getTime();
+		const expected365 = before - 365 * 24 * 60 * 60 * 1000;
+		const expected364 = before - 364 * 24 * 60 * 60 * 1000;
+		expect(sinceMs).toBeGreaterThanOrEqual(expected365 - 1000);
+		expect(sinceMs).toBeLessThan(expected364);
+	});
+
+	it("returns 400 when domain param is missing", async () => {
+		const calls: SummaryCall[] = [];
+		const app = makeApp(calls);
+		const res = await app.request(
+			"/api/v1/mailboxes/m1/dmarc/summary?days=30",
+			{},
+			fakeEnv,
+			fakeCtx,
+		);
+		expect(res.status).toBe(400);
+		expect(calls).toHaveLength(0);
+	});
+});

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -1519,7 +1519,7 @@ export class MailboxDO extends DurableObject<Env> {
 		finalize("ready", summary);
 	}
 
-	async getDmarcSummary(domain: string) {
+	async getDmarcSummary(domain: string, sinceIso: string) {
 		const rows = [
 			...this.ctx.storage.sql.exec(
 				`SELECT
@@ -1532,11 +1532,12 @@ export class MailboxDO extends DurableObject<Env> {
 				   MAX(rep.received_at) as last_seen
 				 FROM dmarc_records r
 				 JOIN dmarc_reports rep ON rep.id = r.report_id
-				 WHERE rep.domain = ?1
+				 WHERE rep.domain = ?1 AND rep.received_at >= ?2
 				 GROUP BY r.source_ip
 				 ORDER BY total_count DESC
 				 LIMIT 200`,
 				domain,
+				sinceIso,
 			),
 		] as Array<{
 			source_ip: string;

--- a/workers/routes/dmarc.ts
+++ b/workers/routes/dmarc.ts
@@ -28,9 +28,15 @@ dmarcRoutes.get("/reports/:reportId/records", async (c) => {
 	return c.json({ records });
 });
 
+const DMARC_SUMMARY_DEFAULT_DAYS = 90;
+const DMARC_SUMMARY_MAX_DAYS = 365;
+
 dmarcRoutes.get("/summary", async (c) => {
 	const domain = c.req.query("domain");
 	if (!domain) return c.json({ error: "domain query param required" }, 400);
-	const summary = await c.var.mailboxStub.getDmarcSummary(domain);
+	const rawDays = Number(c.req.query("days") ?? DMARC_SUMMARY_DEFAULT_DAYS);
+	const days = Math.min(Math.max(Number.isFinite(rawDays) ? rawDays : DMARC_SUMMARY_DEFAULT_DAYS, 1), DMARC_SUMMARY_MAX_DAYS);
+	const sinceIso = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+	const summary = await c.var.mailboxStub.getDmarcSummary(domain, sinceIso);
 	return c.json({ domain, sources: summary });
 });


### PR DESCRIPTION
## Summary

- Adds a 7d / 30d / 90d preset toggle to the DMARC dashboard beside the domain selector; changing it resets and refetches the sending-sources summary.
- Fixes the #380 correctness bug: `getDmarcSummary` had no date filter, so the "last 90 days" label was a lie — all-time data was returned. Now it accepts a `sinceIso` param (mirroring `getDmarcAlignmentTotals`).
- `/summary` route accepts a `days` query param (default 90, clamped server-side to [1, 365]).

Closes #382. Fixes #380.

## Test plan

- [x] `npm test` — 1210 passing, 0 failing (5 new tests in `tests/routes/dmarc.test.ts`)
- [x] `npm run typecheck` — clean

## Choices made

- Default window is 90 days (preserves existing behavior and matches the pre-existing dashboard comment).
- Max clamp is 365 days — sane upper bound without needing a new constant; operators rarely need more than a year of DMARC history in a single view.
- Selector is a pill-style button group (no `<select>`) to match the minimal Kumo aesthetic used elsewhere; the active preset gets `bg-accent text-white`.
- `setSources(null)` on range change keeps the loading state honest while the refetch is in-flight.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X97qDujfCpsfMMFTECGTHf)_