### PR TITLE
security: SHA-pin all Actions uses: refs repo-wide + persist-credentials: false

### DIFF
--- a/.github/workflows/bumblebee.yml
+++ b/.github/workflows/bumblebee.yml
@@ -28,14 +28,14 @@ jobs:
       # persist-credentials: false on both checkouts — nothing after checkout
       # needs git credentials, and this job executes a third-party binary over
       # the workspace, whose .git/config would otherwise hold the GITHUB_TOKEN.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       # Exposure catalogs pinned to an upstream commit, not a branch — catalog
       # content is a trust input, so pin bumps must land as reviewed PRs.
       - name: Checkout pinned upstream exposure catalogs
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: perplexityai/bumblebee
           ref: bf685dde34e2d0a7cfea6a232b515fb53fcd7622
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload scan NDJSON
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bumblebee-scan
           path: scan.ndjson

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -43,9 +45,11 @@ jobs:
       run:
         working-directory: hub
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,13 +25,15 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           languages: javascript-typescript
           queries: security-and-quality
 
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           category: "/language:javascript-typescript"


### PR DESCRIPTION
## Summary

- SHA-pin every `uses:` reference in `ci.yml`, `codeql.yml`, and `bumblebee.yml` to a full 40-character commit SHA with a `# vX.Y.Z` version comment — eliminating mutable tag refs as a supply-chain attack vector
- Add `persist-credentials: false` to the `actions/checkout` steps in `ci.yml` (both jobs) and `codeql.yml` that were still missing it (`bumblebee.yml` already hardened in #470)

Closes #471.

## Test plan

- [x] `npm test` — 1422 passing, 0 failing (112 test files)
- [x] `npm run typecheck` — clean
- [ ] CI green on this PR (`Typecheck & Test`, `Typecheck & Test (hub)`, `Analyze (javascript-typescript)`)
- [ ] `grep -rn "uses:.*@v[0-9]" .github/workflows/` returns nothing ✓ (verified locally)

## Choices made

**SHA lookups** — resolved via `GET https://api.github.com/repos/{owner}/{repo}/git/ref/tags/{tag}`, dereferencing annotated tag objects to their underlying commit SHA:

| Action | Tag | Commit SHA | Version |
|--------|-----|-----------|---------|
| `actions/checkout` | `v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `actions/setup-node` | `v4` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| `github/codeql-action` | `v3` | `dd903d2e4f5405488e5ef1422510ee31c8b32357` | v3.36.2 |
| `actions/upload-artifact` | `v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |

**No version upgrades** — all pins point to the current tip of each existing major-version tag, exactly as the constraint specifies.

**`.github/dependabot.yml` unchanged** — already covers the `github-actions` ecosystem, so Dependabot will open bump PRs when these SHAs drift.

_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdVtz4nRgF8YGa19s4AiEQ)_