### PR TITLE
feat(intel): directory-harvest alerting from catch-all probe rollups

### DIFF
--- a/shared/domain-settings.ts
+++ b/shared/domain-settings.ts
@@ -8,6 +8,30 @@ import {
 } from "./mailbox-settings";
 
 /**
+ * Per-domain catch-all probe capture and harvest-alert settings (#423 epic).
+ *
+ * - `enabled` / `retention_days` / `sample_limit` govern what `CatchallIntelDO`
+ *   stores (wired in #426).
+ * - `harvest_alert_threshold` / `harvest_alert_window_minutes` govern when
+ *   `computeHarvestAlerts` fires an alert (this issue, #429).
+ *
+ * All fields are optional so absent-key-inherits semantics are preserved.
+ * Defaults live in `workers/intel/catchall-alert.ts` (alert fields) and in
+ * the wiring layer of #426 (capture fields), not on this schema.
+ */
+export const CatchallIntelSettings = z
+	.object({
+		enabled: z.boolean().optional(),
+		retention_days: z.number().int().positive().optional(),
+		sample_limit: z.number().int().positive().optional(),
+		harvest_alert_threshold: z.number().int().positive().optional(),
+		harvest_alert_window_minutes: z.number().int().positive().optional(),
+	})
+	.passthrough();
+
+export type CatchallIntelSettings = z.infer<typeof CatchallIntelSettings>;
+
+/**
  * Per-domain settings stored at R2 key `domains/<domain>.json` (#142).
  *
  * Sits between mailbox and org in the inheritance hierarchy:
@@ -41,6 +65,7 @@ export const DomainSettings = z
 		agentModel: z.string().optional(),
 		security: SecuritySettings.optional(),
 		intel: IntelSettings.optional(),
+		catchall_intel: CatchallIntelSettings.optional(),
 	})
 	.passthrough();
 

--- a/tests/intel/catchall-alert.test.ts
+++ b/tests/intel/catchall-alert.test.ts
@@ -1,0 +1,291 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, expect, it } from "vitest";
+
+import {
+	computeHarvestAlerts,
+	DEFAULT_HARVEST_ALERT_CONFIG,
+	resolveAlertConfig,
+	type AlertDebounceStore,
+	type HarvestAlertConfig,
+	type ProbeRollupEntry,
+} from "../../workers/intel/catchall-alert";
+
+// ── In-memory AlertDebounceStore ──────────────────────────────────────────────
+
+/** Record shape stored in the fake — tracks when an alert was last recorded. */
+interface AlertRecord {
+	alertedAt: string;
+	distinctCount: number;
+}
+
+/**
+ * Fake debounce store backed by a plain Map. `getLastAlertTime` replicates the
+ * window-expiry check that the real `CatchallIntelDO` implementation will do.
+ */
+function makeDebounceStore(): AlertDebounceStore & {
+	_alerts: Map<string, AlertRecord>;
+} {
+	const _alerts = new Map<string, AlertRecord>();
+
+	return {
+		_alerts,
+
+		async getLastAlertTime(
+			sourceIp: string,
+			senderDomain: string,
+			windowMinutes: number,
+		): Promise<string | null> {
+			const key = `${sourceIp}|${senderDomain}`;
+			const record = _alerts.get(key);
+			if (!record) return null;
+			const cutoff = new Date(
+				new Date(record.alertedAt).getTime() + windowMinutes * 60_000,
+			);
+			const now = new Date();
+			return now < cutoff ? record.alertedAt : null;
+		},
+
+		async recordAlertTime(
+			sourceIp: string,
+			senderDomain: string,
+			alertedAt: string,
+			distinctCount: number,
+		): Promise<void> {
+			_alerts.set(`${sourceIp}|${senderDomain}`, { alertedAt, distinctCount });
+		},
+	};
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeRollup(overrides: Partial<ProbeRollupEntry> = {}): ProbeRollupEntry {
+	return {
+		source_ip: "1.2.3.4",
+		sender_domain: "spam.example",
+		count: 200,
+		distinct_localparts: 100,
+		max_score: 75,
+		first_seen: "2026-06-05T10:00:00Z",
+		last_seen: "2026-06-05T10:30:00Z",
+		...overrides,
+	};
+}
+
+const defaultConfig: HarvestAlertConfig = {
+	threshold: 50,
+	window_minutes: 60,
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("computeHarvestAlerts", () => {
+	it("returns no alerts for an empty rollup list", async () => {
+		const store = makeDebounceStore();
+		const alerts = await computeHarvestAlerts([], defaultConfig, store);
+		expect(alerts).toEqual([]);
+	});
+
+	it("returns no alert when distinct_localparts is below threshold", async () => {
+		const store = makeDebounceStore();
+		const rollup = makeRollup({ distinct_localparts: 49 });
+		const alerts = await computeHarvestAlerts([rollup], defaultConfig, store);
+		expect(alerts).toEqual([]);
+	});
+
+	it("returns no alert when distinct_localparts equals threshold minus 1", async () => {
+		const store = makeDebounceStore();
+		const rollup = makeRollup({ distinct_localparts: defaultConfig.threshold - 1 });
+		const alerts = await computeHarvestAlerts([rollup], defaultConfig, store);
+		expect(alerts).toHaveLength(0);
+	});
+
+	it("raises an alert when distinct_localparts meets the threshold", async () => {
+		const store = makeDebounceStore();
+		const rollup = makeRollup({ distinct_localparts: defaultConfig.threshold });
+		const now = new Date("2026-06-05T12:00:00Z");
+		const alerts = await computeHarvestAlerts([rollup], defaultConfig, store, now);
+
+		expect(alerts).toHaveLength(1);
+		expect(alerts[0]).toMatchObject({
+			source_ip: "1.2.3.4",
+			sender_domain: "spam.example",
+			distinct_localpart_count: defaultConfig.threshold,
+			triggered_at: now.toISOString(),
+		});
+	});
+
+	it("raises an alert when distinct_localparts exceeds the threshold", async () => {
+		const store = makeDebounceStore();
+		const rollup = makeRollup({ distinct_localparts: 200 });
+		const alerts = await computeHarvestAlerts([rollup], defaultConfig, store);
+		expect(alerts).toHaveLength(1);
+		expect(alerts[0].distinct_localpart_count).toBe(200);
+	});
+
+	it("debounces: does not raise a second alert within the window", async () => {
+		const store = makeDebounceStore();
+		const rollup = makeRollup({ distinct_localparts: 100 });
+
+		// First call — should alert and record in the store with current time.
+		const first = await computeHarvestAlerts([rollup], defaultConfig, store);
+		expect(first).toHaveLength(1);
+
+		// Second call immediately after — the recorded alert is within the 60-min
+		// window so it should be debounced.
+		const second = await computeHarvestAlerts([rollup], defaultConfig, store);
+		expect(second).toHaveLength(0);
+	});
+
+	it("re-raises after the debounce window expires", async () => {
+		const store = makeDebounceStore();
+		const rollup = makeRollup({ distinct_localparts: 100 });
+
+		// Seed an alert that is 61 minutes in the past (outside the 60-min window)
+		const pastAlert = new Date(Date.now() - 61 * 60_000).toISOString();
+		store._alerts.set("1.2.3.4|spam.example", {
+			alertedAt: pastAlert,
+			distinctCount: 100,
+		});
+
+		const alerts = await computeHarvestAlerts([rollup], defaultConfig, store);
+		expect(alerts).toHaveLength(1);
+	});
+
+	it("alerts for multiple sources independently", async () => {
+		const store = makeDebounceStore();
+		const rollups = [
+			makeRollup({ source_ip: "1.1.1.1", distinct_localparts: 60 }),
+			makeRollup({ source_ip: "2.2.2.2", distinct_localparts: 80 }),
+			makeRollup({ source_ip: "3.3.3.3", distinct_localparts: 10 }), // below threshold
+		];
+
+		const alerts = await computeHarvestAlerts(rollups, defaultConfig, store);
+		expect(alerts).toHaveLength(2);
+		expect(alerts.map((a) => a.source_ip).sort()).toEqual(["1.1.1.1", "2.2.2.2"]);
+	});
+
+	it("debounces each (source_ip, sender_domain) pair independently", async () => {
+		const store = makeDebounceStore();
+		const rollups = [
+			makeRollup({ source_ip: "1.1.1.1", sender_domain: "spam.example", distinct_localparts: 60 }),
+			makeRollup({ source_ip: "2.2.2.2", sender_domain: "spam.example", distinct_localparts: 80 }),
+		];
+
+		// First call — both alert
+		await computeHarvestAlerts(rollups, defaultConfig, store);
+
+		// Seed first IP as recently alerted; second IP is NOT seeded here but
+		// was recorded in the first call. Both should be debounced.
+		const second = await computeHarvestAlerts(rollups, defaultConfig, store);
+		expect(second).toHaveLength(0);
+	});
+
+	it("records each alert in the debounce store", async () => {
+		const store = makeDebounceStore();
+		const rollup = makeRollup({ distinct_localparts: 75 });
+		await computeHarvestAlerts([rollup], defaultConfig, store);
+
+		const key = `${rollup.source_ip}|${rollup.sender_domain}`;
+		expect(store._alerts.has(key)).toBe(true);
+		expect(store._alerts.get(key)?.distinctCount).toBe(75);
+	});
+
+	it("alert payload includes correct fields", async () => {
+		const store = makeDebounceStore();
+		const rollup = makeRollup({
+			source_ip: "10.0.0.1",
+			sender_domain: "attacker.io",
+			distinct_localparts: 123,
+		});
+		const now = new Date("2026-06-05T15:00:00Z");
+		const [alert] = await computeHarvestAlerts([rollup], defaultConfig, store, now);
+
+		expect(alert.source_ip).toBe("10.0.0.1");
+		expect(alert.sender_domain).toBe("attacker.io");
+		expect(alert.distinct_localpart_count).toBe(123);
+		expect(alert.triggered_at).toBe("2026-06-05T15:00:00.000Z");
+	});
+});
+
+describe("resolveAlertConfig", () => {
+	it("returns defaults when settings is undefined", () => {
+		expect(resolveAlertConfig(undefined)).toEqual(DEFAULT_HARVEST_ALERT_CONFIG);
+	});
+
+	it("returns defaults when neither alert field is set", () => {
+		expect(resolveAlertConfig({ enabled: true })).toEqual(
+			DEFAULT_HARVEST_ALERT_CONFIG,
+		);
+	});
+
+	it("uses harvest_alert_threshold from settings", () => {
+		const cfg = resolveAlertConfig({ harvest_alert_threshold: 25 });
+		expect(cfg.threshold).toBe(25);
+		expect(cfg.window_minutes).toBe(DEFAULT_HARVEST_ALERT_CONFIG.window_minutes);
+	});
+
+	it("uses harvest_alert_window_minutes from settings", () => {
+		const cfg = resolveAlertConfig({ harvest_alert_window_minutes: 30 });
+		expect(cfg.threshold).toBe(DEFAULT_HARVEST_ALERT_CONFIG.threshold);
+		expect(cfg.window_minutes).toBe(30);
+	});
+
+	it("uses both fields from settings when both are present", () => {
+		const cfg = resolveAlertConfig({
+			harvest_alert_threshold: 10,
+			harvest_alert_window_minutes: 120,
+		});
+		expect(cfg.threshold).toBe(10);
+		expect(cfg.window_minutes).toBe(120);
+	});
+});
+
+describe("CatchallIntelSettings schema round-trip", () => {
+	it("parses a full catchall_intel block from DomainSettings", async () => {
+		const { CatchallIntelSettings } = await import("../../shared/domain-settings");
+		const input = {
+			enabled: true,
+			retention_days: 30,
+			sample_limit: 50,
+			harvest_alert_threshold: 50,
+			harvest_alert_window_minutes: 60,
+		};
+		const result = CatchallIntelSettings.safeParse(input);
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data).toMatchObject(input);
+	});
+
+	it("accepts an empty catchall_intel block (all fields optional)", async () => {
+		const { CatchallIntelSettings } = await import("../../shared/domain-settings");
+		const result = CatchallIntelSettings.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects non-positive threshold", async () => {
+		const { CatchallIntelSettings } = await import("../../shared/domain-settings");
+		const result = CatchallIntelSettings.safeParse({ harvest_alert_threshold: 0 });
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects non-positive window_minutes", async () => {
+		const { CatchallIntelSettings } = await import("../../shared/domain-settings");
+		const result = CatchallIntelSettings.safeParse({ harvest_alert_window_minutes: -5 });
+		expect(result.success).toBe(false);
+	});
+
+	it("round-trips through DomainSettings", async () => {
+		const { parseDomainSettings } = await import("../../shared/domain-settings");
+		const input = {
+			catchall_intel: {
+				enabled: false,
+				harvest_alert_threshold: 75,
+				harvest_alert_window_minutes: 120,
+			},
+		};
+		const result = parseDomainSettings(input);
+		expect(result).not.toBeNull();
+		expect(result?.catchall_intel?.harvest_alert_threshold).toBe(75);
+		expect(result?.catchall_intel?.harvest_alert_window_minutes).toBe(120);
+	});
+});

--- a/workers/intel/catchall-alert.ts
+++ b/workers/intel/catchall-alert.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Directory-harvest alerting driven by catch-all probe rollups (#429).
+ *
+ * Stateless logic layer: `computeHarvestAlerts` inspects a rollup snapshot,
+ * applies the threshold check, consults a `AlertDebounceStore` for prior
+ * alerts within the window, and returns the alerts that should be raised.
+ * Callers (the `receiveCatchall` wiring in #426) act on the returned list —
+ * this module never creates cases or sends notifications directly.
+ *
+ * The `AlertDebounceStore` interface will be implemented by `CatchallIntelDO`
+ * in #425 using a `harvest_alert_log` SQLite table.
+ */
+
+import type { CatchallIntelSettings } from "../../shared/domain-settings";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/** Matches the `probe_rollup` row shape from `CatchallIntelDO` (#425). */
+export interface ProbeRollupEntry {
+	source_ip: string;
+	sender_domain: string;
+	count: number;
+	distinct_localparts: number;
+	max_score: number;
+	first_seen: string;
+	last_seen: string;
+}
+
+/** An alert to raise — returned by `computeHarvestAlerts` for each new
+ *  (source_ip, sender_domain) pair that crossed the threshold this window. */
+export interface HarvestAlert {
+	source_ip: string;
+	sender_domain: string;
+	distinct_localpart_count: number;
+	triggered_at: string;
+}
+
+/** Resolved alert config after applying defaults. */
+export interface HarvestAlertConfig {
+	threshold: number;
+	window_minutes: number;
+}
+
+/** Default alert config used when `catchall_intel` doesn't specify values. */
+export const DEFAULT_HARVEST_ALERT_CONFIG: HarvestAlertConfig = {
+	threshold: 50,
+	window_minutes: 60,
+};
+
+/**
+ * Persistent debounce state for harvest alerts.
+ *
+ * The implementation lives in `CatchallIntelDO` (#425). A test double can be
+ * created with a plain in-memory map — see `tests/intel/catchall-alert.test.ts`.
+ */
+export interface AlertDebounceStore {
+	/**
+	 * Returns the ISO-8601 timestamp of the most recent alert recorded for
+	 * `(sourceIp, senderDomain)` within the last `windowMinutes` minutes, or
+	 * `null` when no in-window alert exists (meaning a new alert SHOULD fire).
+	 */
+	getLastAlertTime(
+		sourceIp: string,
+		senderDomain: string,
+		windowMinutes: number,
+	): Promise<string | null>;
+
+	/**
+	 * Persists a new alert event so subsequent calls to `getLastAlertTime`
+	 * within the window return it and suppress duplicate alerts.
+	 */
+	recordAlertTime(
+		sourceIp: string,
+		senderDomain: string,
+		alertedAt: string,
+		distinctCount: number,
+	): Promise<void>;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve `catchall_intel` settings (possibly absent) into a fully-populated
+ * `HarvestAlertConfig`, filling in defaults for missing fields.
+ */
+export function resolveAlertConfig(
+	settings: CatchallIntelSettings | undefined,
+): HarvestAlertConfig {
+	return {
+		threshold:
+			settings?.harvest_alert_threshold ??
+			DEFAULT_HARVEST_ALERT_CONFIG.threshold,
+		window_minutes:
+			settings?.harvest_alert_window_minutes ??
+			DEFAULT_HARVEST_ALERT_CONFIG.window_minutes,
+	};
+}
+
+// ── Core function ─────────────────────────────────────────────────────────────
+
+/**
+ * Given a rollup snapshot from `CatchallIntelDO.getCatchallSummary`,
+ * determine which (source_ip, sender_domain) pairs should trigger a new
+ * harvest alert.
+ *
+ * For each rollup whose `distinct_localparts` meets or exceeds
+ * `config.threshold`, the function queries `store.getLastAlertTime` to check
+ * whether an alert was already raised within the current window. If not, it
+ * calls `store.recordAlertTime` and adds the entry to the returned list.
+ *
+ * Pass an explicit `now` in tests to control time without patching globals.
+ */
+export async function computeHarvestAlerts(
+	rollups: ProbeRollupEntry[],
+	config: HarvestAlertConfig,
+	store: AlertDebounceStore,
+	now: Date = new Date(),
+): Promise<HarvestAlert[]> {
+	const alerts: HarvestAlert[] = [];
+	const triggeredAt = now.toISOString();
+
+	for (const row of rollups) {
+		if (row.distinct_localparts < config.threshold) continue;
+
+		const lastAlert = await store.getLastAlertTime(
+			row.source_ip,
+			row.sender_domain,
+			config.window_minutes,
+		);
+		if (lastAlert !== null) continue; // debounced
+
+		await store.recordAlertTime(
+			row.source_ip,
+			row.sender_domain,
+			triggeredAt,
+			row.distinct_localparts,
+		);
+
+		alerts.push({
+			source_ip: row.source_ip,
+			sender_domain: row.sender_domain,
+			distinct_localpart_count: row.distinct_localparts,
+			triggered_at: triggeredAt,
+		});
+	}
+
+	return alerts;
+}


### PR DESCRIPTION
## Summary

- Adds `CatchallIntelSettings` Zod schema to `shared/domain-settings.ts` with all catch-all fields: capture settings (`enabled`, `retention_days`, `sample_limit`) and alert settings (`harvest_alert_threshold` default 50, `harvest_alert_window_minutes` default 60).
- Adds `workers/intel/catchall-alert.ts` — pure `computeHarvestAlerts(rollups, config, store, now?)` that filters rollups above threshold, debounces via injected `AlertDebounceStore` interface, and returns `HarvestAlert[]` for callers to act on.
- 21 new tests covering: threshold boundary, first-fire alert, debounce within window, window expiry re-raise, multi-source rollups, per-pair independent debounce, schema round-trip, and config resolution.

Closes #429.

## Integration points (deferred to dependent issues)

- **#425 (`CatchallIntelDO`)** implements `AlertDebounceStore` via a `harvest_alert_log` SQLite table, and its `getCatchallSummary` returns `ProbeRollupEntry[]`.
- **#426 (wiring)** adds `catchall_intel` to `DomainSettings` (schema already here), wires `receiveCatchall()`, and calls `computeHarvestAlerts` after `recordCatchallProbe` — acting on returned alerts by creating cases or logging.
- **#427 (read API)** surfaces harvest alert records on the domain dashboard.

## Test plan

- [x] `npm test` — 1311 passing, 0 failing
- [x] `npm run typecheck` — clean

## Choices made

- Alert module is a pure function (no side-effects beyond calling `store.recordAlertTime`) — callers decide what to do with returned alerts. Keeps the module testable without a mailbox context and avoids coupling to the case/notification system before those integration points exist.
- `CatchallIntelSettings` includes the base capture fields (`enabled`, `retention_days`, `sample_limit`) from #426's spec so both PRs share one schema; #426 just references what's already here.
- Defaults (50 distinct localparts / 60-minute window) live as `DEFAULT_HARVEST_ALERT_CONFIG` in the alert module, not on the Zod schema, preserving absent-key-inherits semantics.

https://claude.ai/code/session_013Ht5asbVgmoApArnCxD4vy

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ht5asbVgmoApArnCxD4vy)_