### PR TITLE
feat: parse DMARC policy (adkim/aspf/sp/pct) + auth_results; source drill-down (#384)

### DIFF
--- a/app/routes/dmarc.tsx
+++ b/app/routes/dmarc.tsx
@@ -29,6 +29,10 @@ interface DmarcReport {
 	date_range_begin: string | null;
 	date_range_end: string | null;
 	policy_p: string | null;
+	policy_adkim?: string | null;
+	policy_aspf?: string | null;
+	policy_sp?: string | null;
+	policy_pct?: string | null;
 }
 
 interface DmarcSource {
@@ -39,6 +43,34 @@ interface DmarcSource {
 	reject_count: number;
 	first_seen: string;
 	last_seen: string;
+}
+
+interface DmarcAuthResultDkim {
+	domain?: string;
+	selector?: string;
+	result?: string;
+}
+
+interface DmarcAuthResultSpf {
+	domain?: string;
+	result?: string;
+}
+
+interface DmarcAuthResults {
+	dkim: DmarcAuthResultDkim[];
+	spf: DmarcAuthResultSpf[];
+}
+
+interface DrillDownRecord {
+	report_id: string;
+	count: number;
+	disposition?: string | null;
+	dkim_result?: string | null;
+	spf_result?: string | null;
+	auth_results?: DmarcAuthResults | null;
+	date_range_begin?: string | null;
+	date_range_end?: string | null;
+	org_name?: string | null;
 }
 
 const RANGE_PRESETS = [7, 30, 90] as const;
@@ -54,6 +86,9 @@ export default function DmarcRoute() {
 	const [domain, setDomain] = useState<string | null>(null);
 	const [sources, setSources] = useState<DmarcSource[] | null>(null);
 	const [days, setDays] = useState<RangeDays>(90);
+	const [selectedIp, setSelectedIp] = useState<string | null>(null);
+	const [drillDown, setDrillDown] = useState<DrillDownRecord[] | null>(null);
+	const [drillDownLoading, setDrillDownLoading] = useState(false);
 
 	useEffect(() => {
 		if (!mailboxId) return;
@@ -74,6 +109,38 @@ export default function DmarcRoute() {
 			.then((r) => setSources(r.sources))
 			.catch((e) => console.error("dmarc summary fetch failed", e));
 	}, [mailboxId, domain, days]);
+
+	// Fetch per-record detail for the selected source IP across recent reports.
+	useEffect(() => {
+		if (!mailboxId || !selectedIp || !reports) return;
+		setDrillDown(null);
+		setDrillDownLoading(true);
+		const domainReports = reports.filter((r) => !domain || r.domain === domain);
+		Promise.all(
+			domainReports.map((rep) =>
+				fetch(`/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/dmarc/reports/${encodeURIComponent(rep.id)}/records`)
+					.then((r) => r.json() as Promise<{ records: Array<{ source_ip: string; count: number; disposition?: string | null; dkim_result?: string | null; spf_result?: string | null; auth_results?: DmarcAuthResults | null }> }>)
+					.then((r) => r.records
+						.filter((rec) => rec.source_ip === selectedIp)
+						.map((rec) => ({
+							report_id: rep.id,
+							count: rec.count,
+							disposition: rec.disposition,
+							dkim_result: rec.dkim_result,
+							spf_result: rec.spf_result,
+							auth_results: rec.auth_results,
+							date_range_begin: rep.date_range_begin,
+							date_range_end: rep.date_range_end,
+							org_name: rep.org_name,
+						})),
+					)
+					.catch(() => [] as DrillDownRecord[]),
+			),
+		).then((groups) => {
+			setDrillDown(groups.flat());
+			setDrillDownLoading(false);
+		});
+	}, [mailboxId, selectedIp, reports, domain]);
 
 	const domains = useMemo(() => {
 		if (!reports) return [];
@@ -108,6 +175,8 @@ export default function DmarcRoute() {
 		);
 	}
 
+	const activePolicyReport = reports.find((r) => !domain || r.domain === domain);
+
 	return (
 		<div className="max-w-5xl px-4 py-6 md:px-8 h-full overflow-y-auto">
 			<h1 className="pp-serif text-ink mb-4">DMARC Reports</h1>
@@ -139,6 +208,31 @@ export default function DmarcRoute() {
 					</div>
 				</div>
 			</div>
+
+			{activePolicyReport && (activePolicyReport.policy_adkim || activePolicyReport.policy_aspf || activePolicyReport.policy_sp || activePolicyReport.policy_pct) && (
+				<div className="mb-6 flex flex-wrap gap-3">
+					{activePolicyReport.policy_adkim && (
+						<span className="inline-flex items-center gap-1 rounded-full border border-line bg-paper-3 px-2 py-0.5 text-xs text-ink-3">
+							<span className="font-medium text-ink">adkim</span>={activePolicyReport.policy_adkim}
+						</span>
+					)}
+					{activePolicyReport.policy_aspf && (
+						<span className="inline-flex items-center gap-1 rounded-full border border-line bg-paper-3 px-2 py-0.5 text-xs text-ink-3">
+							<span className="font-medium text-ink">aspf</span>={activePolicyReport.policy_aspf}
+						</span>
+					)}
+					{activePolicyReport.policy_sp && (
+						<span className="inline-flex items-center gap-1 rounded-full border border-line bg-paper-3 px-2 py-0.5 text-xs text-ink-3">
+							<span className="font-medium text-ink">sp</span>={activePolicyReport.policy_sp}
+						</span>
+					)}
+					{activePolicyReport.policy_pct && (
+						<span className="inline-flex items-center gap-1 rounded-full border border-line bg-paper-3 px-2 py-0.5 text-xs text-ink-3">
+							<span className="font-medium text-ink">pct</span>={activePolicyReport.policy_pct}%
+						</span>
+					)}
+				</div>
+			)}
 
 			<section className="mb-8">
 				<div className="flex items-center justify-between mb-3">
@@ -174,8 +268,13 @@ export default function DmarcRoute() {
 								{sources.map((s) => {
 									const rate = s.total_count > 0 ? s.pass_count / s.total_count : 0;
 									const suspect = rate < 0.5 && s.total_count >= 5;
+									const isSelected = selectedIp === s.source_ip;
 									return (
-										<tr key={s.source_ip} className={`border-t border-line ${suspect ? "bg-paper-3" : ""}`}>
+										<tr
+											key={s.source_ip}
+											className={`border-t border-line cursor-pointer hover:bg-paper-2 ${suspect ? "bg-paper-3" : ""} ${isSelected ? "ring-1 ring-inset ring-accent" : ""}`}
+											onClick={() => setSelectedIp(isSelected ? null : s.source_ip)}
+										>
 											<td className="px-3 py-2 font-mono text-ink">{s.source_ip}</td>
 											<td className="px-3 py-2 text-right">{s.total_count}</td>
 											<td className="px-3 py-2 text-right text-safe">{s.pass_count}</td>
@@ -194,6 +293,73 @@ export default function DmarcRoute() {
 					</div>
 				)}
 			</section>
+
+			{selectedIp && (
+				<section className="mb-8 rounded-lg border border-line p-4">
+					<div className="flex items-center justify-between mb-3">
+						<h2 className="text-sm font-semibold text-ink">
+							Auth results for <span className="font-mono">{selectedIp}</span>
+						</h2>
+						<button
+							type="button"
+							onClick={() => setSelectedIp(null)}
+							className="text-xs text-ink-3 hover:text-ink"
+						>
+							✕ Close
+						</button>
+					</div>
+					{drillDownLoading ? (
+						<div className="text-ink-3 text-sm">Loading…</div>
+					) : !drillDown || drillDown.length === 0 ? (
+						<div className="text-ink-3 text-sm">No detail records found.</div>
+					) : (
+						<div className="space-y-3">
+							{drillDown.map((entry, i) => (
+								<div key={`${entry.report_id}-${i}`} className="rounded border border-line p-3 text-xs">
+									<div className="flex flex-wrap gap-3 mb-2 text-ink-3">
+										{entry.org_name && <span>Reporter: <span className="text-ink">{entry.org_name}</span></span>}
+										{entry.date_range_begin && (
+											<span>
+												Period: <span className="text-ink">
+													{new Date(Number(entry.date_range_begin) * 1000).toLocaleDateString()} – {new Date(Number(entry.date_range_end) * 1000).toLocaleDateString()}
+												</span>
+											</span>
+										)}
+										<span>Messages: <span className="text-ink">{entry.count}</span></span>
+										{entry.disposition && <span>Disposition: <span className={entry.disposition === "none" ? "text-safe" : "text-danger"}>{entry.disposition}</span></span>}
+									</div>
+									{entry.auth_results && (
+										<div className="flex flex-wrap gap-4">
+											{entry.auth_results.dkim.length > 0 && (
+												<div>
+													<div className="font-medium text-ink-3 mb-1">DKIM</div>
+													{entry.auth_results.dkim.map((d, j) => (
+														<div key={j} className="font-mono text-ink">
+															{d.domain}{d.selector ? `/${d.selector}` : ""}&nbsp;
+															<span className={d.result === "pass" ? "text-safe" : "text-danger"}>{d.result}</span>
+														</div>
+													))}
+												</div>
+											)}
+											{entry.auth_results.spf.length > 0 && (
+												<div>
+													<div className="font-medium text-ink-3 mb-1">SPF</div>
+													{entry.auth_results.spf.map((s, j) => (
+														<div key={j} className="font-mono text-ink">
+															{s.domain}&nbsp;
+															<span className={s.result === "pass" ? "text-safe" : "text-danger"}>{s.result}</span>
+														</div>
+													))}
+												</div>
+											)}
+										</div>
+									)}
+								</div>
+							))}
+						</div>
+					)}
+				</section>
+			)}
 
 			<section>
 				<h2 className="text-sm font-semibold text-ink mb-3">Recent reports</h2>

--- a/tests/dmarc/parser.test.ts
+++ b/tests/dmarc/parser.test.ts
@@ -65,6 +65,23 @@ describe("parseDmarcXml", () => {
 		expect(r.policy_p).toBe("reject");
 	});
 
+	it("parses policy alignment fields adkim/aspf/sp/pct", () => {
+		const r = parseDmarcXml(SAMPLE);
+		expect(r.policy_adkim).toBe("r");
+		expect(r.policy_aspf).toBe("r");
+		expect(r.policy_sp).toBe("reject");
+		expect(r.policy_pct).toBe("100");
+	});
+
+	it("returns undefined policy alignment fields when absent", () => {
+		const xml = `<feedback><policy_published><domain>x.com</domain><p>none</p></policy_published></feedback>`;
+		const r = parseDmarcXml(xml);
+		expect(r.policy_adkim).toBeUndefined();
+		expect(r.policy_aspf).toBeUndefined();
+		expect(r.policy_sp).toBeUndefined();
+		expect(r.policy_pct).toBeUndefined();
+	});
+
 	it("parses each <record> into a DmarcRecord", () => {
 		const r = parseDmarcXml(SAMPLE);
 		expect(r.records).toHaveLength(2);
@@ -83,6 +100,58 @@ describe("parseDmarcXml", () => {
 			dkim_result: "fail",
 			spf_result: "fail",
 		});
+	});
+
+	it("parses auth_results from the first record", () => {
+		const r = parseDmarcXml(SAMPLE);
+		const ar = r.records[0].auth_results;
+		expect(ar).toBeDefined();
+		expect(ar!.dkim).toHaveLength(1);
+		expect(ar!.dkim[0]).toMatchObject({ domain: "example.com", result: "pass" });
+		expect(ar!.spf).toHaveLength(1);
+		expect(ar!.spf[0]).toMatchObject({ domain: "example.com", result: "pass" });
+	});
+
+	it("leaves auth_results undefined when the record has no <auth_results> block", () => {
+		const r = parseDmarcXml(SAMPLE);
+		expect(r.records[1].auth_results).toBeUndefined();
+	});
+
+	it("parses DKIM selector from auth_results when present", () => {
+		const xml = `<feedback>
+      <policy_published><domain>x.com</domain><p>none</p></policy_published>
+      <record>
+        <row><source_ip>1.2.3.4</source_ip><count>1</count></row>
+        <auth_results>
+          <dkim><domain>x.com</domain><selector>default</selector><result>pass</result></dkim>
+        </auth_results>
+      </record>
+    </feedback>`;
+		const r = parseDmarcXml(xml);
+		expect(r.records[0].auth_results!.dkim[0]).toMatchObject({
+			domain: "x.com",
+			selector: "default",
+			result: "pass",
+		});
+	});
+
+	it("parses multiple DKIM entries in auth_results", () => {
+		const xml = `<feedback>
+      <policy_published><domain>x.com</domain><p>none</p></policy_published>
+      <record>
+        <row><source_ip>1.2.3.4</source_ip><count>1</count></row>
+        <auth_results>
+          <dkim><domain>x.com</domain><result>pass</result></dkim>
+          <dkim><domain>y.com</domain><result>fail</result></dkim>
+          <spf><domain>x.com</domain><result>pass</result></spf>
+        </auth_results>
+      </record>
+    </feedback>`;
+		const r = parseDmarcXml(xml);
+		const ar = r.records[0].auth_results!;
+		expect(ar.dkim).toHaveLength(2);
+		expect(ar.dkim[1]).toMatchObject({ domain: "y.com", result: "fail" });
+		expect(ar.spf).toHaveLength(1);
 	});
 
 	it("caps `count` at 1,000,000 to guard against crafted reports", () => {

--- a/workers/db/schema.ts
+++ b/workers/db/schema.ts
@@ -143,6 +143,10 @@ export const dmarcReports = sqliteTable("dmarc_reports", {
 	date_range_begin: text("date_range_begin"),
 	date_range_end: text("date_range_end"),
 	policy_p: text("policy_p"),
+	policy_adkim: text("policy_adkim"),
+	policy_aspf: text("policy_aspf"),
+	policy_sp: text("policy_sp"),
+	policy_pct: text("policy_pct"),
 	raw_r2_key: text("raw_r2_key"),
 });
 
@@ -157,6 +161,7 @@ export const dmarcRecords = sqliteTable("dmarc_records", {
 	dkim_result: text("dkim_result"),
 	spf_result: text("spf_result"),
 	header_from: text("header_from"),
+	auth_results_json: text("auth_results_json"),
 });
 
 export const dmarcSources = sqliteTable("dmarc_sources", {

--- a/workers/dmarc/ingest.ts
+++ b/workers/dmarc/ingest.ts
@@ -72,7 +72,7 @@ export async function ingestDmarcReport(
 	if (!report.policy_domain) return { ingested: false, reason: "no policy_domain in XML" };
 
 	const stub = getMailboxStub(env, mailboxId);
-	await stub.insertDmarcReport({
+	const reportRow = {
 		id: messageId,
 		received_at: new Date().toISOString(),
 		org_name: report.org_name ?? null,
@@ -81,8 +81,13 @@ export async function ingestDmarcReport(
 		date_range_begin: report.date_range_begin ?? null,
 		date_range_end: report.date_range_end ?? null,
 		policy_p: report.policy_p ?? null,
+		policy_adkim: report.policy_adkim ?? null,
+		policy_aspf: report.policy_aspf ?? null,
+		policy_sp: report.policy_sp ?? null,
+		policy_pct: report.policy_pct ?? null,
 		raw_r2_key: null,
-	}, report.records.map((r) => ({
+	};
+	const recordsToInsert = report.records.map((r) => ({
 		id: crypto.randomUUID(),
 		source_ip: r.source_ip,
 		count: r.count,
@@ -90,7 +95,9 @@ export async function ingestDmarcReport(
 		dkim_result: r.dkim_result ?? null,
 		spf_result: r.spf_result ?? null,
 		header_from: r.header_from ?? null,
-	})));
+		auth_results_json: r.auth_results ? JSON.stringify(r.auth_results) : null,
+	}));
+	await stub.insertDmarcReport(reportRow, recordsToInsert);
 
 	return { ingested: true };
 }

--- a/workers/dmarc/parser.ts
+++ b/workers/dmarc/parser.ts
@@ -17,7 +17,27 @@ export interface DmarcReport {
 	date_range_end?: string;
 	policy_domain?: string;
 	policy_p?: string;
+	policy_adkim?: string;
+	policy_aspf?: string;
+	policy_sp?: string;
+	policy_pct?: string;
 	records: DmarcRecord[];
+}
+
+export interface DmarcAuthResultDkim {
+	domain?: string;
+	selector?: string;
+	result?: string;
+}
+
+export interface DmarcAuthResultSpf {
+	domain?: string;
+	result?: string;
+}
+
+export interface DmarcAuthResults {
+	dkim: DmarcAuthResultDkim[];
+	spf: DmarcAuthResultSpf[];
 }
 
 export interface DmarcRecord {
@@ -27,6 +47,7 @@ export interface DmarcRecord {
 	dkim_result?: string;
 	spf_result?: string;
 	header_from?: string;
+	auth_results?: DmarcAuthResults;
 }
 
 /** Gunzip an arraybuffer using the runtime's DecompressionStream. */
@@ -70,6 +91,22 @@ export function parseDmarcXml(xml: string): DmarcReport {
 		const source_ip = tag(row, "source_ip")?.trim();
 		if (!source_ip) continue;
 		const countStr = tag(row, "count") ?? "0";
+
+		const authResultsBlock = tag(rec, "auth_results") ?? "";
+		const dkimEntries = allTags(authResultsBlock, "dkim").map((d) => ({
+			domain: tag(d, "domain"),
+			selector: tag(d, "selector"),
+			result: tag(d, "result"),
+		}));
+		const spfEntries = allTags(authResultsBlock, "spf").map((s) => ({
+			domain: tag(s, "domain"),
+			result: tag(s, "result"),
+		}));
+		const auth_results: DmarcAuthResults | undefined =
+			dkimEntries.length > 0 || spfEntries.length > 0
+				? { dkim: dkimEntries, spf: spfEntries }
+				: undefined;
+
 		records.push({
 			source_ip,
 			count: Math.max(0, Math.min(1000000, parseInt(countStr, 10) || 0)),
@@ -77,6 +114,7 @@ export function parseDmarcXml(xml: string): DmarcReport {
 			dkim_result: tag(policyEval, "dkim"),
 			spf_result: tag(policyEval, "spf"),
 			header_from: tag(identifiers, "header_from"),
+			auth_results,
 		});
 	}
 
@@ -87,6 +125,10 @@ export function parseDmarcXml(xml: string): DmarcReport {
 		date_range_end: tag(tag(metadata, "date_range") ?? "", "end"),
 		policy_domain: tag(policy, "domain"),
 		policy_p: tag(policy, "p"),
+		policy_adkim: tag(policy, "adkim"),
+		policy_aspf: tag(policy, "aspf"),
+		policy_sp: tag(policy, "sp"),
+		policy_pct: tag(policy, "pct"),
 		records,
 	};
 }

--- a/workers/durableObject/migrations.ts
+++ b/workers/durableObject/migrations.ts
@@ -498,4 +498,18 @@ export const mailboxMigrations: Migration[] = [
             CREATE INDEX IF NOT EXISTS idx_sender_graph_name ON sender_graph(sender_name);
         `,
 	},
+	{
+		// DMARC policy alignment fields (adkim/aspf/sp/pct) and per-record
+		// auth_results captured from RUA XML (issue #384). Stored on
+		// dmarc_reports for policy posture display; auth_results_json on
+		// dmarc_records enables per-source drill-down of DKIM/SPF selectors.
+		name: "23_dmarc_policy_auth_results",
+		sql: `
+            ALTER TABLE dmarc_reports ADD COLUMN policy_adkim TEXT;
+            ALTER TABLE dmarc_reports ADD COLUMN policy_aspf TEXT;
+            ALTER TABLE dmarc_reports ADD COLUMN policy_sp TEXT;
+            ALTER TABLE dmarc_reports ADD COLUMN policy_pct TEXT;
+            ALTER TABLE dmarc_records ADD COLUMN auth_results_json TEXT;
+        `,
+	},
 ];

--- a/workers/routes/dmarc.ts
+++ b/workers/routes/dmarc.ts
@@ -24,7 +24,15 @@ dmarcRoutes.get("/reports", async (c) => {
 
 dmarcRoutes.get("/reports/:reportId/records", async (c) => {
 	const reportId = c.req.param("reportId");
-	const records = await c.var.mailboxStub.getDmarcRecords(reportId);
+	const raw = await c.var.mailboxStub.getDmarcRecords(reportId);
+	const records = raw.map((r) => {
+		const { auth_results_json, ...rest } = r as typeof r & { auth_results_json?: string | null };
+		let auth_results: unknown = null;
+		if (auth_results_json) {
+			try { auth_results = JSON.parse(auth_results_json); } catch { /* malformed — leave null */ }
+		}
+		return { ...rest, auth_results };
+	});
 	return c.json({ records });
 });
 


### PR DESCRIPTION
## Summary

Closes #384

- **Parser**: `DmarcReport` gains `policy_adkim/aspf/sp/pct`; `DmarcRecord` gains `auth_results` (DKIM domain/selector/result + SPF domain/result) extracted from the RUA XML `<auth_results>` block (RFC 7489 §7.2).
- **Schema + migration**: `dmarc_reports` gets four nullable text columns (`policy_adkim/aspf/sp/pct`); `dmarc_records` gets `auth_results_json TEXT`; migration `23_dmarc_policy_auth_results` adds all five via `ALTER TABLE`.
- **Ingest**: `ingest.ts` passes new fields through a typed variable (avoids TS excess-property check); `auth_results` serialised as JSON string on insert.
- **API**: `GET /reports/:reportId/records` now deserialises `auth_results_json` before returning, exposing structured DKIM/SPF data to clients.
- **Dashboard** (`app/routes/dmarc.tsx`): adds a policy-alignment badge row (`adkim`/`aspf`/`sp`/`pct`) beneath the domain/range controls; source rows are now clickable — selecting one opens an inline drill-down panel showing DKIM/SPF auth detail per report.
- **Tests**: 6 new assertions in `parser.test.ts` covering policy fields, `auth_results` parsing, selector extraction, multi-entry DKIM, and the missing-`<auth_results>`-block edge case (12 tests total, all green).

## Test plan

- [ ] `npm test` — all existing + 6 new parser tests pass
- [ ] `npm run typecheck` — no errors
- [ ] DMARC dashboard: policy badge row appears for domains with alignment fields in ingested reports
- [ ] Clicking a source IP row opens drill-down panel; clicking again or ✕ closes it
- [ ] Drill-down shows DKIM domains/selectors/results and SPF domains/results per report period
- [ ] Records with no `<auth_results>` block render no auth detail (no crash)

https://claude.ai/code/session_01Uqvt1cBFXbAdxSb2MNz2Kh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uqvt1cBFXbAdxSb2MNz2Kh)_