### PR TITLE
feat: sender-source attribution — wire up dmarc_sources (rDNS + provider label)

### DIFF
--- a/app/routes/dmarc.tsx
+++ b/app/routes/dmarc.tsx
@@ -43,6 +43,7 @@ interface DmarcSource {
 	reject_count: number;
 	first_seen: string;
 	last_seen: string;
+	label?: string | null;
 }
 
 interface DmarcAuthResultDkim {
@@ -257,6 +258,7 @@ export default function DmarcRoute() {
 							<thead className="bg-paper-3 text-ink-3 text-xs uppercase">
 								<tr>
 									<th className="text-left px-3 py-2">Source IP</th>
+									<th className="text-left px-3 py-2">Source</th>
 									<th className="text-right px-3 py-2">Messages</th>
 									<th className="text-right px-3 py-2">Pass</th>
 									<th className="text-right px-3 py-2">Quarantine</th>
@@ -276,6 +278,7 @@ export default function DmarcRoute() {
 											onClick={() => setSelectedIp(isSelected ? null : s.source_ip)}
 										>
 											<td className="px-3 py-2 font-mono text-ink">{s.source_ip}</td>
+											<td className="px-3 py-2 text-ink-3">{s.label ?? s.source_ip}</td>
 											<td className="px-3 py-2 text-right">{s.total_count}</td>
 											<td className="px-3 py-2 text-right text-safe">{s.pass_count}</td>
 											<td className="px-3 py-2 text-right text-suspect">{s.quarantine_count}</td>

--- a/shared/dmarc-provider.ts
+++ b/shared/dmarc-provider.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Static PTR-suffix → provider name map for DMARC sender attribution.
+ *
+ * Checked longest-suffix-first so more-specific entries win
+ * (e.g. `mail.protection.outlook.com` matches before `outlook.com`).
+ */
+const PTR_SUFFIXES: Array<[suffix: string, provider: string]> = [
+	[".mail.protection.outlook.com", "Microsoft 365"],
+	[".google.com", "Google"],
+	[".googlemail.com", "Google"],
+	[".outlook.com", "Microsoft 365"],
+	[".microsoft.com", "Microsoft 365"],
+	[".hotmail.com", "Microsoft 365"],
+	[".sendgrid.net", "SendGrid"],
+	[".amazonaws.com", "Amazon SES"],
+	[".mailgun.org", "Mailgun"],
+	[".sparkpostmail.com", "SparkPost"],
+	[".mcsv.net", "Mailchimp"],
+	[".rsgsv.net", "Mailchimp"],
+	[".constantcontact.com", "Constant Contact"],
+	[".salesforce.com", "Salesforce Marketing Cloud"],
+	[".exacttarget.com", "Salesforce Marketing Cloud"],
+	[".zendesk.com", "Zendesk"],
+	[".postmarkapp.com", "Postmark"],
+	[".mandrill.com", "Mailchimp Transactional"],
+];
+
+/**
+ * Given a PTR-resolved hostname, return a human-readable provider name or null.
+ * Comparison is case-insensitive.
+ */
+export function classifyProvider(hostname: string): string | null {
+	const lower = hostname.toLowerCase();
+	for (const [suffix, provider] of PTR_SUFFIXES) {
+		// Match either exact (hostname == suffix without leading dot) or as a suffix.
+		if (lower === suffix.slice(1) || lower.endsWith(suffix)) return provider;
+	}
+	return null;
+}
+
+/**
+ * Build the label to persist in `dmarc_sources.label`:
+ * - known ESP → provider name ("Google", "SendGrid", …)
+ * - unknown PTR → the hostname itself
+ * - no PTR → null
+ */
+export function buildDmarcSourceLabel(hostname: string | null): string | null {
+	if (!hostname) return null;
+	return classifyProvider(hostname) ?? hostname;
+}

--- a/tests/dmarc/ptr-resolve.test.ts
+++ b/tests/dmarc/ptr-resolve.test.ts
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { ipToArpa, PTR_DOH_HOST, resolvePtr } from "../../workers/dmarc/ptr-resolve";
+import { buildDmarcSourceLabel, classifyProvider } from "../../shared/dmarc-provider";
+
+// ── ipToArpa ──────────────────────────────────────────────────────────────
+
+describe("ipToArpa", () => {
+	it("reverses IPv4 octets and appends .in-addr.arpa", () => {
+		expect(ipToArpa("203.0.113.42")).toBe("42.113.0.203.in-addr.arpa");
+	});
+
+	it("returns null for non-IPv4 input", () => {
+		expect(ipToArpa("2001:db8::1")).toBeNull();
+		expect(ipToArpa("not-an-ip")).toBeNull();
+		expect(ipToArpa("")).toBeNull();
+	});
+});
+
+// ── classifyProvider ──────────────────────────────────────────────────────
+
+describe("classifyProvider", () => {
+	it("matches Google sending infrastructure", () => {
+		expect(classifyProvider("mail-sor-f41.google.com")).toBe("Google");
+	});
+
+	it("matches Microsoft 365 protection domain", () => {
+		expect(classifyProvider("mx1.mail.protection.outlook.com")).toBe("Microsoft 365");
+	});
+
+	it("matches SendGrid", () => {
+		expect(classifyProvider("o1.sendgrid.net")).toBe("SendGrid");
+	});
+
+	it("matches Amazon SES", () => {
+		expect(classifyProvider("a-123.us-east-1.amazonses.amazonaws.com")).toBe("Amazon SES");
+	});
+
+	it("returns null for an unknown hostname", () => {
+		expect(classifyProvider("mail.example.com")).toBeNull();
+	});
+
+	it("is case-insensitive", () => {
+		expect(classifyProvider("MAIL-SOR.GOOGLE.COM")).toBe("Google");
+	});
+});
+
+// ── buildDmarcSourceLabel ────────────────────────────────────────────────
+
+describe("buildDmarcSourceLabel", () => {
+	it("returns provider name for a known ESP hostname", () => {
+		expect(buildDmarcSourceLabel("mail-sor.google.com")).toBe("Google");
+	});
+
+	it("returns the hostname itself for an unknown PTR", () => {
+		expect(buildDmarcSourceLabel("mail.acme-corp.com")).toBe("mail.acme-corp.com");
+	});
+
+	it("returns null when no hostname was resolved", () => {
+		expect(buildDmarcSourceLabel(null)).toBeNull();
+	});
+});
+
+// ── resolvePtr (DoH) ──────────────────────────────────────────────────────
+
+function ptrDohResponse(ptrs: string[]): Response {
+	return new Response(
+		JSON.stringify({
+			Status: 0,
+			Answer: ptrs.map((data) => ({ type: 12, data })),
+		}),
+		{ status: 200, headers: { "content-type": "application/dns-json" } },
+	);
+}
+
+function nxdomainResponse(): Response {
+	return new Response(
+		JSON.stringify({ Status: 3, Answer: [] }),
+		{ status: 200, headers: { "content-type": "application/dns-json" } },
+	);
+}
+
+describe("resolvePtr", () => {
+	it("queries cloudflare-dns.com with the reversed ARPA form", async () => {
+		let capturedUrl = "";
+		const fetchImpl = async (url: string) => {
+			capturedUrl = url;
+			// Hostname-based dispatch — no url.startsWith / url.includes (CodeQL gate).
+			const u = new URL(url);
+			expect(u.hostname).toBe(PTR_DOH_HOST);
+			return ptrDohResponse(["mail-sor.google.com."]);
+		};
+		await resolvePtr("203.0.113.42", { fetchImpl });
+		expect(new URL(capturedUrl).searchParams.get("type")).toBe("PTR");
+		expect(new URL(capturedUrl).searchParams.get("name")).toBe(
+			"42.113.0.203.in-addr.arpa",
+		);
+	});
+
+	it("provider-match: returns Google label for a Google PTR", async () => {
+		const fetchImpl = async (_url: string) =>
+			ptrDohResponse(["mail-sor-f41.google.com."]);
+		const hostname = await resolvePtr("74.125.0.1", { fetchImpl });
+		expect(buildDmarcSourceLabel(hostname)).toBe("Google");
+	});
+
+	it("PTR-only: returns hostname as label for an unknown PTR", async () => {
+		const fetchImpl = async (_url: string) =>
+			ptrDohResponse(["mail.acme-corp.com."]);
+		const hostname = await resolvePtr("203.0.113.5", { fetchImpl });
+		expect(hostname).toBe("mail.acme-corp.com");
+		expect(buildDmarcSourceLabel(hostname)).toBe("mail.acme-corp.com");
+	});
+
+	it("unresolved: returns null on NXDOMAIN (no PTR answer)", async () => {
+		const fetchImpl = async (_url: string) => nxdomainResponse();
+		const hostname = await resolvePtr("192.0.2.99", { fetchImpl });
+		expect(hostname).toBeNull();
+		expect(buildDmarcSourceLabel(hostname)).toBeNull();
+	});
+
+	it("unresolved: returns null on HTTP error", async () => {
+		const fetchImpl = async (_url: string) =>
+			new Response("server error", { status: 500 });
+		expect(await resolvePtr("192.0.2.1", { fetchImpl })).toBeNull();
+	});
+
+	it("unresolved: returns null when fetch throws (network failure)", async () => {
+		const fetchImpl = async (_url: string): Promise<Response> => {
+			throw new Error("network failure");
+		};
+		expect(await resolvePtr("192.0.2.1", { fetchImpl })).toBeNull();
+	});
+
+	it("strips the trailing dot from the PTR answer", async () => {
+		const fetchImpl = async (_url: string) =>
+			ptrDohResponse(["mail.example.com."]);
+		expect(await resolvePtr("203.0.113.1", { fetchImpl })).toBe("mail.example.com");
+	});
+
+	it("returns null for a non-IPv4 address without making a DoH call", async () => {
+		let called = false;
+		const fetchImpl = async (_url: string): Promise<Response> => {
+			called = true;
+			return ptrDohResponse([]);
+		};
+		expect(await resolvePtr("2001:db8::1", { fetchImpl })).toBeNull();
+		expect(called).toBe(false);
+	});
+});

--- a/workers/dmarc/ptr-resolve.ts
+++ b/workers/dmarc/ptr-resolve.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Reverse-DNS (PTR) lookup via DNS-over-HTTPS.
+ *
+ * Workers runtime has no `node:dns` — we query cloudflare-dns.com over HTTPS
+ * with `type=PTR` against the `.in-addr.arpa` form of the address.
+ * All failures return null; callers must treat the label as best-effort.
+ */
+
+export const PTR_DOH_HOST = "cloudflare-dns.com";
+const PTR_TIMEOUT_MS = 2000;
+
+/** Convert an IPv4 address to its reverse-ARPA form. Returns null for non-IPv4. */
+export function ipToArpa(ip: string): string | null {
+	const parts = ip.split(".");
+	if (parts.length !== 4 || parts.some((p) => p === "" || Number.isNaN(Number(p)))) return null;
+	return `${parts[3]}.${parts[2]}.${parts[1]}.${parts[0]}.in-addr.arpa`;
+}
+
+type FetchImpl = (url: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Resolve the PTR record for `ip` via DoH.
+ * Returns the hostname (trailing dot stripped) or null on any failure.
+ *
+ * Accepts an optional `fetchImpl` for test injection.
+ */
+export async function resolvePtr(
+	ip: string,
+	{ fetchImpl = fetch }: { fetchImpl?: FetchImpl } = {},
+): Promise<string | null> {
+	const arpa = ipToArpa(ip);
+	if (!arpa) return null;
+
+	let res: Response;
+	try {
+		res = await fetchImpl(
+			`https://${PTR_DOH_HOST}/dns-query?name=${encodeURIComponent(arpa)}&type=PTR`,
+			{
+				headers: { accept: "application/dns-json" },
+				signal: AbortSignal.timeout(PTR_TIMEOUT_MS),
+			},
+		);
+	} catch {
+		return null;
+	}
+
+	if (!res.ok) return null;
+
+	let body: unknown;
+	try {
+		body = await res.json();
+	} catch {
+		return null;
+	}
+
+	const answer = (body as { Answer?: Array<{ type?: number; data?: string }> }).Answer;
+	if (!Array.isArray(answer)) return null;
+
+	for (const a of answer) {
+		// DNS type 12 = PTR
+		if (a.type === 12 && typeof a.data === "string") {
+			return a.data.replace(/\.$/, "");
+		}
+	}
+	return null;
+}

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -15,6 +15,8 @@ import { computeVerdictMix } from "../lib/dashboard-aggregation";
 import { summarizeCase } from "../lib/ai";
 import { dkimObservationCutoffIso } from "../dkim/posture";
 import { parseStageTrace } from "../security/stage-trace";
+import { resolvePtr } from "../dmarc/ptr-resolve";
+import { buildDmarcSourceLabel } from "../../shared/dmarc-provider";
 
 /**
  * SQL expression to normalize email subjects by stripping common
@@ -1305,6 +1307,50 @@ export class MailboxDO extends DurableObject<Env> {
 				.values(records.map((r) => ({ ...r, report_id: report.id })))
 				.run();
 		}
+		// Enrich new source IPs with PTR / provider labels in background.
+		const newIps = this.getNewDmarcSourceIps(records.map((r) => r.source_ip));
+		if (newIps.length > 0) {
+			this.ctx.waitUntil(this.enrichDmarcSources(newIps));
+		}
+	}
+
+	/** Returns IPs from `candidates` that have no row yet in `dmarc_sources`. */
+	private getNewDmarcSourceIps(candidates: string[]): string[] {
+		const distinct = [...new Set(candidates)];
+		return distinct.filter((ip) => {
+			const existing = [
+				...this.ctx.storage.sql.exec(
+					`SELECT 1 FROM dmarc_sources WHERE source_ip = ?1`,
+					ip,
+				),
+			];
+			return existing.length === 0;
+		});
+	}
+
+	/** Resolve PTR for each IP and persist into `dmarc_sources`. Best-effort; never throws. */
+	private async enrichDmarcSources(ips: string[]): Promise<void> {
+		for (const ip of ips) {
+			try {
+				const hostname = await resolvePtr(ip);
+				const label = buildDmarcSourceLabel(hostname);
+				this.ctx.storage.sql.exec(
+					`INSERT OR IGNORE INTO dmarc_sources (source_ip, label) VALUES (?1, ?2)`,
+					ip,
+					label,
+				);
+			} catch {
+				// Best-effort: persist a null-label row so we don't retry on the next ingest.
+				try {
+					this.ctx.storage.sql.exec(
+						`INSERT OR IGNORE INTO dmarc_sources (source_ip, label) VALUES (?1, NULL)`,
+						ip,
+					);
+				} catch {
+					// ignore
+				}
+			}
+		}
 	}
 
 	async listDmarcReports(options: { domain?: string; limit?: number; offset?: number } = {}) {
@@ -1529,9 +1575,11 @@ export class MailboxDO extends DurableObject<Env> {
 				   SUM(CASE WHEN r.disposition = 'quarantine' THEN r.count ELSE 0 END) as quarantine_count,
 				   SUM(CASE WHEN r.disposition = 'reject' THEN r.count ELSE 0 END) as reject_count,
 				   MIN(rep.received_at) as first_seen,
-				   MAX(rep.received_at) as last_seen
+				   MAX(rep.received_at) as last_seen,
+				   ds.label as label
 				 FROM dmarc_records r
 				 JOIN dmarc_reports rep ON rep.id = r.report_id
+				 LEFT JOIN dmarc_sources ds ON ds.source_ip = r.source_ip
 				 WHERE rep.domain = ?1 AND rep.received_at >= ?2
 				 GROUP BY r.source_ip
 				 ORDER BY total_count DESC
@@ -1547,6 +1595,7 @@ export class MailboxDO extends DurableObject<Env> {
 			reject_count: number;
 			first_seen: string;
 			last_seen: string;
+			label: string | null;
 		}>;
 		return rows;
 	}


### PR DESCRIPTION
## Summary

- Add `shared/dmarc-provider.ts`: static PTR-suffix → provider map (`classifyProvider`) and `buildDmarcSourceLabel`, covering Google, Microsoft 365, SendGrid, Amazon SES, Mailgun, Mailchimp, SparkPost, and others.
- Add `workers/dmarc/ptr-resolve.ts`: DoH PTR resolver querying `cloudflare-dns.com` with `type=PTR` against the reverse-ARPA form of the IP. Workers-only (no `node:dns`/`Buffer`/`process`). Accepts optional `fetchImpl` for testability.
- `insertDmarcReport` detects newly-seen source IPs (not already in `dmarc_sources`) and fires enrichment via `this.ctx.waitUntil` — non-blocking, best-effort, nullable on failure.
- `getDmarcSummary` LEFT JOINs `dmarc_sources` and returns `label` alongside existing stats.
- `app/routes/dmarc.tsx`: adds `label` to `DmarcSource` interface and a "Source" column in the Sending-sources table, falling back to raw IP when unlabeled.

Closes #379.

## Test plan

- [x] `npm test` — 1224 passing, 0 failing (19 new tests in `tests/dmarc/ptr-resolve.test.ts`)
- [x] `npm run typecheck` — clean
- [x] DoH mock dispatchers use `new URL(url).hostname === PTR_DOH_HOST` — no `startsWith`/`includes` (CodeQL gate)
- [x] Tests cover: provider-match (Google PTR → "Google"), PTR-only (unknown hostname → label = hostname), unresolved/NXDOMAIN (→ null), HTTP error, network failure, trailing-dot stripping, non-IPv4 short-circuit

## Choices made

- Provider map lives in `shared/` (pure, no runtime deps) so it's importable by both Workers code and tests without Workers globals.
- `INSERT OR IGNORE` on `dmarc_sources` ensures at-most-once enrichment per IP: once a row exists (even with `label = NULL` from a failed PTR lookup), subsequent ingests skip enrichment.
- No new migration needed — `dmarc_sources` schema already has `label TEXT` from the original table creation.

https://claude.ai/code/session_0176H13xm4PJc9PaCiX3jpXY

---
_Generated by [Claude Code](https://claude.ai/code/session_0176H13xm4PJc9PaCiX3jpXY)_