### PR TITLE
chore(intel): fix over-indented FEED_SECRET_ guard in feeds.ts (Closes #419)

### DIFF
--- a/workers/intel/feeds.ts
+++ b/workers/intel/feeds.ts
@@ -88,9 +88,9 @@ function resolveFeeds(env: Env, settings: MailboxIntelSettings): FeedDefinition[
 	for (const f of settings.feeds ?? []) {
 		const base = byId.get(f.id);
 		const headers: Record<string, string> = { ...(f.headers ?? {}) };
-			// Prevent confused deputy / secret exfiltration via unconstrained secret access.
-			// Only allow access to explicitly designated feed secrets.
-			if (f.auth_secret && f.auth_secret.startsWith("FEED_SECRET_")) {
+		// Prevent confused deputy / secret exfiltration via unconstrained secret access.
+		// Only allow access to explicitly designated feed secrets.
+		if (f.auth_secret && f.auth_secret.startsWith("FEED_SECRET_")) {
 			const secretValue = (env as unknown as Record<string, string>)[f.auth_secret];
 			if (secretValue) headers["Authorization"] = secretValue;
 		}


### PR DESCRIPTION
## Summary

- Indentation-only fix in `workers/intel/feeds.ts` (lines 91–93): the two guard comments and the `if (f.auth_secret && f.auth_secret.startsWith("FEED_SECRET_"))` line carried **3** leading tabs; re-indented to **2** tabs to match the surrounding `for`-loop body in `resolveFeeds`.
- **The diff is indentation-only.** `git diff -w` against `main` is empty — zero token, logic, or behavior changes.
- The test-dedup half of #419 (`tests/routes/cases.test.ts` duplicated `describe("report-phish prevents secret exfiltration")` blocks) is **already resolved on `main`** — PR #415's squash left exactly one describe block (verified: `grep -c` returns 1). No test files are touched here.

Closes #419

## Why

PR #415 (the secret-exfiltration fix, GHSA-jfj6-w954-96vg) landed with the guard block over-indented relative to its scope, which misleadingly suggests the guard sits in a nested block. Issue #419 tracks the cleanup.

## Test plan

- [x] `npm run typecheck` passes locally (exit 0)
- [x] `npm test` passes locally — **1378 passed, 0 failed** (109 test files)
- [x] `git diff -w main` is empty, proving the change is whitespace-only
- [ ] Manually exercised the affected flow — N/A: no executable change exists to exercise

## Invariants affected

**None weakened; the diff is whitespace-only.** This touches the confused-deputy / secret-exfiltration guard introduced by PR #415, so stating the invariant explicitly:

> `resolveFeeds` only reads an env secret into a feed's `Authorization` header when the feed's `auth_secret` starts with `FEED_SECRET_`. Feed definitions are user-configurable, so without the prefix allowlist a feed could name any env binding (e.g. an API key) and exfiltrate it to an attacker-controlled feed URL.

How the invariant is preserved:
- The guard condition `f.auth_secret && f.auth_secret.startsWith("FEED_SECRET_")` is byte-identical; only leading tabs changed.
- The guard's position in the control flow is unchanged: it was already inside the `for (const f of settings.feeds ?? [])` body wrapping the env read — the 3-tab indentation was cosmetic, not structural. This PR makes the rendered indentation match the actual scope.
- Regression coverage is untouched: the single `describe("report-phish prevents secret exfiltration")` suite in `tests/routes/cases.test.ts` (with the real `hubEventUuid === null` assertion) still passes, along with the rest of the 1378-test suite.

## Notes for reviewer

- The issue's acceptance criterion mentions `npm run lint`; this repo has no `lint` script and no prettier/eslint/biome/editorconfig at the root, so the verification gate is typecheck + tests (both green). The repo convention is tab indentation, which this change follows.
- Out of scope per the issue: the guard logic itself and the `IntelFeed.auth_secret` schema-parity change (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)