### PR TITLE
security(confirm-token): atomic single-use jti consume via DO SQLite INSERT OR IGNORE

### DIFF
--- a/tests/lib/confirm-token.test.ts
+++ b/tests/lib/confirm-token.test.ts
@@ -80,6 +80,15 @@ describe("verifyConfirmationToken", () => {
 		return signConfirmationToken(payload, SECRET);
 	}
 
+	/** Simulates the DO's atomic INSERT OR IGNORE using a plain Set. */
+	function makeConsumeJti(consumed = new Set<string>()) {
+		return (jti: string): Promise<boolean> => {
+			if (consumed.has(jti)) return Promise.resolve(false);
+			consumed.add(jti);
+			return Promise.resolve(true);
+		};
+	}
+
 	it("succeeds on first use and returns the payload", async () => {
 		const kv = makeKv({ "confirm-jti:abc": "1" });
 		const token = await mintWithJti("abc");
@@ -90,6 +99,7 @@ describe("verifyConfirmationToken", () => {
 			BASE.mailboxId,
 			BASE.payloadHash,
 			kv as unknown as KVNamespace,
+			makeConsumeJti(),
 		);
 
 		expect(result).not.toBeNull();
@@ -99,24 +109,28 @@ describe("verifyConfirmationToken", () => {
 		expect(result!.jti).toBe("abc");
 	});
 
-	it("deletes the jti from KV after successful verification (replay protection)", async () => {
+	it("calls consumeJti on success and not before the KV check (replay protection)", async () => {
 		const kv = makeKv({ "confirm-jti:abc2": "1" });
 		const token = await mintWithJti("abc2");
+		const consumed = new Set<string>();
 
-		await verifyConfirmationToken(
+		const result = await verifyConfirmationToken(
 			token,
 			SECRET,
 			BASE.mailboxId,
 			BASE.payloadHash,
 			kv as unknown as KVNamespace,
+			makeConsumeJti(consumed),
 		);
 
-		expect(kv._store["confirm-jti:abc2"]).toBeUndefined();
+		expect(result).not.toBeNull();
+		expect(consumed.has("abc2")).toBe(true);
 	});
 
 	it("returns null on second use of the same token (replay)", async () => {
 		const kv = makeKv({ "confirm-jti:abc3": "1" });
 		const token = await mintWithJti("abc3");
+		const consumeJti = makeConsumeJti();
 
 		const first = await verifyConfirmationToken(
 			token,
@@ -124,6 +138,7 @@ describe("verifyConfirmationToken", () => {
 			BASE.mailboxId,
 			BASE.payloadHash,
 			kv as unknown as KVNamespace,
+			consumeJti,
 		);
 		expect(first).not.toBeNull();
 
@@ -133,8 +148,23 @@ describe("verifyConfirmationToken", () => {
 			BASE.mailboxId,
 			BASE.payloadHash,
 			kv as unknown as KVNamespace,
+			consumeJti,
 		);
 		expect(second).toBeNull();
+	});
+
+	it("concurrent calls: exactly one succeeds (atomic jti consume)", async () => {
+		const kv = makeKv({ "confirm-jti:race": "1" });
+		const token = await mintWithJti("race");
+		const consumeJti = makeConsumeJti();
+
+		const [r1, r2] = await Promise.all([
+			verifyConfirmationToken(token, SECRET, BASE.mailboxId, BASE.payloadHash, kv as unknown as KVNamespace, consumeJti),
+			verifyConfirmationToken(token, SECRET, BASE.mailboxId, BASE.payloadHash, kv as unknown as KVNamespace, consumeJti),
+		]);
+
+		const successes = [r1, r2].filter(Boolean);
+		expect(successes).toHaveLength(1);
 	});
 
 	it("returns null when jti is not in KV (never issued or already consumed)", async () => {
@@ -147,6 +177,7 @@ describe("verifyConfirmationToken", () => {
 			BASE.mailboxId,
 			BASE.payloadHash,
 			kv as unknown as KVNamespace,
+			makeConsumeJti(),
 		);
 		expect(result).toBeNull();
 	});
@@ -161,6 +192,7 @@ describe("verifyConfirmationToken", () => {
 			"other@example.com", // wrong mailboxId
 			BASE.payloadHash,
 			kv as unknown as KVNamespace,
+			makeConsumeJti(),
 		);
 		expect(result).toBeNull();
 	});
@@ -175,6 +207,7 @@ describe("verifyConfirmationToken", () => {
 			BASE.mailboxId,
 			"b".repeat(64), // wrong hash
 			kv as unknown as KVNamespace,
+			makeConsumeJti(),
 		);
 		expect(result).toBeNull();
 	});
@@ -189,6 +222,7 @@ describe("verifyConfirmationToken", () => {
 			BASE.mailboxId,
 			BASE.payloadHash,
 			kv as unknown as KVNamespace,
+			makeConsumeJti(),
 		);
 		expect(result).toBeNull();
 	});

--- a/tests/lib/send-risk-gate.test.ts
+++ b/tests/lib/send-risk-gate.test.ts
@@ -48,6 +48,7 @@ describe("enforceSendRiskConfirmation — payload binding", () => {
 				body,
 				bcc: "exfil@evil.com",
 			},
+			() => Promise.resolve(true),
 		);
 
 		expect(gate.ok).toBe(false);
@@ -77,6 +78,7 @@ describe("enforceSendRiskConfirmation — agent tier and tier downgrade", () => 
 				body: "Following up on the invoice.",
 				createdBy: "agent",
 			},
+			() => Promise.resolve(true),
 		);
 		expect(result.ok).toBe(false);
 		if (result.ok) return;
@@ -101,6 +103,7 @@ describe("enforceSendRiskConfirmation — agent tier and tier downgrade", () => 
 			{ CONFIRMATION_TOKEN_SECRET: SECRET, BLOOM_KV: kv },
 			token,
 			{ mailboxId: MAILBOX_ID, to, subject, body },
+			() => Promise.resolve(true),
 		);
 		expect(result.ok).toBe(false);
 		if (result.ok) return;
@@ -127,6 +130,7 @@ describe("enforceSendRiskConfirmation — fail closed on missing bindings", () =
 				subject: "Please wire transfer $10,000",
 				body: "Urgent.",
 			},
+			() => Promise.resolve(true),
 		);
 		expect(result.ok).toBe(false);
 		if (result.ok) return;
@@ -144,6 +148,7 @@ describe("enforceSendRiskConfirmation — fail closed on missing bindings", () =
 				subject: "Please wire transfer $10,000",
 				body: "Urgent.",
 			},
+			() => Promise.resolve(true),
 		);
 		expect(result.ok).toBe(false);
 		if (result.ok) return;

--- a/tests/lib/tools-send-risk.test.ts
+++ b/tests/lib/tools-send-risk.test.ts
@@ -94,6 +94,7 @@ function makeKv(initial: Record<string, string> = {}) {
 
 function makeStub(opts: { sendRateLimitError?: string | null } = {}) {
 	const sentEmails: unknown[] = [];
+	const consumedJtis = new Set<string>();
 	return {
 		async checkSendRateLimit() {
 			return opts.sendRateLimitError ?? null;
@@ -104,6 +105,11 @@ function makeStub(opts: { sendRateLimitError?: string | null } = {}) {
 		async createEmail(_folder: unknown, email: unknown) {
 			sentEmails.push(email);
 			return {};
+		},
+		async consumeJti(jti: string): Promise<boolean> {
+			if (consumedJtis.has(jti)) return false;
+			consumedJtis.add(jti);
+			return true;
 		},
 		_sentEmails: sentEmails,
 	};

--- a/tests/routes/confirm.test.ts
+++ b/tests/routes/confirm.test.ts
@@ -286,6 +286,14 @@ describe("POST /api/v1/confirm — replay protection", () => {
 			Buffer.from(token.split(".")[1], "base64url").toString(),
 		);
 
+		// Shared atomic-consume callback (simulates DO INSERT OR IGNORE)
+		const consumed = new Set<string>();
+		const consumeJti = (jti: string): Promise<boolean> => {
+			if (consumed.has(jti)) return Promise.resolve(false);
+			consumed.add(jti);
+			return Promise.resolve(true);
+		};
+
 		// First verify — should succeed
 		const first = await verifyConfirmationToken(
 			token,
@@ -293,16 +301,18 @@ describe("POST /api/v1/confirm — replay protection", () => {
 			payload.mailboxId,
 			payload.payloadHash,
 			kv as unknown as KVNamespace,
+			consumeJti,
 		);
 		expect(first).not.toBeNull();
 
-		// Second verify — jti already deleted, should fail
+		// Second verify — jti already consumed, should fail
 		const second = await verifyConfirmationToken(
 			token,
 			SECRET,
 			payload.mailboxId,
 			payload.payloadHash,
 			kv as unknown as KVNamespace,
+			consumeJti,
 		);
 		expect(second).toBeNull();
 	});

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -2172,6 +2172,24 @@ export class MailboxDO extends DurableObject<Env> {
 		);
 	}
 
+	// ── Confirmation-token single-use consume (issue #461) ───────────────────
+
+	/**
+	 * Atomically consume a jti. Returns true if the jti was newly inserted
+	 * (this call wins the race), false if it was already consumed.
+	 *
+	 * INSERT OR IGNORE on a PRIMARY KEY is an atomic test-and-set in DO SQLite:
+	 * the DO serializes all JS execution, so rowsWritten === 1 means exactly
+	 * one caller consumed the token.
+	 */
+	async consumeJti(jti: string): Promise<boolean> {
+		const cursor = this.ctx.storage.sql.exec(
+			`INSERT OR IGNORE INTO consumed_jti (jti) VALUES (?1)`,
+			jti,
+		);
+		return cursor.rowsWritten === 1;
+	}
+
 	/** List RUF records, optionally filtered by domain. Newest first, max 200. */
 	async listDmarcRufRecords(
 		options: { domain?: string; limit?: number; offset?: number } = {},

--- a/workers/durableObject/migrations.ts
+++ b/workers/durableObject/migrations.ts
@@ -525,6 +525,21 @@ export const mailboxMigrations: Migration[] = [
             ALTER TABLE dmarc_sources ADD COLUMN country TEXT;
         `,
 	},
+	{
+		// Atomic single-use jti consume for step-up confirmation tokens (issue #461).
+		// KV has no compare-and-swap, so the previous get-then-delete was a
+		// non-atomic race. The DO serializes all JS execution, so an
+		// INSERT OR IGNORE with a PRIMARY KEY constraint is the atomic gate:
+		// only the request whose INSERT creates a row (rowsWritten === 1) may proceed.
+		// The KV get-check is still used to verify the token was legitimately issued.
+		name: "25_consumed_jti",
+		sql: `
+            CREATE TABLE IF NOT EXISTS consumed_jti (
+                jti TEXT PRIMARY KEY,
+                consumed_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+        `,
+	},
 ];
 
 /**

--- a/workers/lib/confirm-token.ts
+++ b/workers/lib/confirm-token.ts
@@ -71,7 +71,11 @@ export async function signConfirmationToken(
 /**
  * Verifies a one-shot confirmation token. Returns the payload on success,
  * null if the token is invalid, expired, or has already been used.
- * Consumes the jti on success (replay protection).
+ *
+ * Replay protection is enforced by `consumeJti`: it must atomically record
+ * the jti as consumed and return true only when this is the first consume
+ * (e.g. INSERT OR IGNORE into the per-mailbox DO SQLite with rowsWritten check).
+ * The `bloomKv` get-check verifies the token was legitimately issued.
  */
 export async function verifyConfirmationToken(
 	token: string,
@@ -79,6 +83,7 @@ export async function verifyConfirmationToken(
 	mailboxId: string,
 	payloadHash: string,
 	bloomKv: KVNamespace,
+	consumeJti: (jti: string) => Promise<boolean>,
 ): Promise<ConfirmationTokenPayload | null> {
 	let raw: Record<string, unknown>;
 	try {
@@ -97,7 +102,7 @@ export async function verifyConfirmationToken(
 	const exists = await bloomKv.get(jtiKey);
 	if (!exists) return null;
 
-	await bloomKv.delete(jtiKey);
+	if (!(await consumeJti(jti))) return null;
 
 	return {
 		tier: raw.tier as 0 | 1 | 2,

--- a/workers/lib/send-risk-gate.ts
+++ b/workers/lib/send-risk-gate.ts
@@ -25,11 +25,16 @@ export type SendRiskGateResult =
 /**
  * Classify outbound send risk and enforce step-up confirmation for tier ≥ 1.
  * Shared by POST /emails, /reply, and /forward so none can bypass send-risk.
+ *
+ * `consumeJti` must atomically mark the token's jti as consumed and return
+ * true only on the first consume — use the per-mailbox DO's `consumeJti`
+ * method (INSERT OR IGNORE with rowsWritten check) at every call site.
  */
 export async function enforceSendRiskConfirmation(
 	env: GateEnv,
 	confirmationToken: string | undefined,
 	input: SendRiskGateInput,
+	consumeJti: (jti: string) => Promise<boolean>,
 ): Promise<SendRiskGateResult> {
 	const risk = classifySend({
 		to: input.to,
@@ -75,6 +80,7 @@ export async function enforceSendRiskConfirmation(
 		input.mailboxId,
 		payloadHash,
 		BLOOM_KV,
+		consumeJti,
 	);
 	if (!verified) {
 		return { ok: false, status: 401, body: { error: "invalid or expired confirmation token" } };

--- a/workers/lib/tools.ts
+++ b/workers/lib/tools.ts
@@ -454,6 +454,7 @@ export async function toolSendReply(
 			subject: params.subject,
 			body: params.bodyHtml,
 		},
+		(jti) => (stub as any).consumeJti(jti),
 	);
 	if (!gate.ok) {
 		const body = gate.body;
@@ -564,6 +565,7 @@ export async function toolSendEmail(
 			body: params.bodyHtml,
 			attachments: params.attachments?.map((a) => ({ filename: a.filename })),
 		},
+		(jti) => (stub as any).consumeJti(jti),
 	);
 	if (!gate.ok) {
 		const body = gate.body;

--- a/workers/routes/reply-forward.ts
+++ b/workers/routes/reply-forward.ts
@@ -44,6 +44,7 @@ export async function handleReplyEmail(c: AppContext) {
 			attachments: attachments?.map((a) => ({ filename: a.filename })),
 			createdBy,
 		},
+		(jti) => (stub as any).consumeJti(jti),
 	);
 	if (!gate.ok) return c.json(gate.body, gate.status);
 	const rawOriginal = (await stub.getEmail(id)) as EmailFull | null;
@@ -151,6 +152,7 @@ export async function handleForwardEmail(c: AppContext) {
 			attachments: attachments?.map((a) => ({ filename: a.filename })),
 			createdBy,
 		},
+		(jti) => (stub as any).consumeJti(jti),
 	);
 	if (!gate.ok) return c.json(gate.body, gate.status);
 	const rawOriginal = (await stub.getEmail(id)) as EmailFull | null;

--- a/workers/routes/send-email.ts
+++ b/workers/routes/send-email.ts
@@ -67,6 +67,7 @@ sendEmailRoutes.post("/emails", async (c) => {
 			attachments: attachments?.map((a) => ({ filename: a.filename })),
 			createdBy,
 		},
+		(jti) => (c.var.mailboxStub as any).consumeJti(jti),
 	);
 	if (!gate.ok) return c.json(gate.body, gate.status);
 


### PR DESCRIPTION
## Summary

- Replace the non-atomic KV `get`→`delete` in `verifyConfirmationToken` with a `consumeJti(jti: string) => Promise<boolean>` callback that callers provide from the per-mailbox `MailboxDO`
- Add migration 25: `consumed_jti` table (TEXT PRIMARY KEY) in `MailboxDO` SQLite; `MailboxDO.consumeJti` issues `INSERT OR IGNORE` and returns `rowsWritten === 1` — the DO's single-threaded JS runtime serializes all SQL, so only one concurrent caller wins
- Thread the callback through `enforceSendRiskConfirmation` (new 4th param) and all three call-site files (`send-email.ts`, `reply-forward.ts`, `tools.ts`)

Closes #461.

## Test plan

- [x] `npm test` — 1379 passing, 0 failing
- [x] `npm run typecheck` — clean
- [x] New concurrency test: `Promise.all` with two concurrent `verifyConfirmationToken` calls using a shared `consumeJti` callback — asserts exactly one succeeds
- [x] Replaced "deletes jti from KV" assertion (no longer accurate) with "consumeJti called on success" shape
- [x] Updated `tests/lib/tools-send-risk.test.ts` stub to include `consumeJti`; updated `tests/routes/confirm.test.ts` replay test to pass callback

## Choices made

- KV `get` check is **kept**: it verifies the token was legitimately issued through the mint endpoint. The consume atomicity now comes entirely from the DO INSERT. Removing the KV check would leave no record of "was this jti ever minted?" and would rely solely on JWT signature validity — acceptable but slightly weaker defence-in-depth.
- No TTL/cleanup on `consumed_jti`: tokens live 60 s (enforced by JWT exp), confirmed sends are rare, and the table will be very small. Cleanup is a follow-up concern, not a security invariant.

_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDy8G3oJjXb5xYNxrEgNov)_