### PR TITLE
feat(dmarc): parse full policy + auth_results; per-report source drill-down

### DIFF
--- a/app/routes/dmarc.tsx
+++ b/app/routes/dmarc.tsx
@@ -14,6 +14,10 @@ interface DmarcReport {
 	date_range_begin: string | null;
 	date_range_end: string | null;
 	policy_p: string | null;
+	policy_adkim: string | null;
+	policy_aspf: string | null;
+	policy_sp: string | null;
+	policy_pct: string | null;
 }
 
 interface DmarcSource {
@@ -26,6 +30,33 @@ interface DmarcSource {
 	last_seen: string;
 }
 
+interface AuthDkimResult {
+	domain?: string;
+	selector?: string;
+	result?: string;
+}
+
+interface AuthSpfResult {
+	domain?: string;
+	result?: string;
+}
+
+interface AuthResults {
+	dkim: AuthDkimResult[];
+	spf: AuthSpfResult[];
+}
+
+interface DmarcRecord {
+	id: string;
+	source_ip: string;
+	count: number;
+	disposition: string | null;
+	dkim_result: string | null;
+	spf_result: string | null;
+	header_from: string | null;
+	auth_results: AuthResults | null;
+}
+
 /**
  * DMARC aggregate-report dashboard. Shows legitimate vs forged sending
  * sources for a domain over the last 90 days of ingested reports.
@@ -35,6 +66,9 @@ export default function DmarcRoute() {
 	const [reports, setReports] = useState<DmarcReport[] | null>(null);
 	const [domain, setDomain] = useState<string | null>(null);
 	const [sources, setSources] = useState<DmarcSource[] | null>(null);
+	const [selectedReport, setSelectedReport] = useState<DmarcReport | null>(null);
+	const [drillRecords, setDrillRecords] = useState<DmarcRecord[] | null>(null);
+	const [drillLoading, setDrillLoading] = useState(false);
 
 	useEffect(() => {
 		if (!mailboxId) return;
@@ -54,6 +88,21 @@ export default function DmarcRoute() {
 			.then((r) => setSources(r.sources))
 			.catch((e) => console.error("dmarc summary fetch failed", e));
 	}, [mailboxId, domain]);
+
+	function openDrill(report: DmarcReport) {
+		if (selectedReport?.id === report.id) {
+			setSelectedReport(null);
+			setDrillRecords(null);
+			return;
+		}
+		setSelectedReport(report);
+		setDrillRecords(null);
+		setDrillLoading(true);
+		fetch(`/api/v1/mailboxes/${encodeURIComponent(mailboxId!)}/dmarc/reports/${encodeURIComponent(report.id)}/records`)
+			.then((r) => r.json() as Promise<{ records: DmarcRecord[] }>)
+			.then((r) => { setDrillRecords(r.records); setDrillLoading(false); })
+			.catch((e) => { console.error("dmarc records fetch failed", e); setDrillLoading(false); });
+	}
 
 	const domains = useMemo(() => {
 		if (!reports) return [];
@@ -77,6 +126,8 @@ export default function DmarcRoute() {
 		);
 	}
 
+	const filteredReports = reports.filter((r) => !domain || r.domain === domain);
+
 	return (
 		<div className="max-w-5xl px-4 py-6 md:px-8 h-full overflow-y-auto">
 			<h1 className="pp-serif text-ink mb-4">DMARC Reports</h1>
@@ -85,7 +136,7 @@ export default function DmarcRoute() {
 				<label className="text-sm text-ink-3">Domain:</label>
 				<select
 					value={domain ?? ""}
-					onChange={(e) => setDomain(e.target.value)}
+					onChange={(e) => { setDomain(e.target.value); setSelectedReport(null); setDrillRecords(null); }}
 					className="rounded border border-line bg-paper-3 px-2 py-1 text-sm"
 				>
 					{domains.map((d) => <option key={d} value={d}>{d}</option>)}
@@ -146,20 +197,104 @@ export default function DmarcRoute() {
 								<th className="text-left px-3 py-2">Reporter</th>
 								<th className="text-left px-3 py-2">Domain</th>
 								<th className="text-left px-3 py-2">Policy</th>
+								<th className="text-left px-3 py-2">adkim / aspf</th>
+								<th className="text-left px-3 py-2">sp / pct</th>
 							</tr>
 						</thead>
 						<tbody>
-							{reports.filter((r) => !domain || r.domain === domain).map((r) => (
-								<tr key={r.id} className="border-t border-line">
+							{filteredReports.map((r) => (
+								<tr
+									key={r.id}
+									className={`border-t border-line cursor-pointer hover:bg-paper-3 ${selectedReport?.id === r.id ? "bg-paper-3" : ""}`}
+									onClick={() => openDrill(r)}
+								>
 									<td className="px-3 py-2 text-ink-3">{new Date(r.received_at).toLocaleString()}</td>
 									<td className="px-3 py-2">{r.org_name ?? "unknown"}</td>
 									<td className="px-3 py-2 font-mono">{r.domain}</td>
 									<td className="px-3 py-2">{r.policy_p ?? "none"}</td>
+									<td className="px-3 py-2 text-ink-3">{r.policy_adkim ?? "—"} / {r.policy_aspf ?? "—"}</td>
+									<td className="px-3 py-2 text-ink-3">{r.policy_sp ?? "—"} / {r.policy_pct != null ? `${r.policy_pct}%` : "—"}</td>
 								</tr>
 							))}
 						</tbody>
 					</table>
 				</div>
+
+				{selectedReport && (
+					<div className="mt-4 rounded-lg border border-line p-4">
+						<div className="flex items-center justify-between mb-3">
+							<h3 className="text-sm font-semibold text-ink">
+								Source detail — {selectedReport.org_name ?? "unknown"}{" "}
+								<span className="font-normal text-ink-3">
+									({selectedReport.domain}, policy: {selectedReport.policy_p ?? "none"})
+								</span>
+							</h3>
+							<button
+								className="text-xs text-ink-3 hover:text-ink"
+								onClick={() => { setSelectedReport(null); setDrillRecords(null); }}
+							>
+								✕ close
+							</button>
+						</div>
+
+						{drillLoading ? (
+							<div className="text-ink-3 text-sm">Loading…</div>
+						) : drillRecords && drillRecords.length === 0 ? (
+							<div className="text-ink-3 text-sm">No records for this report.</div>
+						) : drillRecords ? (
+							<div className="overflow-x-auto">
+								<table className="w-full text-xs">
+									<thead className="bg-paper-3 text-ink-3 uppercase">
+										<tr>
+											<th className="text-left px-2 py-1">Source IP</th>
+											<th className="text-right px-2 py-1">Count</th>
+											<th className="text-left px-2 py-1">Disposition</th>
+											<th className="text-left px-2 py-1">DKIM auth</th>
+											<th className="text-left px-2 py-1">SPF auth</th>
+										</tr>
+									</thead>
+									<tbody>
+										{drillRecords.map((rec) => (
+											<tr key={rec.id} className="border-t border-line">
+												<td className="px-2 py-1 font-mono">{rec.source_ip}</td>
+												<td className="px-2 py-1 text-right">{rec.count}</td>
+												<td className="px-2 py-1">{rec.disposition ?? "—"}</td>
+												<td className="px-2 py-1">
+													{rec.auth_results?.dkim && rec.auth_results.dkim.length > 0 ? (
+														<div className="space-y-0.5">
+															{rec.auth_results.dkim.map((d, i) => (
+																<div key={i} className="font-mono">
+																	{d.domain ?? "?"}{d.selector ? `·${d.selector}` : ""}{" "}
+																	<span className={d.result === "pass" ? "text-safe" : "text-danger"}>
+																		{d.result ?? "?"}
+																	</span>
+																</div>
+															))}
+														</div>
+													) : <span className="text-ink-3">—</span>}
+												</td>
+												<td className="px-2 py-1">
+													{rec.auth_results?.spf && rec.auth_results.spf.length > 0 ? (
+														<div className="space-y-0.5">
+															{rec.auth_results.spf.map((s, i) => (
+																<div key={i} className="font-mono">
+																	{s.domain ?? "?"}{" "}
+																	<span className={s.result === "pass" ? "text-safe" : "text-danger"}>
+																		{s.result ?? "?"}
+																	</span>
+																</div>
+															))}
+														</div>
+													) : <span className="text-ink-3">—</span>}
+												</td>
+											</tr>
+										))}
+									</tbody>
+								</table>
+							</div>
+						) : null}
+					</div>
+				)}
 			</section>
 		</div>
 	);

--- a/tests/dmarc/parser.test.ts
+++ b/tests/dmarc/parser.test.ts
@@ -106,4 +106,67 @@ describe("parseDmarcXml", () => {
 	it("handles empty <feedback/> without throwing", () => {
 		expect(() => parseDmarcXml("<feedback></feedback>")).not.toThrow();
 	});
+
+	it("parses policy_published adkim/aspf/sp/pct from SAMPLE", () => {
+		const r = parseDmarcXml(SAMPLE);
+		expect(r.policy_adkim).toBe("r");
+		expect(r.policy_aspf).toBe("r");
+		expect(r.policy_sp).toBe("reject");
+		expect(r.policy_pct).toBe("100");
+	});
+
+	it("returns undefined policy fields when tags are absent", () => {
+		const xml = `<feedback><policy_published><domain>x.com</domain><p>none</p></policy_published></feedback>`;
+		const r = parseDmarcXml(xml);
+		expect(r.policy_adkim).toBeUndefined();
+		expect(r.policy_aspf).toBeUndefined();
+		expect(r.policy_sp).toBeUndefined();
+		expect(r.policy_pct).toBeUndefined();
+	});
+
+	it("parses auth_results for the first record in SAMPLE", () => {
+		const r = parseDmarcXml(SAMPLE);
+		const ar = r.records[0].auth_results;
+		expect(ar).toBeDefined();
+		expect(ar!.dkim).toHaveLength(1);
+		expect(ar!.dkim[0]).toMatchObject({ domain: "example.com", result: "pass" });
+		expect(ar!.spf).toHaveLength(1);
+		expect(ar!.spf[0]).toMatchObject({ domain: "example.com", result: "pass" });
+	});
+
+	it("returns undefined auth_results when the tag is absent", () => {
+		const r = parseDmarcXml(SAMPLE);
+		expect(r.records[1].auth_results).toBeUndefined();
+	});
+
+	it("parses multiple dkim entries in auth_results", () => {
+		const xml = `<feedback>
+  <record>
+    <row><source_ip>1.2.3.4</source_ip><count>3</count><policy_evaluated><disposition>none</disposition><dkim>pass</dkim><spf>pass</spf></policy_evaluated></row>
+    <auth_results>
+      <dkim><domain>a.com</domain><selector>s1</selector><result>pass</result></dkim>
+      <dkim><domain>b.com</domain><selector>s2</selector><result>fail</result></dkim>
+      <spf><domain>a.com</domain><result>pass</result></spf>
+    </auth_results>
+  </record>
+</feedback>`;
+		const r = parseDmarcXml(xml);
+		const ar = r.records[0].auth_results;
+		expect(ar).toBeDefined();
+		expect(ar!.dkim).toHaveLength(2);
+		expect(ar!.dkim[0]).toMatchObject({ domain: "a.com", selector: "s1", result: "pass" });
+		expect(ar!.dkim[1]).toMatchObject({ domain: "b.com", selector: "s2", result: "fail" });
+		expect(ar!.spf).toHaveLength(1);
+	});
+
+	it("returns undefined auth_results when auth_results block is empty", () => {
+		const xml = `<feedback>
+  <record>
+    <row><source_ip>1.2.3.4</source_ip><count>1</count></row>
+    <auth_results></auth_results>
+  </record>
+</feedback>`;
+		const r = parseDmarcXml(xml);
+		expect(r.records[0].auth_results).toBeUndefined();
+	});
 });

--- a/workers/db/schema.ts
+++ b/workers/db/schema.ts
@@ -143,6 +143,10 @@ export const dmarcReports = sqliteTable("dmarc_reports", {
 	date_range_begin: text("date_range_begin"),
 	date_range_end: text("date_range_end"),
 	policy_p: text("policy_p"),
+	policy_adkim: text("policy_adkim"),
+	policy_aspf: text("policy_aspf"),
+	policy_sp: text("policy_sp"),
+	policy_pct: text("policy_pct"),
 	raw_r2_key: text("raw_r2_key"),
 });
 
@@ -157,6 +161,7 @@ export const dmarcRecords = sqliteTable("dmarc_records", {
 	dkim_result: text("dkim_result"),
 	spf_result: text("spf_result"),
 	header_from: text("header_from"),
+	auth_results: text("auth_results"),
 });
 
 export const dmarcSources = sqliteTable("dmarc_sources", {

--- a/workers/dmarc/ingest.ts
+++ b/workers/dmarc/ingest.ts
@@ -81,6 +81,10 @@ export async function ingestDmarcReport(
 		date_range_begin: report.date_range_begin ?? null,
 		date_range_end: report.date_range_end ?? null,
 		policy_p: report.policy_p ?? null,
+		policy_adkim: report.policy_adkim ?? null,
+		policy_aspf: report.policy_aspf ?? null,
+		policy_sp: report.policy_sp ?? null,
+		policy_pct: report.policy_pct ?? null,
 		raw_r2_key: null,
 	}, report.records.map((r) => ({
 		id: crypto.randomUUID(),
@@ -90,6 +94,7 @@ export async function ingestDmarcReport(
 		dkim_result: r.dkim_result ?? null,
 		spf_result: r.spf_result ?? null,
 		header_from: r.header_from ?? null,
+		auth_results: r.auth_results ? JSON.stringify(r.auth_results) : null,
 	})));
 
 	return { ingested: true };

--- a/workers/dmarc/parser.ts
+++ b/workers/dmarc/parser.ts
@@ -10,6 +10,22 @@
  * We only capture the fields needed for the dashboard and forger intel.
  */
 
+export interface AuthDkimResult {
+	domain?: string;
+	selector?: string;
+	result?: string;
+}
+
+export interface AuthSpfResult {
+	domain?: string;
+	result?: string;
+}
+
+export interface AuthResults {
+	dkim: AuthDkimResult[];
+	spf: AuthSpfResult[];
+}
+
 export interface DmarcReport {
 	org_name?: string;
 	report_id?: string;
@@ -17,6 +33,10 @@ export interface DmarcReport {
 	date_range_end?: string;
 	policy_domain?: string;
 	policy_p?: string;
+	policy_adkim?: string;
+	policy_aspf?: string;
+	policy_sp?: string;
+	policy_pct?: string;
 	records: DmarcRecord[];
 }
 
@@ -27,6 +47,7 @@ export interface DmarcRecord {
 	dkim_result?: string;
 	spf_result?: string;
 	header_from?: string;
+	auth_results?: AuthResults;
 }
 
 /** Gunzip an arraybuffer using the runtime's DecompressionStream. */
@@ -58,6 +79,21 @@ function allTags(scope: string, name: string): string[] {
 	return out;
 }
 
+function parseAuthResults(scope: string): AuthResults | undefined {
+	const ar = tag(scope, "auth_results") ?? "";
+	const dkim: AuthDkimResult[] = allTags(ar, "dkim").map((d) => ({
+		domain: tag(d, "domain"),
+		selector: tag(d, "selector"),
+		result: tag(d, "result"),
+	}));
+	const spf: AuthSpfResult[] = allTags(ar, "spf").map((s) => ({
+		domain: tag(s, "domain"),
+		result: tag(s, "result"),
+	}));
+	if (dkim.length === 0 && spf.length === 0) return undefined;
+	return { dkim, spf };
+}
+
 export function parseDmarcXml(xml: string): DmarcReport {
 	const metadata = tag(xml, "report_metadata") ?? "";
 	const policy = tag(xml, "policy_published") ?? "";
@@ -77,6 +113,7 @@ export function parseDmarcXml(xml: string): DmarcReport {
 			dkim_result: tag(policyEval, "dkim"),
 			spf_result: tag(policyEval, "spf"),
 			header_from: tag(identifiers, "header_from"),
+			auth_results: parseAuthResults(rec),
 		});
 	}
 
@@ -87,6 +124,10 @@ export function parseDmarcXml(xml: string): DmarcReport {
 		date_range_end: tag(tag(metadata, "date_range") ?? "", "end"),
 		policy_domain: tag(policy, "domain"),
 		policy_p: tag(policy, "p"),
+		policy_adkim: tag(policy, "adkim"),
+		policy_aspf: tag(policy, "aspf"),
+		policy_sp: tag(policy, "sp"),
+		policy_pct: tag(policy, "pct"),
 		records,
 	};
 }

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -1286,6 +1286,10 @@ export class MailboxDO extends DurableObject<Env> {
 			date_range_begin: string | null;
 			date_range_end: string | null;
 			policy_p: string | null;
+			policy_adkim: string | null;
+			policy_aspf: string | null;
+			policy_sp: string | null;
+			policy_pct: string | null;
 			raw_r2_key: string | null;
 		},
 		records: Array<{
@@ -1296,6 +1300,7 @@ export class MailboxDO extends DurableObject<Env> {
 			dkim_result: string | null;
 			spf_result: string | null;
 			header_from: string | null;
+			auth_results: string | null;
 		}>,
 	) {
 		this.db.insert(schema.dmarcReports).values(report).run();

--- a/workers/durableObject/migrations.ts
+++ b/workers/durableObject/migrations.ts
@@ -498,4 +498,18 @@ export const mailboxMigrations: Migration[] = [
             CREATE INDEX IF NOT EXISTS idx_sender_graph_name ON sender_graph(sender_name);
         `,
 	},
+	{
+		// Full policy_published fields (adkim/aspf/sp/pct) and per-record
+		// auth_results (DKIM/SPF signing domain, selector, raw verdict) from
+		// DMARC RUA XML (issue #384). Columns are nullable so pre-migration
+		// rows continue to read null. auth_results is stored as JSON text.
+		name: "23_dmarc_policy_auth_results",
+		sql: `
+            ALTER TABLE dmarc_reports ADD COLUMN policy_adkim TEXT;
+            ALTER TABLE dmarc_reports ADD COLUMN policy_aspf TEXT;
+            ALTER TABLE dmarc_reports ADD COLUMN policy_sp TEXT;
+            ALTER TABLE dmarc_reports ADD COLUMN policy_pct TEXT;
+            ALTER TABLE dmarc_records ADD COLUMN auth_results TEXT;
+        `,
+	},
 ];

--- a/workers/routes/dmarc.ts
+++ b/workers/routes/dmarc.ts
@@ -24,7 +24,11 @@ dmarcRoutes.get("/reports", async (c) => {
 
 dmarcRoutes.get("/reports/:reportId/records", async (c) => {
 	const reportId = c.req.param("reportId");
-	const records = await c.var.mailboxStub.getDmarcRecords(reportId);
+	const raw = await c.var.mailboxStub.getDmarcRecords(reportId);
+	const records = raw.map((r) => ({
+		...r,
+		auth_results: r.auth_results ? JSON.parse(r.auth_results) : null,
+	}));
 	return c.json({ records });
 });
 


### PR DESCRIPTION
## Summary

- Extends `parseDmarcXml` to capture `adkim/aspf/sp/pct` from `<policy_published>` and a per-record `auth_results` array (DKIM: domain/selector/result; SPF: domain/result) using the existing hand-written tag extractor — no new XML dependency.
- Adds nullable columns to `dmarc_reports` and `dmarc_records` via migration 23; pre-migration rows read null.
- Persists all new fields through the RUA ingest path; the `/reports/:reportId/records` endpoint now returns `auth_results` as a parsed object.
- Adds a clickable report-row drill-down to the DMARC dashboard: click any report to expand a detail panel showing per-source-IP auth details (DKIM domain/selector/result, SPF domain/result) and the full applied policy (adkim/aspf/sp/pct).

Closes #384.

## Test plan

- [x] `npm test` — 1211 passing, 0 failing (12 tests in `tests/dmarc/parser.test.ts` including 5 new: full policy, missing policy tags → undefined, auth_results parse, absent auth_results → undefined, multi-dkim entries)
- [x] `npm run typecheck` — clean

## Choices made

- Stored `auth_results` as JSON text in SQLite (matches the existing pattern in `dmarc_ruf_records.auth_results`). Parsed in the route handler before returning so the API delivers a structured object, not a double-encoded string.
- Drill-down is triggered by clicking a **report** row (not source IP) since the existing endpoint is keyed by `reportId`. Clicking the same row again collapses the panel.
- `parseAuthResults` returns `undefined` (not an empty object) when no `<auth_results>` tag or entries exist, keeping the falsy check consistent with the other optional parser fields.

---
_Generated by [Claude Code](https://claude.ai/code/session_0125GF7Sf6bBCf3e33cg93P9)_