### PR TITLE
security: constrain IntelFeed.auth_secret to FEED_SECRET_ prefix at schema layer (#418)

### DIFF
--- a/shared/mailbox-settings.ts
+++ b/shared/mailbox-settings.ts
@@ -95,7 +95,7 @@ export const IntelFeed = z
     kind: z.enum(["domain", "url", "ip-cidr"]).optional(),
     refresh_hours: z.number().optional(),
     headers: z.record(z.string(), z.string()).optional(),
-    auth_secret: z.string().optional(),
+    auth_secret: z.string().min(1).startsWith("FEED_SECRET_", { message: "Secret name must start with FEED_SECRET_" }).optional(),
   })
   .passthrough();
 

--- a/tests/agent/settings.test.ts
+++ b/tests/agent/settings.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
 
 import { describe, expect, it } from "vitest";
-import { MailboxSettings } from "../../shared/mailbox-settings";
+import { IntelFeed, MailboxSettings } from "../../shared/mailbox-settings";
 
 describe("MailboxSettings", () => {
   // Post-#106: schema-layer defaults are deliberately gone. The resolver in
@@ -169,5 +169,38 @@ describe("MailboxSettings", () => {
       security: { classification: { skip_on_timeout: "yes" } },
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe("IntelFeed schema — auth_secret FEED_SECRET_ prefix (#418)", () => {
+  it("rejects a non-FEED_SECRET_ auth_secret at parse time", () => {
+    const result = IntelFeed.safeParse({ id: "feed-1", auth_secret: "MASTER_DB_PASSWORD" });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an absent auth_secret (optional — no Authorization header sent)", () => {
+    const result = IntelFeed.safeParse({ id: "feed-1" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.auth_secret).toBeUndefined();
+  });
+
+  it("accepts a valid FEED_SECRET_* auth_secret", () => {
+    const result = IntelFeed.safeParse({ id: "feed-1", auth_secret: "FEED_SECRET_THREATFOX" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.auth_secret).toBe("FEED_SECRET_THREATFOX");
+  });
+
+  it("rejects a non-FEED_SECRET_ auth_secret nested via MailboxSettings.intel.feeds", () => {
+    const result = MailboxSettings.safeParse({
+      intel: { feeds: [{ id: "feed-1", auth_secret: "MASTER_DB_PASSWORD" }] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a valid FEED_SECRET_* value nested via MailboxSettings.intel.feeds", () => {
+    const result = MailboxSettings.safeParse({
+      intel: { feeds: [{ id: "feed-1", auth_secret: "FEED_SECRET_OPENPHISH" }] },
+    });
+    expect(result.success).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `.min(1).startsWith("FEED_SECRET_", { message: "..." })` to `IntelFeed.auth_secret` in `shared/mailbox-settings.ts` so a non-prefixed value (e.g. `"MASTER_DB_PASSWORD"`) is rejected at parse time with a 400, not silently stored.
- Mirrors the `PEER_SECRET_` schema-layer pattern from `hub/src/routes/admin.ts` (PR #372) and parallels the `HubConfig.api_key_secret_name` constraint from PR #415.
- The runtime guard in `workers/intel/feeds.ts:93` is preserved as belt-and-suspenders.

Closes #418.

## Test plan

- [x] `npm test` — 1290 passing, 0 failing
- [x] `npm run typecheck` — clean

## Choices made

- Added a human-readable `.message` to `startsWith()` (same as the `hub/src/routes/admin.ts` `PEER_SECRET_` precedent) so the Zod parse error is actionable rather than generic.

https://claude.ai/code/session_01EDHFEhTzZbZUr5Zqd6jqhF

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDHFEhTzZbZUr5Zqd6jqhF)_