### PR TITLE
security(intel): close residual SSRF gaps — IPv4-mapped IPv6 + AAAA validation

### DIFF
--- a/tests/intel/url-resolver.test.ts
+++ b/tests/intel/url-resolver.test.ts
@@ -6,8 +6,10 @@ const DOH_HOST = "cloudflare-dns.com";
 /**
  * Minimal fetch stub that plays back scripted responses by URL.
  *
- * DoH A-record queries to cloudflare-dns.com are intercepted and answered
- * from `dohMap` (hostname → IPv4 strings). When a hostname is absent from
+ * DoH A/AAAA queries to cloudflare-dns.com are intercepted and answered
+ * from `dohMap` (hostname → IP strings, IPv4 and/or IPv6). Entries are
+ * routed by record type: dotted-quads answer A queries (type 1), colon
+ * forms answer AAAA queries (type 28). When a hostname is absent from
  * `dohMap`, the answer section is empty — the SSRF guard treats an empty
  * answer as "no private IPs found" and allows the request.
  */
@@ -20,9 +22,13 @@ function stubFetch(
 		const parsed = new URL(url);
 		if (parsed.hostname === DOH_HOST) {
 			const name = parsed.searchParams.get("name") ?? "";
-			const ips = dohMap[name] ?? [];
+			const qtype = parsed.searchParams.get("type") ?? "A";
+			const ips = (dohMap[name] ?? []).filter((ip) =>
+				qtype === "AAAA" ? ip.includes(":") : !ip.includes(":"),
+			);
+			const typeNum = qtype === "AAAA" ? 28 : 1;
 			return new Response(
-				JSON.stringify({ Answer: ips.map((ip) => ({ type: 1, data: ip })) }),
+				JSON.stringify({ Answer: ips.map((ip) => ({ type: typeNum, data: ip })) }),
 				{ status: 200, headers: { "content-type": "application/dns-json" } },
 			);
 		}
@@ -179,5 +185,74 @@ describe("resolveUrl SSRF guard", () => {
 		}) as typeof fetch;
 		const r = await resolveUrl("https://legit.example/", fetchImpl);
 		expect(r?.final_status).toBe(200);
+	});
+});
+
+describe("resolveUrl SSRF guard — residual gaps (GHSA-vpmq-j44v-vjr6)", () => {
+	it("blocks an IPv4-mapped IPv6 loopback literal (http://[::ffff:127.0.0.1]/) before the first fetch", async () => {
+		// WHATWG URL serializes the hostname to [::ffff:7f00:1]; the guard must
+		// unwrap the embedded IPv4 and treat it as loopback.
+		const r = await resolveUrl("http://[::ffff:127.0.0.1]/admin", stubFetch({}));
+		expect(r?.final_status).toBe(0);
+	});
+
+	it("blocks an IPv4-mapped IPv6 RFC-1918 literal (http://[::ffff:10.0.0.1]/)", async () => {
+		const r = await resolveUrl("http://[::ffff:10.0.0.1]/internal", stubFetch({}));
+		expect(r?.final_status).toBe(0);
+	});
+
+	it("blocks the unspecified-address literals 0.0.0.0 and [::]", async () => {
+		const r4 = await resolveUrl("http://0.0.0.0/", stubFetch({}));
+		expect(r4?.final_status).toBe(0);
+		const r6 = await resolveUrl("http://[::]/", stubFetch({}));
+		expect(r6?.final_status).toBe(0);
+	});
+
+	it("blocks a hostname whose AAAA record resolves to ::1", async () => {
+		const fetchImpl = stubFetch(
+			{},
+			{ "v6-loopback.example": ["::1"] },
+		);
+		const r = await resolveUrl("http://v6-loopback.example/", fetchImpl);
+		expect(r?.final_status).toBe(0);
+	});
+
+	it("blocks a hostname whose AAAA record resolves to a unique-local (fc00::/7) address", async () => {
+		const fetchImpl = stubFetch(
+			{},
+			{ "v6-ula.example": ["fd12:3456:789a::1"] },
+		);
+		const r = await resolveUrl("http://v6-ula.example/", fetchImpl);
+		expect(r?.final_status).toBe(0);
+	});
+
+	it("blocks a redirect to a hostname whose AAAA record is private even when its A record is public", async () => {
+		const fetchImpl = stubFetch(
+			{
+				"https://short.example/go": new Response("", {
+					status: 302,
+					headers: { location: "https://dual.corp.example/portal" },
+				}),
+			},
+			{ "dual.corp.example": ["93.184.216.34", "fc00::5"] },
+		);
+		const r = await resolveUrl("https://short.example/go", fetchImpl);
+		// Chain stopped at short.example; the private-v6 hop was never fetched.
+		expect(r?.resolved).toBe("https://short.example/go");
+	});
+
+	it("allows a hostname with public A and AAAA records (no happy-path regression)", async () => {
+		const fetchImpl = stubFetch(
+			{
+				"https://dualstack.example/page": new Response("<title>Hi</title>", {
+					status: 200,
+					headers: { "content-type": "text/html" },
+				}),
+			},
+			{ "dualstack.example": ["93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"] },
+		);
+		const r = await resolveUrl("https://dualstack.example/page", fetchImpl);
+		expect(r?.final_status).toBe(200);
+		expect(r?.resolved).toBe("https://dualstack.example/page");
 	});
 });

--- a/tests/security/auth.test.ts
+++ b/tests/security/auth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	emptyVerdict,
 	extractReceivedFromIp,
+	isPrivateOrLoopbackIp,
 	parseAuthResults,
 	scoreAuth,
 } from "../../workers/security/auth";
@@ -402,5 +403,53 @@ describe("extractReceivedFromIp", () => {
 				header("Received", "from sender [203.0.113.55] by mx"),
 			]),
 		).toBe("203.0.113.55");
+	});
+});
+
+describe("isPrivateOrLoopbackIp — IPv4-mapped IPv6, NAT64, unspecified (GHSA-vpmq-j44v-vjr6)", () => {
+	it("blocks IPv4-mapped IPv6 loopback in dotted form (::ffff:127.0.0.1)", () => {
+		expect(isPrivateOrLoopbackIp("::ffff:127.0.0.1")).toBe(true);
+	});
+
+	it("blocks IPv4-mapped IPv6 loopback in hex form (::ffff:7f00:1)", () => {
+		// WHATWG URL serializes http://[::ffff:127.0.0.1]/ to this hex form.
+		expect(isPrivateOrLoopbackIp("::ffff:7f00:1")).toBe(true);
+	});
+
+	it("blocks IPv4-mapped RFC-1918 space in dotted and hex forms", () => {
+		expect(isPrivateOrLoopbackIp("::ffff:10.0.0.1")).toBe(true);
+		expect(isPrivateOrLoopbackIp("::ffff:a00:1")).toBe(true); // 10.0.0.1
+		expect(isPrivateOrLoopbackIp("::ffff:192.168.1.50")).toBe(true);
+		expect(isPrivateOrLoopbackIp("::ffff:169.254.169.254")).toBe(true);
+	});
+
+	it("blocks fully-expanded IPv4-mapped loopback (0:0:0:0:0:ffff:7f00:1)", () => {
+		expect(isPrivateOrLoopbackIp("0:0:0:0:0:ffff:7f00:1")).toBe(true);
+	});
+
+	it("blocks the unspecified addresses 0.0.0.0 and ::", () => {
+		expect(isPrivateOrLoopbackIp("0.0.0.0")).toBe(true);
+		expect(isPrivateOrLoopbackIp("::")).toBe(true);
+		expect(isPrivateOrLoopbackIp("0:0:0:0:0:0:0:0")).toBe(true);
+	});
+
+	it("blocks NAT64-wrapped private/loopback (64:ff9b::/96 with embedded private v4)", () => {
+		expect(isPrivateOrLoopbackIp("64:ff9b::7f00:1")).toBe(true); // 127.0.0.1
+		expect(isPrivateOrLoopbackIp("64:ff9b::127.0.0.1")).toBe(true);
+		expect(isPrivateOrLoopbackIp("64:ff9b::a9fe:a9fe")).toBe(true); // 169.254.169.254
+	});
+
+	it("still allows public addresses, including public IPv4-mapped and NAT64 forms", () => {
+		expect(isPrivateOrLoopbackIp("8.8.8.8")).toBe(false);
+		expect(isPrivateOrLoopbackIp("::ffff:8.8.8.8")).toBe(false);
+		expect(isPrivateOrLoopbackIp("::ffff:808:808")).toBe(false); // 8.8.8.8
+		expect(isPrivateOrLoopbackIp("64:ff9b::808:808")).toBe(false);
+		expect(isPrivateOrLoopbackIp("2606:4700:4700::1111")).toBe(false);
+	});
+
+	it("keeps blocking the existing IPv6 private ranges", () => {
+		expect(isPrivateOrLoopbackIp("::1")).toBe(true);
+		expect(isPrivateOrLoopbackIp("fe80::1")).toBe(true);
+		expect(isPrivateOrLoopbackIp("fd00::1")).toBe(true);
 	});
 });

--- a/workers/intel/url-resolver.ts
+++ b/workers/intel/url-resolver.ts
@@ -40,9 +40,11 @@ export interface ResolvedUrl {
 }
 
 /**
- * Resolve a hostname to its A records via Cloudflare DNS-over-HTTPS.
+ * Resolve a hostname to its A and AAAA records via Cloudflare DNS-over-HTTPS.
  * Used by the SSRF guard to check whether a redirect destination resolves
- * to a private/loopback/link-local IP before following the hop.
+ * to a private/loopback/link-local IP before following the hop. AAAA is
+ * queried alongside A so a hostname whose v6 record points at ::1 / fc00::/7
+ * is caught too (GHSA-vpmq-j44v-vjr6).
  *
  * Returns [] on any failure so the guard degrades gracefully (fail-open);
  * the Workers platform already blocks private destinations at the network
@@ -52,9 +54,24 @@ export async function resolveHostIps(
 	hostname: string,
 	fetchImpl: typeof fetch,
 ): Promise<string[]> {
+	const [a, aaaa] = await Promise.all([
+		queryDoh(hostname, "A", fetchImpl),
+		queryDoh(hostname, "AAAA", fetchImpl),
+	]);
+	return [...a, ...aaaa];
+}
+
+/** Answer record type numbers per RFC 1035 / RFC 3596. */
+const DOH_RECORD_TYPE = { A: 1, AAAA: 28 } as const;
+
+async function queryDoh(
+	hostname: string,
+	type: keyof typeof DOH_RECORD_TYPE,
+	fetchImpl: typeof fetch,
+): Promise<string[]> {
 	try {
 		const res = await fetchImpl(
-			`https://${DOH_HOST}/dns-query?name=${encodeURIComponent(hostname)}&type=A`,
+			`https://${DOH_HOST}/dns-query?name=${encodeURIComponent(hostname)}&type=${type}`,
 			{
 				headers: { accept: "application/dns-json" },
 				signal: AbortSignal.timeout(SSRF_DOH_TIMEOUT_MS),
@@ -66,10 +83,15 @@ export async function resolveHostIps(
 		if (!Array.isArray(answer)) return [];
 		const ips: string[] = [];
 		for (const a of answer) {
-			if (a.type !== 1) continue;
+			if (a.type !== DOH_RECORD_TYPE[type]) continue;
 			if (typeof a.data !== "string") continue;
-			// Reject anything not a plain dotted-quad (paranoia: DoH data is inserted into log strings).
-			if (!/^\d{1,3}(?:\.\d{1,3}){3}$/.test(a.data)) continue;
+			// Reject anything not shaped like the expected IP literal
+			// (paranoia: DoH data is inserted into log strings).
+			if (type === "A") {
+				if (!/^\d{1,3}(?:\.\d{1,3}){3}$/.test(a.data)) continue;
+			} else {
+				if (!/^[0-9a-fA-F:.]{2,45}$/.test(a.data) || !a.data.includes(":")) continue;
+			}
 			ips.push(a.data);
 		}
 		return ips;
@@ -86,7 +108,8 @@ export async function resolveHostIps(
  *  - Non-http/https schemes.
  *  - Bare IPv4/IPv6 literals in the hostname that map to loopback,
  *    link-local, RFC-1918, IPv6-ULA, or cloud-metadata ranges.
- *  - Hostnames whose DoH-resolved A records land in those same ranges.
+ *  - Hostnames whose DoH-resolved A or AAAA records land in those same
+ *    ranges.
  */
 async function checkSsrf(
 	url: string,
@@ -116,7 +139,7 @@ async function checkSsrf(
 		return isPrivateOrLoopbackIp(ipStr) ? `blocked:private-ip:${hostname}` : null;
 	}
 
-	// Resolve hostname via DoH and check every returned A record.
+	// Resolve hostname via DoH and check every returned A/AAAA record.
 	const ips = await dnsLookup(hostname);
 	for (const ip of ips) {
 		if (isPrivateOrLoopbackIp(ip)) {

--- a/workers/security/auth.ts
+++ b/workers/security/auth.ts
@@ -301,24 +301,96 @@ export function isPrivateOrLoopbackIp(ip: string): boolean {
 	const lower = ip.toLowerCase().replace(/^ipv6:/, "");
 	// IPv4
 	if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(lower)) {
-		const parts = lower.split(".").map((p) => parseInt(p, 10));
-		if (parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return true;
-		const [a, b] = parts;
-		if (a === 10) return true;
-		if (a === 127) return true;
-		if (a === 172 && b >= 16 && b <= 31) return true;
-		if (a === 192 && b === 168) return true;
-		if (a === 169 && b === 254) return true;
-		if (a === 0) return true;
-		return false;
+		return isPrivateOrLoopbackIpv4(lower);
 	}
 	// IPv6
 	if (lower === "::1") return true;
+	if (lower === "::") return true; // unspecified address
 	if (lower.startsWith("fe8") || lower.startsWith("fe9") || lower.startsWith("fea") || lower.startsWith("feb")) return true;
 	if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+	// IPv4-mapped (::ffff:0:0/96) and NAT64 well-known prefix (64:ff9b::/96)
+	// embed an IPv4 address in the low 32 bits. WHATWG URL serializes
+	// http://[::ffff:127.0.0.1]/ to the hex form ::ffff:7f00:1, so both the
+	// dotted-quad and hex spellings must unwrap to the embedded IPv4 and
+	// re-run the IPv4 private/loopback checks (GHSA-vpmq-j44v-vjr6).
+	if (lower.includes(":")) {
+		const groups = expandIpv6(lower);
+		if (groups) {
+			if (groups.every((g) => g === 0)) return true; // expanded unspecified (::)
+			if (groups[7] === 1 && groups.slice(0, 7).every((g) => g === 0)) return true; // expanded ::1
+			const isV4Mapped =
+				groups[0] === 0 && groups[1] === 0 && groups[2] === 0 &&
+				groups[3] === 0 && groups[4] === 0 && groups[5] === 0xffff;
+			const isNat64 =
+				groups[0] === 0x64 && groups[1] === 0xff9b &&
+				groups[2] === 0 && groups[3] === 0 && groups[4] === 0 && groups[5] === 0;
+			if (isV4Mapped || isNat64) {
+				const embedded = `${groups[6] >> 8}.${groups[6] & 0xff}.${groups[7] >> 8}.${groups[7] & 0xff}`;
+				return isPrivateOrLoopbackIpv4(embedded);
+			}
+		}
+	}
 	// Treat anything that's not a recognisable IP as "skip" rather than "use".
 	if (!/[0-9]/.test(lower)) return true;
 	return false;
+}
+
+/** IPv4 private/loopback/link-local/unspecified check on a dotted-quad string. */
+function isPrivateOrLoopbackIpv4(ip: string): boolean {
+	const parts = ip.split(".").map((p) => parseInt(p, 10));
+	if (parts.length !== 4 || parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return true;
+	const [a, b] = parts;
+	if (a === 10) return true;
+	if (a === 127) return true;
+	if (a === 172 && b >= 16 && b <= 31) return true;
+	if (a === 192 && b === 168) return true;
+	if (a === 169 && b === 254) return true;
+	if (a === 0) return true;
+	return false;
+}
+
+/**
+ * Expand an IPv6 textual address into its 8 hextet values (0–0xffff).
+ * Handles `::` zero-compression and a trailing embedded dotted-quad
+ * (`::ffff:127.0.0.1`). Returns null when the string is not a parseable
+ * IPv6 address — callers treat null as "not an IPv6 literal".
+ */
+function expandIpv6(ip: string): number[] | null {
+	let s = ip;
+	// Convert a trailing embedded dotted-quad into its two hextets so the
+	// rest of the parse only deals with hex groups.
+	if (s.includes(".")) {
+		const lastColon = s.lastIndexOf(":");
+		if (lastColon === -1) return null;
+		const quad = s.slice(lastColon + 1).split(".");
+		if (quad.length !== 4) return null;
+		const bytes = quad.map((p) => (/^\d{1,3}$/.test(p) ? parseInt(p, 10) : NaN));
+		if (bytes.some((n) => Number.isNaN(n) || n > 255)) return null;
+		const hi = ((bytes[0] << 8) | bytes[1]).toString(16);
+		const lo = ((bytes[2] << 8) | bytes[3]).toString(16);
+		s = `${s.slice(0, lastColon + 1)}${hi}:${lo}`;
+	}
+	const halves = s.split("::");
+	if (halves.length > 2) return null;
+	const parseGroups = (part: string): number[] | null => {
+		if (part === "") return [];
+		const out: number[] = [];
+		for (const g of part.split(":")) {
+			if (!/^[0-9a-f]{1,4}$/.test(g)) return null;
+			out.push(parseInt(g, 16));
+		}
+		return out;
+	};
+	const head = parseGroups(halves[0]);
+	if (head === null) return null;
+	if (halves.length === 1) {
+		return head.length === 8 ? head : null;
+	}
+	const tail = parseGroups(halves[1]);
+	if (tail === null) return null;
+	const fill = 8 - head.length - tail.length;
+	if (fill < 1) return null; // `::` must stand for at least one zero group
+	return [...head, ...new Array<number>(fill).fill(0), ...tail];
 }
 
 /**


### PR DESCRIPTION
Follow-up to #467 for private advisory GHSA-vpmq-j44v-vjr6 — closes the two residual gaps the initial deep-scan SSRF guard left open.

## What changed

- **`workers/security/auth.ts` — `isPrivateOrLoopbackIp`**: now unwraps IPv4-mapped IPv6 (`::ffff:0:0/96`, both dotted-quad and hex spellings, including fully-expanded forms) and NAT64 (`64:ff9b::/96`) addresses and runs the existing IPv4 private/loopback/link-local checks on the embedded address. The unspecified addresses `0.0.0.0` and `::` are blocked outright. Public addresses (including public IPv4-mapped/NAT64 forms) are unaffected.
- **`workers/intel/url-resolver.ts` — `resolveHostIps`**: queries AAAA records alongside A via DoH, so a hostname whose v6 record points at `::1` / `fc00::/7` is caught. The existing per-fetch and per-redirect-hop `checkSsrf` calls are unchanged.

## Acceptance tests

`tests/security/auth.test.ts` (`isPrivateOrLoopbackIp — IPv4-mapped IPv6, NAT64, unspecified`):
- blocks IPv4-mapped IPv6 loopback in dotted form (`::ffff:127.0.0.1`)
- blocks IPv4-mapped IPv6 loopback in hex form (`::ffff:7f00:1`)
- blocks IPv4-mapped RFC-1918 space in dotted and hex forms
- blocks fully-expanded IPv4-mapped loopback
- blocks the unspecified addresses `0.0.0.0` and `::`
- blocks NAT64-wrapped private/loopback (`64:ff9b::/96` with embedded private v4)
- still allows public addresses, including public IPv4-mapped and NAT64 forms
- keeps blocking the existing IPv6 private ranges

`tests/intel/url-resolver.test.ts` (`resolveUrl SSRF guard — residual gaps`):
- blocks an IPv4-mapped IPv6 loopback literal before the first fetch
- blocks an IPv4-mapped IPv6 RFC-1918 literal
- blocks the unspecified-address literals `0.0.0.0` and `[::]`
- blocks a hostname whose AAAA record resolves to `::1`
- blocks a hostname whose AAAA record resolves to a unique-local (`fc00::/7`) address
- blocks a redirect to a hostname whose AAAA record is private even when its A record is public
- allows a hostname with public A and AAAA records (no happy-path regression)

## Gates

- `npm run typecheck`: pass (exit 0)
- `npm test`: 112 test files passed, 1437 tests passed, 0 failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)