### PR TITLE
security(dmarc): cap RUA gzip decompression and record count (issue #460)

### DIFF
--- a/tests/dmarc/ingest.test.ts
+++ b/tests/dmarc/ingest.test.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+import { describe, expect, it, vi } from "vitest";
+import type { Email } from "postal-mime";
+import { DMARC_MAX_DECOMPRESSED_BYTES } from "../../workers/dmarc/parser";
+import { ingestDmarcReport, isDmarcReport } from "../../workers/dmarc/ingest";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function compress(data: Uint8Array): Promise<ArrayBuffer> {
+	const stream = new Response(data).body!.pipeThrough(new CompressionStream("gzip"));
+	return new Response(stream).arrayBuffer();
+}
+
+function makeEmail(overrides: Partial<Email> = {}): Email {
+	return {
+		from: { address: "dmarc-report@reporter.example", name: "" },
+		subject: "Report Domain: example.com Submitter: reporter.example",
+		attachments: [],
+		headers: [],
+		...overrides,
+	} as unknown as Email;
+}
+
+function mailboxStubMock(insertSpy: ReturnType<typeof vi.fn>) {
+	return { insertDmarcReport: insertSpy };
+}
+
+function envWith(stub: { insertDmarcReport: ReturnType<typeof vi.fn> }) {
+	return {
+		MAILBOX: {
+			idFromName: () => "id",
+			get: () => stub,
+		},
+	} as never;
+}
+
+// Minimal valid DMARC RUA aggregate XML.
+function makeXml(recordCount: number): string {
+	const records = Array.from(
+		{ length: recordCount },
+		(_, i) =>
+			`<record><row><source_ip>203.0.113.${i % 256}</source_ip><count>1</count></row></record>`,
+	).join("\n");
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<feedback>
+  <report_metadata>
+    <org_name>test.example</org_name>
+    <report_id>r-${recordCount}</report_id>
+    <date_range><begin>1700000000</begin><end>1700086400</end></date_range>
+  </report_metadata>
+  <policy_published><domain>example.com</domain><p>reject</p></policy_published>
+  ${records}
+</feedback>`;
+}
+
+// ---------------------------------------------------------------------------
+// isDmarcReport
+// ---------------------------------------------------------------------------
+
+describe("isDmarcReport", () => {
+	it("matches a .xml.gz attachment", () => {
+		const e = makeEmail({
+			subject: "ignore me",
+			attachments: [
+				{ filename: "google.com!example.com!1.xml.gz", mimeType: "application/gzip", content: new Uint8Array() } as never,
+			],
+		});
+		expect(isDmarcReport(e)).toBe(true);
+	});
+
+	it("does NOT match a plain text attachment from an unrelated sender", () => {
+		const e = makeEmail({
+			subject: "hello world",
+			from: { address: "alice@example.com", name: "Alice" },
+			attachments: [
+				{ filename: "report.txt", mimeType: "text/plain", content: new Uint8Array() } as never,
+			],
+		});
+		expect(isDmarcReport(e)).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ingestDmarcReport — gzip size cap
+// ---------------------------------------------------------------------------
+
+describe("ingestDmarcReport — gzip size cap (issue #460)", () => {
+	it("rejects a gzip attachment that decompresses past DMARC_MAX_DECOMPRESSED_BYTES", async () => {
+		// A large run of zeros compresses very efficiently — a few KB of gzip
+		// decompresses to well over 5 MB.
+		const oversized = new Uint8Array(DMARC_MAX_DECOMPRESSED_BYTES + 1);
+		const gz = await compress(oversized);
+
+		const insertSpy = vi.fn();
+		const stub = mailboxStubMock(insertSpy);
+		const e = makeEmail({
+			attachments: [
+				{
+					filename: "report.xml.gz",
+					mimeType: "application/gzip",
+					content: new Uint8Array(gz),
+				} as never,
+			],
+		});
+
+		const result = await ingestDmarcReport(envWith(stub), "mb-1", "msg-1", e);
+		expect(result.ingested).toBe(false);
+		expect(result.reason).toMatch(/cap/i);
+		expect(insertSpy).not.toHaveBeenCalled();
+	});
+
+	it("accepts a legitimate small .xml.gz attachment", async () => {
+		const xml = makeXml(1);
+		const gz = await compress(new TextEncoder().encode(xml));
+
+		const insertSpy = vi.fn().mockResolvedValue(undefined);
+		const stub = mailboxStubMock(insertSpy);
+		const e = makeEmail({
+			attachments: [
+				{
+					filename: "report.xml.gz",
+					mimeType: "application/gzip",
+					content: new Uint8Array(gz),
+				} as never,
+			],
+		});
+
+		const result = await ingestDmarcReport(envWith(stub), "mb-1", "msg-2", e);
+		expect(result.ingested).toBe(true);
+		expect(insertSpy).toHaveBeenCalledOnce();
+		const [reportRow, records] = insertSpy.mock.calls[0];
+		expect(reportRow.domain).toBe("example.com");
+		expect(records).toHaveLength(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ingestDmarcReport — record count cap
+// ---------------------------------------------------------------------------
+
+describe("ingestDmarcReport — record count cap (issue #460)", () => {
+	it("inserts at most 1 000 records even when the XML contains more", async () => {
+		// Build XML with 1 100 records (100 over the cap) and gzip it.
+		const xml = makeXml(1_100);
+		const gz = await compress(new TextEncoder().encode(xml));
+
+		const insertSpy = vi.fn().mockResolvedValue(undefined);
+		const stub = mailboxStubMock(insertSpy);
+		const e = makeEmail({
+			attachments: [
+				{
+					filename: "report.xml.gz",
+					mimeType: "application/gzip",
+					content: new Uint8Array(gz),
+				} as never,
+			],
+		});
+
+		const result = await ingestDmarcReport(envWith(stub), "mb-1", "msg-3", e);
+		expect(result.ingested).toBe(true);
+		const [, records] = insertSpy.mock.calls[0];
+		expect(records.length).toBeLessThanOrEqual(1_000);
+	});
+});

--- a/workers/dmarc/ingest.ts
+++ b/workers/dmarc/ingest.ts
@@ -15,11 +15,14 @@
 import type { Email } from "postal-mime";
 import type { Env } from "../types";
 import { getMailboxStub } from "../lib/email-helpers";
-import { bufferToXmlText, gunzip, parseDmarcXml } from "./parser";
+import { bufferToXmlText, DMARC_MAX_DECOMPRESSED_BYTES, gunzip, parseDmarcXml } from "./parser";
 import { parseDmarcRuf } from "./ruf-parser";
 import type { RufIngestionSettings } from "../security/defaults";
 
 export { isDmarcRuf } from "./ruf-parser";
+
+/** Hard cap on records per aggregate report before the bulk DO insert. */
+const DMARC_MAX_RECORDS = 1_000;
 
 /** Heuristic: does this parsed email look like a DMARC aggregate report? */
 export function isDmarcReport(parsed: Email): boolean {
@@ -54,6 +57,12 @@ export async function ingestDmarcReport(
 		if (fn.endsWith(".xml.gz") || (att.mimeType ?? "").toLowerCase() === "application/gzip") {
 			try {
 				const decompressed = await gunzip(raw);
+				if (decompressed === null) {
+					return {
+						ingested: false,
+						reason: `decompressed DMARC payload exceeds ${DMARC_MAX_DECOMPRESSED_BYTES}-byte cap`,
+					};
+				}
 				xmlText = bufferToXmlText(decompressed);
 				break;
 			} catch (e) {
@@ -87,7 +96,8 @@ export async function ingestDmarcReport(
 		policy_pct: report.policy_pct ?? null,
 		raw_r2_key: null,
 	};
-	const recordsToInsert = report.records.map((r) => ({
+	const cappedRecords = report.records.slice(0, DMARC_MAX_RECORDS);
+	const recordsToInsert = cappedRecords.map((r) => ({
 		id: crypto.randomUUID(),
 		source_ip: r.source_ip,
 		count: r.count,

--- a/workers/dmarc/parser.ts
+++ b/workers/dmarc/parser.ts
@@ -50,10 +50,49 @@ export interface DmarcRecord {
 	auth_results?: DmarcAuthResults;
 }
 
-/** Gunzip an arraybuffer using the runtime's DecompressionStream. */
-export async function gunzip(buf: ArrayBuffer): Promise<ArrayBuffer> {
+/** Hard cap on decompressed DMARC RUA payload — mirrors the TLS-RPT / RUF siblings. */
+export const DMARC_MAX_DECOMPRESSED_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Gunzip an arraybuffer using the runtime's DecompressionStream.
+ *
+ * Reads chunks incrementally and stops as soon as accumulated bytes exceed
+ * maxBytes, so a gzip bomb is rejected mid-stream rather than after the
+ * full payload has been materialised in memory.
+ *
+ * Returns null when the cap is exceeded; throws on malformed gzip input.
+ */
+export async function gunzip(
+	buf: ArrayBuffer,
+	maxBytes: number = DMARC_MAX_DECOMPRESSED_BYTES,
+): Promise<ArrayBuffer | null> {
 	const stream = new Response(buf).body!.pipeThrough(new DecompressionStream("gzip"));
-	return new Response(stream).arrayBuffer();
+	const reader = stream.getReader();
+	const chunks: Uint8Array[] = [];
+	let accumulated = 0;
+	let capExceeded = false;
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			accumulated += value.byteLength;
+			if (accumulated > maxBytes) {
+				capExceeded = true;
+				break;
+			}
+			chunks.push(value);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+	if (capExceeded) return null;
+	const out = new Uint8Array(accumulated);
+	let offset = 0;
+	for (const chunk of chunks) {
+		out.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return out.buffer as ArrayBuffer;
 }
 
 /** Read the first XML-looking text out of a raw buffer. */


### PR DESCRIPTION
## Summary

- `workers/dmarc/parser.ts`: add `DMARC_MAX_DECOMPRESSED_BYTES = 5 MB` constant and rewrite `gunzip` to read the `DecompressionStream` incrementally — the stream is cancelled mid-read once accumulated bytes exceed the cap, so a gzip bomb never fully materialises in Worker memory.
- `workers/dmarc/ingest.ts`: handle the `null` return from the new `gunzip` (cap exceeded) by returning `{ ingested: false, reason: "..." }` immediately; add `DMARC_MAX_RECORDS = 1 000` and slice `report.records` before the bulk DO insert.

Closes #460.

## Test plan

- [x] `npm test` — 1383 passing, 0 failing
- [x] `npm run typecheck` — clean
- [x] New test: oversized `.xml.gz` → `ingested: false` with reason matching `/cap/i`
- [x] New test: XML with 1 100 records → insert capped at ≤ 1 000
- [x] New test: legitimate small `.xml.gz` → `ingested: true`, correct reportRow + records

## Choices made

- `DMARC_MAX_RECORDS = 1 000`: no prior constant in the codebase; 1 000 records per aggregate report is well above any legitimate sender volume while bounding the bulk insert size.
- `null` return from `gunzip` (rather than a typed error class): avoids adding a new exported class for a single caller; the distinction between "cap exceeded" (`null`) and "malformed gzip" (`throw`) is clear at the call site.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WogBf8GwjpyEmtWvGMjXaC)_