### PR TITLE
feat: shadow-IT / unknown-sender flagging via dmarc_sources.legitimate

### DIFF
--- a/app/routes/dmarc.tsx
+++ b/app/routes/dmarc.tsx
@@ -44,6 +44,7 @@ interface DmarcSource {
 	first_seen: string;
 	last_seen: string;
 	label?: string | null;
+	legitimate: number;
 }
 
 interface DmarcAuthResultDkim {
@@ -103,6 +104,8 @@ export default function DmarcRoute() {
 	const [drillDown, setDrillDown] = useState<DrillDownRecord[] | null>(null);
 	const [drillDownLoading, setDrillDownLoading] = useState(false);
 	const [rollup, setRollup] = useState<DmarcRollup | null>(null);
+	const [showUnknownOnly, setShowUnknownOnly] = useState(false);
+	const [togglingIp, setTogglingIp] = useState<string | null>(null);
 
 	useEffect(() => {
 		if (!mailboxId) return;
@@ -181,6 +184,34 @@ export default function DmarcRoute() {
 		URL.revokeObjectURL(url);
 	}
 
+	async function toggleLegitimate(source: DmarcSource) {
+		if (!mailboxId) return;
+		setTogglingIp(source.source_ip);
+		try {
+			await fetch(
+				`/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/dmarc/sources/${encodeURIComponent(source.source_ip)}`,
+				{
+					method: "PATCH",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ legitimate: source.legitimate === 0 }),
+				},
+			);
+			setSources((prev) =>
+				prev
+					? prev.map((s) =>
+							s.source_ip === source.source_ip
+								? { ...s, legitimate: source.legitimate === 0 ? 1 : 0 }
+								: s,
+					  )
+					: prev,
+			);
+		} catch (e) {
+			console.error("toggle legitimate failed", e);
+		} finally {
+			setTogglingIp(null);
+		}
+	}
+
 	if (!reports) {
 		return <div className="flex justify-center py-20"><Loader size="lg" /></div>;
 	}
@@ -198,6 +229,11 @@ export default function DmarcRoute() {
 	}
 
 	const activePolicyReport = reports.find((r) => !domain || r.domain === domain);
+	const displayedSources = sources
+		? showUnknownOnly
+			? sources.filter((s) => s.legitimate === 0)
+			: sources
+		: null;
 
 	return (
 		<div className="max-w-5xl px-4 py-6 md:px-8 h-full overflow-y-auto">
@@ -306,19 +342,34 @@ export default function DmarcRoute() {
 				<div className="flex items-center justify-between mb-3">
 					<h2 className="text-sm font-semibold text-ink">Sending sources</h2>
 					{sources && sources.length > 0 && (
-						<button
-							type="button"
-							onClick={handleDownloadCsv}
-							className="text-xs px-2 py-1 rounded border border-line bg-paper-3 hover:bg-paper-2 text-ink-2"
-						>
-							Download CSV
-						</button>
+						<div className="flex items-center gap-3">
+							<label className="flex items-center gap-2 text-sm text-ink-3 cursor-pointer">
+								<input
+									type="checkbox"
+									checked={showUnknownOnly}
+									onChange={(e) => setShowUnknownOnly(e.target.checked)}
+									className="rounded"
+								/>
+								Show only unknown sources
+							</label>
+							<button
+								type="button"
+								onClick={handleDownloadCsv}
+								className="text-xs px-2 py-1 rounded border border-line bg-paper-3 hover:bg-paper-2 text-ink-2"
+							>
+								Download CSV
+							</button>
+						</div>
 					)}
 				</div>
-				{!sources ? (
+				{!displayedSources ? (
 					<div className="text-ink-3 text-sm">Loading…</div>
-				) : sources.length === 0 ? (
-					<div className="text-ink-3 text-sm">No records for this domain.</div>
+				) : displayedSources.length === 0 ? (
+					<div className="text-ink-3 text-sm">
+						{showUnknownOnly && sources && sources.length > 0
+							? "No unknown sources — all sources marked legitimate."
+							: "No records for this domain."}
+					</div>
 				) : (
 					<div className="overflow-x-auto rounded-lg border border-line">
 						<table className="w-full text-sm">
@@ -331,13 +382,16 @@ export default function DmarcRoute() {
 									<th className="text-right px-3 py-2">Quarantine</th>
 									<th className="text-right px-3 py-2">Reject</th>
 									<th className="text-left px-3 py-2">Pass rate</th>
+									<th className="text-left px-3 py-2">Status</th>
 								</tr>
 							</thead>
 							<tbody>
-								{sources.map((s) => {
+								{displayedSources.map((s) => {
 									const rate = s.total_count > 0 ? s.pass_count / s.total_count : 0;
 									const suspect = rate < 0.5 && s.total_count >= 5;
 									const isSelected = selectedIp === s.source_ip;
+									const isUnknown = s.legitimate === 0;
+									const isToggling = togglingIp === s.source_ip;
 									return (
 										<tr
 											key={s.source_ip}
@@ -354,6 +408,26 @@ export default function DmarcRoute() {
 												<span className={suspect ? "text-danger" : "text-ink"}>
 													{Math.round(rate * 100)}%
 												</span>
+											</td>
+											<td className="px-3 py-2">
+												<div className="flex items-center gap-2">
+													{isUnknown ? (
+														<span className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
+															Shadow IT / Unknown
+														</span>
+													) : (
+														<span className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">
+															Legitimate
+														</span>
+													)}
+													<button
+														onClick={() => toggleLegitimate(s)}
+														disabled={isToggling}
+														className="text-xs text-ink-3 hover:text-ink underline disabled:opacity-50"
+													>
+														{isToggling ? "…" : isUnknown ? "Mark legitimate" : "Mark unknown"}
+													</button>
+												</div>
 											</td>
 										</tr>
 									);

--- a/tests/dmarc/sources.test.ts
+++ b/tests/dmarc/sources.test.ts
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Tests for shadow-IT / legitimate-source flagging (issue #385):
+ *   - PATCH /dmarc/sources/:sourceIp: validates IP, accepts boolean, writes to stub
+ *   - GET /dmarc/summary: propagates the `legitimate` field from getDmarcSummary
+ */
+
+import { Hono } from "hono";
+import { createMiddleware } from "hono/factory";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../workers/lib/mailbox", async (orig) => {
+	const original = await orig<typeof import("../../workers/lib/mailbox")>();
+	return {
+		...original,
+		requireMailbox: createMiddleware(async (_c, next) => {
+			await next();
+		}),
+	};
+});
+
+import { dmarcRoutes } from "../../workers/routes/dmarc";
+import type { MailboxContext } from "../../workers/lib/mailbox";
+
+function makeStub(overrides: Partial<{
+	getDmarcSummary: (domain: string) => Promise<unknown[]>;
+	setSourceLegitimate: (ip: string, legitimate: boolean, notes: string | null) => Promise<void>;
+}> = {}) {
+	return {
+		getDmarcSummary: vi.fn().mockResolvedValue([]),
+		setSourceLegitimate: vi.fn().mockResolvedValue(undefined),
+		...overrides,
+	};
+}
+
+function makeApp(stub: ReturnType<typeof makeStub>) {
+	const app = new Hono<MailboxContext>();
+	app.use("*", async (c, next) => {
+		c.set("mailboxStub", stub as unknown as Parameters<typeof c.set>[1]);
+		await next();
+	});
+	app.route("/", dmarcRoutes);
+	return app;
+}
+
+// ── PATCH /sources/:sourceIp ──────────────────────────────────────────────────
+
+describe("PATCH /dmarc/sources/:sourceIp", () => {
+	it("calls setSourceLegitimate with the right args when marking legitimate", async () => {
+		const stub = makeStub();
+		const app = makeApp(stub);
+		const res = await app.request("/sources/1.2.3.4", {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ legitimate: true }),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect((body as { ok: boolean }).ok).toBe(true);
+		expect(stub.setSourceLegitimate).toHaveBeenCalledWith("1.2.3.4", true, null);
+	});
+
+	it("calls setSourceLegitimate with false when marking unknown", async () => {
+		const stub = makeStub();
+		const app = makeApp(stub);
+		const res = await app.request("/sources/203.0.113.42", {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ legitimate: false }),
+		});
+		expect(res.status).toBe(200);
+		expect(stub.setSourceLegitimate).toHaveBeenCalledWith("203.0.113.42", false, null);
+	});
+
+	it("forwards optional notes to setSourceLegitimate", async () => {
+		const stub = makeStub();
+		const app = makeApp(stub);
+		const res = await app.request("/sources/10.0.0.1", {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ legitimate: true, notes: "our mail relay" }),
+		});
+		expect(res.status).toBe(200);
+		expect(stub.setSourceLegitimate).toHaveBeenCalledWith("10.0.0.1", true, "our mail relay");
+	});
+
+	it("returns 400 for a non-IP sourceIp parameter", async () => {
+		const stub = makeStub();
+		const app = makeApp(stub);
+		const res = await app.request("/sources/not-an-ip", {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ legitimate: true }),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect((body as { error: string }).error).toMatch(/invalid source_ip/);
+		expect(stub.setSourceLegitimate).not.toHaveBeenCalled();
+	});
+
+	it("returns 400 when an octet exceeds 255", async () => {
+		const stub = makeStub();
+		const app = makeApp(stub);
+		const res = await app.request("/sources/1.2.3.999", {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ legitimate: true }),
+		});
+		expect(res.status).toBe(400);
+		expect(stub.setSourceLegitimate).not.toHaveBeenCalled();
+	});
+
+	it("returns 400 when legitimate is a string, not boolean", async () => {
+		const stub = makeStub();
+		const app = makeApp(stub);
+		const res = await app.request("/sources/1.2.3.4", {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ legitimate: "yes" }),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect((body as { error: string }).error).toMatch(/boolean/);
+		expect(stub.setSourceLegitimate).not.toHaveBeenCalled();
+	});
+
+	it("accepts a valid IPv6 address", async () => {
+		const stub = makeStub();
+		const app = makeApp(stub);
+		const ipv6 = "2001:db8::1";
+		const res = await app.request(`/sources/${encodeURIComponent(ipv6)}`, {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ legitimate: true }),
+		});
+		expect(res.status).toBe(200);
+		expect(stub.setSourceLegitimate).toHaveBeenCalledWith(ipv6, true, null);
+	});
+});
+
+// ── GET /summary — legitimate field propagation ───────────────────────────────
+
+describe("GET /dmarc/summary", () => {
+	it("includes legitimate field in summary source rows", async () => {
+		const sourceRows = [
+			{
+				source_ip: "1.2.3.4",
+				total_count: 100,
+				pass_count: 90,
+				quarantine_count: 5,
+				reject_count: 5,
+				first_seen: "2026-01-01",
+				last_seen: "2026-01-31",
+				legitimate: 1,
+			},
+			{
+				source_ip: "5.6.7.8",
+				total_count: 50,
+				pass_count: 10,
+				quarantine_count: 20,
+				reject_count: 20,
+				first_seen: "2026-01-05",
+				last_seen: "2026-01-30",
+				legitimate: 0,
+			},
+		];
+		const stub = makeStub({ getDmarcSummary: vi.fn().mockResolvedValue(sourceRows) });
+		const app = makeApp(stub);
+		const res = await app.request("/summary?domain=example.com");
+		expect(res.status).toBe(200);
+		const body = await res.json() as { domain: string; sources: typeof sourceRows };
+		expect(body.domain).toBe("example.com");
+		expect(body.sources).toHaveLength(2);
+		expect(body.sources[0].legitimate).toBe(1);
+		expect(body.sources[1].legitimate).toBe(0);
+	});
+
+	it("returns 400 when domain query param is missing", async () => {
+		const stub = makeStub();
+		const app = makeApp(stub);
+		const res = await app.request("/summary");
+		expect(res.status).toBe(400);
+	});
+});

--- a/tests/frontend/dmarc.test.ts
+++ b/tests/frontend/dmarc.test.ts
@@ -42,6 +42,7 @@ describe("sourcesToCsv", () => {
 				reject_count: 1,
 				first_seen: "2026-01-01",
 				last_seen: "2026-01-31",
+				legitimate: 0,
 			},
 		]);
 		const lines = csv.split("\r\n");
@@ -62,6 +63,7 @@ describe("sourcesToCsv", () => {
 				reject_count: 0,
 				first_seen: "2026-01-01",
 				last_seen: "2026-01-31",
+				legitimate: 0,
 			},
 		]);
 		const lines = csv.split("\r\n");
@@ -78,6 +80,7 @@ describe("sourcesToCsv", () => {
 				reject_count: 0,
 				first_seen: "2026-01-01",
 				last_seen: "2026-01-02",
+				legitimate: 0,
 			},
 		]);
 		expect(csv).toContain("\r\n");

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -1576,7 +1576,8 @@ export class MailboxDO extends DurableObject<Env> {
 				   SUM(CASE WHEN r.disposition = 'reject' THEN r.count ELSE 0 END) as reject_count,
 				   MIN(rep.received_at) as first_seen,
 				   MAX(rep.received_at) as last_seen,
-				   ds.label as label
+				   ds.label as label,
+				   COALESCE(ds.legitimate, 0) as legitimate
 				 FROM dmarc_records r
 				 JOIN dmarc_reports rep ON rep.id = r.report_id
 				 LEFT JOIN dmarc_sources ds ON ds.source_ip = r.source_ip
@@ -1596,8 +1597,22 @@ export class MailboxDO extends DurableObject<Env> {
 			first_seen: string;
 			last_seen: string;
 			label: string | null;
+			legitimate: number;
 		}>;
 		return rows;
+	}
+
+	async setSourceLegitimate(source_ip: string, legitimate: boolean, notes: string | null = null) {
+		this.ctx.storage.sql.exec(
+			`INSERT INTO dmarc_sources (source_ip, legitimate, notes)
+			 VALUES (?1, ?2, ?3)
+			 ON CONFLICT(source_ip) DO UPDATE SET
+			   legitimate = excluded.legitimate,
+			   notes = CASE WHEN excluded.notes IS NOT NULL THEN excluded.notes ELSE dmarc_sources.notes END`,
+			source_ip,
+			legitimate ? 1 : 0,
+			notes,
+		);
 	}
 
 	async getDmarcAlignmentTotals(domain: string, sinceIso: string) {

--- a/workers/routes/dmarc.ts
+++ b/workers/routes/dmarc.ts
@@ -61,3 +61,28 @@ dmarcRoutes.get("/rollup", async (c) => {
 	const domains = await c.var.mailboxStub.getDmarcRollup(sinceIso);
 	return c.json({ window_days: days, since: sinceIso, domains });
 });
+
+function isValidIp(ip: string): boolean {
+	if (ip.length > 45) return false;
+	if (/^(\d{1,3}\.){3}\d{1,3}$/.test(ip)) {
+		return ip.split(".").every((o) => Number(o) <= 255);
+	}
+	return /^[0-9a-fA-F:.]{2,45}$/.test(ip) && ip.includes(":");
+}
+
+dmarcRoutes.patch("/sources/:sourceIp", async (c) => {
+	const sourceIp = decodeURIComponent(c.req.param("sourceIp"));
+	if (!isValidIp(sourceIp)) return c.json({ error: "invalid source_ip" }, 400);
+	let body: unknown;
+	try {
+		body = await c.req.json();
+	} catch {
+		return c.json({ error: "invalid JSON body" }, 400);
+	}
+	if (typeof (body as { legitimate?: unknown }).legitimate !== "boolean") {
+		return c.json({ error: "legitimate must be boolean" }, 400);
+	}
+	const { legitimate, notes } = body as { legitimate: boolean; notes?: string };
+	await c.var.mailboxStub.setSourceLegitimate(sourceIp, legitimate, notes ?? null);
+	return c.json({ ok: true });
+});


### PR DESCRIPTION
## Summary

- Extends `getDmarcSummary` with a `LEFT JOIN dmarc_sources` so every source row now includes the `legitimate` flag (0 = unknown, 1 = marked legitimate).
- Adds `setSourceLegitimate(source_ip, legitimate, notes)` DO method — UPSERTs into `dmarc_sources`, preserving existing notes when none are supplied.
- Adds `PATCH /api/v1/mailboxes/:mailboxId/dmarc/sources/:sourceIp` route with IPv4/IPv6 validation; rejects non-IP values or octets > 255.
- DMARC dashboard Sending-sources table: "Shadow IT / Unknown" amber badge for `legitimate=0` rows, "Legitimate" green badge for flagged rows, per-row toggle button, and "Show only unknown sources" filter checkbox with optimistic UI update.

Closes #385.

## Test plan

- [x] `npm test` — 1214 passing, 0 failing
- [x] `npm run typecheck` — clean

## Choices made

- **Optimistic UI update**: the toggle flips the local state immediately on success (no re-fetch); if the PATCH fails the error is logged and the old state remains. Keeps the UX snappy without adding loading states per row beyond the in-flight indicator.
- **Notes UPSERT semantics**: when `notes` is omitted from the PATCH body (null), the existing notes value is preserved (`CASE WHEN excluded.notes IS NOT NULL THEN excluded.notes ELSE dmarc_sources.notes END`).
- **IP validation**: simple regex-based check (IPv4 octet bounds + IPv6 character set + colon presence); covers the DMARC source space without pulling in a full IP-parsing library.

_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_016HQUbwgWG17ZZR3xKbBrqg)_