### PR TITLE
feat: add CSV export for DMARC sending-sources table

### DIFF
--- a/app/lib/dmarc-csv.ts
+++ b/app/lib/dmarc-csv.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Pure CSV-generation helpers for the DMARC sending-sources export.
+ * Kept in a separate module so they can be unit-tested in the node
+ * environment without pulling in any React or JSX dependencies.
+ */
+
+export interface DmarcSourceForCsv {
+	source_ip: string;
+	total_count: number;
+	pass_count: number;
+	quarantine_count: number;
+	reject_count: number;
+}
+
+/**
+ * Wraps a value in double quotes and escapes any embedded double quotes as `""`.
+ * Newlines are replaced with a space to keep each CSV record on one line.
+ */
+export function csvField(v: string | number | boolean): string {
+	return '"' + String(v).replace(/"/g, '""').replace(/\r?\n/g, " ") + '"';
+}
+
+const CSV_HEADERS = ["source_ip", "label", "message_count", "pass_count", "fail_count", "legitimate"];
+
+/**
+ * Converts a DmarcSource array into a well-formed CSV string.
+ * - All fields are double-quoted.
+ * - Embedded double quotes are escaped as `""`.
+ * - `label` is left empty (not present in the summary rollup).
+ * - `fail_count` = quarantine_count + reject_count.
+ * - `legitimate` = true when pass_count equals total_count and total_count > 0.
+ */
+export function buildDmarcCsv(sources: DmarcSourceForCsv[]): string {
+	const header = CSV_HEADERS.map(csvField).join(",");
+	const rows = sources.map((s) => {
+		const failCount = s.quarantine_count + s.reject_count;
+		const legitimate = s.total_count > 0 && s.pass_count === s.total_count;
+		return [
+			csvField(s.source_ip),
+			csvField(""),
+			csvField(s.total_count),
+			csvField(s.pass_count),
+			csvField(failCount),
+			csvField(legitimate),
+		].join(",");
+	});
+	return [header, ...rows].join("\r\n");
+}

--- a/app/routes/dmarc.tsx
+++ b/app/routes/dmarc.tsx
@@ -5,6 +5,7 @@
 import { Loader } from "@cloudflare/kumo";
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router";
+import { buildDmarcCsv } from "~/lib/dmarc-csv";
 
 interface DmarcReport {
 	id: string;
@@ -61,6 +62,19 @@ export default function DmarcRoute() {
 		return Array.from(set).sort();
 	}, [reports]);
 
+	function downloadSourcesCsv() {
+		if (!sources || sources.length === 0) return;
+		const csv = buildDmarcCsv(sources);
+		const blob = new Blob([csv], { type: "text/csv" });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		const date = new Date().toISOString().slice(0, 10);
+		a.href = url;
+		a.download = `dmarc-sources-${domain ?? "unknown"}-${date}.csv`;
+		a.click();
+		URL.revokeObjectURL(url);
+	}
+
 	if (!reports) {
 		return <div className="flex justify-center py-20"><Loader size="lg" /></div>;
 	}
@@ -93,7 +107,18 @@ export default function DmarcRoute() {
 			</div>
 
 			<section className="mb-8">
-				<h2 className="text-sm font-semibold text-ink mb-3">Sending sources</h2>
+				<div className="flex items-center justify-between mb-3">
+					<h2 className="text-sm font-semibold text-ink">Sending sources</h2>
+					{sources && sources.length > 0 && (
+						<button
+							type="button"
+							onClick={downloadSourcesCsv}
+							className="text-xs text-ink-3 hover:text-ink border border-line rounded px-2 py-1"
+						>
+							Download CSV
+						</button>
+					)}
+				</div>
 				{!sources ? (
 					<div className="text-ink-3 text-sm">Loading…</div>
 				) : sources.length === 0 ? (

--- a/tests/dmarc/csv-export.test.ts
+++ b/tests/dmarc/csv-export.test.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { buildDmarcCsv, csvField } from "../../app/lib/dmarc-csv";
+
+// Minimal shape needed for the CSV builder — mirrors the DmarcSource interface.
+function makeSource(overrides: {
+	source_ip: string;
+	total_count?: number;
+	pass_count?: number;
+	quarantine_count?: number;
+	reject_count?: number;
+}) {
+	return {
+		source_ip: overrides.source_ip,
+		total_count: overrides.total_count ?? 10,
+		pass_count: overrides.pass_count ?? 8,
+		quarantine_count: overrides.quarantine_count ?? 1,
+		reject_count: overrides.reject_count ?? 1,
+		first_seen: "2026-01-01T00:00:00Z",
+		last_seen: "2026-01-31T00:00:00Z",
+	};
+}
+
+describe("csvField", () => {
+	it("wraps a plain string in double quotes", () => {
+		expect(csvField("hello")).toBe('"hello"');
+	});
+
+	it("escapes embedded double quotes as double-double-quotes", () => {
+		expect(csvField('say "hi"')).toBe('"say ""hi"""');
+	});
+
+	it("replaces embedded newlines with a space", () => {
+		expect(csvField("line1\nline2")).toBe('"line1 line2"');
+		expect(csvField("line1\r\nline2")).toBe('"line1 line2"');
+	});
+
+	it("coerces numbers and booleans to strings", () => {
+		expect(csvField(42)).toBe('"42"');
+		expect(csvField(true)).toBe('"true"');
+		expect(csvField(false)).toBe('"false"');
+	});
+});
+
+describe("buildDmarcCsv", () => {
+	it("produces a header row as the first line", () => {
+		const csv = buildDmarcCsv([]);
+		const firstLine = csv.split("\r\n")[0];
+		expect(firstLine).toBe(
+			'"source_ip","label","message_count","pass_count","fail_count","legitimate"',
+		);
+	});
+
+	it("returns only the header when sources is empty", () => {
+		const csv = buildDmarcCsv([]);
+		const lines = csv.split("\r\n");
+		expect(lines).toHaveLength(1);
+	});
+
+	it("maps counts into the correct columns", () => {
+		const csv = buildDmarcCsv([
+			makeSource({ source_ip: "203.0.113.1", total_count: 10, pass_count: 8, quarantine_count: 1, reject_count: 1 }),
+		]);
+		const lines = csv.split("\r\n");
+		// header + 1 data row
+		expect(lines).toHaveLength(2);
+		// fail_count = quarantine + reject = 1 + 1 = 2
+		expect(lines[1]).toBe('"203.0.113.1","","10","8","2","false"');
+	});
+
+	it("sets legitimate=true when pass_count equals total_count", () => {
+		const csv = buildDmarcCsv([
+			makeSource({ source_ip: "198.51.100.1", total_count: 5, pass_count: 5, quarantine_count: 0, reject_count: 0 }),
+		]);
+		const dataRow = csv.split("\r\n")[1];
+		expect(dataRow).toContain('"true"');
+	});
+
+	it("sets legitimate=false when pass_count is less than total_count", () => {
+		const csv = buildDmarcCsv([
+			makeSource({ source_ip: "198.51.100.2", total_count: 5, pass_count: 3, quarantine_count: 2, reject_count: 0 }),
+		]);
+		const dataRow = csv.split("\r\n")[1];
+		expect(dataRow).toContain('"false"');
+	});
+
+	it("sets legitimate=false when total_count is 0", () => {
+		const csv = buildDmarcCsv([
+			makeSource({ source_ip: "198.51.100.3", total_count: 0, pass_count: 0, quarantine_count: 0, reject_count: 0 }),
+		]);
+		const dataRow = csv.split("\r\n")[1];
+		expect(dataRow).toContain('"false"');
+	});
+
+	it("wraps a field containing a comma in double quotes without altering the comma", () => {
+		// A comma inside a quoted CSV field must remain as-is (no escaping needed
+		// for commas — the surrounding quotes make the comma non-structural).
+		const field = csvField("192.0.2.1, extra");
+		// The output is a double-quoted string; the comma is preserved verbatim.
+		expect(field).toBe('"192.0.2.1, extra"');
+		// The quoted wrapper starts and ends with a double-quote.
+		expect(field.startsWith('"')).toBe(true);
+		expect(field.endsWith('"')).toBe(true);
+		// The raw comma is still present inside the quotes (a CSV parser would
+		// correctly read this as a single field value "192.0.2.1, extra").
+		expect(field).toContain(",");
+	});
+
+	it("properly escapes a field containing a double-quote", () => {
+		// Simulate a label or annotation with an embedded quote (e.g. nickname).
+		const field = csvField('Acme "Corp" Mailer');
+		expect(field).toBe('"Acme ""Corp"" Mailer"');
+	});
+
+	it("produces a valid multi-row CSV with sources containing commas and quotes in IP/label data", () => {
+		// Construct sources where the source_ip includes a comma and a double-quote
+		// (not real IPs, but stress-tests the escaping path end-to-end).
+		const sources = [
+			makeSource({ source_ip: "203.0.113.1,extra", total_count: 20, pass_count: 20, quarantine_count: 0, reject_count: 0 }),
+			makeSource({ source_ip: '198.51.100.1 "alias"', total_count: 7, pass_count: 3, quarantine_count: 2, reject_count: 2 }),
+		];
+		const csv = buildDmarcCsv(sources);
+		const lines = csv.split("\r\n");
+		expect(lines).toHaveLength(3); // header + 2 rows
+
+		// Row 1: comma in source_ip → wrapped and escaped; fail_count = 0; legitimate = true
+		expect(lines[1]).toBe('"203.0.113.1,extra","","20","20","0","true"');
+
+		// Row 2: double-quote in source_ip → escaped as ""; fail_count = 4; legitimate = false
+		expect(lines[2]).toBe('"198.51.100.1 ""alias""","","7","3","4","false"');
+	});
+
+	it("uses CRLF (\\r\\n) line endings", () => {
+		const csv = buildDmarcCsv([makeSource({ source_ip: "1.2.3.4" })]);
+		expect(csv).toContain("\r\n");
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a **Download CSV** button to the Sending-sources section of the DMARC dashboard (`app/routes/dmarc.tsx`). The button appears only when sources data is loaded and non-empty.
- Client-side CSV generation from already-fetched data — no server changes required.
- Pure helpers (`csvField`, `buildDmarcCsv`) extracted to `app/lib/dmarc-csv.ts` so they can be unit-tested in the Node environment without pulling in React/JSX.
- **CSV escaping is safe**: every field is double-quoted; embedded `"` chars are escaped as `""`; embedded newlines are replaced with a space.
- Column order: `source_ip`, `label` (empty — not present in summary rollup), `message_count`, `pass_count`, `fail_count` (quarantine + reject), `legitimate` (true when pass_count === total_count > 0).
- Filename is `dmarc-sources-<domain>-<YYYY-MM-DD>.csv`. Blob URL is revoked after click.

Closes #387

## Test plan

- [ ] 14 new unit tests in `tests/dmarc/csv-export.test.ts` (node environment, no DOM needed):
  - `csvField` — plain string, embedded double-quote (`"` → `""`), embedded newlines, number and boolean coercion
  - `buildDmarcCsv` — header row, empty sources, column mapping, `legitimate` flag derivation (true/false/zero-count), field containing a comma, field containing a double-quote, multi-row CSV with both injection chars, CRLF line endings
- [ ] Run `npm test` — 14 new tests pass; pre-existing `hub-settings` timeout failures are unrelated to this change and also fail on `main`.
- [ ] Run `npm run typecheck` — exits 0, no new errors.
- [ ] Manual: open DMARC page for a mailbox with reports, confirm "Download CSV" button appears next to "Sending sources" heading, click it, verify downloaded file opens correctly in a spreadsheet with properly quoted fields.

https://claude.ai/code/session_01Uqvt1cBFXbAdxSb2MNz2Kh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uqvt1cBFXbAdxSb2MNz2Kh)_