### PR TITLE
security(agent): enforce per-mailbox ACL on the EmailAgent path

### DIFF
--- a/tests/lib/mailbox-acl.test.ts
+++ b/tests/lib/mailbox-acl.test.ts
@@ -2,9 +2,25 @@
 
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
-import { callerInAcl, callerGroupsFromJwt, readMailboxAcl, writeMailboxAcl, deleteMailboxAcl } from "../../workers/lib/mailbox-acl";
+import {
+	callerInAcl,
+	callerGroupsFromJwt,
+	callerEmailFromJwt,
+	callerAllowedForMailbox,
+	emailAgentMailboxIdFromPath,
+	readMailboxAcl,
+	writeMailboxAcl,
+	deleteMailboxAcl,
+} from "../../workers/lib/mailbox-acl";
 import type { MailboxAcl } from "../../workers/lib/mailbox-acl";
 import { requireMailbox } from "../../workers/lib/mailbox";
+
+// Helper: build a fake (unsigned) JWT carrying arbitrary claims (email/groups).
+// decodeJwt from jose just base64url-decodes the payload — no sig check needed.
+function makeFakeJwt(claims: Record<string, unknown>): string {
+	const b64url = (s: string) => btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+	return `${b64url('{"alg":"none"}')}.${b64url(JSON.stringify(claims))}.`;
+}
 
 // Helper: build a fake (unsigned) JWT carrying the given groups claim.
 // decodeJwt from jose just base64url-decodes the payload — no sig check needed.
@@ -384,5 +400,170 @@ describe("requireMailbox — group-grant ACL (#295)", () => {
 		const app = makeFakeMailboxAppWithJwt(store, "eve@example.com", null);
 		const res = await app.fetch("/mailboxes/alice@example.com/test");
 		expect(res.status).toBe(403);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// callerEmailFromJwt — identity from the verified token, never a header (f17)
+// ---------------------------------------------------------------------------
+
+describe("callerEmailFromJwt", () => {
+	it("returns null for absent/malformed tokens", () => {
+		expect(callerEmailFromJwt(null)).toBeNull();
+		expect(callerEmailFromJwt(undefined)).toBeNull();
+		expect(callerEmailFromJwt("")).toBeNull();
+		expect(callerEmailFromJwt("not.a.jwt")).toBeNull();
+	});
+
+	it("returns the email claim from a valid token", () => {
+		expect(callerEmailFromJwt(makeFakeJwt({ email: "alice@example.com" }))).toBe("alice@example.com");
+	});
+
+	it("returns null when the token has no email claim (e.g. a service token)", () => {
+		expect(callerEmailFromJwt(makeFakeJwt({ common_name: "svc-token" }))).toBeNull();
+		expect(callerEmailFromJwt(makeFakeJwt({ groups: ["soc-analysts"] }))).toBeNull();
+	});
+
+	it("returns null for a non-string or empty email claim", () => {
+		expect(callerEmailFromJwt(makeFakeJwt({ email: 42 }))).toBeNull();
+		expect(callerEmailFromJwt(makeFakeJwt({ email: "" }))).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// emailAgentMailboxIdFromPath — only the per-mailbox EmailAgent path (f15)
+// ---------------------------------------------------------------------------
+
+describe("emailAgentMailboxIdFromPath", () => {
+	it("extracts the mailboxId from an EmailAgent path", () => {
+		expect(emailAgentMailboxIdFromPath("/agents/email-agent/alice@example.com")).toBe("alice@example.com");
+	});
+
+	it("extracts it for deeper sub-paths (chat / websocket endpoints)", () => {
+		expect(emailAgentMailboxIdFromPath("/agents/email-agent/alice@example.com/get-messages")).toBe(
+			"alice@example.com",
+		);
+	});
+
+	it("URL-decodes the mailboxId segment", () => {
+		expect(emailAgentMailboxIdFromPath("/agents/email-agent/alice%40example.com")).toBe("alice@example.com");
+	});
+
+	it("returns null for OrgAgent and other agents (not gated here)", () => {
+		expect(emailAgentMailboxIdFromPath("/agents/org-agent/default")).toBeNull();
+	});
+
+	it("returns null for non-agent or incomplete paths", () => {
+		expect(emailAgentMailboxIdFromPath("/api/v1/mailboxes/alice@example.com/emails")).toBeNull();
+		expect(emailAgentMailboxIdFromPath("/agents/email-agent")).toBeNull();
+		expect(emailAgentMailboxIdFromPath("/agents")).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// callerAllowedForMailbox — agent-path ACL core, fail-closed in prod (f15/f17)
+// ---------------------------------------------------------------------------
+
+describe("callerAllowedForMailbox", () => {
+	const mailboxId = "alice@example.com";
+	const aclKey = `mailboxes-acl/${mailboxId}.json`;
+	const aliceAcl: MailboxAcl = { owner: mailboxId, members: [mailboxId], groups: ["soc-analysts"] };
+	const env = (store: Record<string, string>) => ({ BUCKET: makeR2Stub(store) as unknown as R2Bucket });
+
+	it("allows when no ACL blob exists (backwards-compat)", async () => {
+		expect(await callerAllowedForMailbox(env({}), mailboxId, makeFakeJwt({ email: "eve@evil.com" }), false)).toBe(
+			true,
+		);
+	});
+
+	it("allows a member identified by the verified-JWT email", async () => {
+		const e = env({ [aclKey]: JSON.stringify(aliceAcl) });
+		expect(await callerAllowedForMailbox(e, mailboxId, makeFakeJwt({ email: mailboxId }), false)).toBe(true);
+	});
+
+	it("allows a caller in a granted group (groups from the JWT)", async () => {
+		const e = env({ [aclKey]: JSON.stringify(aliceAcl) });
+		expect(
+			await callerAllowedForMailbox(e, mailboxId, makeFakeJwt({ email: "bob@example.com", groups: ["soc-analysts"] }), false),
+		).toBe(true);
+	});
+
+	it("DENIES a non-member teammate (the f15 cross-tenant bypass)", async () => {
+		const e = env({ [aclKey]: JSON.stringify(aliceAcl) });
+		expect(await callerAllowedForMailbox(e, mailboxId, makeFakeJwt({ email: "eve@example.com" }), false)).toBe(false);
+	});
+
+	it("DENIES (fail-closed) in prod when the JWT carries no email — e.g. a service token", async () => {
+		const e = env({ [aclKey]: JSON.stringify(aliceAcl) });
+		expect(await callerAllowedForMailbox(e, mailboxId, makeFakeJwt({ common_name: "svc" }), false)).toBe(false);
+		expect(await callerAllowedForMailbox(e, mailboxId, null, false)).toBe(false);
+	});
+
+	it("ignores a forged email header — identity comes only from the JWT", async () => {
+		// No JWT email claim → denied, even though a caller could set any
+		// cf-access-authenticated-user-email header on a direct-origin request.
+		const e = env({ [aclKey]: JSON.stringify(aliceAcl) });
+		expect(await callerAllowedForMailbox(e, mailboxId, makeFakeJwt({}), false)).toBe(false);
+	});
+
+	it("allows in dev mode (no CF Access in front) regardless of ACL", async () => {
+		const e = env({ [aclKey]: JSON.stringify(aliceAcl) });
+		expect(await callerAllowedForMailbox(e, mailboxId, null, true)).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Agent-route gate — wires emailAgentMailboxIdFromPath + callerAllowedForMailbox
+// the same way workers/app.ts does, asserting the 403 the route returns (f15).
+// ---------------------------------------------------------------------------
+
+describe("agent-route ACL gate (f15)", () => {
+	const mailboxId = "alice@example.com";
+	const aclKey = `mailboxes-acl/${mailboxId}.json`;
+	const aliceAcl: MailboxAcl = { owner: mailboxId, members: [mailboxId] };
+
+	function makeAgentGateApp(store: Record<string, string>, jwt: string | null) {
+		const bucket = makeR2Stub(store);
+		const app = new Hono<{ Bindings: { BUCKET: typeof bucket } }>();
+		// Mirror of the workers/app.ts "/agents/*" handler (isDev=false → prod).
+		app.all("/agents/*", async (c) => {
+			const id = emailAgentMailboxIdFromPath(new URL(c.req.url).pathname);
+			if (id) {
+				const allowed = await callerAllowedForMailbox(c.env, id, c.req.header("cf-access-jwt-assertion"), false);
+				if (!allowed) return c.json({ error: "Forbidden" }, 403);
+			}
+			return c.json({ routed: true }); // stand-in for routeAgentRequest
+		});
+		return {
+			fetch: (path: string) => {
+				const headers: Record<string, string> = {};
+				if (jwt) headers["cf-access-jwt-assertion"] = jwt;
+				return app.request(path, { headers }, { BUCKET: bucket as unknown as R2Bucket });
+			},
+		};
+	}
+
+	it("returns 403 for a teammate not in the mailbox ACL (cross-tenant bypass closed)", async () => {
+		const app = makeAgentGateApp({ [aclKey]: JSON.stringify(aliceAcl) }, makeFakeJwt({ email: "eve@example.com" }));
+		const res = await app.fetch("/agents/email-agent/alice@example.com");
+		expect(res.status).toBe(403);
+	});
+
+	it("returns 403 when the JWT has no email claim (header-strip / service token)", async () => {
+		const app = makeAgentGateApp({ [aclKey]: JSON.stringify(aliceAcl) }, makeFakeJwt({ common_name: "svc" }));
+		const res = await app.fetch("/agents/email-agent/alice@example.com");
+		expect(res.status).toBe(403);
+	});
+
+	it("allows a member through the gate", async () => {
+		const app = makeAgentGateApp({ [aclKey]: JSON.stringify(aliceAcl) }, makeFakeJwt({ email: mailboxId }));
+		const res = await app.fetch("/agents/email-agent/alice@example.com");
+		expect(res.status).toBe(200);
+	});
+
+	it("does not gate the OrgAgent path", async () => {
+		const app = makeAgentGateApp({ [aclKey]: JSON.stringify(aliceAcl) }, makeFakeJwt({ email: "eve@example.com" }));
+		const res = await app.fetch("/agents/org-agent/default");
+		expect(res.status).toBe(200);
 	});
 });

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -11,6 +11,7 @@ import { normalizeInbound } from "./providers/cf-routing";
 import { EmailMCP } from "./mcp";
 import { refreshAllFeeds } from "./intel/feeds";
 import { confirmRoute } from "./routes/confirm";
+import { callerAllowedForMailbox, emailAgentMailboxIdFromPath } from "./lib/mailbox-acl";
 import type { Env } from "./types";
 
 export { MailboxDO } from "./durableObject";
@@ -114,6 +115,24 @@ app.route("/", apiApp);
 
 // Agent WebSocket routing - must be before React Router catch-all
 app.all("/agents/*", async (c) => {
+	// Per-mailbox ACL enforcement for the EmailAgent path — parity with the
+	// HTTP `requireMailbox` and MCP `verifyMailbox` gates (#27/#295). The agent
+	// instance name IS the mailboxId (attacker-chosen via the connection URL),
+	// and the full email toolset is built for it, so without this check any
+	// teammate admitted by the shared CF Access policy could read and mutate
+	// any other mailbox over the agent WebSocket. Runs after the global CF
+	// Access JWT middleware (token verified-present) and before
+	// `routeAgentRequest`, covering both the WebSocket upgrade and HTTP.
+	const mailboxId = emailAgentMailboxIdFromPath(new URL(c.req.url).pathname);
+	if (mailboxId) {
+		const allowed = await callerAllowedForMailbox(
+			c.env,
+			mailboxId,
+			c.req.header("cf-access-jwt-assertion"),
+			import.meta.env.DEV,
+		);
+		if (!allowed) return c.json({ error: "Forbidden" }, 403);
+	}
 	const response = await routeAgentRequest(c.req.raw, c.env);
 	if (response) return response;
 	return c.text("Agent not found", 404);

--- a/workers/lib/mailbox-acl.ts
+++ b/workers/lib/mailbox-acl.ts
@@ -108,3 +108,69 @@ export function callerInAcl(
 	if (acl.groups?.some((g) => callerGroups.includes(g))) return true;
 	return false;
 }
+
+/**
+ * Decodes the `email` claim from a CF Access JWT without re-verifying the
+ * signature (the global CF Access middleware already verified it). Returns null
+ * when the token is absent, malformed, or carries no string `email` claim
+ * (e.g. a CF Access *service token*, which has no `email`).
+ *
+ * Identity for an authorization decision must be sourced from the verified
+ * token — never from the `cf-access-authenticated-user-email` header, which is
+ * decoupled from the JWT and forgeable on a direct-to-origin request.
+ */
+export function callerEmailFromJwt(jwtToken: string | null | undefined): string | null {
+	if (!jwtToken) return null;
+	try {
+		const email = decodeJwt(jwtToken)["email"];
+		return typeof email === "string" && email.length > 0 ? email : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Extracts the EmailAgent instance name (the mailboxId) from an `/agents/*`
+ * request path, or null when the path does not target the per-mailbox
+ * EmailAgent. The Agents SDK routes EmailAgent under the kebab-cased class
+ * name, i.e. `/agents/email-agent/<mailboxId>[/...]` (see
+ * `camelCaseToKebabCase("EmailAgent")`). OrgAgent (`/agents/org-agent/...`) is
+ * intentionally excluded — it exposes only aggregate data.
+ */
+export function emailAgentMailboxIdFromPath(pathname: string): string | null {
+	const segments = pathname.split("/").filter(Boolean);
+	if (segments[0] === "agents" && segments[1] === "email-agent" && segments[2]) {
+		try {
+			return decodeURIComponent(segments[2]);
+		} catch {
+			return segments[2];
+		}
+	}
+	return null;
+}
+
+/**
+ * Authorizes a caller for a mailbox from their CF Access JWT — the same ACL
+ * boundary that `requireMailbox` (HTTP) and `verifyMailbox` (MCP) enforce, but
+ * usable from a non-Hono entry point (the EmailAgent WebSocket/agent route).
+ * Fails CLOSED in production when identity cannot be established.
+ *
+ * - No ACL blob → allow (backwards-compat: pre-#27 mailboxes / single-user).
+ * - `isDev` → allow (local dev, no CF Access in front — matches `callerInAcl`).
+ * - Production: require a verified-JWT email; a missing email (no token, or a
+ *   service token with no `email` claim) is DENIED. Otherwise defer to
+ *   `callerInAcl` for members + group grants.
+ */
+export async function callerAllowedForMailbox(
+	env: { BUCKET: R2Bucket },
+	mailboxId: string,
+	jwtToken: string | null | undefined,
+	isDev: boolean,
+): Promise<boolean> {
+	const acl = await readMailboxAcl(env, mailboxId);
+	if (acl === null) return true;
+	if (isDev) return true;
+	const email = callerEmailFromJwt(jwtToken);
+	if (!email) return false;
+	return callerInAcl(acl, email, callerGroupsFromJwt(jwtToken));
+}


### PR DESCRIPTION
## Task

The `EmailAgent` WebSocket/agent route (`/agents/email-agent/<mailboxId>`) built the full email toolset for the connection's instance name with **no ACL check**. The per-mailbox ACL (#27/#295) is enforced on the HTTP path (`requireMailbox`) and the MCP path (`verifyMailbox`), but not on the agent path — so any teammate admitted by the shared Cloudflare Access policy could read and mutate **any** other mailbox over the agent WebSocket (list/get/search emails, draft, move, discard).

This gates `/agents/email-agent/*` with the same ACL, before `routeAgentRequest`, covering both the WebSocket upgrade and HTTP.

Tracks private advisory **GHSA-g3v6-6xph-3vx6** (finding f15, High).

## Changes

- `workers/lib/mailbox-acl.ts` — new `callerEmailFromJwt` (identity from the **verified** CF Access JWT, not the spoofable `cf-access-authenticated-user-email` header), `emailAgentMailboxIdFromPath` (parses `/agents/email-agent/<id>`, excludes OrgAgent), and `callerAllowedForMailbox` (the reusable agent-path ACL check — **fails closed** in production when no JWT email is present, e.g. a service token).
- `workers/app.ts` — the `/agents/*` handler now runs the ACL gate before `routeAgentRequest`.
- `tests/lib/mailbox-acl.test.ts` — +20 tests.

## Acceptance criteria

- [x] A teammate absent from mailbox A's ACL gets **403** on `/agents/email-agent/A` (WS upgrade + HTTP).
- [x] Identity derived from the verified JWT `email` claim, not the header.
- [x] Fails closed in production on a null/absent JWT email (service token); dev (no Access) and no-ACL (backwards-compat) paths preserved.
- [x] OrgAgent path not gated.
- [x] `npm run typecheck` clean; `npm test` 1442 passing.

## Out of scope (follow-up)

- Finding **f17** (same advisory): migrate the remaining HTTP/MCP call sites (`requireMailbox`, `workers/index.ts` ×5, `workers/routes/acl-members.ts` ×7, `workers/mcp`, `org-search`) off the `cf-access-authenticated-user-email` header to the verified JWT, and make `callerInAcl` fail closed on null email in production. Larger cross-cutting change; separate PR.
- Setting `workers_dev: false` — deferred because `wrangler.jsonc` configures no custom domain/route, so disabling the workers.dev origin would make the worker unreachable. The JWT-derived identity closes the direct-origin bypass regardless.

Do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)