### PR TITLE
docs: correct CodeGuard license note from MIT to Apache-2.0

### DIFF
--- a/docs/codeguard-evaluation.md
+++ b/docs/codeguard-evaluation.md
@@ -2,7 +2,7 @@
 
 **Decision:** Partial-adopt — three rule categories installed under `.claude/rules/`  
 **Date:** 2026-05-25 · **Issue:** #321  
-**License:** CodeGuard is [CC BY 4.0](https://github.com/cosai-oasis/project-codeguard/blob/main/LICENSE.md). Vendored rule content in `.claude/rules/` is attributed at the file head. Compatible with this repo's MIT license (attribution-only requirement; no copyleft).
+**License:** CodeGuard is [CC BY 4.0](https://github.com/cosai-oasis/project-codeguard/blob/main/LICENSE.md). Vendored rule content in `.claude/rules/` is attributed at the file head. Compatible with this repo's Apache-2.0 license (CC BY 4.0 is attribution-only with no copyleft; satisfies Apache-2.0's attribution/NOTICE requirements).
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix `docs/codeguard-evaluation.md` license note that incorrectly described PhishSOC as MIT-licensed; the repo is Apache-2.0.

## Why

`docs/codeguard-evaluation.md:5` stated the vendored CC BY 4.0 rule content is "Compatible with this repo's MIT license (attribution-only requirement; no copyleft)." That is factually wrong — PhishSOC is licensed **Apache-2.0** (`package.json` → `"license": "Apache-2.0"`; root `LICENSE` is the Apache License Version 2.0).

The compatibility conclusion is unchanged and still holds: CC BY 4.0 is attribution-only with no copyleft, which satisfies Apache-2.0's attribution/NOTICE requirements. The line now reads:

> Compatible with this repo's Apache-2.0 license (CC BY 4.0 is attribution-only with no copyleft; satisfies Apache-2.0's attribution/NOTICE requirements).

Scope check: `git grep -iE 'mit[- ]licen'` across all tracked files returns nothing — no other committed doc claimed an MIT license. (Other "MIT" hits in the tree are unrelated: a `.envrc` comment in `README.md` and "MITM'd" in `SECURITY_SPEC.md`.)

## Test plan

- [ ] `npm run typecheck` — n/a (docs-only change, no code touched)
- [ ] `npm test` — n/a (docs-only change)
- [x] Verified `package.json` license is `Apache-2.0` and root `LICENSE` is Apache 2.0
- [x] `git grep -iE 'mit[- ]licen'` confirms no committed doc claims MIT after the fix

## Notes for reviewer

Single-line documentation correction. No functional impact.