### PR TITLE
feat: cross-domain DMARC RUA rollup (one rua, many domains)

### DIFF
--- a/app/routes/dmarc.tsx
+++ b/app/routes/dmarc.tsx
@@ -76,6 +76,18 @@ interface DrillDownRecord {
 
 const RANGE_PRESETS = [7, 30, 90] as const;
 type RangeDays = (typeof RANGE_PRESETS)[number];
+interface DmarcRollupRow {
+	domain: string;
+	total: number;
+	aligned: number;
+	failing: number;
+}
+
+interface DmarcRollup {
+	window_days: number;
+	since: string;
+	domains: DmarcRollupRow[];
+}
 
 /**
  * DMARC aggregate-report dashboard. Shows legitimate vs forged sending
@@ -90,6 +102,7 @@ export default function DmarcRoute() {
 	const [selectedIp, setSelectedIp] = useState<string | null>(null);
 	const [drillDown, setDrillDown] = useState<DrillDownRecord[] | null>(null);
 	const [drillDownLoading, setDrillDownLoading] = useState(false);
+	const [rollup, setRollup] = useState<DmarcRollup | null>(null);
 
 	useEffect(() => {
 		if (!mailboxId) return;
@@ -143,6 +156,14 @@ export default function DmarcRoute() {
 		});
 	}, [mailboxId, selectedIp, reports, domain]);
 
+	useEffect(() => {
+		if (!mailboxId) return;
+		fetch(`/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/dmarc/rollup`)
+			.then((r) => r.json() as Promise<DmarcRollup>)
+			.then((r) => setRollup(r))
+			.catch((e) => console.error("dmarc rollup fetch failed", e));
+	}, [mailboxId]);
+
 	const domains = useMemo(() => {
 		if (!reports) return [];
 		const set = new Set(reports.map((r) => r.domain));
@@ -181,6 +202,52 @@ export default function DmarcRoute() {
 	return (
 		<div className="max-w-5xl px-4 py-6 md:px-8 h-full overflow-y-auto">
 			<h1 className="pp-serif text-ink mb-4">DMARC Reports</h1>
+
+			{rollup && rollup.domains.length > 1 && (
+				<section className="mb-8">
+					<h2 className="text-sm font-semibold text-ink mb-1">All-domain rollup</h2>
+					<p className="text-xs text-ink-3 mb-3">
+						Ingested RUA data · last {rollup.window_days} days · sorted by worst alignment first
+					</p>
+					<div className="overflow-x-auto rounded-lg border border-line">
+						<table className="w-full text-sm">
+							<thead className="bg-paper-3 text-ink-3 text-xs uppercase">
+								<tr>
+									<th className="text-left px-3 py-2">Domain</th>
+									<th className="text-right px-3 py-2">Messages</th>
+									<th className="text-right px-3 py-2">Aligned</th>
+									<th className="text-right px-3 py-2">Failing</th>
+									<th className="text-left px-3 py-2">Alignment rate</th>
+								</tr>
+							</thead>
+							<tbody>
+								{rollup.domains.map((row) => {
+									const rate = row.total > 0 ? row.aligned / row.total : 0;
+									const isBad = rate < 0.5 && row.total >= 5;
+									return (
+										<tr
+											key={row.domain}
+											className={`border-t border-line cursor-pointer hover:bg-paper-3 transition-colors ${isBad ? "bg-paper-3" : ""}`}
+											onClick={() => setDomain(row.domain)}
+											title={`View ${row.domain} in detail below`}
+										>
+											<td className="px-3 py-2 font-mono text-ink">{row.domain}</td>
+											<td className="px-3 py-2 text-right">{row.total}</td>
+											<td className="px-3 py-2 text-right text-safe">{row.aligned}</td>
+											<td className="px-3 py-2 text-right text-danger">{row.failing}</td>
+											<td className="px-3 py-2">
+												<span className={isBad ? "text-danger" : "text-ink"}>
+													{Math.round(rate * 100)}%
+												</span>
+											</td>
+										</tr>
+									);
+								})}
+							</tbody>
+						</table>
+					</div>
+				</section>
+			)}
 
 			<div className="mb-6 flex items-center gap-4 flex-wrap">
 				<div className="flex items-center gap-2">

--- a/tests/routes/dmarc-rollup.test.ts
+++ b/tests/routes/dmarc-rollup.test.ts
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { Hono } from "hono";
+import { createMiddleware } from "hono/factory";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../workers/lib/mailbox", async (orig) => {
+	const original = await orig<typeof import("../../workers/lib/mailbox")>();
+	return {
+		...original,
+		requireMailbox: createMiddleware(async (_c, next) => {
+			await next();
+		}),
+	};
+});
+
+import { dmarcRoutes } from "../../workers/routes/dmarc";
+import type { MailboxContext } from "../../workers/lib/mailbox";
+
+interface RollupRow {
+	domain: string;
+	total: number;
+	aligned: number;
+	failing: number;
+}
+
+function makeStub(rows: RollupRow[]) {
+	const calls: Array<{ sinceIso: string }> = [];
+	const stub = {
+		async getDmarcRollup(sinceIso: string) {
+			calls.push({ sinceIso });
+			return rows;
+		},
+	};
+	return { stub, calls };
+}
+
+const fakeEnv = {
+	BUCKET: {
+		async get() { return null; },
+		async head() { return { key: "mailboxes/m1.json" }; },
+		async put() { /* no-op */ },
+	},
+	MAILBOX: {
+		idFromName() { return {}; },
+		get() { return {}; },
+	},
+} as unknown as Parameters<Hono["request"]>[2];
+
+const fakeCtx = {
+	waitUntil: () => {},
+	passThroughOnException: () => {},
+} as unknown as ExecutionContext;
+
+function makeApp(stub: ReturnType<typeof makeStub>["stub"]) {
+	const app = new Hono<MailboxContext>();
+	app.use("*", async (c, next) => {
+		c.set("mailboxStub", stub as unknown as DurableObjectStub<never>);
+		await next();
+	});
+	app.route("/api/v1/mailboxes/:mailboxId/dmarc", dmarcRoutes);
+	return app;
+}
+
+describe("GET /dmarc/rollup — issue #383 cross-domain RUA rollup", () => {
+	it("returns rollup rows for multiple domains sorted by caller-provided order", async () => {
+		const { stub } = makeStub([
+			{ domain: "evil.example", total: 100, aligned: 10, failing: 90 },
+			{ domain: "good.example", total: 200, aligned: 195, failing: 2 },
+		]);
+		const app = makeApp(stub);
+
+		const res = await app.request(
+			"/api/v1/mailboxes/m1/dmarc/rollup",
+			{},
+			fakeEnv,
+			fakeCtx,
+		);
+		expect(res.status).toBe(200);
+
+		const body = (await res.json()) as {
+			window_days: number;
+			since: string;
+			domains: RollupRow[];
+		};
+		expect(body.window_days).toBe(90);
+		expect(typeof body.since).toBe("string");
+		expect(body.domains).toHaveLength(2);
+		expect(body.domains[0].domain).toBe("evil.example");
+		expect(body.domains[1].domain).toBe("good.example");
+	});
+
+	it("respects the days query param and clamps to 365", async () => {
+		const { stub, calls } = makeStub([]);
+		const app = makeApp(stub);
+
+		// days=30
+		const res30 = await app.request(
+			"/api/v1/mailboxes/m1/dmarc/rollup?days=30",
+			{},
+			fakeEnv,
+			fakeCtx,
+		);
+		expect(res30.status).toBe(200);
+		const body30 = (await res30.json()) as { window_days: number };
+		expect(body30.window_days).toBe(30);
+
+		// days=9999 → clamped to 365
+		const res999 = await app.request(
+			"/api/v1/mailboxes/m1/dmarc/rollup?days=9999",
+			{},
+			fakeEnv,
+			fakeCtx,
+		);
+		expect(res999.status).toBe(200);
+		const body999 = (await res999.json()) as { window_days: number };
+		expect(body999.window_days).toBe(365);
+
+		expect(calls).toHaveLength(2);
+		// The sinceIso passed to getDmarcRollup must be a valid ISO timestamp
+		for (const call of calls) {
+			expect(() => new Date(call.sinceIso)).not.toThrow();
+			expect(new Date(call.sinceIso).getTime()).toBeLessThan(Date.now());
+		}
+	});
+
+	it("falls back to 90-day default for invalid days param", async () => {
+		const { stub } = makeStub([]);
+		const app = makeApp(stub);
+
+		const res = await app.request(
+			"/api/v1/mailboxes/m1/dmarc/rollup?days=notanumber",
+			{},
+			fakeEnv,
+			fakeCtx,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { window_days: number };
+		expect(body.window_days).toBe(90);
+	});
+
+	it("returns empty domains array when no RUA reports are in scope", async () => {
+		const { stub } = makeStub([]);
+		const app = makeApp(stub);
+
+		const res = await app.request(
+			"/api/v1/mailboxes/m1/dmarc/rollup",
+			{},
+			fakeEnv,
+			fakeCtx,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { domains: RollupRow[] };
+		expect(body.domains).toHaveLength(0);
+	});
+});

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -1619,6 +1619,31 @@ export class MailboxDO extends DurableObject<Env> {
 		};
 	}
 
+	async getDmarcRollup(sinceIso: string) {
+		const rows = [
+			...this.ctx.storage.sql.exec(
+				`SELECT
+				   rep.domain,
+				   SUM(r.count) as total,
+				   SUM(CASE WHEN r.dkim_result = 'pass' OR r.spf_result = 'pass' THEN r.count ELSE 0 END) as aligned,
+				   SUM(CASE WHEN r.disposition = 'quarantine' OR r.disposition = 'reject' THEN r.count ELSE 0 END) as failing
+				 FROM dmarc_records r
+				 JOIN dmarc_reports rep ON rep.id = r.report_id
+				 WHERE rep.received_at >= ?1
+				 GROUP BY rep.domain
+				 ORDER BY (SUM(r.count) - SUM(CASE WHEN r.dkim_result = 'pass' OR r.spf_result = 'pass' THEN r.count ELSE 0 END)) DESC, SUM(r.count) DESC
+				 LIMIT 100`,
+				sinceIso,
+			),
+		] as Array<{
+			domain: string;
+			total: number;
+			aligned: number;
+			failing: number;
+		}>;
+		return rows;
+	}
+
 	// ── TLS-RPT (RFC 8460 inbound report ingestion) ───────────────────
 
 	async insertTlsRptReport(

--- a/workers/routes/dmarc.ts
+++ b/workers/routes/dmarc.ts
@@ -48,3 +48,16 @@ dmarcRoutes.get("/summary", async (c) => {
 	const summary = await c.var.mailboxStub.getDmarcSummary(domain, sinceIso);
 	return c.json({ domain, sources: summary });
 });
+
+const ROLLUP_MAX_DAYS = 365;
+const ROLLUP_DEFAULT_DAYS = 90;
+
+dmarcRoutes.get("/rollup", async (c) => {
+	const rawDays = Number(c.req.query("days") ?? ROLLUP_DEFAULT_DAYS);
+	const days = Number.isFinite(rawDays) && rawDays > 0
+		? Math.min(rawDays, ROLLUP_MAX_DAYS)
+		: ROLLUP_DEFAULT_DAYS;
+	const sinceIso = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+	const domains = await c.var.mailboxStub.getDmarcRollup(sinceIso);
+	return c.json({ window_days: days, since: sinceIso, domains });
+});


### PR DESCRIPTION
## Summary

- Adds `getDmarcRollup(sinceIso)` to `MailboxDO` — a single SQL query grouped by `rep.domain` (no per-domain filter) returning `{domain, total, aligned, failing}` ordered by worst alignment first.
- New `GET /api/v1/mailboxes/:mailboxId/dmarc/rollup?days=N` endpoint (default 90, max 365) in `workers/routes/dmarc.ts`.
- DMARC dashboard (`app/routes/dmarc.tsx`) shows an "All-domain rollup" section above the per-domain view when ≥2 domains exist — each row is clickable to drill down by setting the domain selector. Clearly distinct from the #141 posture comparison (which uses live DoH / `reduceDmarcAlignmentRate`, not ingested RUA data).

Closes #383.

## Test plan

- [x] `npm test` — 1209 passing, 0 failing (4 new tests in `tests/routes/dmarc-rollup.test.ts`)
- [x] `npm run typecheck` — clean

## Choices made

- `days` clamped to 1–365 server-side; invalid/negative values fall back to 90 (matches #382's convention).
- Rollup SQL uses `OR` alignment (`dkim='pass' OR spf='pass'`) consistent with `getDmarcAlignmentTotals`, not the stricter `AND` in `getDmarcSummary`.
- Rollup section hidden when only 1 domain — no comparison value.

_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrX5m2xf123WQtjwQZGEid)_