### PR TITLE
feat(security): catchall no-AI analyzer — Core B (epic #423)

### DIFF
--- a/test/security/catchall.test.ts
+++ b/test/security/catchall.test.ts
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Unit tests for `analyzeCatchall`.
+ *
+ * Key invariants verified:
+ *   - `env.AI` is NEVER invoked (asserted by a throwing stub)
+ *   - Auth failures score correctly
+ *   - Homograph and shortener URLs score correctly
+ *   - CrowdSec CTI reputation contributes to score
+ *   - All-clean email scores 0
+ *   - All external CTI calls are intercepted; suite is hermetic
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { analyzeCatchall } from "../../workers/security/catchall";
+import type { Env } from "../../workers/types";
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function makeAuthHeaders(opts: {
+	spf?: string;
+	dkim?: string;
+	dmarc?: string;
+	authserv?: string;
+}): unknown[] {
+	const { spf = "pass", dkim = "pass", dmarc = "pass", authserv = "mx.example.com" } = opts;
+	const value = `${authserv}; spf=${spf} header.from=example.com; dkim=${dkim} header.d=example.com header.s=sel1; dmarc=${dmarc} header.from=example.com`;
+	return [{ key: "authentication-results", value }];
+}
+
+/** No authentication-results header → auth score = 0, no boost or deduction. */
+function noAuthHeaders(): unknown[] {
+	return [];
+}
+
+function makeReceivedHeaders(ip: string): unknown[] {
+	return [{ key: "received", value: `from mail.attacker.net ([${ip}]) by mx.example.com` }];
+}
+
+/** AI stub that throws if invoked — verifies the catch-all path never calls it. */
+const AI_NEVER_CALLED = {
+	run() {
+		throw new Error("env.AI must never be invoked on the catch-all path");
+	},
+} as unknown as Ai;
+
+function makeEnv(opts: { apiKey?: string } = {}): Env {
+	return {
+		AI: AI_NEVER_CALLED,
+		CROWDSEC_CTI_API_KEY: opts.apiKey,
+	} as unknown as Env;
+}
+
+function ctiResponse(reputation: string, status = 200): Response {
+	const body = {
+		reputation,
+		classifications: [],
+		behaviors: [],
+		scores: { overall: { threat: 50, aggressiveness: 30, trust: 20 } },
+	};
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("analyzeCatchall — no-AI invariant", () => {
+	it("does not invoke env.AI even when auth or URLs are suspicious", async () => {
+		const result = await analyzeCatchall({
+			parsedEmail: {
+				headers: makeAuthHeaders({ dmarc: "fail", spf: "fail", dkim: "fail" }),
+				html: '<a href="http://goog1e.com/login">click</a>',
+			},
+			env: makeEnv(),
+		});
+		// If AI_NEVER_CALLED.run() had fired, the test would have thrown.
+		expect(result.score).toBeGreaterThan(0);
+	});
+});
+
+describe("analyzeCatchall — auth scoring", () => {
+	it("clean email (all pass) scores 0 from auth", async () => {
+		const result = await analyzeCatchall({
+			parsedEmail: {
+				headers: makeAuthHeaders({ spf: "pass", dkim: "pass", dmarc: "pass" }),
+				html: "<p>Hello</p>",
+			},
+			env: makeEnv(),
+		});
+		expect(result.score).toBe(0);
+		expect(result.signals).toHaveLength(0);
+	});
+
+	it("DMARC fail contributes +20", async () => {
+		const result = await analyzeCatchall({
+			parsedEmail: {
+				headers: makeAuthHeaders({ dmarc: "fail" }),
+			},
+			env: makeEnv(),
+		});
+		// DMARC fail = +20, capped at 30 total by scoreAuth
+		expect(result.score).toBe(20);
+		expect(result.signals).toContain("DMARC failed");
+		expect(result.auth.dmarc).toBe("fail");
+	});
+
+	it("SPF + DKIM fail contribute up to 30 (scoreAuth cap)", async () => {
+		const result = await analyzeCatchall({
+			parsedEmail: {
+				headers: makeAuthHeaders({ spf: "fail", dkim: "fail", dmarc: "fail" }),
+			},
+			env: makeEnv(),
+		});
+		// DMARC(20) + SPF(10) + DKIM(10) = 40, but scoreAuth caps at 30
+		expect(result.score).toBe(30);
+		expect(result.auth.spf).toBe("fail");
+		expect(result.auth.dkim).toBe("fail");
+	});
+});
+
+describe("analyzeCatchall — URL heuristics", () => {
+	it("homograph URL contributes +20", async () => {
+		// No auth headers → auth score 0, isolating the URL signal.
+		const result = await analyzeCatchall({
+			parsedEmail: {
+				headers: noAuthHeaders(),
+				html: '<a href="http://goog1e.com/login">login</a>',
+			},
+			env: makeEnv(),
+		});
+		expect(result.score).toBe(20);
+		expect(result.signals.some((s) => s.includes("homograph"))).toBe(true);
+		expect(result.homographUrls).toBe(1);
+	});
+
+	it("shortener link contributes +5", async () => {
+		// No auth headers → auth score 0, isolating the URL signal.
+		const result = await analyzeCatchall({
+			parsedEmail: {
+				headers: noAuthHeaders(),
+				html: '<a href="https://bit.ly/xyz123">click</a>',
+			},
+			env: makeEnv(),
+		});
+		expect(result.score).toBe(5);
+		expect(result.shortenerUrls).toBe(1);
+	});
+
+	it("urlCount matches extracted links", async () => {
+		const result = await analyzeCatchall({
+			parsedEmail: {
+				headers: makeAuthHeaders({}),
+				html: '<a href="https://example.com">a</a><a href="https://example.org">b</a>',
+			},
+			env: makeEnv(),
+		});
+		expect(result.urlCount).toBe(2);
+	});
+
+	it("no body → urlCount 0 and no URL signals", async () => {
+		const result = await analyzeCatchall({
+			parsedEmail: { headers: makeAuthHeaders({}) },
+			env: makeEnv(),
+		});
+		expect(result.urlCount).toBe(0);
+		expect(result.homographUrls).toBe(0);
+		expect(result.shortenerUrls).toBe(0);
+	});
+});
+
+describe("analyzeCatchall — CrowdSec CTI", () => {
+	const MALICIOUS_IP = "1.2.3.4";
+
+	beforeEach(() => {
+		vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+			const url = typeof input === "string" ? input : (input as Request).url;
+			const u = new URL(url);
+			if (u.hostname === "cti.api.crowdsec.net" && u.pathname.startsWith("/v2/smoke/")) {
+				return ctiResponse("malicious");
+			}
+			return new Response("not found", { status: 404 });
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("malicious CTI reputation adds +20 to score", async () => {
+		// No auth headers → auth score 0, isolating the CTI signal.
+		const result = await analyzeCatchall({
+			parsedEmail: {
+				headers: [
+					...noAuthHeaders(),
+					...makeReceivedHeaders(MALICIOUS_IP),
+				],
+			},
+			env: makeEnv({ apiKey: "test-key" }),
+		});
+		expect(result.score).toBe(20);
+		expect(result.ctiReputation).toBe("malicious");
+		expect(result.senderIp).toBe(MALICIOUS_IP);
+		expect(result.signals.some((s) => s.includes("malicious"))).toBe(true);
+	});
+
+	it("no API key → skips CTI, ctiReputation is null", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		const result = await analyzeCatchall({
+			parsedEmail: {
+				headers: [
+					...noAuthHeaders(),
+					...makeReceivedHeaders(MALICIOUS_IP),
+				],
+			},
+			env: makeEnv(),
+		});
+		expect(result.ctiReputation).toBeNull();
+		// CTI fetch must NOT be called when key is absent
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("CTI network failure is swallowed, score unaffected", async () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network error"));
+		const result = await analyzeCatchall({
+			parsedEmail: {
+				headers: [
+					...noAuthHeaders(),
+					...makeReceivedHeaders(MALICIOUS_IP),
+				],
+			},
+			env: makeEnv({ apiKey: "test-key" }),
+		});
+		expect(result.ctiReputation).toBeNull();
+		expect(result.score).toBe(0);
+	});
+});
+
+describe("analyzeCatchall — result shape", () => {
+	it("returns all documented fields", async () => {
+		const result = await analyzeCatchall({
+			parsedEmail: {
+				headers: makeAuthHeaders({}),
+			},
+			env: makeEnv(),
+		});
+		expect(result).toMatchObject({
+			score: expect.any(Number),
+			signals: expect.any(Array),
+			auth: expect.objectContaining({ spf: expect.any(String) }),
+			urlCount: expect.any(Number),
+			homographUrls: expect.any(Number),
+			shortenerUrls: expect.any(Number),
+			ctiReputation: null,
+		});
+	});
+
+	it("score is clamped to 0..100", async () => {
+		const result = await analyzeCatchall({
+			parsedEmail: {
+				// All-fail auth + homograph URL — well over 100 raw
+				headers: makeAuthHeaders({ spf: "fail", dkim: "fail", dmarc: "fail" }),
+				html: '<a href="http://goog1e.com">x</a>',
+			},
+			env: makeEnv(),
+		});
+		expect(result.score).toBeGreaterThanOrEqual(0);
+		expect(result.score).toBeLessThanOrEqual(100);
+	});
+});

--- a/workers/security/catchall.ts
+++ b/workers/security/catchall.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Catch-all probe analyzer — no AI, no EmailAgent, no R2 writes.
+ *
+ * Composes the pure heuristic scorers from the synchronous security pipeline
+ * (auth + URL heuristics) with CrowdSec CTI IP reputation. Intentionally
+ * omits the LLM classifier, attachment OCR, and per-mailbox sender-reputation
+ * store — catch-all mail is unsolicited and attacker-shaped; feeding it to
+ * the classifier would inflate costs and pollute per-mailbox state.
+ *
+ * Spamhaus DROP/EDROP lookup is deferred to Follow-up F: `checkIpAgainstFeeds`
+ * is `mailboxId`-scoped and needs domain-level feed resolution before it can
+ * be called from the catch-all path.
+ */
+
+import type { Env } from "../types";
+import {
+	parseAuthResults,
+	extractReceivedFromIp,
+	scoreAuth,
+	type AuthVerdict,
+} from "./auth";
+import { extractUrls, scoreUrls } from "./urls";
+import { lookupIp, type CtiSummary } from "../intel/crowdsec-cti";
+import { firstTimeSenderPriorFromCti } from "./reputation";
+
+export interface CatchallInput {
+	parsedEmail: {
+		/** Raw headers array as produced by PostalMime. */
+		headers: unknown;
+		from?: { address?: string; name?: string };
+		html?: string;
+		text?: string;
+	};
+	env: Env;
+}
+
+export interface CatchallAnalysisResult {
+	/** Aggregate threat score, 0–100. */
+	score: number;
+	/** Human-readable signal labels (auth fail, homograph, CTI reputation). */
+	signals: string[];
+	auth: AuthVerdict;
+	/** Originating external IP extracted from `Received:` headers, if found. */
+	senderIp: string | undefined;
+	urlCount: number;
+	homographUrls: number;
+	shortenerUrls: number;
+	/** CrowdSec CTI reputation bucket, or null when CTI is unconfigured / returned no data. */
+	ctiReputation: CtiSummary["reputation"] | null;
+}
+
+/**
+ * Analyze a catch-all probe email without invoking the LLM or accessing any
+ * mailbox Durable Object. Returns a scored result suitable for persistence by
+ * `CatchallIntelDO` (Core C).
+ *
+ * Never throws: all external lookups (CrowdSec CTI) are wrapped. A transient
+ * CTI failure returns null for `ctiReputation` without degrading the auth or
+ * URL portions of the score.
+ */
+export async function analyzeCatchall(
+	input: CatchallInput,
+): Promise<CatchallAnalysisResult> {
+	const { parsedEmail, env } = input;
+	const signals: string[] = [];
+
+	// ── Stage 1: auth (SPF / DKIM / DMARC) ────────────────────────────
+	const auth = parseAuthResults(parsedEmail.headers);
+	const authResult = scoreAuth(auth);
+	signals.push(...authResult.reasons);
+
+	// ── Stage 2: URL heuristics ────────────────────────────────────────
+	const body = parsedEmail.html ?? parsedEmail.text ?? "";
+	const urls = extractUrls(body);
+	const urlResult = scoreUrls(urls);
+	signals.push(...urlResult.reasons);
+
+	// ── Stage 3: CrowdSec CTI IP reputation ───────────────────────────
+	// Only runs when the API key is configured; absent key is a no-op.
+	const senderIp = extractReceivedFromIp(parsedEmail.headers);
+	let ctiReputation: CtiSummary["reputation"] | null = null;
+	let ctiScore = 0;
+
+	if (senderIp && env.CROWDSEC_CTI_API_KEY) {
+		const summary = await lookupIp(env, senderIp).catch(() => null);
+		if (summary) {
+			ctiReputation = summary.reputation;
+			const prior = firstTimeSenderPriorFromCti(senderIp, summary);
+			ctiScore = prior.score;
+			signals.push(prior.reason);
+		}
+	}
+
+	const score = Math.min(100, Math.max(0, authResult.score + urlResult.score + ctiScore));
+
+	return {
+		score,
+		signals,
+		auth,
+		senderIp,
+		urlCount: urls.length,
+		homographUrls: urls.filter((u) => u.is_homograph).length,
+		shortenerUrls: urls.filter((u) => u.is_shortener).length,
+		ctiReputation,
+	};
+}


### PR DESCRIPTION
## Summary

- Adds `analyzeCatchall` in `workers/security/catchall.ts`: a no-LLM, no-EmailAgent probe analyzer for mail that hits an unregistered local-part on an owned domain.
- Composes existing heuristic scorers: `parseAuthResults`/`scoreAuth` (SPF/DKIM/DMARC), `extractUrls`/`scoreUrls` (homograph + shortener detection), and CrowdSec CTI IP reputation via `lookupIp`/`firstTimeSenderPriorFromCti`.
- 13 tests in `test/security/catchall.test.ts` assert the no-AI invariant (`env.AI` throws if invoked), per-signal scoring, and CTI network-failure resilience.

Part of #423.

## Test plan

- [x] `npm test` — 1303 passing, 0 failing (includes 13 new catchall tests)
- [x] `npm run typecheck` — clean

## Choices made

- Spamhaus DROP/EDROP lookup deferred to Follow-up F (#435): `checkIpAgainstFeeds` is `mailboxId`-scoped; a domain-scoped variant needs its own issue.
- Auth score can go negative (DMARC pass deducts 10) — this is correct per `scoreAuth`'s design; `Math.max(0, ...)` in the final score prevents the output from going below zero.

## Deferred

Child issues for the remaining cores and follow-ups, filed and linked to #423:

- Core C — `CatchallIntelDO` per-domain rollup store → #432
- Core D — domain setting + normalizer dispatch + `receiveCatchall` → #433
- Core E — read API + domain dashboard card → #434
- Follow-up F — domain-scoped URL bloom-feed matching → #435
- Follow-up G — directory-harvest alerting → #436
- Follow-up H — hub reporting for high-score probes → #437
- Follow-up I — async deep-scan for high-score probes → #438


---
_Generated by [Claude Code](https://claude.ai/code/session_01M5gksYrrhHeAZQcXuQGm8L)_