### PR TITLE
ci: add Dependabot npm version updates for /hub manifest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,25 @@ updates:
           - "@react-router/*"
           - "workers-ai-provider"
 
+  - package-ecosystem: npm
+    directory: "/hub"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 3
+    versioning-strategy: increase-if-necessary
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        patterns:
+          - "*"
+      production-dependencies:
+        dependency-type: production
+        patterns:
+          - "*"
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/docs/security-policies.md
+++ b/docs/security-policies.md
@@ -10,7 +10,8 @@ OSPS-VM-05.02, and OSPS-VM-06.01.
 ## 1. SCA (Software Composition Analysis) — Dependabot
 
 Dependabot runs weekly (every Monday, 07:00 UTC) and opens PRs against the
-`main` branch for npm packages and GitHub Actions. See
+`main` branch for npm packages and GitHub Actions. Both npm manifests are
+covered: the root app (`/`) and the community hub sub-app (`/hub`). See
 [`.github/dependabot.yml`](../.github/dependabot.yml) for the full
 configuration.
 


### PR DESCRIPTION
## Summary

`.github/dependabot.yml` configured npm version updates only for `directory: "/"`, but the repo has a second committed npm lockfile at `hub/package-lock.json` (the MISP-compatible community hub sub-app, deployed as its own Worker with its own `hub/package.json`). That manifest therefore received no Dependabot version-update PRs.

This PR adds a second `package-ecosystem: npm` entry for `directory: "/hub"`:

- Same weekly schedule as the root entry (Monday, 07:00 UTC)
- `open-pull-requests-limit: 3` (root uses 5; hub has only 2 prod + 5 dev dependencies)
- Same `versioning-strategy: increase-if-necessary` as the root entry
- Simple grouping: one `dev-dependencies` group and one `production-dependencies` group (group names are scoped per update entry, so reusing the root entry's names is valid and keeps PR titles consistent)

Also adds a one-line note to `docs/security-policies.md` section 1 stating that both npm manifests (`/` and `/hub`) are covered.

## Note on alerts vs. version updates

Dependabot **alerts** already covered hub — alert scanning reads every manifest/lockfile in the repository regardless of `dependabot.yml`. What was missing was only the scheduled **version-update PRs** for `/hub`, which is what this change adds.

## Validation

- `dependabot.yml` parses as valid YAML with all three update entries (npm `/`, npm `/hub`, github-actions `/`)
- The `/hub` entry mirrors the root schedule fields exactly (`weekly`, `monday`, `07:00`, `Etc/UTC`)

https://claude.ai/code/session_01GKxRrEXy6LzZpJ9CTyDyqo

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKxRrEXy6LzZpJ9CTyDyqo)_