### PR TITLE
security(threading): require DMARC alignment + trusted auth for subject-merge

### DIFF
--- a/tests/security/thread-auth-gate.test.ts
+++ b/tests/security/thread-auth-gate.test.ts
@@ -1,15 +1,32 @@
 // Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
 
 /**
- * receiveEmail-level regression for subject-match thread-splicing fix (issue #463).
+ * receiveEmail-level regression for subject-match thread-splicing fix
+ * (issue #463, hardened for GHSA-m9f6-j7mm-wc4m).
+ *
+ * The subject-merge gate must require From:-aligned, trustworthy
+ * authentication before splicing a referenceless message into an existing
+ * thread:
+ *
+ *   - SPF authenticates the envelope MAIL-FROM and DKIM the signing d=
+ *     domain — neither is aligned to the From: header an attacker spoofs,
+ *     so spf=pass / dkim=pass alone must NOT unlock the merge.
+ *   - Only dmarc=pass implies From: alignment, and it only counts when
+ *     reported by an operator-trusted authserv-id (`authVerdict.trusted`),
+ *     mirroring `evaluateHardAllow` in workers/security/triage.ts —
+ *     otherwise a forged Authentication-Results header claiming dmarc=pass
+ *     is honored on default deployments (empty trusted_authserv_ids).
  *
  * Verifies that:
- *   - Unauthenticated sender (all auth headers fail/none) → findThreadBySubject NOT called
- *   - Authenticated sender (dmarc=pass) → findThreadBySubject IS called; thread adopted
- *   - Authenticated sender (spf=pass) → findThreadBySubject IS called; thread adopted
- *   - Authenticated sender (dkim=pass) → findThreadBySubject IS called; thread adopted
- *   - Quarantined + subject-matched → detachEmailFromThread IS called
- *   - Blocked + subject-matched → detachEmailFromThread IS called
+ *   - dmarc=fail + spf=pass + dkim=pass (forged splice) → NOT merged; own thread_id
+ *   - spf=pass only → NOT merged
+ *   - dkim=pass only → NOT merged
+ *   - dmarc=pass from a trusted authserv-id → merged (happy path intact)
+ *   - dmarc=pass with empty trusted_authserv_ids (default deploy, forged
+ *     Authentication-Results) → NOT merged
+ *   - dmarc=pass from an UNtrusted authserv-id on a configured deploy → NOT merged
+ *   - Unauthenticated sender (all fail / no headers) → NOT merged
+ *   - Quarantined/blocked + subject-matched → detachEmailFromThread IS called
  *   - Quarantined without subject-match → detachEmailFromThread NOT called
  */
 
@@ -57,9 +74,10 @@ const mockedPipeline = vi.mocked(runSecurityPipeline);
 
 const MAILBOX_ID = "inbox@example.com";
 const EXISTING_THREAD_ID = "existing-thread-uuid";
+const TRUSTED_AUTHSERV = "authserv.example";
 
-function makeAuthHeader(spf: string, dkim: string, dmarc: string) {
-	return { key: "Authentication-Results", value: `authserv.example; spf=${spf}; dkim=${dkim}; dmarc=${dmarc}` };
+function makeAuthHeader(spf: string, dkim: string, dmarc: string, authservId: string = TRUSTED_AUTHSERV) {
+	return { key: "Authentication-Results", value: `${authservId}; spf=${spf}; dkim=${dkim}; dmarc=${dmarc}` };
 }
 
 function makeEmail(authHeader?: { key: string; value: string }): Email {
@@ -100,13 +118,23 @@ function makeCtx(): ExecutionContext {
 	return { waitUntil: vi.fn() } as unknown as ExecutionContext;
 }
 
-const BASE_SETTINGS = {
-	security: { enabled: true, ruf_ingestion: { enabled: false }, thresholds: {} },
-	autoDraft: { enabled: false },
-	raw: undefined,
-} as unknown as Awaited<ReturnType<typeof resolveMailboxSettings>>;
+function makeSettings(trustedAuthservIds: string[]) {
+	return {
+		security: {
+			enabled: true,
+			ruf_ingestion: { enabled: false },
+			thresholds: {},
+			trusted_authserv_ids: trustedAuthservIds,
+		},
+		autoDraft: { enabled: false },
+		raw: undefined,
+	} as unknown as Awaited<ReturnType<typeof resolveMailboxSettings>>;
+}
 
-describe("receiveEmail — subject-match thread-auth gate (issue #463)", () => {
+/** Default deploy for these tests: operator HAS configured a trusted authserv-id. */
+const BASE_SETTINGS = makeSettings([TRUSTED_AUTHSERV]);
+
+describe("receiveEmail — subject-match thread-auth gate (issue #463 / GHSA-m9f6-j7mm-wc4m)", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockedResolve.mockResolvedValue(BASE_SETTINGS);
@@ -117,7 +145,70 @@ describe("receiveEmail — subject-match thread-auth gate (issue #463)", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("unauthenticated sender: findThreadBySubject NOT called", async () => {
+	it("forged splice (dmarc=fail, spf=pass, dkim=pass): NOT merged; gets its own thread_id", async () => {
+		const stub = makeMailboxStub(EXISTING_THREAD_ID);
+		const email = makeEmail(makeAuthHeader("pass", "pass", "fail"));
+		await receiveEmail(makeNormalized(email), makeEnv(stub), makeCtx());
+
+		expect(stub.findThreadBySubject).not.toHaveBeenCalled();
+		const [, emailArgs] = stub.createEmail.mock.calls[0] as [unknown, { id: string; thread_id: string }];
+		expect(emailArgs.thread_id).not.toBe(EXISTING_THREAD_ID);
+		// Own thread: a referenceless unauthenticated message threads to itself.
+		expect(emailArgs.thread_id).toBe(emailArgs.id);
+	});
+
+	it("spf=pass alone: findThreadBySubject NOT called (SPF is not From-aligned)", async () => {
+		const stub = makeMailboxStub(EXISTING_THREAD_ID);
+		const email = makeEmail(makeAuthHeader("pass", "none", "none"));
+		await receiveEmail(makeNormalized(email), makeEnv(stub), makeCtx());
+
+		expect(stub.findThreadBySubject).not.toHaveBeenCalled();
+		const [, emailArgs] = stub.createEmail.mock.calls[0] as [unknown, { id: string; thread_id: string }];
+		expect(emailArgs.thread_id).toBe(emailArgs.id);
+	});
+
+	it("dkim=pass alone: findThreadBySubject NOT called (DKIM d= is not From-aligned)", async () => {
+		const stub = makeMailboxStub(EXISTING_THREAD_ID);
+		const email = makeEmail(makeAuthHeader("none", "pass", "none"));
+		await receiveEmail(makeNormalized(email), makeEnv(stub), makeCtx());
+
+		expect(stub.findThreadBySubject).not.toHaveBeenCalled();
+		const [, emailArgs] = stub.createEmail.mock.calls[0] as [unknown, { id: string; thread_id: string }];
+		expect(emailArgs.thread_id).toBe(emailArgs.id);
+	});
+
+	it("dmarc=pass from trusted authserv-id: findThreadBySubject IS called; thread adopted", async () => {
+		const stub = makeMailboxStub(EXISTING_THREAD_ID);
+		const email = makeEmail(makeAuthHeader("fail", "none", "pass"));
+		await receiveEmail(makeNormalized(email), makeEnv(stub), makeCtx());
+
+		expect(stub.findThreadBySubject).toHaveBeenCalledOnce();
+		const [, emailArgs] = stub.createEmail.mock.calls[0] as [unknown, { thread_id: string }];
+		expect(emailArgs.thread_id).toBe(EXISTING_THREAD_ID);
+	});
+
+	it("dmarc=pass with empty trusted_authserv_ids (default deploy): forged Authentication-Results NOT honored", async () => {
+		mockedResolve.mockResolvedValue(makeSettings([]));
+		const stub = makeMailboxStub(EXISTING_THREAD_ID);
+		const email = makeEmail(makeAuthHeader("pass", "pass", "pass"));
+		await receiveEmail(makeNormalized(email), makeEnv(stub), makeCtx());
+
+		expect(stub.findThreadBySubject).not.toHaveBeenCalled();
+		const [, emailArgs] = stub.createEmail.mock.calls[0] as [unknown, { id: string; thread_id: string }];
+		expect(emailArgs.thread_id).toBe(emailArgs.id);
+	});
+
+	it("dmarc=pass from an UNtrusted authserv-id on a configured deploy: NOT merged", async () => {
+		const stub = makeMailboxStub(EXISTING_THREAD_ID);
+		const email = makeEmail(makeAuthHeader("pass", "pass", "pass", "attacker.example"));
+		await receiveEmail(makeNormalized(email), makeEnv(stub), makeCtx());
+
+		expect(stub.findThreadBySubject).not.toHaveBeenCalled();
+		const [, emailArgs] = stub.createEmail.mock.calls[0] as [unknown, { id: string; thread_id: string }];
+		expect(emailArgs.thread_id).toBe(emailArgs.id);
+	});
+
+	it("unauthenticated sender (all fail): findThreadBySubject NOT called", async () => {
 		const stub = makeMailboxStub(EXISTING_THREAD_ID);
 		const email = makeEmail(makeAuthHeader("fail", "fail", "fail"));
 		await receiveEmail(makeNormalized(email), makeEnv(stub), makeCtx());
@@ -135,40 +226,10 @@ describe("receiveEmail — subject-match thread-auth gate (issue #463)", () => {
 		expect(stub.findThreadBySubject).not.toHaveBeenCalled();
 	});
 
-	it("authenticated (dmarc=pass): findThreadBySubject IS called; thread adopted", async () => {
-		const stub = makeMailboxStub(EXISTING_THREAD_ID);
-		const email = makeEmail(makeAuthHeader("fail", "none", "pass"));
-		await receiveEmail(makeNormalized(email), makeEnv(stub), makeCtx());
-
-		expect(stub.findThreadBySubject).toHaveBeenCalledOnce();
-		const [, emailArgs] = stub.createEmail.mock.calls[0] as [unknown, { thread_id: string }];
-		expect(emailArgs.thread_id).toBe(EXISTING_THREAD_ID);
-	});
-
-	it("authenticated (spf=pass): findThreadBySubject IS called; thread adopted", async () => {
-		const stub = makeMailboxStub(EXISTING_THREAD_ID);
-		const email = makeEmail(makeAuthHeader("pass", "none", "none"));
-		await receiveEmail(makeNormalized(email), makeEnv(stub), makeCtx());
-
-		expect(stub.findThreadBySubject).toHaveBeenCalledOnce();
-		const [, emailArgs] = stub.createEmail.mock.calls[0] as [unknown, { thread_id: string }];
-		expect(emailArgs.thread_id).toBe(EXISTING_THREAD_ID);
-	});
-
-	it("authenticated (dkim=pass): findThreadBySubject IS called; thread adopted", async () => {
-		const stub = makeMailboxStub(EXISTING_THREAD_ID);
-		const email = makeEmail(makeAuthHeader("none", "pass", "none"));
-		await receiveEmail(makeNormalized(email), makeEnv(stub), makeCtx());
-
-		expect(stub.findThreadBySubject).toHaveBeenCalledOnce();
-		const [, emailArgs] = stub.createEmail.mock.calls[0] as [unknown, { thread_id: string }];
-		expect(emailArgs.thread_id).toBe(EXISTING_THREAD_ID);
-	});
-
 	it("quarantined + subject-matched: detachEmailFromThread IS called", async () => {
 		mockedPipeline.mockResolvedValue({ verdict: { action: "quarantine", score: 80, signals: [], explanation: "" }, skipped: false } as never);
 		const stub = makeMailboxStub(EXISTING_THREAD_ID);
-		const email = makeEmail(makeAuthHeader("pass", "none", "none"));
+		const email = makeEmail(makeAuthHeader("pass", "pass", "pass"));
 		await receiveEmail(makeNormalized(email), makeEnv(stub), makeCtx());
 
 		expect(stub.moveEmail).toHaveBeenCalledWith(expect.any(String), "quarantine");
@@ -178,7 +239,7 @@ describe("receiveEmail — subject-match thread-auth gate (issue #463)", () => {
 	it("blocked + subject-matched: detachEmailFromThread IS called", async () => {
 		mockedPipeline.mockResolvedValue({ verdict: { action: "block", score: 95, signals: [], explanation: "" }, skipped: false } as never);
 		const stub = makeMailboxStub(EXISTING_THREAD_ID);
-		const email = makeEmail(makeAuthHeader("pass", "none", "none"));
+		const email = makeEmail(makeAuthHeader("pass", "pass", "pass"));
 		await receiveEmail(makeNormalized(email), makeEnv(stub), makeCtx());
 
 		expect(stub.moveEmail).toHaveBeenCalledWith(expect.any(String), "quarantine");
@@ -189,7 +250,7 @@ describe("receiveEmail — subject-match thread-auth gate (issue #463)", () => {
 		mockedPipeline.mockResolvedValue({ verdict: { action: "quarantine", score: 80, signals: [], explanation: "" }, skipped: false } as never);
 		// findThreadBySubject returns null — no subject match
 		const stub = makeMailboxStub(null);
-		const email = makeEmail(makeAuthHeader("pass", "none", "none"));
+		const email = makeEmail(makeAuthHeader("pass", "pass", "pass"));
 		await receiveEmail(makeNormalized(email), makeEnv(stub), makeCtx());
 
 		expect(stub.moveEmail).toHaveBeenCalledWith(expect.any(String), "quarantine");

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -1340,11 +1340,23 @@ async function receiveEmail(normalized: MailboxInbound, env: Env, ctx: Execution
 	let subjectMatchedThread = false;
 
 	if (!inReplyTo && emailReferences.length === 0) {
-		const authVerdict = parseAuthResults(parsedEmail.headers);
+		// GHSA-m9f6-j7mm-wc4m: subject-merge requires From:-aligned,
+		// trustworthy authentication. SPF authenticates the envelope
+		// MAIL-FROM and DKIM the signing d= domain — neither is aligned to
+		// the From: header an attacker spoofs, so spf=pass / dkim=pass alone
+		// must NOT unlock thread merging. Only dmarc=pass implies alignment,
+		// and it only counts when reported by an operator-trusted
+		// authserv-id (`authVerdict.trusted`) — same invariant as
+		// `evaluateHardAllow` in workers/security/triage.ts. Without the
+		// trusted gate, a forged Authentication-Results header claiming
+		// dmarc=pass is honored on default deployments (empty
+		// trusted_authserv_ids).
+		const { security } = await resolveMailboxSettings(env, mailboxId);
+		const authVerdict = parseAuthResults(parsedEmail.headers, {
+			trustedAuthservIds: security.trusted_authserv_ids,
+		});
 		const senderIsAuthenticated =
-			authVerdict.dmarc === "pass" ||
-			authVerdict.spf === "pass" ||
-			authVerdict.dkim === "pass";
+			authVerdict.dmarc === "pass" && authVerdict.trusted === true;
 		if (senderIsAuthenticated) {
 			const subjectThread = await (stub as any).findThreadBySubject(parsedEmail.subject || "", parsedEmail.from?.address || undefined);
 			if (subjectThread) {


### PR DESCRIPTION
## Summary

Closes the residual thread-splicing gap left open by PR #465 (private advisory GHSA-m9f6-j7mm-wc4m).

The inbound subject-merge gate in `workers/index.ts` (`receiveEmail`) authenticated the sender with `dmarc === "pass" || spf === "pass" || dkim === "pass"`. SPF authenticates the envelope MAIL-FROM and DKIM the signing `d=` domain — neither is aligned to the `From:` header, so a sender controlling their own SPF/DKIM-valid domain could still satisfy the gate while spoofing `From:`. The gate also called `parseAuthResults` without `trusted_authserv_ids`, so a forged `Authentication-Results` header was honored on default deployments.

## What changed

- The gate now requires `authVerdict.dmarc === "pass" && authVerdict.trusted === true` — the same invariant `evaluateHardAllow` enforces in `workers/security/triage.ts`.
- `parseAuthResults` is now called with the mailbox's resolved `trusted_authserv_ids`, mirroring the synchronous pipeline (`workers/security/index.ts`).
- Unauthenticated referenceless messages keep the existing fallback: `thread_id` = their own message id (no merge).

## Tests (`tests/security/thread-auth-gate.test.ts`)

- `dmarc=fail` with `spf=pass`/`dkim=pass` and a matching subject is NOT merged; gets its own `thread_id`
- `spf=pass` alone / `dkim=pass` alone are NOT merged
- `dmarc=pass` from a trusted authserv-id still threads correctly (happy path intact)
- `dmarc=pass` with empty `trusted_authserv_ids` (default deploy) is NOT honored
- `dmarc=pass` from an untrusted authserv-id on a configured deploy is NOT merged
- Quarantine/block detach behavior unchanged

## Gates

- `npm run typecheck` — clean (exit 0)
- `npm test` — 112 files, 1425 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)