### PR TITLE
ci: adopt Bumblebee (scoped) for supply-chain exposure scanning

### DIFF
--- a/.github/workflows/bumblebee.yml
+++ b/.github/workflows/bumblebee.yml
@@ -1,0 +1,72 @@
+name: Bumblebee
+
+# Supply-chain exposure scan: matches the repo's two committed npm lockfiles
+# (package-lock.json, hub/package-lock.json) against curated incident catalogs
+# of known-trojaned package versions. Adoption decision and incident runbook:
+# docs/bumblebee-evaluation.md (issue #413). Match handling / SLA:
+# docs/security-policies.md section 3.
+
+on:
+  schedule:
+    # Mondays 07:27 UTC — offset from CodeQL's "27 6 * * 1".
+    - cron: "27 7 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: bumblebee-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Exposure scan (npm lockfiles)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      # Exposure catalogs pinned to an upstream commit, not a branch — catalog
+      # content is a trust input, so pin bumps must land as reviewed PRs.
+      - name: Checkout pinned upstream exposure catalogs
+        uses: actions/checkout@v4
+        with:
+          repository: perplexityai/bumblebee
+          ref: bf685dde34e2d0a7cfea6a232b515fb53fcd7622
+          path: bumblebee-upstream
+          sparse-checkout: threat_intel
+
+      # Pinned release binary, sha256-verified against the checksum recorded
+      # here (sourced from the release's checksums.txt). NEVER `go install
+      # @latest` — an unpinned scanner is itself a supply-chain exposure.
+      - name: Fetch and verify Bumblebee v0.1.1
+        run: |
+          curl -fsSLO https://github.com/perplexityai/bumblebee/releases/download/v0.1.1/bumblebee_0.1.1_linux_amd64.tar.gz
+          echo "0ef1c56c85a67c10f7211883c0eb5fb902de705cc30bbca0bc6f4d60941547da  bumblebee_0.1.1_linux_amd64.tar.gz" | sha256sum -c -
+          tar -xzf bumblebee_0.1.1_linux_amd64.tar.gz
+
+      - name: Selftest
+        run: ./bumblebee selftest
+
+      # --exposure-catalog pointed at a directory merges all *.json in it
+      # (non-recursive). The checked-out catalog files are not lockfiles, so
+      # scanning the workspace they sit in yields no records from them.
+      - name: Scan repository against pinned catalogs
+        run: ./bumblebee scan --profile project --root "$GITHUB_WORKSPACE" --exposure-catalog ./bumblebee-upstream/threat_intel/ > scan.ndjson
+
+      # REQUIRED gate: bumblebee's exit code does NOT reflect findings — this
+      # jq pass is the actual failure mechanism. Fails the job on any
+      # `finding` record, on a missing/duplicated `scan_summary`, or on a
+      # summary whose status is not "complete" (partial/timed-out run).
+      - name: Gate on findings and scan completeness
+        run: |
+          jq -s -e '([.[]|select(.record_type=="finding")]|length==0) and ([.[]|select(.record_type=="scan_summary")]|length==1) and (all(.[]|select(.record_type=="scan_summary"); .status=="complete"))' scan.ndjson
+
+      - name: Upload scan NDJSON
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bumblebee-scan
+          path: scan.ndjson
+          retention-days: 30

--- a/docs/bumblebee-evaluation.md
+++ b/docs/bumblebee-evaluation.md
@@ -1,0 +1,206 @@
+# Perplexity Bumblebee — Evaluation and Adoption Decision
+
+**Decision:** Adopt (scoped) — weekly repo-checkout scan of the two committed npm lockfiles, plus an assemble-on-advisory incident runbook  
+**Date:** 2026-06-10 · **Issue:** #413  
+**License:** Bumblebee is [Apache-2.0](https://github.com/perplexityai/bumblebee/blob/main/LICENSE) — the same license as this repo. Usage in CI and local incident response is clean; no vendored source, only a checksum-pinned release binary fetched at workflow run time.
+
+---
+
+## What Bumblebee answers that existing tooling does not
+
+| Tool | Question it answers | Surface | What it does *not* do |
+|---|---|---|---|
+| **Dependabot** (SCA) | "Is a newer/patched version available?" — version drift, registry advisories | npm packages + GitHub Actions | Does not tell you a *specific known-bad version* is on disk right now |
+| **CodeQL** (SAST) | "Does *our* source contain a security flaw?" | `javascript-typescript` in this repo | No dependency provenance; never looks at lockfiles |
+| **`npm audit`** | "Do installed deps match registry advisories?" | npm only | Registry advisories lag campaign disclosure; no curated incident catalog; no agent-skill/MCP/extension inventory |
+| **Bumblebee** | "An advisory names trojaned `X@1.2.3` — is it present on disk *right now*?" | npm lockfiles + (endpoint-side) skill-lock manifests, MCP host configs, editor/browser extensions | Ships **no advisory feed** — exposure catalogs are operator-supplied; v0.1 matches **exact versions only** (no ranges) |
+
+**Bumblebee does not replace Dependabot, CodeQL, or `npm audit`.** It is the
+incident-response complement: when a supply-chain campaign advisory lands, it
+answers the exposure question in seconds instead of a manual lockfile grep.
+
+### Scope corrections relative to issue #413's assumptions
+
+Two surfaces the issue hoped to cover are **not** covered by this adoption,
+verified against the v0.1.1 inventory sources:
+
+- **`.claude/skills/` is NOT covered.** Bumblebee v0.1.1 enumerates only the
+  skills.sh / vercel-labs lock manifests (`skills-lock.json` and
+  `~/.agents/.skill-lock.json`). Loose `SKILL.md` directories — which is what
+  this repo's `.claude/skills/` contains — are not an inventory source.
+  Revisit if upstream adds loose-skill-directory enumeration.
+- **MCP coverage is endpoint-side, not repo-side.** Bumblebee parses MCP
+  *host* configs (`.mcp.json`, `claude_desktop_config.json`,
+  `~/.claude.json`). This repo commits none of those files, and
+  `workers/mcp/` is an MCP *server implementation*, not a host config — so
+  the repo-checkout scan gains no MCP coverage. MCP-config scanning only
+  pays off on developer endpoints (fleet rollout is explicitly out of scope
+  for #413; file separately if wanted).
+
+What the repo-checkout scan *does* cover: `package-lock.json` (709 packages)
+and `hub/package-lock.json` (202 packages) — the full committed npm
+dependency surface of the deployed Worker and the hub.
+
+---
+
+## Integration shape chosen: scheduled CI scan + incident runbook
+
+1. **Weekly scheduled scan** — [`.github/workflows/bumblebee.yml`](../.github/workflows/bumblebee.yml),
+   Mondays 07:27 UTC (offset from CodeQL's 06:27), mirroring `codeql.yml`
+   conventions: least-privilege `permissions: contents: read`,
+   `timeout-minutes`, concurrency group, `workflow_dispatch` for manual runs.
+   The binary is a checksum-pinned v0.1.1 release artifact — never
+   `go install @latest`.
+2. **Assemble-on-advisory runbook** (below) for the hours-after-disclosure
+   window when the pinned catalogs don't yet cover a new campaign.
+
+Bumblebee runs **only in CI and on operator endpoints** — it is a Go binary
+and has no place in the deployed Cloudflare Worker.
+
+### Exposure-catalog source (resolved)
+
+Bumblebee ships no built-in advisory feed; catalogs are operator-supplied via
+`--exposure-catalog`. Two sources, both resolved here:
+
+- **(a) Scheduled scans use upstream `threat_intel/*.json`** — 10 maintained
+  campaign catalogs (Mini Shai-Hulud waves, GlassWorm, node-ipc, GemStuffer,
+  Laravel Lang, TrapDoor, and others) checked out at pinned upstream commit
+  `bf685dde34e2d0a7cfea6a232b515fb53fcd7622`. Catalog content is a trust
+  input, so the pin is bumped only via reviewed PRs — never tracked at a
+  branch head.
+- **(b) Optional broader corpus** — upstream's `tools/osvcatalog` converts
+  the OSSF [malicious-packages](https://github.com/ossf/malicious-packages)
+  OSV tree into a Bumblebee catalog, fully offline. Worth running during an
+  incident when the curated catalogs feel too narrow. Caveat: v0.1 matches
+  **exact versions only**, and many OSV records for malicious packages list
+  no versions at all (every version is bad) — exact-match semantics
+  undercount those.
+
+---
+
+## Incident runbook: assemble-on-advisory
+
+When an advisory names a compromised package `X@v`:
+
+1. **Check upstream first.** Look in
+   [`threat_intel/`](https://github.com/perplexityai/bumblebee/tree/main/threat_intel)
+   (at HEAD, not the pin) for a catalog already covering the campaign. If one
+   exists, use it directly.
+2. **Else write a minimal catalog.** The file must be a JSON **object** with
+   `schema_version` and `entries` — bare arrays are rejected
+   (`parse exposure catalog: root must be a JSON object with
+   'schema_version' and 'entries' keys`):
+
+   ```json
+   {
+     "schema_version": "0.1.0",
+     "entries": [
+       {
+         "id": "INCIDENT-2026-NNNN",
+         "name": "Short campaign description",
+         "ecosystem": "npm",
+         "package": "exact-package-name",
+         "versions": ["1.2.3", "1.2.4"],
+         "severity": "critical"
+       }
+     ]
+   }
+   ```
+
+3. **Run locally** (deep is the incident-response profile and intentionally
+   requires an explicit `--root`):
+
+   ```sh
+   bumblebee scan --profile deep --root <repo-path> \
+     --exposure-catalog ./catalog.json --findings-only
+   ```
+
+   For a repo-only check, `--profile project --root <repo-path>` is faster
+   and sufficient. Add `--root "$HOME"` under `deep` to also sweep
+   endpoint-side surfaces (installed extensions, MCP host configs,
+   skill-lock manifests).
+4. **Any `record_type: "finding"` line is a confirmed exposure.** Findings do
+   **not** change the exit code — inspect the NDJSON, don't trust `$?`.
+   Handle per [`docs/security-policies.md` section 3](security-policies.md):
+   Critical SCA, 7-day SLA, immediate day-0 triage.
+
+### Binary install (pinned, checksum-verified)
+
+Checksums come from the v0.1.1 release's `checksums.txt`. macOS arm64:
+
+```sh
+curl -fsSLO https://github.com/perplexityai/bumblebee/releases/download/v0.1.1/bumblebee_0.1.1_darwin_arm64.tar.gz \
+  && echo "dc0a620e54e85f998c2280b0323763c342973a25eda475d8036d16b01820a2bf  bumblebee_0.1.1_darwin_arm64.tar.gz" | shasum -a 256 -c - \
+  && tar -xzf bumblebee_0.1.1_darwin_arm64.tar.gz \
+  && ./bumblebee selftest
+```
+
+Linux amd64 (what CI uses):
+`0ef1c56c85a67c10f7211883c0eb5fb902de705cc30bbca0bc6f4d60941547da  bumblebee_0.1.1_linux_amd64.tar.gz`
+
+---
+
+## Verified gate behavior — why the jq pass is mandatory
+
+Bumblebee's exit code reflects only operational failure, **not findings**. A
+scan that confirms a trojaned package on disk still exits 0. The CI job
+therefore gates on the NDJSON itself:
+
+```sh
+jq -s -e '([.[]|select(.record_type=="finding")]|length==0)
+  and ([.[]|select(.record_type=="scan_summary")]|length==1)
+  and (all(.[]|select(.record_type=="scan_summary"); .status=="complete"))' scan.ndjson
+```
+
+Verified locally against the real v0.1.1 binary (darwin_arm64,
+checksum-verified) and the pinned upstream catalogs:
+
+- Clean scan of this repo: `scan_summary` `status:"complete"`, 0 findings,
+  911 package records (709 root lockfile + 202 hub lockfile) → gate exits 0.
+- Synthetic catalog entry matching a real lockfile package version
+  (`@cloudflare/kv-asset-handler@0.4.2`): scanner still exits 0, emits
+  `finding` records → gate exits 1.
+- `status` forced to `"partial"`, or `scan_summary` line removed (simulating
+  a truncated/timed-out run) → gate exits 1 in both cases.
+- Scanning a directory containing only catalog JSON files yields 0 package
+  records and 0 findings — pointing `--root` at a workspace that also holds
+  the checked-out `threat_intel/` is harmless.
+
+---
+
+## Threat model / security notes
+
+The scanner itself is a supply-chain trust input; the integration is shaped
+so adopting it does not widen the attack surface it exists to watch:
+
+- **Pinned binary, verified before execution.** CI fetches the v0.1.1
+  release tarball and `sha256sum -c`'s it against a checksum literal
+  committed in the workflow file before untarring. A compromised release
+  re-upload or a `latest` hijack fails the checksum, not the trust boundary.
+  `go install @latest` is explicitly banned.
+- **Pinned catalogs.** `--exposure-catalog` content decides what counts as a
+  finding; a malicious catalog could *suppress* alerts (or spam them). CI
+  checks catalogs out at a fixed upstream commit SHA; bumps are reviewed PRs.
+- **Least privilege.** The workflow runs with `permissions: contents: read`,
+  on `schedule`/`workflow_dispatch` only — no untrusted event payloads are
+  interpolated anywhere, and no write scopes exist to escalate to.
+- **Read-only by design.** Bumblebee inventories on-disk metadata; it
+  executes no dependency code and never runs in the deployed Worker. The
+  email-pipeline invariants in `SECURITY_SPEC.md` are untouched — this is a
+  CI/endpoint control on the repo's *own* dependency surface.
+- **Fail-closed gate.** The jq gate fails on incomplete runs
+  (missing/duplicated `scan_summary`, non-`complete` status), so a scanner
+  crash or truncated output surfaces as a red run instead of silent green.
+
+---
+
+## Why scoped adoption, not full
+
+- The npm-lockfile surface is the only Bumblebee inventory source this repo
+  actually commits (see scope corrections above) — a weekly repo scan plus
+  on-advisory runbook captures all the available value at near-zero cost.
+- Fleet/MDM endpoint rollout (where the skill/MCP/extension coverage pays
+  off) is explicitly out of scope for #413; file separately if the
+  repo-scoped scan proves valuable.
+- Building a PhishSOC-branded exposure-catalog feed is the `hub/`
+  destroylist's separate domain, not this adoption.

--- a/docs/security-policies.md
+++ b/docs/security-policies.md
@@ -1,9 +1,10 @@
 # Security Policies
 
 This document defines PhishSOC's remediation SLAs and merge-gate policies for
-vulnerabilities surfaced by automated security tooling: Dependabot (SCA) and
-CodeQL (SAST). It satisfies OSPS Baseline L3 requirements OSPS-VM-05.01,
-OSPS-VM-05.02, and OSPS-VM-06.01.
+vulnerabilities surfaced by automated security tooling: Dependabot (SCA),
+CodeQL (SAST), and Bumblebee (supply-chain exposure scanning). It satisfies
+OSPS Baseline L3 requirements OSPS-VM-05.01, OSPS-VM-05.02, and
+OSPS-VM-06.01.
 
 ---
 
@@ -131,7 +132,48 @@ Suppressing a High alert without a second-maintainer sign-off is not allowed.
 
 ---
 
-## 3. Consistency with coordinated-disclosure timeline
+## 3. Exposure scanning — Bumblebee
+
+Bumblebee matches the repo's two committed npm lockfiles
+(`package-lock.json`, `hub/package-lock.json`) against curated catalogs of
+known-trojaned package versions. See
+[`docs/bumblebee-evaluation.md`](bumblebee-evaluation.md) for the adoption
+decision, scope, and the assemble-on-advisory incident runbook.
+
+### 3.1 Cadence
+
+| Trigger | Mechanism |
+|---------|-----------|
+| Weekly (Mondays, 07:27 UTC) | [`.github/workflows/bumblebee.yml`](../.github/workflows/bumblebee.yml), pinned binary + pinned upstream catalogs |
+| On advisory (incident) | Assemble-on-advisory runbook in [`docs/bumblebee-evaluation.md`](bumblebee-evaluation.md) — local run against a campaign-specific catalog |
+
+### 3.2 Match handling
+
+**A catalog match (any NDJSON `finding` record) is treated as a Critical SCA
+finding** and inherits the Critical 7-day SLA from section 1.2, with
+immediate day-0 triage on top:
+
+1. Verify the match against the originating advisory (package, version,
+   campaign).
+2. Remove or replace the affected version in the lockfile.
+3. Rotate any credentials the trojaned package could have read at install or
+   build time (npm tokens, CI secrets, wrangler/Cloudflare API tokens).
+
+Unlike Dependabot severity labels, there is no lower band: an exposure
+catalog only contains versions already confirmed malicious, so every match
+is Critical by construction.
+
+### 3.3 Alert path
+
+The workflow's jq gate fails the job on any `finding` record — or on an
+incomplete scan (missing `scan_summary`, status not `complete`) — so the
+alert path is the failed-scheduled-workflow notification to repository
+maintainers. The full `scan.ndjson` is uploaded as a workflow artifact
+(30-day retention) and serves as the evidence record for triage.
+
+---
+
+## 4. Consistency with coordinated-disclosure timeline
 
 The SLAs above are intentionally consistent with the vulnerability-disclosure
 timeline in [`.github/SECURITY.md`](../.github/SECURITY.md):
@@ -142,6 +184,7 @@ timeline in [`.github/SECURITY.md`](../.github/SECURITY.md):
 | Fix or mitigation for high-severity issue | 30 days |
 | SCA High/Critical fix (Dependabot) | 7 days (stricter, because fixes are automated) |
 | SAST High fix (CodeQL) | 14 days |
+| Exposure-catalog match (Bumblebee) | 7 days, with day-0 triage (section 3.2) |
 
 The 7-day SCA window is stricter than the external-report SLA because
 Dependabot PRs are largely automated — the marginal effort to merge a
@@ -150,15 +193,16 @@ engineering judgment needed to fix a code-level finding.
 
 ---
 
-## 4. Tooling references
+## 5. Tooling references
 
 | Tool | Configuration | Dashboard |
 |------|--------------|-----------|
 | Dependabot (SCA) | [`.github/dependabot.yml`](../.github/dependabot.yml) | GitHub → Security → Dependabot alerts |
 | CodeQL (SAST) | [`.github/workflows/codeql.yml`](../.github/workflows/codeql.yml) | GitHub → Security → Code scanning alerts |
+| Bumblebee (exposure) | [`.github/workflows/bumblebee.yml`](../.github/workflows/bumblebee.yml) | GitHub → Actions → Bumblebee runs + NDJSON artifacts |
 
 ---
 
 *This document was introduced to satisfy OSPS Baseline L3 controls
 OSPS-VM-05.01 (SCA policy), OSPS-VM-05.02 (SCA merge gate), and
-OSPS-VM-06.01 (SAST policy). Last updated: 2026-05-28.*
+OSPS-VM-06.01 (SAST policy). Last updated: 2026-06-10.*


### PR DESCRIPTION
## Summary

- Records the **Adopt (scoped)** decision for [Perplexity Bumblebee](https://github.com/perplexityai/bumblebee) in `docs/bumblebee-evaluation.md` (mirrors `docs/codeguard-evaluation.md`): weekly repo-checkout scan of the two committed npm lockfiles + an assemble-on-advisory incident runbook. Explicitly states Bumblebee does **not** replace Dependabot, CodeQL, or `npm audit`.
- Adds `.github/workflows/bumblebee.yml`: weekly cron `27 7 * * 1` (offset from CodeQL's `27 6`) + `workflow_dispatch`; `permissions: contents: read`; `timeout-minutes: 10`; `bumblebee-${{ github.ref }}` concurrency group; sha256-verified pinned v0.1.1 binary; `selftest`; scan against catalogs pinned at upstream commit `bf685dde34e2d0a7cfea6a232b515fb53fcd7622`; jq NDJSON gate; `scan.ndjson` artifact with `if: always()` (30-day retention).
- Extends `docs/security-policies.md` with section 3 "Exposure scanning — Bumblebee" (cadence, match handling = Critical SCA with 7-day SLA + day-0 triage, alert path) and updates the intro tooling sentence; existing sections renumbered 3→4, 4→5.

Closes #413

## Why

PhishSOC is a security product; its own supply chain is in the threat model. Dependabot answers "is a newer version available?", CodeQL answers "is our code flawed?" — neither answers the incident-response question "advisory names trojaned `X@1.2.3`; is it on disk right now?". Bumblebee fills exactly that gap with exact-version matching against curated incident catalogs.

Two corrections to the issue's assumptions, recorded in the decision doc:

1. **`.claude/skills/` is NOT covered** — v0.1.1 only enumerates skills.sh / vercel-labs lock manifests (`skills-lock.json` / `~/.agents/.skill-lock.json`); loose `SKILL.md` dirs are not an inventory source. Revisit if upstream adds it.
2. **MCP coverage is endpoint-side** — Bumblebee parses MCP *host* configs (`.mcp.json`, `claude_desktop_config.json`, `~/.claude.json`); this repo commits none, and `workers/mcp/` is a server implementation, not a host config.

## Invariants affected

This lane touches security tooling, so the supply-chain invariants are stated explicitly (also in the doc's "Threat model / security notes" section):

- **Pinned, checksum-verified scanner binary.** CI fetches the v0.1.1 release tarball and runs `sha256sum -c` against the literal `0ef1c56c85a67c10f7211883c0eb5fb902de705cc30bbca0bc6f4d60941547da` committed in the workflow *before* untarring. The spec's checksum matches upstream's release `checksums.txt` (verified during this work). `go install @latest` is banned — an unpinned scanner is itself a supply-chain exposure.
- **Pinned catalogs.** Catalog content decides what counts as a finding (a malicious catalog could suppress alerts), so catalogs are checked out at a fixed upstream commit SHA; pin bumps are reviewed PRs, never a branch ref.
- **Least privilege, no injection surface.** `permissions: contents: read`; triggers are `schedule`/`workflow_dispatch` only; the only `${{ }}` interpolation is `github.ref` in the concurrency key — no untrusted event payload reaches a `run:` body.
- **Fail-closed gate.** Bumblebee's exit code does NOT reflect findings, so the jq gate is the actual failure mechanism, and it also fails on incomplete runs (missing/duplicated `scan_summary`, status ≠ `complete`) — a crashed or truncated scan goes red, not silently green.
- **Runtime untouched.** Read-only scanner, CI/endpoint only; nothing under `workers/`, `app/`, `shared/`, `hub/` code, or wrangler configs changed. `SECURITY_SPEC.md` email-pipeline invariants are unaffected.

## Test plan

Gate logic verified locally with the **real pinned v0.1.1 darwin_arm64 binary** (sha256 `dc0a620e…20a2bf` verified against upstream `checksums.txt`; `selftest OK`) and the catalogs checked out at the pinned upstream commit (10 catalog JSONs, matching the spec):

- Clean scan of this worktree: `scan_summary` `status:"complete"`, **0 findings, 911 package records (709 `package-lock.json` + 202 `hub/package-lock.json` — both lockfiles covered)** → jq gate exits 0.
- Injected a synthetic catalog entry matching a real lockfile package (`@cloudflare/kv-asset-handler@0.4.2`): scanner **still exits 0** (confirming findings don't affect exit code), emits `finding` records → jq gate exits 1.
- Forced `status:"partial"` and removed the `scan_summary` line (truncated-run simulation) → gate exits 1 in both cases.
- Bare-array catalog rejected with `parse exposure catalog: root must be a JSON object with 'schema_version' and 'entries' keys` (documented in the runbook); `--profile deep` without `--root` refuses to run (documented); scanning a directory holding only catalog JSONs yields 0 packages / 0 findings (so the `bumblebee-upstream/` checkout inside the workspace is harmless).
- Workflow YAML parses (PyYAML): `on` = schedule + dispatch, `permissions: {contents: read}`, `timeout-minutes: 10`, concurrency group present, 7 steps.

Repo gates (docs/CI-only change, run anyway):

- [x] `npm run typecheck` passes locally (exit 0)
- [x] `npm test` passes locally — **109 files, 1378 tests passing, 0 failing**
- [x] hub: `npm run typecheck` exit 0, `npm test` — **10 files, 102 tests passing, 0 failing**
- [x] Manually exercised the affected flow: ran the pinned binary + pinned catalogs against this worktree and exercised the jq gate in both directions (details above)

## Notes for reviewer

- The new workflow's first scheduled run is next Monday 07:27 UTC; `workflow_dispatch` allows an immediate manual run after merge.
- `README.md:123` and `.github/SECURITY.md:37` summarize security-policies.md as "(Dependabot / CodeQL)" — left untouched as out of this PR's scope (they link to the whole doc, no section anchors, so the renumbering breaks nothing). Happy to file a trivial `docs:` follow-up if wanted.
- Per the issue's out-of-scope list, fleet/MDM endpoint rollout (where skill/MCP/extension coverage pays off) is not included; the decision doc notes it as a separate file-if-valuable follow-up.
- Do not enable auto-merge (lane instruction); review-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)