### PR TITLE
feat(catchall-intel): add read API + domain dashboard card (#427)

### DIFF
--- a/app/queries/domains.ts
+++ b/app/queries/domains.ts
@@ -2,7 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import api from "~/services/api";
-import type { DomainListEntry, DomainStats, DmarcRufRecord } from "~/types";
+import type { CatchallSummary, DomainListEntry, DomainStats, DmarcRufRecord } from "~/types";
 import { queryKeys } from "./keys";
 
 /**
@@ -60,6 +60,18 @@ export function useRufRecords(domain: string | undefined) {
 		queryKey: domain ? ["domains", domain, "ruf-records"] : ["domains", "_disabled", "ruf-records"],
 		queryFn: ({ signal }) =>
 			api.getDomainRufRecords(domain!, { signal }) as Promise<RufRecordsResponse>,
+		enabled: !!domain,
+		staleTime: 60_000,
+	});
+}
+
+export function useCatchallIntel(domain: string | undefined) {
+	return useQuery<CatchallSummary>({
+		queryKey: domain
+			? queryKeys.domains.catchallIntel(domain)
+			: ["domains", "_disabled", "catchall-intel"],
+		queryFn: ({ signal }) =>
+			api.getDomainCatchallIntel(domain!, { signal }) as Promise<CatchallSummary>,
 		enabled: !!domain,
 		staleTime: 60_000,
 	});

--- a/app/queries/keys.ts
+++ b/app/queries/keys.ts
@@ -39,6 +39,7 @@ export const queryKeys = {
 		list: ["domains"] as const,
 		detail: (domain: string) => ["domains", domain] as const,
 		settings: (domain: string) => ["domains", domain, "settings"] as const,
+		catchallIntel: (domain: string) => ["domains", domain, "catchall-intel"] as const,
 	},
 	hub: {
 		contributions: (mailboxId: string) => ["hub", mailboxId, "contributions"] as const,

--- a/app/routes/domain-detail.tsx
+++ b/app/routes/domain-detail.tsx
@@ -4,13 +4,17 @@ import { Loader } from "@cloudflare/kumo";
 import {
 	BriefcaseIcon,
 	EnvelopeIcon,
+	EyeIcon,
 	ShieldCheckIcon,
 	WarningIcon,
 } from "@phosphor-icons/react";
 import { Link as RouterLink, useParams } from "react-router";
 import Shell from "~/components/phishsoc/Shell";
-import { useDomainStats, useRufRecords } from "~/queries/domains";
+import { useCatchallIntel, useDomainStats, useRufRecords } from "~/queries/domains";
 import type {
+	CatchallRecentSample,
+	CatchallSourceRollup,
+	CatchallSummary,
 	DmarcRufRecord,
 	DnssecPosture,
 	DomainStats,
@@ -25,6 +29,7 @@ export default function DomainDetailRoute() {
 	const { domain } = useParams<{ domain: string }>();
 	const { data, isLoading, isError, refetch } = useDomainStats(domain);
 	const rufQuery = useRufRecords(domain);
+	const catchallQuery = useCatchallIntel(domain);
 
 	return (
 		<Shell>
@@ -38,7 +43,7 @@ export default function DomainDetailRoute() {
 				) : isError ? (
 					<DomainError onRetry={() => refetch()} />
 				) : data ? (
-					<DomainBody data={data} rufData={rufQuery.data} />
+					<DomainBody data={data} rufData={rufQuery.data} catchallData={catchallQuery.data} catchallLoading={catchallQuery.isLoading} />
 				) : null}
 			</div>
 		</Shell>
@@ -92,7 +97,17 @@ function DomainError({ onRetry }: { onRetry: () => void }) {
 	);
 }
 
-function DomainBody({ data, rufData }: { data: DomainStats; rufData: import("~/queries/domains").RufRecordsResponse | undefined }) {
+function DomainBody({
+	data,
+	rufData,
+	catchallData,
+	catchallLoading,
+}: {
+	data: DomainStats;
+	rufData: import("~/queries/domains").RufRecordsResponse | undefined;
+	catchallData: CatchallSummary | undefined;
+	catchallLoading: boolean;
+}) {
 	return (
 		<>
 			<KpiGrid data={data} />
@@ -115,6 +130,7 @@ function DomainBody({ data, rufData }: { data: DomainStats; rufData: import("~/q
 			{rufData?.enabled && rufData.records.length > 0 && (
 				<RufFailuresTable records={rufData.records} />
 			)}
+			<CatchallProbesCard data={catchallData} isLoading={catchallLoading} />
 		</>
 	);
 }
@@ -625,6 +641,142 @@ function RecentCasesList({
 					</li>
 				))}
 			</ul>
+		</div>
+	);
+}
+
+function CatchallProbesCard({
+	data,
+	isLoading,
+}: {
+	data: CatchallSummary | undefined;
+	isLoading: boolean;
+}) {
+	if (isLoading) {
+		return (
+			<div className="pp-card p-5">
+				<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-3 flex items-center gap-1.5">
+					<EyeIcon size={12} />
+					Catch-all probes
+				</div>
+				<div className="flex justify-center py-4">
+					<Loader size="sm" />
+				</div>
+			</div>
+		);
+	}
+
+	const empty = !data || data.totals.probe_count === 0;
+	return (
+		<div className="pp-card p-5">
+			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-3 flex items-center gap-1.5">
+				<EyeIcon size={12} />
+				Catch-all probes
+			</div>
+			{empty ? (
+				<p className="text-[12.5px] text-ink-3">
+					No catch-all probe activity recorded. Enable <span className="pp-mono">catchall_intel</span> on this domain to start collecting directory-harvest data.
+				</p>
+			) : (
+				<div className="space-y-5">
+					<dl className="grid grid-cols-3 gap-4">
+						<div>
+							<dt className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-1">Probes</dt>
+							<dd className="pp-serif text-[28px] leading-none text-ink">{data.totals.probe_count}</dd>
+						</div>
+						<div>
+							<dt className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-1">Sources</dt>
+							<dd className="pp-serif text-[28px] leading-none text-ink">{data.totals.distinct_sources}</dd>
+						</div>
+						<div>
+							<dt className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-1">Local-parts tried</dt>
+							<dd className="pp-serif text-[28px] leading-none text-ink">{data.totals.distinct_localparts}</dd>
+						</div>
+					</dl>
+					{data.topSources.length > 0 && (
+						<CatchallTopSourcesTable sources={data.topSources} />
+					)}
+					{data.recent.length > 0 && (
+						<CatchallRecentSamplesTable samples={data.recent} />
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function CatchallTopSourcesTable({ sources }: { sources: CatchallSourceRollup[] }) {
+	return (
+		<div>
+			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-2">
+				Top sources
+			</div>
+			<div className="overflow-x-auto">
+				<table className="w-full text-[12px] text-ink-2">
+					<thead>
+						<tr className="text-left text-[10.5px] uppercase tracking-[0.06em] text-ink-3 border-b border-line">
+							<th className="pb-2 pr-4 font-normal">Source IP</th>
+							<th className="pb-2 pr-4 font-normal">Sender domain</th>
+							<th className="pb-2 pr-4 font-normal text-right">Probes</th>
+							<th className="pb-2 pr-4 font-normal text-right">Local-parts</th>
+							<th className="pb-2 font-normal text-right">Max score</th>
+						</tr>
+					</thead>
+					<tbody className="divide-y divide-line">
+						{sources.map((s) => (
+							<tr key={`${s.source_ip}:${s.sender_domain}`} className="align-top">
+								<td className="py-2 pr-4 pp-mono text-ink-2">{s.source_ip}</td>
+								<td className="py-2 pr-4 text-ink-2">{s.sender_domain}</td>
+								<td className="py-2 pr-4 pp-mono tabular-nums text-ink-2 text-right">{s.count}</td>
+								<td className="py-2 pr-4 pp-mono tabular-nums text-ink-2 text-right">{s.distinct_localparts}</td>
+								<td className="py-2 pp-mono tabular-nums text-ink-2 text-right">{s.max_score}</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	);
+}
+
+function CatchallRecentSamplesTable({ samples }: { samples: CatchallRecentSample[] }) {
+	return (
+		<div>
+			<div className="text-[10.5px] uppercase tracking-[0.06em] text-ink-3 mb-2">
+				Recent samples
+			</div>
+			<div className="overflow-x-auto">
+				<table className="w-full text-[12px] text-ink-2">
+					<thead>
+						<tr className="text-left text-[10.5px] uppercase tracking-[0.06em] text-ink-3 border-b border-line">
+							<th className="pb-2 pr-4 font-normal">Time</th>
+							<th className="pb-2 pr-4 font-normal">Local-part</th>
+							<th className="pb-2 pr-4 font-normal">Sender</th>
+							<th className="pb-2 pr-4 font-normal">Source IP</th>
+							<th className="pb-2 font-normal">Score / band</th>
+						</tr>
+					</thead>
+					<tbody className="divide-y divide-line">
+						{samples.map((s) => (
+							<tr key={s.id} className="align-top">
+								<td className="py-2 pr-4 pp-mono tabular-nums text-ink-3 whitespace-nowrap">
+									{new Date(s.ts).toLocaleString(undefined, {
+										month: "short",
+										day: "numeric",
+										hour: "2-digit",
+										minute: "2-digit",
+									})}
+								</td>
+								{/* attacker-controlled fields — rendered as text; React escapes by default */}
+								<td className="py-2 pr-4 pp-mono text-ink-2 max-w-[10rem] truncate">{s.localpart}</td>
+								<td className="py-2 pr-4 text-ink-2 max-w-[12rem] truncate">{s.sender}</td>
+								<td className="py-2 pr-4 pp-mono text-ink-2">{s.source_ip}</td>
+								<td className="py-2 pp-mono tabular-nums text-ink-2">{s.score} · {s.band}</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
 		</div>
 	);
 }

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 import type {
+	CatchallSummary,
 	DashboardSummary,
 	DomainListEntry,
 	DomainStats,
@@ -273,6 +274,11 @@ const api = {
 	getDomainRufRecords: (domain: string, opts?: { signal?: AbortSignal }) =>
 		get<{ enabled: boolean; records: DmarcRufRecord[] }>(
 			`/api/v1/domains/${encodeURIComponent(domain)}/ruf-records`,
+			{ signal: opts?.signal },
+		),
+	getDomainCatchallIntel: (domain: string, opts?: { signal?: AbortSignal }) =>
+		get<CatchallSummary>(
+			`/api/v1/domains/${encodeURIComponent(domain)}/catchall-intel`,
 			{ signal: opts?.signal },
 		),
 

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -402,6 +402,40 @@ export interface DomainStats {
 	recentCases: DashboardCase[];
 }
 
+/** Source-IP rollup row from CatchallIntelDO (#425/#427). */
+export interface CatchallSourceRollup {
+	source_ip: string;
+	sender_domain: string;
+	count: number;
+	distinct_localparts: number;
+	max_score: number;
+	first_seen: string;
+	last_seen: string;
+}
+
+/** Recent probe sample row from CatchallIntelDO (#425/#427).
+ * `localpart`, `sender`, `subject_snippet` are attacker-controlled — render
+ * as text only, never dangerouslySetInnerHTML. */
+export interface CatchallRecentSample {
+	id: number;
+	ts: string;
+	source_ip: string;
+	sender_domain: string;
+	sender: string;
+	localpart: string;
+	subject_snippet: string;
+	score: number;
+	band: string;
+	signals_json: string;
+}
+
+/** Shape returned by `GET /api/v1/domains/:domain/catchall-intel` (#427). */
+export interface CatchallSummary {
+	totals: { probe_count: number; distinct_sources: number; distinct_localparts: number };
+	topSources: CatchallSourceRollup[];
+	recent: CatchallRecentSample[];
+}
+
 export interface HubContribution {
 	uuid: string;
 	info: string;

--- a/tests/frontend/domain-detail.test.tsx
+++ b/tests/frontend/domain-detail.test.tsx
@@ -4,7 +4,7 @@ import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Route, Routes } from "react-router";
-import type { DomainStats } from "~/types";
+import type { CatchallSummary, DomainStats } from "~/types";
 import {
 	shellDashboardMock,
 	shellDomainsMock,
@@ -314,5 +314,76 @@ describe("DomainDetailRoute", () => {
 		expect(within(dmarcCard).getByText("100%")).toBeInTheDocument();
 		expect(within(dmarcCard).getByText("configured")).toBeInTheDocument();
 		expect(within(dmarcCard).getByText("97%")).toBeInTheDocument();
+	});
+
+	it("renders the catch-all probes empty-state when no probe data is available (#427)", () => {
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderDomainDetail("acme.com");
+		const card = screen
+			.getByText(/catch-all probes/i)
+			.closest(".pp-card") as HTMLElement;
+		expect(
+			within(card).getByText(/no catch-all probe activity recorded/i),
+		).toBeInTheDocument();
+	});
+
+	it("renders catch-all probes populated card when useCatchallIntel returns data (#427)", async () => {
+		const domainsModule = await import("~/queries/domains");
+		const catchallData: CatchallSummary = {
+			totals: { probe_count: 42, distinct_sources: 3, distinct_localparts: 17 },
+			topSources: [
+				{
+					source_ip: "198.51.100.5",
+					sender_domain: "evil.example",
+					count: 30,
+					distinct_localparts: 12,
+					max_score: 85,
+					first_seen: "2026-06-01T00:00:00Z",
+					last_seen: "2026-06-05T12:00:00Z",
+				},
+			],
+			recent: [
+				{
+					id: 1,
+					ts: "2026-06-05T12:00:00Z",
+					source_ip: "198.51.100.5",
+					sender_domain: "evil.example",
+					sender: "probe@evil.example",
+					localpart: "admin",
+					subject_snippet: "Test subject",
+					score: 75,
+					band: "high",
+					signals_json: "[]",
+				},
+			],
+		};
+		vi.spyOn(domainsModule, "useCatchallIntel").mockReturnValue({
+			data: catchallData,
+			isLoading: false,
+			isError: false,
+		} as ReturnType<typeof domainsModule.useCatchallIntel>);
+
+		queryState = { data: populated, isLoading: false, isError: false };
+		renderDomainDetail("acme.com");
+
+		const card = screen
+			.getByText(/catch-all probes/i)
+			.closest(".pp-card") as HTMLElement;
+
+		// Totals
+		expect(within(card).getByText("42")).toBeInTheDocument();
+		expect(within(card).getByText("3")).toBeInTheDocument();
+		expect(within(card).getByText("17")).toBeInTheDocument();
+
+		// Top sources table (source_ip and sender_domain are operator data, not attacker)
+		// Both tables render source_ip, so use getAllByText.
+		expect(within(card).getAllByText("198.51.100.5").length).toBeGreaterThanOrEqual(1);
+		expect(within(card).getAllByText("evil.example").length).toBeGreaterThanOrEqual(1);
+
+		// Recent samples — attacker-controlled fields rendered as text, not HTML.
+		expect(within(card).getByText("admin")).toBeInTheDocument();
+		expect(within(card).getByText("probe@evil.example")).toBeInTheDocument();
+
+		vi.restoreAllMocks();
 	});
 });

--- a/tests/frontend/shell-mocks.ts
+++ b/tests/frontend/shell-mocks.ts
@@ -91,6 +91,7 @@ export interface ShellDomainsMockOverrides {
 	useAddDomain?: () => unknown;
 	useRemoveDomain?: () => unknown;
 	useRufRecords?: () => QueryStub<unknown>;
+	useCatchallIntel?: () => QueryStub<unknown>;
 	[key: string]: unknown;
 }
 
@@ -113,6 +114,7 @@ export function shellDomainsMock(
 		useAddDomain: () => ({ mutateAsync: vi.fn(), isPending: false }),
 		useRemoveDomain: () => ({ mutateAsync: vi.fn(), isPending: false }),
 		useRufRecords: () => ({ data: undefined, isLoading: false, isError: false }),
+		useCatchallIntel: () => ({ data: undefined, isLoading: false, isError: false }),
 		...overrides,
 	};
 }

--- a/tests/routes/catchall-intel.test.ts
+++ b/tests/routes/catchall-intel.test.ts
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Route-level tests for `GET /api/v1/domains/:domain/catchall-intel` (#427).
+ *
+ * Mirrors the handler in `workers/index.ts` (same pattern as me.test.ts /
+ * config.test.ts): builds a minimal Hono app with just the handler under test
+ * so the full worker graph isn't loaded. The DO is stubbed inline.
+ */
+
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Types (mirrors workers/index.ts definitions)
+// ---------------------------------------------------------------------------
+
+interface CatchallSourceRollup {
+	source_ip: string;
+	sender_domain: string;
+	count: number;
+	distinct_localparts: number;
+	max_score: number;
+	first_seen: string;
+	last_seen: string;
+}
+
+interface CatchallRecentSample {
+	id: number;
+	ts: string;
+	source_ip: string;
+	sender_domain: string;
+	sender: string;
+	localpart: string;
+	subject_snippet: string;
+	score: number;
+	band: string;
+	signals_json: string;
+}
+
+interface CatchallSummary {
+	totals: { probe_count: number; distinct_sources: number; distinct_localparts: number };
+	topSources: CatchallSourceRollup[];
+	recent: CatchallRecentSample[];
+}
+
+// ---------------------------------------------------------------------------
+// DO stub
+// ---------------------------------------------------------------------------
+
+function makeCatchallIntelDO(
+	response: CatchallSummary | "throw",
+): {
+	idFromName: (name: string) => { id: string };
+	get: (id: { id: string }) => { getCatchallSummary: (opts: { limit: number }) => Promise<CatchallSummary> };
+} {
+	return {
+		idFromName: (name: string) => ({ id: `do-id:${name}` }),
+		get: (_id) => ({
+			getCatchallSummary: async (_opts) => {
+				if (response === "throw") throw new Error("DO unavailable");
+				return response;
+			},
+		}),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Handler mirror (keep in sync with workers/index.ts)
+// ---------------------------------------------------------------------------
+
+const DOMAIN_REGEX =
+	/^(?=.{1,253}$)[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$/i;
+
+function emptyCatchallSummary(): CatchallSummary {
+	return { totals: { probe_count: 0, distinct_sources: 0, distinct_localparts: 0 }, topSources: [], recent: [] };
+}
+
+type CatchallIntelDONamespace = ReturnType<typeof makeCatchallIntelDO>;
+
+function makeApp(catchallIntel: CatchallIntelDONamespace) {
+	const app = new Hono<{ Bindings: { CATCHALL_INTEL: CatchallIntelDONamespace } }>();
+
+	app.get("/api/v1/domains/:domain/catchall-intel", async (c) => {
+		const raw = c.req.param("domain") ?? "";
+		const domain = decodeURIComponent(raw).toLowerCase();
+		if (!DOMAIN_REGEX.test(domain)) return c.json({ error: "Malformed domain" }, 400);
+
+		const limit = Math.min(parseInt(c.req.query("limit") ?? "20", 10) || 20, 100);
+
+		try {
+			const doId = c.env.CATCHALL_INTEL.idFromName(domain);
+			const stub = c.env.CATCHALL_INTEL.get(doId) as unknown as {
+				getCatchallSummary(opts: { limit: number }): Promise<CatchallSummary>;
+			};
+			const summary = await stub.getCatchallSummary({ limit });
+			return c.json(summary);
+		} catch {
+			return c.json(emptyCatchallSummary());
+		}
+	});
+
+	return app;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const populated: CatchallSummary = {
+	totals: { probe_count: 42, distinct_sources: 3, distinct_localparts: 17 },
+	topSources: [
+		{
+			source_ip: "198.51.100.5",
+			sender_domain: "evil.example",
+			count: 30,
+			distinct_localparts: 12,
+			max_score: 85,
+			first_seen: "2026-06-01T00:00:00Z",
+			last_seen: "2026-06-05T12:00:00Z",
+		},
+	],
+	recent: [
+		{
+			id: 1,
+			ts: "2026-06-05T12:00:00Z",
+			source_ip: "198.51.100.5",
+			sender_domain: "evil.example",
+			sender: "probe@evil.example",
+			localpart: "admin",
+			subject_snippet: "Test",
+			score: 75,
+			band: "high",
+			signals_json: "[]",
+		},
+	],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// Auth boundary: the handler is mounted in `apiApp` (`workers/index.ts`) and
+// `workers/app.ts` wraps the whole `apiApp` under the CF-Access JWT middleware
+// (same boundary as /api/v1/org/overview). The handler itself adds no auth —
+// the middleware is the gate. These tests exercise the handler contract only.
+
+describe("GET /api/v1/domains/:domain/catchall-intel (#427)", () => {
+	it("returns { totals, topSources, recent } for a domain with probe data", async () => {
+		const do_ = makeCatchallIntelDO(populated);
+		const app = makeApp(do_);
+		const res = await app.request(
+			"/api/v1/domains/acme.com/catchall-intel",
+			{},
+			{ CATCHALL_INTEL: do_ },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as CatchallSummary;
+		expect(body.totals.probe_count).toBe(42);
+		expect(body.totals.distinct_sources).toBe(3);
+		expect(body.totals.distinct_localparts).toBe(17);
+		expect(body.topSources).toHaveLength(1);
+		expect(body.topSources[0].source_ip).toBe("198.51.100.5");
+		expect(body.recent).toHaveLength(1);
+		expect(body.recent[0].localpart).toBe("admin");
+	});
+
+	it("returns an empty summary when the DO has no probe data", async () => {
+		const empty = emptyCatchallSummary();
+		const do_ = makeCatchallIntelDO(empty);
+		const app = makeApp(do_);
+		const res = await app.request(
+			"/api/v1/domains/quiet.example/catchall-intel",
+			{},
+			{ CATCHALL_INTEL: do_ },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as CatchallSummary;
+		expect(body.totals.probe_count).toBe(0);
+		expect(body.topSources).toEqual([]);
+		expect(body.recent).toEqual([]);
+	});
+
+	it("returns an empty summary when the DO throws (graceful degradation)", async () => {
+		const do_ = makeCatchallIntelDO("throw");
+		const app = makeApp(do_);
+		const res = await app.request(
+			"/api/v1/domains/acme.com/catchall-intel",
+			{},
+			{ CATCHALL_INTEL: do_ },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as CatchallSummary;
+		expect(body.totals.probe_count).toBe(0);
+		expect(body.topSources).toEqual([]);
+	});
+
+	it("returns 400 for a malformed domain", async () => {
+		const do_ = makeCatchallIntelDO(emptyCatchallSummary());
+		const app = makeApp(do_);
+		// Empty string produces /domains//catchall-intel which Hono routes as 404
+		// (the param never reaches the handler), so it's excluded from this list.
+		for (const bad of ["no-tld", "has@at.com", "has%2Fpath.com", "https%3A%2F%2Fevil.com"]) {
+			const res = await app.request(
+				`/api/v1/domains/${bad}/catchall-intel`,
+				{},
+				{ CATCHALL_INTEL: do_ },
+			);
+			expect(res.status, `expected 400 for "${bad}"`).toBe(400);
+		}
+	});
+
+	it("caps limit at 100 and defaults to 20", async () => {
+		let capturedLimit = 0;
+		const do_: CatchallIntelDONamespace = {
+			idFromName: (name) => ({ id: name }),
+			get: (_id) => ({
+				getCatchallSummary: async (opts) => {
+					capturedLimit = opts.limit;
+					return emptyCatchallSummary();
+				},
+			}),
+		};
+		const app = makeApp(do_);
+
+		await app.request("/api/v1/domains/acme.com/catchall-intel", {}, { CATCHALL_INTEL: do_ });
+		expect(capturedLimit).toBe(20);
+
+		await app.request(
+			"/api/v1/domains/acme.com/catchall-intel?limit=999",
+			{},
+			{ CATCHALL_INTEL: do_ },
+		);
+		expect(capturedLimit).toBe(100);
+
+		await app.request(
+			"/api/v1/domains/acme.com/catchall-intel?limit=50",
+			{},
+			{ CATCHALL_INTEL: do_ },
+		);
+		expect(capturedLimit).toBe(50);
+	});
+});

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -840,6 +840,66 @@ app.get("/api/v1/domains/:domain/ruf-records", async (c) => {
 	return c.json({ enabled: anyEnabled, records: sorted });
 });
 
+// ---------------------------------------------------------------------------
+// Catch-all probe intel (#427)
+// ---------------------------------------------------------------------------
+
+interface CatchallSourceRollup {
+	source_ip: string;
+	sender_domain: string;
+	count: number;
+	distinct_localparts: number;
+	max_score: number;
+	first_seen: string;
+	last_seen: string;
+}
+
+interface CatchallRecentSample {
+	id: number;
+	ts: string;
+	source_ip: string;
+	sender_domain: string;
+	sender: string;
+	localpart: string;
+	subject_snippet: string;
+	score: number;
+	band: string;
+	signals_json: string;
+}
+
+interface CatchallSummary {
+	totals: { probe_count: number; distinct_sources: number; distinct_localparts: number };
+	topSources: CatchallSourceRollup[];
+	recent: CatchallRecentSample[];
+}
+
+function emptyCatchallSummary(): CatchallSummary {
+	return { totals: { probe_count: 0, distinct_sources: 0, distinct_localparts: 0 }, topSources: [], recent: [] };
+}
+
+/** Per-domain catch-all probe rollup (#427). Same CF-Access auth boundary as
+ * all `/api/v1/` routes. Returns empty summary for domains with no probe data
+ * or where CATCHALL_INTEL is not yet wired (#425/#426 deferred). */
+app.get("/api/v1/domains/:domain/catchall-intel", async (c) => {
+	const raw = c.req.param("domain") ?? "";
+	const domain = decodeURIComponent(raw).toLowerCase();
+	if (!DOMAIN_REGEX.test(domain)) return c.json({ error: "Malformed domain" }, 400);
+
+	const limit = Math.min(parseInt(c.req.query("limit") ?? "20", 10) || 20, 100);
+
+	try {
+		const doId = c.env.CATCHALL_INTEL.idFromName(domain);
+		const stub = c.env.CATCHALL_INTEL.get(doId) as unknown as {
+			getCatchallSummary(opts: { limit: number }): Promise<CatchallSummary>;
+		};
+		const summary = await stub.getCatchallSummary({ limit });
+		return c.json(summary);
+	} catch (e) {
+		console.error("catchall-intel: DO fetch failed:", (e as Error).message);
+		return c.json(emptyCatchallSummary());
+	}
+});
+
 app.post("/api/v1/mailboxes", async (c) => {
 	const { name, settings, email: rawEmail } = CreateMailboxBody.parse(await c.req.json());
 	const email = rawEmail.toLowerCase();

--- a/workers/types.ts
+++ b/workers/types.ts
@@ -29,4 +29,9 @@ export interface Env extends Cloudflare.Env {
 	 * When absent, the yaramail callback route returns 503.
 	 */
 	YARAMAIL_CALLBACK_SECRET?: string;
+	/**
+	 * Per-domain catch-all probe rollup store (#425). DO binding registered in
+	 * wrangler.jsonc by #425 alongside the CatchallIntelDO class and migration.
+	 */
+	CATCHALL_INTEL: DurableObjectNamespace;
 }


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/domains/:domain/catchall-intel` endpoint backed by `CatchallIntelDO` via the `CATCHALL_INTEL` binding; returns `{ totals, topSources[], recent[] }` and degrades gracefully to an empty summary if the DO throws (resilient before #425/#426 land).
- Adds "Catch-all probes" card to `domain-detail.tsx` showing probe totals, top source-IP rollups, and recent samples; attacker-controlled fields (`localpart`, `sender`, `subject_snippet`) rendered as text only (no `dangerouslySetInnerHTML`).
- Adds `useCatchallIntel` query hook, `getDomainCatchallIntel` API method, and `queryKeys.domains.catchallIntel` key factory.

Closes #427.

## Test plan

- [x] `npm test` — 1297/1297 passing (103 files)
- [x] `npm run typecheck` — clean (exit 0)
- Route-level tests: `tests/routes/catchall-intel.test.ts` — populated domain, empty domain, DO error fallback, malformed domain (400), limit clamping
- Frontend tests: `tests/frontend/domain-detail.test.tsx` — empty-state card, populated card via `vi.spyOn`

## Choices made

- `CATCHALL_INTEL: DurableObjectNamespace` added directly to `workers/types.ts` (not via `wrangler.jsonc`) to avoid conflicting with #425 which owns the DO binding registration and migration. After #425 lands, `wrangler types` will also emit the binding in `Cloudflare.Env`; the two declarations are compatible.
- DO stub typed with a local `getCatchallSummary` interface (cast via `as unknown as { getCatchallSummary(...) }`) — the full `CatchallIntelDO` class is defined by #425.
- `limit` defaults to 20, capped at 100; the frontend passes no explicit limit (uses the default).

## Deferred

- `wrangler.jsonc` DO binding + migration entry → #425
- `CatchallIntelDO` SQLite implementation + `recordCatchallProbe` RPC → #425
- Receive-path wiring (`catchall_intel` domain setting, `normalizeInbound` union, `receiveCatchall`) → #426

https://claude.ai/code/session_01B1WhGojswnDHxfJYfGY79j

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1WhGojswnDHxfJYfGY79j)_