### PR TITLE
security(intel): SSRF guard on deep-scan URL resolver (T1)

### DIFF
--- a/test/security/deep-scan-cti.test.ts
+++ b/test/security/deep-scan-cti.test.ts
@@ -227,11 +227,10 @@ describe("runDeepScan + CrowdSec CTI", () => {
 			new URL(String(c[0])).hostname === "cti.api.crowdsec.net",
 		);
 		expect(ctiCalls.length).toBe(0);
-		// And no DoH calls — the CTI stage gates DoH on the API key.
-		const dohCalls = fetchMock.mock.calls.filter((c) =>
-			new URL(String(c[0])).hostname === "cloudflare-dns.com",
-		);
-		expect(dohCalls.length).toBe(0);
+		// SSRF-guard DoH calls (cloudflare-dns.com) are now made by resolveUrl
+		// for every URL hop regardless of CTI configuration; the CTI-stage
+		// resolveHostsToIps is still gated on the API key.  Only assert that
+		// no CTI API calls happened.
 		// No CTI reasons.
 		expect(result.reasons.join(" ")).not.toMatch(/redirect target IP/);
 	});

--- a/tests/intel/url-resolver.test.ts
+++ b/tests/intel/url-resolver.test.ts
@@ -1,10 +1,31 @@
 import { describe, expect, it } from "vitest";
 import { extractTitle, resolveUrl } from "../../workers/intel/url-resolver";
 
-/** Minimal fetch stub that plays back a scripted chain of responses by URL. */
-function stubFetch(chain: Record<string, Response>): typeof fetch {
+const DOH_HOST = "cloudflare-dns.com";
+
+/**
+ * Minimal fetch stub that plays back scripted responses by URL.
+ *
+ * DoH A-record queries to cloudflare-dns.com are intercepted and answered
+ * from `dohMap` (hostname → IPv4 strings). When a hostname is absent from
+ * `dohMap`, the answer section is empty — the SSRF guard treats an empty
+ * answer as "no private IPs found" and allows the request.
+ */
+function stubFetch(
+	chain: Record<string, Response>,
+	dohMap: Record<string, string[]> = {},
+): typeof fetch {
 	return (async (input: string | URL | Request) => {
 		const url = typeof input === "string" ? input : (input as Request).url ?? String(input);
+		const parsed = new URL(url);
+		if (parsed.hostname === DOH_HOST) {
+			const name = parsed.searchParams.get("name") ?? "";
+			const ips = dohMap[name] ?? [];
+			return new Response(
+				JSON.stringify({ Answer: ips.map((ip) => ({ type: 1, data: ip })) }),
+				{ status: 200, headers: { "content-type": "application/dns-json" } },
+			);
+		}
 		const res = chain[url];
 		if (!res) throw new Error(`unexpected URL: ${url}`);
 		return res;
@@ -83,5 +104,80 @@ describe("resolveUrl", () => {
 	it("returns null for a URL that cannot be parsed", async () => {
 		const r = await resolveUrl("not a url");
 		expect(r).toBeNull();
+	});
+});
+
+describe("resolveUrl SSRF guard", () => {
+	it("blocks non-http/https schemes and returns final_status=0", async () => {
+		const r = await resolveUrl("ftp://files.example/payload", stubFetch({}));
+		expect(r?.final_status).toBe(0);
+		expect(r?.resolved).toBe("ftp://files.example/payload");
+	});
+
+	it("blocks direct loopback IPv4 (127.0.0.1) before the first fetch", async () => {
+		const fetchSpy = stubFetch({});
+		const r = await resolveUrl("http://127.0.0.1/admin", fetchSpy);
+		expect(r?.final_status).toBe(0);
+	});
+
+	it("blocks direct RFC-1918 IPv4 (10.x.x.x) before the first fetch", async () => {
+		const r = await resolveUrl("http://10.0.0.1/internal", stubFetch({}));
+		expect(r?.final_status).toBe(0);
+	});
+
+	it("blocks cloud-metadata IP (169.254.169.254) before the first fetch", async () => {
+		const r = await resolveUrl("http://169.254.169.254/latest/meta-data/", stubFetch({}));
+		expect(r?.final_status).toBe(0);
+	});
+
+	it("blocks a hostname that resolves to a private IP via DoH", async () => {
+		const fetchImpl = stubFetch(
+			{},
+			{ "internal.corp.example": ["192.168.1.50"] },
+		);
+		const r = await resolveUrl("http://internal.corp.example/", fetchImpl);
+		expect(r?.final_status).toBe(0);
+	});
+
+	it("blocks a redirect whose absolutized Location resolves to a private IP", async () => {
+		// short.example is public; the redirect target resolves to RFC-1918.
+		const fetchImpl = stubFetch(
+			{
+				"https://short.example/track": new Response("", {
+					status: 302,
+					headers: { location: "https://intranet.corp.example/portal" },
+				}),
+			},
+			{ "intranet.corp.example": ["172.16.0.5"] },
+		);
+		const r = await resolveUrl("https://short.example/track", fetchImpl);
+		// Chain stopped at short.example; the private hop was never fetched.
+		expect(r?.resolved).toBe("https://short.example/track");
+	});
+
+	it("allows a URL whose hostname resolves to a public IP", async () => {
+		const fetchImpl = stubFetch(
+			{
+				"https://public.example/page": new Response("<title>Hello</title>", {
+					status: 200,
+					headers: { "content-type": "text/html" },
+				}),
+			},
+			{ "public.example": ["93.184.216.34"] },
+		);
+		const r = await resolveUrl("https://public.example/page", fetchImpl);
+		expect(r?.resolved).toBe("https://public.example/page");
+		expect(r?.final_status).toBe(200);
+	});
+
+	it("allows a URL when DoH lookup fails (fail-open)", async () => {
+		// DoH throws → resolveHostIps returns [] → no private IPs → allow.
+		const fetchImpl = (async (input: string | URL | Request) => {
+			const url = typeof input === "string" ? input : String(input);
+			if (new URL(url).hostname === DOH_HOST) throw new Error("dns error");
+			return new Response("ok", { status: 200 });
+		}) as typeof fetch;
+		const r = await resolveUrl("https://legit.example/", fetchImpl);
+		expect(r?.final_status).toBe(200);
 	});
 });

--- a/workers/intel/url-resolver.ts
+++ b/workers/intel/url-resolver.ts
@@ -15,8 +15,15 @@
  * network; production callers use the global `fetch`.
  */
 
+import { isPrivateOrLoopbackIp } from "../security/auth";
+
 export const MAX_REDIRECT_HOPS = 5;
 export const RESOLVE_TIMEOUT_MS = 8000;
+
+/** Timeout for each DoH lookup performed by the SSRF guard. */
+export const SSRF_DOH_TIMEOUT_MS = 2000;
+
+const DOH_HOST = "cloudflare-dns.com";
 
 export interface ResolvedUrl {
 	original: string;
@@ -32,12 +39,102 @@ export interface ResolvedUrl {
 	truncated: boolean;
 }
 
+/**
+ * Resolve a hostname to its A records via Cloudflare DNS-over-HTTPS.
+ * Used by the SSRF guard to check whether a redirect destination resolves
+ * to a private/loopback/link-local IP before following the hop.
+ *
+ * Returns [] on any failure so the guard degrades gracefully (fail-open);
+ * the Workers platform already blocks private destinations at the network
+ * layer, so a transient DNS error here does not introduce new SSRF reach.
+ */
+export async function resolveHostIps(
+	hostname: string,
+	fetchImpl: typeof fetch,
+): Promise<string[]> {
+	try {
+		const res = await fetchImpl(
+			`https://${DOH_HOST}/dns-query?name=${encodeURIComponent(hostname)}&type=A`,
+			{
+				headers: { accept: "application/dns-json" },
+				signal: AbortSignal.timeout(SSRF_DOH_TIMEOUT_MS),
+			},
+		);
+		if (!res.ok) return [];
+		const body = await res.json() as { Answer?: Array<{ type?: number; data?: unknown }> };
+		const answer = body.Answer;
+		if (!Array.isArray(answer)) return [];
+		const ips: string[] = [];
+		for (const a of answer) {
+			if (a.type !== 1) continue;
+			if (typeof a.data !== "string") continue;
+			// Reject anything not a plain dotted-quad (paranoia: DoH data is inserted into log strings).
+			if (!/^\d{1,3}(?:\.\d{1,3}){3}$/.test(a.data)) continue;
+			ips.push(a.data);
+		}
+		return ips;
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * SSRF guard: return a blocked-reason string if `url` must not be fetched,
+ * or null if the destination is acceptable.
+ *
+ * Rejects:
+ *  - Non-http/https schemes.
+ *  - Bare IPv4/IPv6 literals in the hostname that map to loopback,
+ *    link-local, RFC-1918, IPv6-ULA, or cloud-metadata ranges.
+ *  - Hostnames whose DoH-resolved A records land in those same ranges.
+ */
+async function checkSsrf(
+	url: string,
+	dnsLookup: (hostname: string) => Promise<string[]>,
+): Promise<string | null> {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return "blocked:invalid-url";
+	}
+
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		return `blocked:scheme:${parsed.protocol}`;
+	}
+
+	const { hostname } = parsed;
+
+	// Strip IPv6 brackets added by the URL serializer: "[::1]" → "::1".
+	const ipStr = hostname.startsWith("[") && hostname.endsWith("]")
+		? hostname.slice(1, -1)
+		: hostname;
+
+	// Check bare IP literals without a DNS round-trip.
+	const isIpLiteral = /^\d{1,3}(?:\.\d{1,3}){3}$/.test(ipStr) || ipStr.includes(":");
+	if (isIpLiteral) {
+		return isPrivateOrLoopbackIp(ipStr) ? `blocked:private-ip:${hostname}` : null;
+	}
+
+	// Resolve hostname via DoH and check every returned A record.
+	const ips = await dnsLookup(hostname);
+	for (const ip of ips) {
+		if (isPrivateOrLoopbackIp(ip)) {
+			return `blocked:private-ip:${ip}`;
+		}
+	}
+
+	return null;
+}
+
 export async function resolveUrl(
 	rawUrl: string,
 	fetchImpl: typeof fetch = fetch,
 ): Promise<ResolvedUrl | null> {
 	const startHost = safeHost(rawUrl);
 	if (!startHost) return null;
+
+	const dnsLookup = (h: string) => resolveHostIps(h, fetchImpl);
 
 	const result: ResolvedUrl = {
 		original: rawUrl,
@@ -59,6 +156,14 @@ export async function resolveUrl(
 			result.truncated = true;
 			break;
 		}
+
+		// SSRF guard — enforce scheme ∈ {http, https} and reject private/
+		// loopback/cloud-metadata destinations before each fetch.
+		if (await checkSsrf(current, dnsLookup)) {
+			result.final_status = 0;
+			break;
+		}
+
 		let res: Response;
 		try {
 			res = await fetchImpl(current, {
@@ -83,6 +188,15 @@ export async function resolveUrl(
 			if (!loc) break;
 			const next = absolutize(current, loc);
 			if (!next) break;
+
+			// SSRF guard — also enforce on the absolutized redirect target
+			// before updating current, so an attacker-supplied Location header
+			// pointing at an internal host is caught immediately.
+			if (await checkSsrf(next, dnsLookup)) {
+				result.resolved = current;
+				break;
+			}
+
 			current = next;
 			continue;
 		}

--- a/workers/security/auth.ts
+++ b/workers/security/auth.ts
@@ -297,7 +297,7 @@ const RECEIVED_IPV6_RE = /(?:IPv6:)?([0-9a-f]{0,4}(?::[0-9a-f]{0,4}){2,7})/gi;
  *     fact that Email Routing's outermost `Received:` line records the
  *     real client IP).
  */
-function isPrivateOrLoopbackIp(ip: string): boolean {
+export function isPrivateOrLoopbackIp(ip: string): boolean {
 	const lower = ip.toLowerCase().replace(/^ipv6:/, "");
 	// IPv4
 	if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(lower)) {


### PR DESCRIPTION
## Summary

- Export `isPrivateOrLoopbackIp` from `workers/security/auth.ts` so it is importable from `workers/intel/`.
- Add `resolveHostIps(hostname, fetchImpl)` to `workers/intel/url-resolver.ts` — DoH A-record lookup via the same injected `fetchImpl`, consistent with `resolveHostA` in `deep-scan.ts`. Fail-open on errors (returns `[]`) since Workers already blocks private destinations at the platform layer.
- Add private `checkSsrf(url, dnsLookup)` that enforces `scheme ∈ {http, https}`, checks bare IPv4/IPv6 literals directly, then falls back to DoH for plain hostnames and rejects any IP that `isPrivateOrLoopbackIp` flags.
- Guard fires at **two** explicit points inside `resolveUrl`'s loop: before each `fetchImpl` call and after each `absolutize()` result, closing the SSRF primitive described as T1 in `docs/security/THREAT_MODEL.md`.

Closes #458.

## Test plan

- [x] `npm test` — 1386 passing, 0 failing
- [x] `npm run typecheck` — environment missing `wrangler` / CF types (pre-existing infra gap, not introduced here); `tsc -b` reports only pre-existing missing-type-definition errors unrelated to the changed files
- [x] New test cases: scheme blocking (`ftp://`), direct loopback/RFC-1918/cloud-metadata IP, DoH-resolved private IP, redirect whose `absolutize()`'d target resolves to a private IP, public-IP pass-through, DoH-failure fail-open

## Choices made

- **Fail-open on DoH error** — `resolveHostIps` returns `[]` on any exception so a transient DNS failure does not block legitimate scanning. This is consistent with every other DoH consumer in the codebase and relies on the Workers platform already refusing private-range connections.
- **DoH via injected `fetchImpl`** — reuses the existing `fetchImpl` parameter rather than adding a third parameter, keeping the public API unchanged and making SSRF tests straightforward to write alongside existing redirect tests.
- **A-records only** — matches the `resolveHostA` pattern in `deep-scan.ts`; AAAA lookups deferred since `isPrivateOrLoopbackIp` already catches IPv6 literals in the URL hostname directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cGuSY6XjMv6b1jJASrWR8)_