### PR TITLE
ci: set persist-credentials: false on bumblebee checkout steps

### DIFF
--- a/.github/workflows/bumblebee.yml
+++ b/.github/workflows/bumblebee.yml
@@ -25,7 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # persist-credentials: false on both checkouts — nothing after checkout
+      # needs git credentials, and this job executes a third-party binary over
+      # the workspace, whose .git/config would otherwise hold the GITHUB_TOKEN.
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # Exposure catalogs pinned to an upstream commit, not a branch — catalog
       # content is a trust input, so pin bumps must land as reviewed PRs.
@@ -36,6 +41,7 @@ jobs:
           ref: bf685dde34e2d0a7cfea6a232b515fb53fcd7622
           path: bumblebee-upstream
           sparse-checkout: threat_intel
+          persist-credentials: false
 
       # Pinned release binary, sha256-verified against the checksum recorded
       # here (sourced from the release's checksums.txt). NEVER `go install


### PR DESCRIPTION
## What

Adds `persist-credentials: false` to both `actions/checkout` steps in `.github/workflows/bumblebee.yml`.

## Why

Hardening follow-up from the security review on #457 (merged before the fixup could be pushed to its branch): `actions/checkout` persists the `GITHUB_TOKEN` into `.git/config` by default, and this job then executes a third-party binary (`./bumblebee`) pointed at `--root "$GITHUB_WORKSPACE"` — the directory holding that config. The token is read-only and short-lived, but nothing in the job needs git credentials after checkout, so dropping them is free.

The review's other warning (tag-pinned `uses:` refs) is deliberately **not** addressed here — it spans `ci.yml` and `codeql.yml` too and is tracked as a separate repo-wide `security:` issue.

## Verification

- YAML parses (PyYAML).
- Diff is 6 added lines in one workflow file; no app code, no `${{ }}` interpolation added, so unit tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)