### PR TITLE
feat: wire DMARC time-series chart to 7d/30d/90d range selector

### DIFF
--- a/app/routes/dmarc.tsx
+++ b/app/routes/dmarc.tsx
@@ -260,11 +260,11 @@ export default function DmarcRoute() {
 	useEffect(() => {
 		if (!mailboxId || !domain) return;
 		setTimeseries(null);
-		fetch(`/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/dmarc/timeseries?domain=${encodeURIComponent(domain)}`)
+		fetch(`/api/v1/mailboxes/${encodeURIComponent(mailboxId)}/dmarc/timeseries?domain=${encodeURIComponent(domain)}&days=${days}`)
 			.then((r) => r.json() as Promise<{ timeseries: DmarcTimeSeriesPoint[] }>)
 			.then((r) => setTimeseries(r.timeseries))
 			.catch((e) => console.error("dmarc timeseries fetch failed", e));
-	}, [mailboxId, domain]);
+	}, [mailboxId, domain, days]);
 
 	const domains = useMemo(() => {
 		if (!reports) return [];
@@ -438,7 +438,7 @@ export default function DmarcRoute() {
 			)}
 
 			<section className="mb-8">
-				<h2 className="text-sm font-semibold text-ink mb-3">Daily aligned vs failing (90 days)</h2>
+				<h2 className="text-sm font-semibold text-ink mb-3">Daily aligned vs failing (last {days} days)</h2>
 				{!timeseries ? (
 					<div className="text-ink-3 text-sm">Loading…</div>
 				) : timeseries.length === 0 ? (

--- a/tests/routes/dmarc-timeseries.test.ts
+++ b/tests/routes/dmarc-timeseries.test.ts
@@ -266,4 +266,59 @@ describe("GET /timeseries", () => {
 		const body = await res.json() as { timeseries: unknown[] };
 		expect(body.timeseries).toEqual([]);
 	});
+
+	it("defaults to 90-day window when ?days is absent", async () => {
+		// Plant one record 89 days ago (within default window) and one 91 days ago (outside).
+		const now = Date.now();
+		const within = new Date(now - 89 * 24 * 60 * 60 * 1000).toISOString();
+		const outside = new Date(now - 91 * 24 * 60 * 60 * 1000).toISOString();
+		const records: FakeDmarcRecord[] = [
+			{ domain: "test.com", received_at: within, count: 5, dkim_result: "pass", spf_result: "fail" },
+			{ domain: "test.com", received_at: outside, count: 3, dkim_result: "pass", spf_result: "fail" },
+		];
+		const app = makeApp(records);
+		const res = await app.fetch("/timeseries?domain=test.com");
+		expect(res.status).toBe(200);
+		const body = await res.json() as { timeseries: { day: string; aligned: number; failing: number }[] };
+		// Only the within-window record should appear.
+		expect(body.timeseries).toHaveLength(1);
+		expect(body.timeseries[0].aligned).toBe(5);
+	});
+
+	it("respects ?days=7 and excludes records older than 7 days", async () => {
+		const now = Date.now();
+		const within = new Date(now - 6 * 24 * 60 * 60 * 1000).toISOString();
+		const outside = new Date(now - 8 * 24 * 60 * 60 * 1000).toISOString();
+		const records: FakeDmarcRecord[] = [
+			{ domain: "test.com", received_at: within, count: 2, dkim_result: "pass", spf_result: "fail" },
+			{ domain: "test.com", received_at: outside, count: 9, dkim_result: "pass", spf_result: "fail" },
+		];
+		const app = makeApp(records);
+		const res = await app.fetch("/timeseries?domain=test.com&days=7");
+		expect(res.status).toBe(200);
+		const body = await res.json() as { timeseries: { day: string; aligned: number; failing: number }[] };
+		expect(body.timeseries).toHaveLength(1);
+		expect(body.timeseries[0].aligned).toBe(2);
+	});
+
+	it("clamps ?days above 365 to 365", async () => {
+		const now = Date.now();
+		// A record 364 days ago — always within a 365-day (or larger) window.
+		const within = new Date(now - 364 * 24 * 60 * 60 * 1000).toISOString();
+		const records: FakeDmarcRecord[] = [
+			{ domain: "test.com", received_at: within, count: 1, dkim_result: "pass", spf_result: "fail" },
+		];
+		const app = makeApp(records);
+		const res = await app.fetch("/timeseries?domain=test.com&days=9999");
+		expect(res.status).toBe(200);
+		const body = await res.json() as { timeseries: { day: string; aligned: number; failing: number }[] };
+		// Clamped to 365 — the 364-day-old record is still within window.
+		expect(body.timeseries).toHaveLength(1);
+	});
+
+	it("falls back to the default when ?days is not a valid number", async () => {
+		const app = makeApp([]);
+		const res = await app.fetch("/timeseries?domain=test.com&days=abc");
+		expect(res.status).toBe(200);
+	});
 });

--- a/workers/routes/dmarc.ts
+++ b/workers/routes/dmarc.ts
@@ -87,15 +87,12 @@ dmarcRoutes.patch("/sources/:sourceIp", async (c) => {
 	return c.json({ ok: true });
 });
 
-/** Window constant mirrors `DMARC_ALIGNMENT_WINDOW_DAYS` in workers/index.ts. */
-const TIMESERIES_WINDOW_DAYS = 90;
-
 dmarcRoutes.get("/timeseries", async (c) => {
 	const domain = c.req.query("domain");
 	if (!domain) return c.json({ error: "domain query param required" }, 400);
-	const sinceIso = new Date(
-		Date.now() - TIMESERIES_WINDOW_DAYS * 24 * 60 * 60 * 1000,
-	).toISOString();
+	const rawDays = Number(c.req.query("days") ?? DMARC_SUMMARY_DEFAULT_DAYS);
+	const days = Math.min(Math.max(Number.isFinite(rawDays) ? rawDays : DMARC_SUMMARY_DEFAULT_DAYS, 1), DMARC_SUMMARY_MAX_DAYS);
+	const sinceIso = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
 	const timeseries = await c.var.mailboxStub.getDmarcTimeSeries(domain, sinceIso);
 	return c.json({ domain, timeseries });
 });


### PR DESCRIPTION
## Summary

- `/dmarc/timeseries` now reads `?days=` and clamps to `[1, 365]`, defaulting to 90 — matching the `/summary` pattern exactly. `TIMESERIES_WINDOW_DAYS` removed.
- Frontend `useEffect` appends `&days=${days}` to the timeseries fetch URL and adds `days` to the deps array, so changing the range selector re-fetches the chart.
- Chart section header updated from the hardcoded `"(90 days)"` to `"(last N days)"` reflecting the active selection.

Closes #402.

## Test plan
- [x] `npm test` — 1281 passing, 0 failing
- [x] `npm run typecheck` — clean

## Choices made

- Reused `DMARC_SUMMARY_DEFAULT_DAYS` / `DMARC_SUMMARY_MAX_DAYS` constants rather than introducing new ones — keeps the two endpoints in sync and removes duplication.

https://claude.ai/code/session_01DLd1YGVKGT31sNumJCbJ4H

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLd1YGVKGT31sNumJCbJ4H)_