### PR TITLE
feat: CSV export of the DMARC sending-sources table

### DIFF
--- a/app/routes/dmarc.tsx
+++ b/app/routes/dmarc.tsx
@@ -6,6 +6,21 @@ import { Loader } from "@cloudflare/kumo";
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router";
 
+/** RFC 4180 field escape: always wraps in double-quotes, escapes embedded quotes by doubling. */
+export function csvEscapeField(value: string | number): string {
+	return `"${String(value).replace(/"/g, '""')}"`;
+}
+
+export function sourcesToCsv(sources: DmarcSource[]): string {
+	const header = "source_ip,total_count,pass_count,quarantine_count,reject_count,first_seen,last_seen";
+	const rows = sources.map((s) =>
+		[s.source_ip, s.total_count, s.pass_count, s.quarantine_count, s.reject_count, s.first_seen, s.last_seen]
+			.map(csvEscapeField)
+			.join(","),
+	);
+	return [header, ...rows].join("\r\n");
+}
+
 interface DmarcReport {
 	id: string;
 	received_at: string;
@@ -61,6 +76,17 @@ export default function DmarcRoute() {
 		return Array.from(set).sort();
 	}, [reports]);
 
+	function handleDownloadCsv() {
+		if (!sources || sources.length === 0) return;
+		const blob = new Blob([sourcesToCsv(sources)], { type: "text/csv;charset=utf-8;" });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = `dmarc-sources-${domain ?? "export"}.csv`;
+		a.click();
+		URL.revokeObjectURL(url);
+	}
+
 	if (!reports) {
 		return <div className="flex justify-center py-20"><Loader size="lg" /></div>;
 	}
@@ -93,7 +119,18 @@ export default function DmarcRoute() {
 			</div>
 
 			<section className="mb-8">
-				<h2 className="text-sm font-semibold text-ink mb-3">Sending sources</h2>
+				<div className="flex items-center justify-between mb-3">
+					<h2 className="text-sm font-semibold text-ink">Sending sources</h2>
+					{sources && sources.length > 0 && (
+						<button
+							type="button"
+							onClick={handleDownloadCsv}
+							className="text-xs px-2 py-1 rounded border border-line bg-paper-3 hover:bg-paper-2 text-ink-2"
+						>
+							Download CSV
+						</button>
+					)}
+				</div>
 				{!sources ? (
 					<div className="text-ink-3 text-sm">Loading…</div>
 				) : sources.length === 0 ? (

--- a/tests/frontend/dmarc.test.ts
+++ b/tests/frontend/dmarc.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, expect, it } from "vitest";
+import { csvEscapeField, sourcesToCsv } from "~/routes/dmarc";
+
+describe("csvEscapeField", () => {
+	it("wraps a plain string in double-quotes", () => {
+		expect(csvEscapeField("hello")).toBe('"hello"');
+	});
+
+	it("preserves embedded commas inside the quoted field", () => {
+		expect(csvEscapeField("hello, world")).toBe('"hello, world"');
+	});
+
+	it("doubles embedded double-quotes", () => {
+		expect(csvEscapeField('say "hi"')).toBe('"say ""hi"""');
+	});
+
+	it("escapes a field containing both commas and double-quotes", () => {
+		expect(csvEscapeField('a, "b", c')).toBe('"a, ""b"", c"');
+	});
+
+	it("handles numeric values", () => {
+		expect(csvEscapeField(42)).toBe('"42"');
+	});
+});
+
+describe("sourcesToCsv", () => {
+	it("returns only the header row for an empty sources array", () => {
+		expect(sourcesToCsv([])).toBe(
+			"source_ip,total_count,pass_count,quarantine_count,reject_count,first_seen,last_seen",
+		);
+	});
+
+	it("produces a well-formed two-line CSV for a single source", () => {
+		const csv = sourcesToCsv([
+			{
+				source_ip: "203.0.113.1",
+				total_count: 10,
+				pass_count: 8,
+				quarantine_count: 1,
+				reject_count: 1,
+				first_seen: "2026-01-01",
+				last_seen: "2026-01-31",
+			},
+		]);
+		const lines = csv.split("\r\n");
+		expect(lines).toHaveLength(2);
+		expect(lines[0]).toBe(
+			"source_ip,total_count,pass_count,quarantine_count,reject_count,first_seen,last_seen",
+		);
+		expect(lines[1]).toBe('"203.0.113.1","10","8","1","1","2026-01-01","2026-01-31"');
+	});
+
+	it("safely escapes a source_ip that contains commas and quotes", () => {
+		const csv = sourcesToCsv([
+			{
+				source_ip: '1.2.3.4, "label"',
+				total_count: 1,
+				pass_count: 1,
+				quarantine_count: 0,
+				reject_count: 0,
+				first_seen: "2026-01-01",
+				last_seen: "2026-01-31",
+			},
+		]);
+		const lines = csv.split("\r\n");
+		expect(lines[1]).toContain('"1.2.3.4, ""label"""');
+	});
+
+	it("produces CRLF line endings", () => {
+		const csv = sourcesToCsv([
+			{
+				source_ip: "1.1.1.1",
+				total_count: 1,
+				pass_count: 1,
+				quarantine_count: 0,
+				reject_count: 0,
+				first_seen: "2026-01-01",
+				last_seen: "2026-01-02",
+			},
+		]);
+		expect(csv).toContain("\r\n");
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a **Download CSV** button inline with the "Sending sources" heading; only rendered when rows exist.
- Client-side generation from the already-fetched `sources` state — no server changes needed.
- RFC 4180 escaping: fields always double-quoted, embedded `"` doubled; CRLF row separators.

Closes #387.

## Test plan

- [x] `npm test` — 1214 passing, 0 failing (includes new `tests/frontend/dmarc.test.ts`)
- [x] `npm run typecheck` — clean
- [ ] Manual: open DMARC dashboard, select a domain with sources, click "Download CSV", verify file opens correctly in a spreadsheet

## Choices made

- **Client-side CSV** over `format=csv` server mode: the data is already in React state; no round-trip needed and no Worker changes required.
- **Export columns** match the current view (`source_ip`, `total_count`, `pass_count`, `quarantine_count`, `reject_count`, `first_seen`, `last_seen`). `label` and `legitimate` columns referenced in the issue body are not yet in the data model; they'll be addable when #379 / #385 land.

https://claude.ai/code/session_01DNtPvNYgoYvxtEC8dbV7XF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNtPvNYgoYvxtEC8dbV7XF)_