### PR TITLE
security(intel): pin hub & feed credential destinations to a host allowlist

### DIFF
--- a/tests/intel/feed-auth-allowlist.test.ts
+++ b/tests/intel/feed-auth-allowlist.test.ts
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Feed-credential destination pin for GHSA-jfj6-w954-96vg (finding f27).
+ *
+ * `resolveFeeds` attaches `env[f.auth_secret]` as an `Authorization` header
+ * on the feed refresh fetch. The `FEED_SECRET_` prefix guard (#418)
+ * constrains WHICH secret may be named, but the destination `f.url` is
+ * teammate-editable settings data — without a host pin, a feed pointed at
+ * `https://attacker.example` receives the raw secret.
+ *
+ * Pin: the Authorization header is only attached when the feed URL's host
+ * is on `FEED_ALLOWED_HOSTS` (CSV) UNION the hostnames of the built-in
+ * `DEFAULT_FEEDS` (so operator-trusted default secret-bearing feeds keep
+ * working with no new config), and the URL is https. An off-allowlist feed
+ * still fetches — public no-secret feeds are never blocked — it just never
+ * carries the credential.
+ *
+ * Exercised through `refreshAllFeeds` (the real fetch path) with a mocked
+ * `globalThis.fetch`, so the assertion is on the headers that actually
+ * leave the worker.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { refreshAllFeeds } from "../../workers/intel/feeds";
+import { DEFAULT_FEEDS } from "../../workers/intel/defaults";
+import { clearOrgSettingsCache } from "../../workers/lib/org-settings";
+import { clearDomainSettingsCache } from "../../workers/lib/domain-settings";
+import type { Env } from "../../workers/types";
+
+const MAILBOX_ID = "user@example.com";
+
+// ── Fakes ─────────────────────────────────────────────────────────────
+
+function makeKv() {
+	const store = new Map<string, string>();
+	return {
+		store,
+		async get(key: string) {
+			return store.get(key) ?? null;
+		},
+		async put(key: string, value: string) {
+			store.set(key, value);
+		},
+	};
+}
+
+/** R2 fake routing by key: one mailbox listed, mailbox settings JSON served,
+ *  org/domain tiers absent. */
+function makeBucket(mailboxSettings: unknown) {
+	return {
+		async list(_opts: { prefix: string }) {
+			return { objects: [{ key: `mailboxes/${MAILBOX_ID}.json` }] };
+		},
+		async get(key: string) {
+			if (key !== `mailboxes/${MAILBOX_ID}.json`) return null;
+			return {
+				etag: "etag-1",
+				async json() {
+					return mailboxSettings;
+				},
+			};
+		},
+	};
+}
+
+function makeMailboxStub() {
+	return {
+		async getIntelFeedState(_feedId: string) {
+			return null;
+		},
+		async upsertIntelFeedState(_feedId: string, _state: unknown) {},
+	};
+}
+
+function makeEnv(opts: {
+	mailboxSettings: unknown;
+	feedAllowedHosts?: string;
+	secrets?: Record<string, string>;
+}): Env {
+	const stub = makeMailboxStub();
+	const mailboxNs = {
+		idFromName(name: string) {
+			return { toString: () => name } as unknown as DurableObjectId;
+		},
+		get(_id: DurableObjectId) {
+			return stub as unknown as DurableObjectStub;
+		},
+	} as unknown as DurableObjectNamespace;
+	return {
+		BLOOM_KV: makeKv() as unknown as KVNamespace,
+		BUCKET: makeBucket(opts.mailboxSettings) as unknown as R2Bucket,
+		MAILBOX: mailboxNs,
+		FEED_ALLOWED_HOSTS: opts.feedAllowedHosts,
+		...(opts.secrets ?? {}),
+	} as unknown as Env;
+}
+
+/** Capture every fetch the refresh makes; serve an empty 200 domain list. */
+function mockFetch() {
+	const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+	const fn = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input.toString();
+		const headers = { ...((init?.headers as Record<string, string>) ?? {}) };
+		calls.push({ url, headers });
+		return new Response("# empty feed\n", { status: 200 });
+	});
+	globalThis.fetch = fn as unknown as typeof fetch;
+	return calls;
+}
+
+function callsToHost(
+	calls: Array<{ url: string; headers: Record<string, string> }>,
+	hostname: string,
+) {
+	// Parse and compare hostname — never substring-match URLs (CodeQL
+	// js/incomplete-url-substring-sanitization).
+	return calls.filter((c) => new URL(c.url).hostname === hostname);
+}
+
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+	originalFetch = globalThis.fetch;
+	clearOrgSettingsCache();
+	clearDomainSettingsCache();
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("feed Authorization host pin (GHSA-jfj6-w954-96vg f27)", () => {
+	it("does NOT attach the FEED_SECRET_ Authorization header when the feed host is off-allowlist", async () => {
+		const calls = mockFetch();
+		const env = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [
+						{
+							id: "exfil",
+							url: "https://attacker.example/collect.txt",
+							kind: "domain",
+							auth_secret: "FEED_SECRET_CROWDSEC",
+						},
+					],
+				},
+			},
+			feedAllowedHosts: "feeds.trusted.example",
+			secrets: { FEED_SECRET_CROWDSEC: "super-secret-key" },
+		});
+
+		await refreshAllFeeds(env);
+
+		const hit = callsToHost(calls, "attacker.example");
+		// The fetch itself still proceeds (public feeds are never blocked)…
+		expect(hit.length).toBe(1);
+		// …but the credential must not ride along.
+		expect(hit[0].headers["Authorization"]).toBeUndefined();
+	});
+
+	it("attaches the Authorization header for a host on FEED_ALLOWED_HOSTS", async () => {
+		const calls = mockFetch();
+		const env = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [
+						{
+							id: "trusted",
+							url: "https://feeds.trusted.example/list.txt",
+							kind: "domain",
+							auth_secret: "FEED_SECRET_CROWDSEC",
+						},
+					],
+				},
+			},
+			feedAllowedHosts: "feeds.trusted.example",
+			secrets: { FEED_SECRET_CROWDSEC: "super-secret-key" },
+		});
+
+		await refreshAllFeeds(env);
+
+		const hit = callsToHost(calls, "feeds.trusted.example");
+		expect(hit.length).toBe(1);
+		expect(hit[0].headers["Authorization"]).toBe("super-secret-key");
+	});
+
+	it("attaches the Authorization header for a built-in DEFAULT_FEEDS host with no FEED_ALLOWED_HOSTS config", async () => {
+		// Pick a real default-feed host so the union keeps operator-trusted
+		// defaults working with zero new config.
+		const defaultUrl = DEFAULT_FEEDS.find((f) => f.url)!.url;
+		const defaultHost = new URL(defaultUrl).hostname;
+		const calls = mockFetch();
+		const env = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [
+						{
+							id: "default-override",
+							url: defaultUrl,
+							kind: "domain",
+							auth_secret: "FEED_SECRET_DEFAULT",
+						},
+					],
+				},
+			},
+			// Deliberately no FEED_ALLOWED_HOSTS.
+			secrets: { FEED_SECRET_DEFAULT: "default-feed-key" },
+		});
+
+		await refreshAllFeeds(env);
+
+		const hit = callsToHost(calls, defaultHost);
+		expect(hit.length).toBe(1);
+		expect(hit[0].headers["Authorization"]).toBe("default-feed-key");
+	});
+
+	it("does NOT attach the Authorization header for a non-https feed URL even when the host is allowlisted", async () => {
+		const calls = mockFetch();
+		const env = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [
+						{
+							id: "plaintext",
+							url: "http://feeds.trusted.example/list.txt",
+							kind: "domain",
+							auth_secret: "FEED_SECRET_CROWDSEC",
+						},
+					],
+				},
+			},
+			feedAllowedHosts: "feeds.trusted.example",
+			secrets: { FEED_SECRET_CROWDSEC: "super-secret-key" },
+		});
+
+		await refreshAllFeeds(env);
+
+		const hit = callsToHost(calls, "feeds.trusted.example");
+		expect(hit.length).toBe(1);
+		expect(hit[0].headers["Authorization"]).toBeUndefined();
+	});
+
+	it("public no-secret feeds still resolve and fetch regardless of the allowlist", async () => {
+		const calls = mockFetch();
+		const env = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [
+						{
+							id: "public",
+							url: "https://public.lists.example/feed.txt",
+							kind: "domain",
+						},
+					],
+				},
+			},
+			// No allowlist, no secrets.
+		});
+
+		const result = await refreshAllFeeds(env);
+
+		const hit = callsToHost(calls, "public.lists.example");
+		expect(hit.length).toBe(1);
+		expect(hit[0].headers["Authorization"]).toBeUndefined();
+		expect(result.feeds).toBe(1);
+	});
+
+	it("default feeds (no per-mailbox feeds configured) still refresh without Authorization headers", async () => {
+		const calls = mockFetch();
+		const env = makeEnv({ mailboxSettings: {} });
+
+		const result = await refreshAllFeeds(env);
+
+		// Every non-placeholder default feed is fetched, none carry credentials.
+		const expected = DEFAULT_FEEDS.filter((f) => f.url).length;
+		expect(result.feeds).toBe(expected);
+		for (const call of calls) {
+			expect(call.headers["Authorization"]).toBeUndefined();
+		}
+	});
+});

--- a/tests/lib/host-allowlist.test.ts
+++ b/tests/lib/host-allowlist.test.ts
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Host-allowlist coverage for GHSA-jfj6-w954-96vg (findings f29 hub / f27
+ * feed) — confused-deputy credential exfiltration.
+ *
+ * The `HUB_SECRET_` / `FEED_SECRET_` prefix guards (#415/#418) constrain
+ * WHICH secret a teammate-editable settings blob may name, but not WHERE
+ * that secret is sent. Without a destination pin, any authenticated
+ * teammate who can edit `intel.hub.url` (or a `feed.url`) can point the
+ * worker at `https://attacker.example` and receive the raw credential in
+ * an `Authorization` header.
+ *
+ * This file asserts the missing half:
+ *   1. `hostAllowed` — the shared helper: https-only, exact hostname
+ *      match against a CSV allowlist (case-insensitive), defensive parse.
+ *   2. `loadHubConfig` / `loadHubCredentials` — a hub credential is only
+ *      resolvable when the hub URL's host is on `HUB_ALLOWED_HOSTS`.
+ *      Unset/empty allowlist means the hub secret can never be sent →
+ *      treated as not-configured (deliberate, documented behavior change:
+ *      operators must set HUB_ALLOWED_HOSTS to use a hub secret).
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { hostAllowed } from "../../workers/lib/host-allowlist";
+import { loadHubConfig, loadHubCredentials } from "../../workers/lib/hub-config";
+import { clearOrgSettingsCache } from "../../workers/lib/org-settings";
+import { clearDomainSettingsCache } from "../../workers/lib/domain-settings";
+
+// ── hostAllowed helper ────────────────────────────────────────────────
+
+describe("hostAllowed", () => {
+	it("allows an https URL whose hostname is on the CSV allowlist", () => {
+		expect(hostAllowed("https://hub.example.com/api", "hub.example.com", [])).toBe(true);
+	});
+
+	it("rejects a hostname not on the allowlist", () => {
+		expect(hostAllowed("https://attacker.example/api", "hub.example.com", [])).toBe(false);
+	});
+
+	it("rejects every host when the allowlist is unset or empty", () => {
+		expect(hostAllowed("https://hub.example.com", undefined, [])).toBe(false);
+		expect(hostAllowed("https://hub.example.com", "", [])).toBe(false);
+		expect(hostAllowed("https://hub.example.com", " , ", [])).toBe(false);
+	});
+
+	it("rejects non-https schemes even for an allowlisted host", () => {
+		expect(hostAllowed("http://hub.example.com", "hub.example.com", [])).toBe(false);
+		expect(hostAllowed("ftp://hub.example.com", "hub.example.com", [])).toBe(false);
+	});
+
+	it("matches case-insensitively on both sides", () => {
+		expect(hostAllowed("https://HUB.Example.COM/x", "Hub.EXAMPLE.com", [])).toBe(true);
+	});
+
+	it("parses CSV entries with whitespace and ignores empties", () => {
+		expect(hostAllowed("https://b.example", " a.example , b.example ,, ", [])).toBe(true);
+		expect(hostAllowed("https://c.example", " a.example , b.example ", [])).toBe(false);
+	});
+
+	it("requires exact hostname match — no suffix/substring tricks", () => {
+		expect(hostAllowed("https://evilhub.example.com", "hub.example.com", [])).toBe(false);
+		expect(hostAllowed("https://hub.example.com.attacker.example", "hub.example.com", [])).toBe(false);
+	});
+
+	it("returns false on a malformed URL instead of throwing", () => {
+		expect(hostAllowed("not a url", "hub.example.com", [])).toBe(false);
+		expect(hostAllowed("", "hub.example.com", [])).toBe(false);
+	});
+
+	it("unions extraHosts with the CSV allowlist (case-insensitive)", () => {
+		expect(hostAllowed("https://default.feed.example", undefined, ["default.feed.example"])).toBe(true);
+		expect(hostAllowed("https://Default.Feed.Example", "", ["default.feed.example"])).toBe(true);
+		// extraHosts don't bypass the https requirement.
+		expect(hostAllowed("http://default.feed.example", undefined, ["default.feed.example"])).toBe(false);
+	});
+});
+
+// ── loadHubConfig / loadHubCredentials destination pin ────────────────
+
+const MAILBOX_ID = "user@example.com";
+const MAILBOX_KEY = `mailboxes/${MAILBOX_ID}.json`;
+
+interface FakeBucket {
+	get(key: string): Promise<{ etag: string; json(): Promise<unknown> } | null>;
+}
+
+function makeBucket(byKey: Record<string, unknown>): FakeBucket {
+	let etag = 0;
+	return {
+		async get(key: string) {
+			if (!(key in byKey)) return null;
+			etag += 1;
+			const body = JSON.stringify(byKey[key]);
+			return {
+				etag: `etag-${etag}`,
+				async json() {
+					return JSON.parse(body);
+				},
+			};
+		},
+	};
+}
+
+function hubEnv(opts: {
+	hubUrl: string;
+	allowedHosts?: string;
+	secrets?: Record<string, string>;
+}) {
+	const bucket = makeBucket({
+		[MAILBOX_KEY]: {
+			intel: {
+				hub: {
+					url: opts.hubUrl,
+					org_uuid: "org-uuid-1",
+					api_key_secret_name: "HUB_SECRET_KEY",
+					auto_report: true,
+				},
+			},
+		},
+	});
+	return {
+		BUCKET: bucket as unknown as R2Bucket,
+		HUB_ALLOWED_HOSTS: opts.allowedHosts,
+		...(opts.secrets ?? {}),
+	};
+}
+
+describe("loadHubConfig — HUB_ALLOWED_HOSTS destination pin (GHSA-jfj6-w954-96vg f29)", () => {
+	beforeEach(() => {
+		clearOrgSettingsCache();
+		clearDomainSettingsCache();
+	});
+
+	it("returns the config when the hub URL host is on HUB_ALLOWED_HOSTS (https)", async () => {
+		const env = hubEnv({
+			hubUrl: "https://hub.example.com",
+			allowedHosts: "hub.example.com",
+		});
+		const cfg = await loadHubConfig(env, MAILBOX_ID);
+		expect(cfg).not.toBeNull();
+		expect(cfg?.url).toBe("https://hub.example.com");
+		expect(cfg?.api_key_secret_name).toBe("HUB_SECRET_KEY");
+	});
+
+	it("returns null when the hub URL host is NOT on HUB_ALLOWED_HOSTS", async () => {
+		const env = hubEnv({
+			hubUrl: "https://attacker.example/collect",
+			allowedHosts: "hub.example.com",
+		});
+		expect(await loadHubConfig(env, MAILBOX_ID)).toBeNull();
+	});
+
+	it("returns null when HUB_ALLOWED_HOSTS is unset — hub secret cannot be sent anywhere", async () => {
+		const env = hubEnv({ hubUrl: "https://hub.example.com" });
+		expect(await loadHubConfig(env, MAILBOX_ID)).toBeNull();
+	});
+
+	it("returns null when HUB_ALLOWED_HOSTS is empty", async () => {
+		const env = hubEnv({ hubUrl: "https://hub.example.com", allowedHosts: "" });
+		expect(await loadHubConfig(env, MAILBOX_ID)).toBeNull();
+	});
+
+	it("returns null for a non-https hub URL even when the host is allowlisted", async () => {
+		const env = hubEnv({
+			hubUrl: "http://hub.example.com",
+			allowedHosts: "hub.example.com",
+		});
+		expect(await loadHubConfig(env, MAILBOX_ID)).toBeNull();
+	});
+
+	it("supports a multi-entry CSV allowlist", async () => {
+		const env = hubEnv({
+			hubUrl: "https://hub2.example.com",
+			allowedHosts: "hub.example.com, hub2.example.com",
+		});
+		const cfg = await loadHubConfig(env, MAILBOX_ID);
+		expect(cfg?.url).toBe("https://hub2.example.com");
+	});
+});
+
+describe("loadHubCredentials — never resolves a secret for an off-allowlist hub", () => {
+	beforeEach(() => {
+		clearOrgSettingsCache();
+		clearDomainSettingsCache();
+	});
+
+	it("returns the credentials for an allowlisted https hub", async () => {
+		const env = hubEnv({
+			hubUrl: "https://hub.example.com",
+			allowedHosts: "hub.example.com",
+			secrets: { HUB_SECRET_KEY: "live-api-key" },
+		});
+		const creds = await loadHubCredentials(env, MAILBOX_ID);
+		expect(creds).not.toBeNull();
+		expect(creds?.apiKey).toBe("live-api-key");
+	});
+
+	it("returns null (secret NOT exposed) when the hub URL host is off-allowlist", async () => {
+		const env = hubEnv({
+			hubUrl: "https://attacker.example",
+			allowedHosts: "hub.example.com",
+			secrets: { HUB_SECRET_KEY: "live-api-key" },
+		});
+		expect(await loadHubCredentials(env, MAILBOX_ID)).toBeNull();
+	});
+
+	it("returns null (secret NOT exposed) when HUB_ALLOWED_HOSTS is unset", async () => {
+		const env = hubEnv({
+			hubUrl: "https://hub.example.com",
+			secrets: { HUB_SECRET_KEY: "live-api-key" },
+		});
+		expect(await loadHubCredentials(env, MAILBOX_ID)).toBeNull();
+	});
+});

--- a/tests/lib/resolve-mailbox-settings.test.ts
+++ b/tests/lib/resolve-mailbox-settings.test.ts
@@ -647,7 +647,11 @@ describe("resolveMailboxSettings — intel.hub inheritance (#121 audit Q1)", () 
 			"org/settings.json": { intel: { hub: orgHub } },
 			[MAILBOX_KEY]: {},
 		});
-		const cfg = await loadHubConfig(makeEnv(bucket), MAILBOX_ID);
+		// Since GHSA-jfj6-w954-96vg (f29), loadHubConfig also requires the hub
+		// URL host to be on the operator-set HUB_ALLOWED_HOSTS env allowlist —
+		// see tests/lib/host-allowlist.test.ts for that surface.
+		const env = { ...makeEnv(bucket), HUB_ALLOWED_HOSTS: "hub.example.com" };
+		const cfg = await loadHubConfig(env, MAILBOX_ID);
 		expect(cfg).not.toBeNull();
 		expect(cfg?.url).toBe(orgHub.url);
 		expect(cfg?.org_uuid).toBe(orgHub.org_uuid);

--- a/workers/intel/feeds.ts
+++ b/workers/intel/feeds.ts
@@ -32,6 +32,7 @@ import {
 } from "./bloom";
 import { findCidrMatch, parseCidr, parseIpv4, type Ipv4Cidr } from "./cidr";
 import { getMailboxStub, listMailboxes } from "../lib/email-helpers";
+import { hostAllowed } from "../lib/host-allowlist";
 import { resolveMailboxSettings } from "../lib/mailbox-settings";
 
 const EXACT_KEY_CAP = 2000; // per-feed cap — we only fast-path confirm up to this many
@@ -81,22 +82,45 @@ async function loadMailboxIntelSettings(env: Env, mailboxId: string): Promise<Ma
 	}
 }
 
+/**
+ * Hostnames of the built-in default feeds. Always part of the
+ * credential-destination allowlist below: a secret-bearing override of an
+ * operator-trusted default feed keeps working with no extra config.
+ */
+const DEFAULT_FEED_HOSTS: string[] = DEFAULT_FEEDS.map((f) => safeHostname(f.url)).filter(
+	(h): h is string => h !== null,
+);
+
 function resolveFeeds(env: Env, settings: MailboxIntelSettings): FeedDefinition[] {
 	const defaults = settings.feeds && settings.feeds.length > 0 ? [] : DEFAULT_FEEDS;
 	const byId = new Map<string, FeedDefinition>(DEFAULT_FEEDS.map((f) => [f.id, f]));
 	const user: FeedDefinition[] = [];
 	for (const f of settings.feeds ?? []) {
 		const base = byId.get(f.id);
+		const url = f.url ?? base?.url ?? "";
 		const headers: Record<string, string> = { ...(f.headers ?? {}) };
-			// Prevent confused deputy / secret exfiltration via unconstrained secret access.
-			// Only allow access to explicitly designated feed secrets.
-			if (f.auth_secret && f.auth_secret.startsWith("FEED_SECRET_")) {
+		// Prevent confused deputy / secret exfiltration via unconstrained secret access.
+		// Two conditions, both required (GHSA-jfj6-w954-96vg f27):
+		//   1. Only explicitly designated feed secrets (`FEED_SECRET_` prefix)
+		//      may be referenced from settings.
+		//   2. The destination host must be pinned: the feed URL is
+		//      teammate-editable, so the secret is only attached when the URL
+		//      is https AND its hostname is on the operator-set
+		//      `FEED_ALLOWED_HOSTS` env allowlist (or is a built-in
+		//      DEFAULT_FEEDS host). Off-allowlist feeds still fetch — public
+		//      no-secret feeds are never blocked — they just never carry the
+		//      credential.
+		if (
+			f.auth_secret &&
+			f.auth_secret.startsWith("FEED_SECRET_") &&
+			hostAllowed(url, env.FEED_ALLOWED_HOSTS, DEFAULT_FEED_HOSTS)
+		) {
 			const secretValue = (env as unknown as Record<string, string>)[f.auth_secret];
 			if (secretValue) headers["Authorization"] = secretValue;
 		}
 		user.push({
 			id: f.id,
-			url: f.url ?? base?.url ?? "",
+			url,
 			kind: f.kind ?? base?.kind ?? "url",
 			refreshHours: f.refresh_hours ?? base?.refreshHours ?? 6,
 			description: base?.description ?? "User-configured feed",

--- a/workers/lib/host-allowlist.ts
+++ b/workers/lib/host-allowlist.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Destination host allowlisting for credential-bearing outbound fetches
+ * (GHSA-jfj6-w954-96vg, findings f29 hub / f27 feed).
+ *
+ * The `HUB_SECRET_` / `FEED_SECRET_` name-prefix guards constrain WHICH
+ * worker secret a teammate-editable settings blob may reference, but not
+ * WHERE the resolved secret is sent. Destination URLs (`intel.hub.url`,
+ * `intel.feeds[].url`) live in org/mailbox settings that any authenticated
+ * teammate can edit — so the secret must additionally be pinned to an
+ * operator-controlled hostname allowlist supplied via worker env vars
+ * (`HUB_ALLOWED_HOSTS` / `FEED_ALLOWED_HOSTS`), which settings edits
+ * cannot touch.
+ */
+
+/**
+ * Returns true only when `url` parses, uses `https:`, and its hostname is
+ * present (case-insensitive, exact match) in the union of the
+ * comma-separated `allowedCsv` allowlist and `extraHosts`.
+ *
+ * Defensive by design: a malformed URL, a non-https scheme, or an
+ * unset/empty allowlist all yield `false` — the caller must treat that as
+ * "do not send the credential".
+ */
+export function hostAllowed(
+	url: string,
+	allowedCsv: string | undefined,
+	extraHosts: string[] = [],
+): boolean {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return false;
+	}
+	if (parsed.protocol !== "https:") return false;
+	const host = parsed.hostname.toLowerCase();
+
+	const allowed = new Set<string>();
+	for (const extra of extraHosts) {
+		const t = extra.trim().toLowerCase();
+		if (t) allowed.add(t);
+	}
+	for (const entry of (allowedCsv ?? "").split(",")) {
+		const t = entry.trim().toLowerCase();
+		if (t) allowed.add(t);
+	}
+	return allowed.has(host);
+}

--- a/workers/lib/hub-config.ts
+++ b/workers/lib/hub-config.ts
@@ -9,6 +9,7 @@
  * from `c.env` at call time so an org can rotate without rewriting blobs.
  */
 
+import { hostAllowed } from "./host-allowlist";
 import { resolveMailboxSettings } from "./mailbox-settings";
 
 export interface HubConfig {
@@ -21,6 +22,8 @@ export interface HubConfig {
 
 interface BucketEnv {
 	BUCKET: R2Bucket;
+	/** Operator-set hostname allowlist for `cfg.url` — see `workers/types.ts`. */
+	HUB_ALLOWED_HOSTS?: string;
 }
 
 /** Returns the resolved hub config for a mailbox, or null when neither
@@ -37,6 +40,12 @@ export async function loadHubConfig(
 	// Prevent confused deputy / secret exfiltration via unconstrained secret access.
 	// Only allow access to explicitly designated hub secrets.
 	if (!cfg.api_key_secret_name.startsWith("HUB_SECRET_")) return null;
+	// Pin the destination too (GHSA-jfj6-w954-96vg f29): `cfg.url` is
+	// teammate-editable settings data, so the secret named above may only be
+	// sent to an https host on the operator-set `HUB_ALLOWED_HOSTS` env
+	// allowlist. Off-allowlist (or no allowlist configured) → treat the hub
+	// as not configured rather than ship the credential to an arbitrary URL.
+	if (!hostAllowed(cfg.url, env.HUB_ALLOWED_HOSTS)) return null;
 	return {
 		url: cfg.url,
 		org_uuid: cfg.org_uuid,

--- a/workers/types.ts
+++ b/workers/types.ts
@@ -29,4 +29,22 @@ export interface Env extends Cloudflare.Env {
 	 * When absent, the yaramail callback route returns 503.
 	 */
 	YARAMAIL_CALLBACK_SECRET?: string;
+	/**
+	 * Comma-separated hostname allowlist for the community-hub URL
+	 * (GHSA-jfj6-w954-96vg f29). A `HUB_SECRET_*` API key is only resolved
+	 * and sent when `intel.hub.url` is https AND its hostname is on this
+	 * list. Unset/empty → hub credentials are never released, so operators
+	 * MUST set this (e.g. `hub.example.com`) to use a hub secret. Pinning
+	 * the destination in env (not settings) is the point: settings are
+	 * teammate-editable, env vars are operator-only.
+	 */
+	HUB_ALLOWED_HOSTS?: string;
+	/**
+	 * Comma-separated hostname allowlist for credential-bearing intel-feed
+	 * fetches (GHSA-jfj6-w954-96vg f27). A `FEED_SECRET_*` Authorization
+	 * header is only attached when the feed URL is https AND its hostname
+	 * is on this list or belongs to a built-in `DEFAULT_FEEDS` entry.
+	 * Off-allowlist feeds still fetch — they just never carry the secret.
+	 */
+	FEED_ALLOWED_HOSTS?: string;
 }


### PR DESCRIPTION
Fixes advisory **GHSA-jfj6-w954-96vg** (findings f29 hub / f27 feed) — confused-deputy credential exfiltration.

## Problem

The `HUB_SECRET_` / `FEED_SECRET_` name-prefix guards (#415/#418) constrain **which** worker secret teammate-editable settings may reference, but not **where** the resolved secret is sent. `intel.hub.url` and `intel.feeds[].url` are editable by any authenticated teammate, so a hub/feed credential could be steered to an arbitrary destination URL.

## Fix

Pin the destination host in **operator-only env vars** (settings edits can't touch them):

- New shared helper `workers/lib/host-allowlist.ts` — `hostAllowed(url, allowedCsv, extraHosts)`: https-only, exact hostname match (case-insensitive) against a CSV allowlist; returns false on malformed URLs.
- **`HUB_ALLOWED_HOSTS`** (new env var): `loadHubConfig` now also requires the hub URL host to be on this allowlist, otherwise it returns `null` (hub treated as not configured). Every call site — hub UI, cases report-phish, dashboard corroboration, catchall hub report — inherits the check.
- **`FEED_ALLOWED_HOSTS`** (new env var): `resolveFeeds` only attaches the `FEED_SECRET_*` `Authorization` header when the effective feed URL host is on this allowlist **or** is a built-in `DEFAULT_FEEDS` host (so operator-trusted default feeds keep working with no new config). Off-allowlist feeds still fetch — public no-secret feeds are never blocked — they just never carry the credential.

## ⚠️ Behavior change (deliberate)

Operators using a community-hub secret **must set `HUB_ALLOWED_HOSTS`** (comma-separated hostnames, e.g. `hub.example.com`) or hub integration is treated as not configured. Existing `HUB_SECRET_`/`FEED_SECRET_` prefix guards are unchanged and still enforced.

## Acceptance tests

- `tests/lib/host-allowlist.test.ts` (18): `hostAllowed` unit coverage (https-only, exact match, CSV parsing, extraHosts union, malformed URLs); `loadHubConfig`/`loadHubCredentials` return `null` for off-allowlist / unset-allowlist / non-https hub URLs, and return the config/credentials for an allowlisted https hub.
- `tests/intel/feed-auth-allowlist.test.ts` (6): Authorization header is omitted for off-allowlist and non-https feed URLs, attached for a `FEED_ALLOWED_HOSTS` host and for a `DEFAULT_FEEDS` host with zero config; public no-secret feeds and default-feed refresh keep working.
- Updated `tests/lib/resolve-mailbox-settings.test.ts` flow-through test to supply `HUB_ALLOWED_HOSTS` per the new contract.

## Gates

- `npm run typecheck` — exit 0
- `npm test` — **1464 passed (1464)** (1440 baseline + 24 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)