### PR TITLE
fix: scope getDmarcSummary to 90-day window matching dashboard copy

### DIFF
--- a/tests/dmarc/summary.test.ts
+++ b/tests/dmarc/summary.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Route-level tests for the DMARC sending-sources summary endpoint (#380).
+ *
+ * Verifies that:
+ *   1. The route passes a `sinceIso` parameter to `getDmarcSummary` that
+ *      represents approximately the last 90 days.
+ *   2. Sources returned by the DO (i.e. within the window) appear in the
+ *      response; the stub simulates the DO's date-filtered SQL result.
+ *   3. Missing `domain` param yields 400.
+ */
+
+import { Hono } from "hono";
+import { createMiddleware } from "hono/factory";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../workers/lib/mailbox", async (orig) => {
+	const original = await orig<typeof import("../../workers/lib/mailbox")>();
+	return {
+		...original,
+		requireMailbox: createMiddleware(async (_c, next) => {
+			await next();
+		}),
+	};
+});
+
+import { dmarcRoutes } from "../../workers/routes/dmarc";
+import type { MailboxContext } from "../../workers/lib/mailbox";
+
+interface DmarcSource {
+	source_ip: string;
+	total_count: number;
+	pass_count: number;
+	quarantine_count: number;
+	reject_count: number;
+	first_seen: string;
+	last_seen: string;
+}
+
+function makeStub(sources: DmarcSource[] = []) {
+	return {
+		getDmarcSummary: vi.fn().mockResolvedValue(sources),
+	};
+}
+
+function makeApp(stub: ReturnType<typeof makeStub>) {
+	const app = new Hono<MailboxContext>();
+	app.use("*", async (c, next) => {
+		c.set("mailboxStub", stub as unknown as import("@cloudflare/workers-types").DurableObjectStub<never>);
+		await next();
+	});
+	app.route("/api/v1/mailboxes/:mailboxId/dmarc", dmarcRoutes);
+	return app;
+}
+
+describe("GET /dmarc/summary", () => {
+	it("returns 400 when domain query param is missing", async () => {
+		const stub = makeStub();
+		const app = makeApp(stub);
+		const res = await app.request("/api/v1/mailboxes/mb-1/dmarc/summary");
+		expect(res.status).toBe(400);
+		const body = await res.json() as { error: string };
+		expect(body.error).toMatch(/domain/i);
+	});
+
+	it("calls getDmarcSummary with domain and a sinceIso ~90 days ago", async () => {
+		const stub = makeStub([]);
+		const app = makeApp(stub);
+		const before = Date.now();
+		await app.request("/api/v1/mailboxes/mb-1/dmarc/summary?domain=example.com");
+		const after = Date.now();
+
+		expect(stub.getDmarcSummary).toHaveBeenCalledOnce();
+		const [calledDomain, calledSinceIso] = stub.getDmarcSummary.mock.calls[0] as [string, string];
+		expect(calledDomain).toBe("example.com");
+
+		const sinceMs = new Date(calledSinceIso).getTime();
+		const expectedWindowMs = 90 * 24 * 60 * 60 * 1000;
+		// sinceIso must be between (before - 90d) and (after - 90d), within 1s slack
+		expect(sinceMs).toBeGreaterThanOrEqual(before - expectedWindowMs - 1000);
+		expect(sinceMs).toBeLessThanOrEqual(after - expectedWindowMs + 1000);
+	});
+
+	it("returns sources from within the window in the response body", async () => {
+		const windowSources: DmarcSource[] = [
+			{
+				source_ip: "192.0.2.1",
+				total_count: 50,
+				pass_count: 48,
+				quarantine_count: 1,
+				reject_count: 1,
+				first_seen: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(),
+				last_seen: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+			},
+		];
+		const stub = makeStub(windowSources);
+		const app = makeApp(stub);
+		const res = await app.request("/api/v1/mailboxes/mb-1/dmarc/summary?domain=example.com");
+		expect(res.status).toBe(200);
+		const body = await res.json() as { domain: string; sources: DmarcSource[] };
+		expect(body.domain).toBe("example.com");
+		expect(body.sources).toHaveLength(1);
+		expect(body.sources[0].source_ip).toBe("192.0.2.1");
+	});
+
+	it("returns empty sources when the stub filters out all stale records", async () => {
+		// Simulates the DO returning no rows because all reports pre-date sinceIso.
+		const stub = makeStub([]);
+		const app = makeApp(stub);
+		const res = await app.request("/api/v1/mailboxes/mb-1/dmarc/summary?domain=stale.example");
+		expect(res.status).toBe(200);
+		const body = await res.json() as { domain: string; sources: DmarcSource[] };
+		expect(body.domain).toBe("stale.example");
+		expect(body.sources).toHaveLength(0);
+	});
+});

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -1519,7 +1519,7 @@ export class MailboxDO extends DurableObject<Env> {
 		finalize("ready", summary);
 	}
 
-	async getDmarcSummary(domain: string) {
+	async getDmarcSummary(domain: string, sinceIso: string) {
 		const rows = [
 			...this.ctx.storage.sql.exec(
 				`SELECT
@@ -1532,11 +1532,12 @@ export class MailboxDO extends DurableObject<Env> {
 				   MAX(rep.received_at) as last_seen
 				 FROM dmarc_records r
 				 JOIN dmarc_reports rep ON rep.id = r.report_id
-				 WHERE rep.domain = ?1
+				 WHERE rep.domain = ?1 AND rep.received_at >= ?2
 				 GROUP BY r.source_ip
 				 ORDER BY total_count DESC
 				 LIMIT 200`,
 				domain,
+				sinceIso,
 			),
 		] as Array<{
 			source_ip: string;

--- a/workers/routes/dmarc.ts
+++ b/workers/routes/dmarc.ts
@@ -10,6 +10,9 @@
 import { Hono } from "hono";
 import { requireMailbox, type MailboxContext } from "../lib/mailbox";
 
+/** How far back the sending-sources summary looks. Matches the "last 90 days" copy in the DMARC dashboard. */
+const DMARC_SUMMARY_WINDOW_DAYS = 90;
+
 export const dmarcRoutes = new Hono<MailboxContext>();
 
 dmarcRoutes.use("*", requireMailbox);
@@ -31,6 +34,9 @@ dmarcRoutes.get("/reports/:reportId/records", async (c) => {
 dmarcRoutes.get("/summary", async (c) => {
 	const domain = c.req.query("domain");
 	if (!domain) return c.json({ error: "domain query param required" }, 400);
-	const summary = await c.var.mailboxStub.getDmarcSummary(domain);
+	const sinceIso = new Date(
+		Date.now() - DMARC_SUMMARY_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+	).toISOString();
+	const summary = await c.var.mailboxStub.getDmarcSummary(domain, sinceIso);
 	return c.json({ domain, sources: summary });
 });


### PR DESCRIPTION
## Summary

- `getDmarcSummary` was returning an all-time rollup despite the DMARC dashboard copy claiming "last 90 days", making retired senders appear current and inflating counts.
- Added `sinceIso: string` parameter to `getDmarcSummary` (same pattern as `getDmarcAlignmentTotals`) and filtered with `AND rep.received_at >= ?2`.
- Added `DMARC_SUMMARY_WINDOW_DAYS = 90` constant in `workers/routes/dmarc.ts`; route computes `sinceIso` and passes it through.

Closes #380.

## Test plan

- [x] `npm test` — 1209 passing, 0 failing (4 new tests in `tests/dmarc/summary.test.ts`)
- [x] `npm run typecheck` — clean

## Choices made

- **90-day window constant in the route handler, not the DO.** The DO method is a general-purpose query; the window policy belongs to the caller (same split as `getDmarcAlignmentTotals` / `DMARC_ALIGNMENT_WINDOW_DAYS` in `workers/index.ts`).
- **Kept alignment window at 7 days.** `DMARC_ALIGNMENT_WINDOW_DAYS` serves a different purpose (per-domain alignment rate on the domains tile). The sending-sources summary warrants a wider 90-day view, matching existing UI copy.

## Deferred

- **AND/OR mismatch in `pass_count`:** `getDmarcSummary` counts `dkim='pass' AND spf='pass'`, while `getDmarcAlignmentTotals` uses `OR` (the DMARC-correct aligned definition). This is out of scope per the issue. Will file a follow-up.

https://claude.ai/code/session_012RabBj9tfoj5s1znh4yUQj

---
_Generated by [Claude Code](https://claude.ai/code/session_012RabBj9tfoj5s1znh4yUQj)_