### PR TITLE
security(acl): derive caller identity from the verified JWT, fail closed on null email

### DIFF
--- a/tests/lib/mailbox-acl.test.ts
+++ b/tests/lib/mailbox-acl.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
 
 import { Hono } from "hono";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	callerInAcl,
 	callerGroupsFromJwt,
@@ -41,11 +41,20 @@ describe("callerInAcl", () => {
 		expect(callerInAcl(null, null)).toBe(true);
 	});
 
-	it("returns true when callerEmail is falsy (dev mode, no Access in front)", () => {
+	it("FAILS CLOSED on a falsy callerEmail in production (f17)", () => {
 		const acl: MailboxAcl = { owner: "alice@example.com", members: ["alice@example.com"] };
-		expect(callerInAcl(acl, null)).toBe(true);
-		expect(callerInAcl(acl, "")).toBe(true);
-		expect(callerInAcl(acl, undefined)).toBe(true);
+		// Default isDev = false → production semantics: deny.
+		expect(callerInAcl(acl, null)).toBe(false);
+		expect(callerInAcl(acl, "")).toBe(false);
+		expect(callerInAcl(acl, undefined)).toBe(false);
+		expect(callerInAcl(acl, null, [], false)).toBe(false);
+	});
+
+	it("allows a falsy callerEmail only in dev mode (isDev = true, no Access in front)", () => {
+		const acl: MailboxAcl = { owner: "alice@example.com", members: ["alice@example.com"] };
+		expect(callerInAcl(acl, null, [], true)).toBe(true);
+		expect(callerInAcl(acl, "", [], true)).toBe(true);
+		expect(callerInAcl(acl, undefined, [], true)).toBe(true);
 	});
 
 	it("returns true when caller is in members list", () => {
@@ -179,9 +188,12 @@ function makeFakeMailboxApp(
 	app.get("/mailboxes/:mailboxId/test", (c) => c.json({ ok: true }));
 
 	return {
-		fetch: (path: string) => {
-			const headers: Record<string, string> = {};
-			if (callerEmail) headers["cf-access-authenticated-user-email"] = callerEmail;
+		// Identity travels in the fake CF Access JWT (f17) — requireMailbox no
+		// longer reads the cf-access-authenticated-user-email header. Extra
+		// headers (e.g. a forged email header) can be layered on top.
+		fetch: (path: string, extraHeaders: Record<string, string> = {}) => {
+			const headers: Record<string, string> = { ...extraHeaders };
+			if (callerEmail) headers["cf-access-jwt-assertion"] = makeFakeJwt({ email: callerEmail });
 			return app.request(path, { headers }, { BUCKET: bucket as unknown as R2Bucket, MAILBOX: MAILBOX as unknown as DurableObjectNamespace });
 		},
 	};
@@ -229,13 +241,18 @@ describe("requireMailbox — ACL enforcement", () => {
 	});
 
 	it("allows access in dev mode (no callerEmail) regardless of ACL", async () => {
-		const store = {
-			[mailboxKey]: "{}",
-			[aclKey]: JSON.stringify(aliceAcl),
-		};
-		const app = makeFakeMailboxApp(store, null);
-		const res = await app.fetch("/mailboxes/alice@example.com/test");
-		expect(res.status).toBe(200);
+		vi.stubEnv("DEV", true);
+		try {
+			const store = {
+				[mailboxKey]: "{}",
+				[aclKey]: JSON.stringify(aliceAcl),
+			};
+			const app = makeFakeMailboxApp(store, null);
+			const res = await app.fetch("/mailboxes/alice@example.com/test");
+			expect(res.status).toBe(200);
+		} finally {
+			vi.unstubAllEnvs();
+		}
 	});
 
 	it("ACL comparison is case-insensitive", async () => {
@@ -244,6 +261,85 @@ describe("requireMailbox — ACL enforcement", () => {
 			[aclKey]: JSON.stringify(aliceAcl),
 		};
 		const app = makeFakeMailboxApp(store, "ALICE@EXAMPLE.COM");
+		const res = await app.fetch("/mailboxes/alice@example.com/test");
+		expect(res.status).toBe(200);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// requireMailbox — identity from the verified JWT, fail closed in prod (f17)
+// ---------------------------------------------------------------------------
+
+describe("requireMailbox — verified-JWT identity, fail-closed (f17)", () => {
+	const mailboxKey = "mailboxes/alice@example.com.json";
+	const aclKey = "mailboxes-acl/alice@example.com.json";
+	const aliceAcl: MailboxAcl = {
+		owner: "alice@example.com",
+		members: ["alice@example.com"],
+	};
+	const scopedStore = () => ({
+		[mailboxKey]: "{}",
+		[aclKey]: JSON.stringify(aliceAcl),
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("DENIES in production when the JWT carries no email and an ACL exists (was fail-open)", async () => {
+		vi.stubEnv("DEV", false);
+		// Valid (middleware-verified) JWT, but no email claim — e.g. a service
+		// token, or a caller that stripped the identity.
+		const app = makeFakeMailboxApp(scopedStore(), null);
+		const res = await app.fetch("/mailboxes/alice@example.com/test", {
+			"cf-access-jwt-assertion": makeFakeJwt({ common_name: "svc-token" }),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it("DENIES in production when no JWT is present at all and an ACL exists", async () => {
+		vi.stubEnv("DEV", false);
+		const app = makeFakeMailboxApp(scopedStore(), null);
+		const res = await app.fetch("/mailboxes/alice@example.com/test");
+		expect(res.status).toBe(403);
+	});
+
+	it("ignores a forged cf-access-authenticated-user-email header when the JWT email differs", async () => {
+		// Eve's JWT says eve@; the forged header claims the victim's identity.
+		const app = makeFakeMailboxApp(scopedStore(), "eve@example.com");
+		const res = await app.fetch("/mailboxes/alice@example.com/test", {
+			"cf-access-authenticated-user-email": "alice@example.com",
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it("ignores a forged cf-access-authenticated-user-email header when the JWT has no email (prod)", async () => {
+		vi.stubEnv("DEV", false);
+		const app = makeFakeMailboxApp(scopedStore(), null);
+		const res = await app.fetch("/mailboxes/alice@example.com/test", {
+			"cf-access-authenticated-user-email": "alice@example.com",
+			"cf-access-jwt-assertion": makeFakeJwt({ common_name: "svc-token" }),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it("still allows anyone in production when no ACL exists (backwards-compat)", async () => {
+		vi.stubEnv("DEV", false);
+		const app = makeFakeMailboxApp({ [mailboxKey]: "{}" }, null);
+		const res = await app.fetch("/mailboxes/alice@example.com/test");
+		expect(res.status).toBe(200);
+	});
+
+	it("still allows in dev mode when no email can be derived (no CF Access in front)", async () => {
+		vi.stubEnv("DEV", true);
+		const app = makeFakeMailboxApp(scopedStore(), null);
+		const res = await app.fetch("/mailboxes/alice@example.com/test");
+		expect(res.status).toBe(200);
+	});
+
+	it("allows an ACL member identified by the verified-JWT email claim", async () => {
+		vi.stubEnv("DEV", false);
+		const app = makeFakeMailboxApp(scopedStore(), "alice@example.com");
 		const res = await app.fetch("/mailboxes/alice@example.com/test");
 		expect(res.status).toBe(200);
 	});
@@ -333,7 +429,6 @@ describe("callerGroupsFromJwt (#295)", () => {
 
 function makeFakeMailboxAppWithJwt(
 	bucketStore: Record<string, string>,
-	callerEmail: string | null,
 	jwtToken: string | null = null,
 ) {
 	const bucket = makeFullR2Stub(bucketStore);
@@ -350,7 +445,6 @@ function makeFakeMailboxAppWithJwt(
 	return {
 		fetch: (path: string) => {
 			const headers: Record<string, string> = {};
-			if (callerEmail) headers["cf-access-authenticated-user-email"] = callerEmail;
 			if (jwtToken) headers["cf-access-jwt-assertion"] = jwtToken;
 			return app.request(
 				path,
@@ -370,13 +464,17 @@ describe("requireMailbox — group-grant ACL (#295)", () => {
 		groups: ["soc-analysts"],
 	};
 
-	it("allows a caller in a granted group (group membership from JWT)", async () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("allows a caller in a granted group (email + group membership from JWT)", async () => {
 		const store = {
 			[mailboxKey]: "{}",
 			[aclKey]: JSON.stringify(groupAcl),
 		};
-		const jwt = makeFakeGroupJwt(["soc-analysts"]);
-		const app = makeFakeMailboxAppWithJwt(store, "bob@example.com", jwt);
+		const jwt = makeFakeJwt({ email: "bob@example.com", groups: ["soc-analysts"] });
+		const app = makeFakeMailboxAppWithJwt(store, jwt);
 		const res = await app.fetch("/mailboxes/alice@example.com/test");
 		expect(res.status).toBe(200);
 	});
@@ -386,18 +484,19 @@ describe("requireMailbox — group-grant ACL (#295)", () => {
 			[mailboxKey]: "{}",
 			[aclKey]: JSON.stringify(groupAcl),
 		};
-		const jwt = makeFakeGroupJwt(["other-team"]);
-		const app = makeFakeMailboxAppWithJwt(store, "eve@example.com", jwt);
+		const jwt = makeFakeJwt({ email: "eve@example.com", groups: ["other-team"] });
+		const app = makeFakeMailboxAppWithJwt(store, jwt);
 		const res = await app.fetch("/mailboxes/alice@example.com/test");
 		expect(res.status).toBe(403);
 	});
 
-	it("denies a caller with no JWT and not in members", async () => {
+	it("denies a caller with no JWT in production", async () => {
+		vi.stubEnv("DEV", false);
 		const store = {
 			[mailboxKey]: "{}",
 			[aclKey]: JSON.stringify(groupAcl),
 		};
-		const app = makeFakeMailboxAppWithJwt(store, "eve@example.com", null);
+		const app = makeFakeMailboxAppWithJwt(store, null);
 		const res = await app.fetch("/mailboxes/alice@example.com/test");
 		expect(res.status).toBe(403);
 	});

--- a/tests/lib/org-search.test.ts
+++ b/tests/lib/org-search.test.ts
@@ -34,6 +34,29 @@ describe("mailboxesForOrgSearch (#27 ACL)", () => {
 		const visible = mailboxesForOrgSearch(mailboxes, acls, "bob@acme.com", ["soc"]);
 		expect(visible).toHaveLength(1);
 	});
+
+	it("FAILS CLOSED in production on a null caller email — scoped hidden, unscoped kept (f17)", () => {
+		const mailboxes = [
+			{ id: "scoped@acme.com", email: "scoped@acme.com" },
+			{ id: "unscoped@acme.com", email: "unscoped@acme.com" },
+		];
+		const acls: Array<MailboxAcl | null> = [
+			{ owner: "alice@acme.com", members: ["alice@acme.com"] },
+			null, // no ACL → backwards-compat allow
+		];
+		const visible = mailboxesForOrgSearch(mailboxes, acls, null, [], false);
+		expect(visible.map((m) => m.id)).toEqual(["unscoped@acme.com"]);
+	});
+
+	it("keeps scoped mailboxes visible for a null caller only in dev mode (f17)", () => {
+		const mailboxes = [{ id: "scoped@acme.com", email: "scoped@acme.com" }];
+		const acls: Array<MailboxAcl | null> = [
+			{ owner: "alice@acme.com", members: ["alice@acme.com"] },
+		];
+		expect(mailboxesForOrgSearch(mailboxes, acls, null, [], true)).toHaveLength(1);
+		// Default (no isDev argument) must behave like production.
+		expect(mailboxesForOrgSearch(mailboxes, acls, null, [])).toHaveLength(0);
+	});
 });
 
 describe("aggregateOrgSearch", () => {

--- a/tests/routes/acl-members.test.ts
+++ b/tests/routes/acl-members.test.ts
@@ -15,6 +15,15 @@ import { requireMailbox, type MailboxContext } from "../../workers/lib/mailbox";
 import { aclMemberRoutes } from "../../workers/routes/acl-members";
 import type { MailboxAcl } from "../../workers/lib/mailbox-acl";
 
+// Helper: build a fake (unsigned) JWT carrying arbitrary claims. The routes
+// decode identity from the cf-access-jwt-assertion token (f17), not from the
+// cf-access-authenticated-user-email header; decodeJwt from jose just
+// base64url-decodes the payload — no sig check needed in unit tests.
+function makeFakeJwt(claims: Record<string, unknown>): string {
+	const b64url = (s: string) => btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+	return `${b64url('{"alg":"none"}')}.${b64url(JSON.stringify(claims))}.`;
+}
+
 // ---------------------------------------------------------------------------
 // Shared in-memory R2 stub (mirrors makeFullR2Stub from mailbox-acl.test.ts)
 // ---------------------------------------------------------------------------
@@ -59,7 +68,8 @@ function makeApp(bucketStore: Record<string, string>, callerEmail: string | null
 	return {
 		fetch(path: string, options?: RequestInit) {
 			const hdrs: Record<string, string> = {};
-			if (callerEmail) hdrs["cf-access-authenticated-user-email"] = callerEmail;
+			// Caller identity travels in the fake verified JWT (f17).
+			if (callerEmail) hdrs["cf-access-jwt-assertion"] = makeFakeJwt({ email: callerEmail });
 			if (options?.headers) Object.assign(hdrs, options.headers as Record<string, string>);
 			return app.request(
 				path,
@@ -492,5 +502,45 @@ describe("DELETE /acl/groups/:groupName — remove group", () => {
 		expect(res.status).toBe(200);
 		const stored = JSON.parse(bucket._store[aclKey]) as MailboxAcl;
 		expect(stored.groups).not.toContain("soc analysts");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// f17 — owner identity comes from the verified JWT, never the email header
+// ---------------------------------------------------------------------------
+
+describe("ACL member routes — forged email header is ignored (f17)", () => {
+	it("a forged cf-access-authenticated-user-email header does not grant owner rights", async () => {
+		// Bob is a member (passes requireMailbox) but not the owner. He forges
+		// the legacy email header to claim Alice's identity — the routes must
+		// keep using his JWT email and return 403 on an owner-only write.
+		const { fetch, bucket } = makeApp(storeWithAcl(aliceAndBobAcl), "bob@example.com");
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl/members`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"cf-access-authenticated-user-email": "alice@example.com",
+			},
+			body: JSON.stringify({ email: "mallory@example.com" }),
+		});
+		expect(res.status).toBe(403);
+		const stored = JSON.parse(bucket._store[aclKey]) as MailboxAcl;
+		expect(stored.members).not.toContain("mallory@example.com");
+	});
+
+	it("a forged header alone (JWT without email claim) cannot lock down a mailbox", async () => {
+		// No email claim in the JWT → no identity → the lock-down endpoint
+		// must refuse to bootstrap an ACL even when the header names a victim.
+		const bucketStore = { [mailboxKey]: "{}" };
+		const { fetch, bucket } = makeApp(bucketStore, null);
+		const res = await fetch(`/api/v1/mailboxes/${mailboxId}/acl`, {
+			method: "POST",
+			headers: {
+				"cf-access-authenticated-user-email": "alice@example.com",
+				"cf-access-jwt-assertion": makeFakeJwt({ common_name: "svc-token" }),
+			},
+		});
+		expect(res.status).toBe(400);
+		expect(bucket._store[aclKey]).toBeUndefined();
 	});
 });

--- a/tests/routes/mailbox-create-owner.test.ts
+++ b/tests/routes/mailbox-create-owner.test.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Owner-ACL bootstrap on mailbox creation (f17).
+ *
+ * POST /api/v1/mailboxes seeds `mailboxes-acl/<id>.json` with the creator as
+ * owner. The owner identity MUST come from the `email` claim of the verified
+ * `cf-access-jwt-assertion` token — never from the forgeable
+ * `cf-access-authenticated-user-email` header (advisory finding f17).
+ *
+ * Same replica pattern as tests/routes/me.test.ts: the full
+ * `workers/index.ts` graph needs live env bindings just to be evaluated, so
+ * we mirror the owner-bootstrap section of the production handler here.
+ * Keep in sync with POST /api/v1/mailboxes in workers/index.ts.
+ */
+
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { writeMailboxAcl, callerEmailFromJwt } from "../../workers/lib/mailbox-acl";
+import type { MailboxAcl } from "../../workers/lib/mailbox-acl";
+
+// Helper: build a fake (unsigned) JWT carrying arbitrary claims.
+function makeFakeJwt(claims: Record<string, unknown>): string {
+	const b64url = (s: string) => btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+	return `${b64url('{"alg":"none"}')}.${b64url(JSON.stringify(claims))}.`;
+}
+
+function makeR2Stub(initial: Record<string, string> = {}) {
+	const store = { ...initial };
+	return {
+		async head(key: string) {
+			return store[key] !== undefined ? { key } : null;
+		},
+		async get(key: string) {
+			const val = store[key];
+			if (!val) return null;
+			return { json: async <T>() => JSON.parse(val) as T };
+		},
+		async put(key: string, value: string) {
+			store[key] = value;
+		},
+		async delete(key: string) {
+			delete store[key];
+		},
+		_store: store,
+	};
+}
+
+function makeCreateApp(bucketStore: Record<string, string> = {}) {
+	const bucket = makeR2Stub(bucketStore);
+	const app = new Hono<{ Bindings: { BUCKET: R2Bucket } }>();
+
+	app.post("/api/v1/mailboxes", async (c) => {
+		const { email: rawEmail } = (await c.req.json()) as { email: string };
+		const email = rawEmail.toLowerCase();
+		const key = `mailboxes/${email}.json`;
+		if (await c.env.BUCKET.head(key)) return c.json({ error: "Mailbox already exists" }, 409);
+		await c.env.BUCKET.put(key, "{}");
+
+		// Mirror of the production owner bootstrap in workers/index.ts (f17).
+		// Keep in sync: owner identity from the VERIFIED JWT, never the header.
+		const creatorEmail = callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"));
+		if (creatorEmail) {
+			const owner = creatorEmail.toLowerCase();
+			await writeMailboxAcl(c.env, email, { owner, members: [owner] });
+		}
+
+		return c.json({ id: email, email }, 201);
+	});
+
+	return {
+		create(email: string, headers: Record<string, string> = {}) {
+			return app.request(
+				"/api/v1/mailboxes",
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json", ...headers },
+					body: JSON.stringify({ email }),
+				},
+				{ BUCKET: bucket as unknown as R2Bucket },
+			);
+		},
+		bucket,
+	};
+}
+
+const newMailbox = "team@example.com";
+const newAclKey = `mailboxes-acl/${newMailbox}.json`;
+
+describe("POST /api/v1/mailboxes — owner ACL from the verified JWT (f17)", () => {
+	it("sets the ACL owner from the JWT email claim", async () => {
+		const { create, bucket } = makeCreateApp();
+		const res = await create(newMailbox, {
+			"cf-access-jwt-assertion": makeFakeJwt({ email: "Creator@Example.com" }),
+		});
+		expect(res.status).toBe(201);
+		const stored = JSON.parse(bucket._store[newAclKey]) as MailboxAcl;
+		expect(stored.owner).toBe("creator@example.com");
+		expect(stored.members).toEqual(["creator@example.com"]);
+	});
+
+	it("ignores a forged cf-access-authenticated-user-email header — JWT email wins", async () => {
+		const { create, bucket } = makeCreateApp();
+		const res = await create(newMailbox, {
+			"cf-access-jwt-assertion": makeFakeJwt({ email: "creator@example.com" }),
+			"cf-access-authenticated-user-email": "mallory@example.com",
+		});
+		expect(res.status).toBe(201);
+		const stored = JSON.parse(bucket._store[newAclKey]) as MailboxAcl;
+		expect(stored.owner).toBe("creator@example.com");
+		expect(stored.members).not.toContain("mallory@example.com");
+	});
+
+	it("does not seed an ACL from a forged header when the JWT has no email claim", async () => {
+		const { create, bucket } = makeCreateApp();
+		const res = await create(newMailbox, {
+			"cf-access-jwt-assertion": makeFakeJwt({ common_name: "svc-token" }),
+			"cf-access-authenticated-user-email": "mallory@example.com",
+		});
+		expect(res.status).toBe(201);
+		// No identity → no owner ACL (dev / pre-#27 backwards-compat path).
+		expect(bucket._store[newAclKey]).toBeUndefined();
+	});
+});

--- a/tests/routes/mailbox-root-acl.test.ts
+++ b/tests/routes/mailbox-root-acl.test.ts
@@ -12,6 +12,14 @@ import { describe, expect, it } from "vitest";
 import { requireMailbox, type MailboxContext } from "../../workers/lib/mailbox";
 import type { MailboxAcl } from "../../workers/lib/mailbox-acl";
 
+// Helper: build a fake (unsigned) JWT carrying arbitrary claims. Identity is
+// decoded from the cf-access-jwt-assertion token (f17), never from the
+// cf-access-authenticated-user-email header.
+function makeFakeJwt(claims: Record<string, unknown>): string {
+	const b64url = (s: string) => btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+	return `${b64url('{"alg":"none"}')}.${b64url(JSON.stringify(claims))}.`;
+}
+
 function makeR2Stub(initial: Record<string, string> = {}) {
 	const store = { ...initial };
 	return {
@@ -60,7 +68,8 @@ function makeRootMailboxApp(bucketStore: Record<string, string>, callerEmail: st
 	return {
 		fetch(path: string, options?: RequestInit) {
 			const hdrs = new Headers(options?.headers);
-			if (callerEmail) hdrs.set("cf-access-authenticated-user-email", callerEmail);
+			// Caller identity travels in the fake verified JWT (f17).
+			if (callerEmail) hdrs.set("cf-access-jwt-assertion", makeFakeJwt({ email: callerEmail }));
 			return app.request(path, { ...options, headers: hdrs }, {
 				BUCKET: bucket as unknown as R2Bucket,
 				MAILBOX: MAILBOX as unknown as DurableObjectNamespace,

--- a/tests/routes/mailboxes-acl-status.test.ts
+++ b/tests/routes/mailboxes-acl-status.test.ts
@@ -12,9 +12,22 @@ import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import { requireMailbox, type MailboxContext } from "../../workers/lib/mailbox";
 import { aclMemberRoutes } from "../../workers/routes/acl-members";
-import { readMailboxAcl, writeMailboxAcl, callerInAcl } from "../../workers/lib/mailbox-acl";
+import {
+	readMailboxAcl,
+	writeMailboxAcl,
+	callerInAcl,
+	callerEmailFromJwt,
+} from "../../workers/lib/mailbox-acl";
 import { listMailboxes } from "../../workers/lib/email-helpers";
 import type { MailboxAcl } from "../../workers/lib/mailbox-acl";
+
+// Helper: build a fake (unsigned) JWT carrying arbitrary claims. Identity is
+// decoded from the cf-access-jwt-assertion token (f17), never from the
+// cf-access-authenticated-user-email header.
+function makeFakeJwt(claims: Record<string, unknown>): string {
+	const b64url = (s: string) => btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+	return `${b64url('{"alg":"none"}')}.${b64url(JSON.stringify(claims))}.`;
+}
 
 // ---------------------------------------------------------------------------
 // In-memory R2 stub (supports head / get / put / delete / list)
@@ -51,20 +64,27 @@ function makeR2Stub(initial: Record<string, string> = {}) {
 // Minimal list-endpoint app (replicates GET /api/v1/mailboxes from index.ts)
 // ---------------------------------------------------------------------------
 
-function makeListApp(bucketStore: Record<string, string>, callerEmail: string | null) {
+function makeListApp(
+	bucketStore: Record<string, string>,
+	callerEmail: string | null,
+	dev = true,
+) {
 	const bucket = makeR2Stub(bucketStore);
 	const MAILBOX = { idFromName: () => "fake-id", get: () => ({}) };
 
 	const app = new Hono<{ Bindings: { BUCKET: typeof bucket; MAILBOX: typeof MAILBOX } }>();
 
 	app.get("/api/v1/mailboxes", async (c) => {
+		// Mirror of the production handler in workers/index.ts (f17). Keep in
+		// sync: the show-all branch is dev-only; production fails closed for a
+		// missing caller email (scoped mailboxes hidden, unscoped still shown).
 		const caller = callerEmail;
 		const allMailboxes = await listMailboxes(c.env.BUCKET as unknown as R2Bucket);
 		const acls = await Promise.all(
 			allMailboxes.map((m) => readMailboxAcl(c.env as unknown as { BUCKET: R2Bucket }, m.id)),
 		);
 
-		if (!caller) {
+		if (!caller && dev) {
 			return c.json(
 				allMailboxes.map((m, i) => ({
 					...m,
@@ -76,7 +96,7 @@ function makeListApp(bucketStore: Record<string, string>, callerEmail: string | 
 
 		const visible = allMailboxes
 			.map((m, i) => ({ mailbox: m, acl: acls[i] }))
-			.filter(({ acl }) => callerInAcl(acl, caller));
+			.filter(({ acl }) => callerInAcl(acl, caller, [], dev));
 
 		return c.json(
 			visible.map(({ mailbox, acl }) => ({
@@ -117,7 +137,8 @@ function makeLockDownApp(bucketStore: Record<string, string>, callerEmail: strin
 	return {
 		post(mailboxId: string) {
 			const hdrs: Record<string, string> = {};
-			if (callerEmail) hdrs["cf-access-authenticated-user-email"] = callerEmail;
+			// Caller identity travels in the fake verified JWT (f17).
+			if (callerEmail) hdrs["cf-access-jwt-assertion"] = makeFakeJwt({ email: callerEmail });
 			return app.request(
 				`/api/v1/mailboxes/${mailboxId}/acl`,
 				{ method: "POST", headers: hdrs },
@@ -274,8 +295,10 @@ function makeBulkLockDownApp(bucketStore: Record<string, string>, callerEmail: s
 	const app = new Hono<{ Bindings: { BUCKET: typeof bucket; MAILBOX: typeof MAILBOX } }>();
 
 	app.post("/api/v1/mailboxes/bulk-lockdown", async (c) => {
+		// Mirror of the production handler in workers/index.ts (f17): owner
+		// identity from the verified JWT, never the email header. Keep in sync.
 		const caller =
-			c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+			callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"))?.toLowerCase() ?? null;
 
 		if (!caller) {
 			return c.json({ error: "CF Access email required" }, 400);
@@ -313,9 +336,10 @@ function makeBulkLockDownApp(bucketStore: Record<string, string>, callerEmail: s
 	});
 
 	return {
-		post() {
-			const hdrs: Record<string, string> = {};
-			if (callerEmail) hdrs["cf-access-authenticated-user-email"] = callerEmail;
+		post(extraHeaders: Record<string, string> = {}) {
+			const hdrs: Record<string, string> = { ...extraHeaders };
+			// Caller identity travels in the fake verified JWT (f17).
+			if (callerEmail) hdrs["cf-access-jwt-assertion"] = makeFakeJwt({ email: callerEmail });
 			return app.request(
 				"/api/v1/mailboxes/bulk-lockdown",
 				{ method: "POST", headers: hdrs },
@@ -429,5 +453,65 @@ describe("POST /api/v1/mailboxes/bulk-lockdown (#294)", () => {
 		const body = await res.json() as { locked: number; skipped: number; errors: string[] };
 		expect(body.locked).toBe(1);
 		expect(body.errors).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// f17 — fail-closed listing and JWT-derived bulk lock-down owner
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/mailboxes — fail-closed in production (f17)", () => {
+	const aliceKey = `mailboxes/alice@example.com.json`;
+	const aliceAclKey = `mailboxes-acl/alice@example.com.json`;
+	const bobKey = `mailboxes/bob@example.com.json`;
+	const aliceAcl: MailboxAcl = { owner: "alice@example.com", members: ["alice@example.com"] };
+
+	it("hides scoped mailboxes (but keeps unscoped) when no caller email exists in production", async () => {
+		const store = {
+			[aliceKey]: "{}",
+			[aliceAclKey]: JSON.stringify(aliceAcl),
+			[bobKey]: "{}", // unscoped — backwards-compat, stays visible
+		};
+		const { fetch } = makeListApp(store, null, /* dev */ false);
+		const res = await fetch();
+		expect(res.status).toBe(200);
+		const body = await res.json() as Array<{ id: string }>;
+		expect(body.map((m) => m.id)).toEqual(["bob@example.com"]);
+	});
+
+	it("still shows everything for a null caller in dev mode", async () => {
+		const store = {
+			[aliceKey]: "{}",
+			[aliceAclKey]: JSON.stringify(aliceAcl),
+			[bobKey]: "{}",
+		};
+		const { fetch } = makeListApp(store, null, /* dev */ true);
+		const res = await fetch();
+		const body = await res.json() as Array<{ id: string }>;
+		expect(body).toHaveLength(2);
+	});
+});
+
+describe("POST /api/v1/mailboxes/bulk-lockdown — owner from the verified JWT (f17)", () => {
+	const aliceKey = `mailboxes/alice@example.com.json`;
+	const aliceAclKey = `mailboxes-acl/alice@example.com.json`;
+
+	it("a forged cf-access-authenticated-user-email header cannot seed ownership", async () => {
+		const store = { [aliceKey]: "{}" };
+		const { post, bucket } = makeBulkLockDownApp(store, null);
+		// Forged header, no JWT email → 400, nothing written.
+		const res = await post({ "cf-access-authenticated-user-email": "mallory@example.com" });
+		expect(res.status).toBe(400);
+		expect(bucket._store[aliceAclKey]).toBeUndefined();
+	});
+
+	it("owner comes from the JWT email even when a different header is forged", async () => {
+		const store = { [aliceKey]: "{}" };
+		const { post, bucket } = makeBulkLockDownApp(store, "operator@example.com");
+		const res = await post({ "cf-access-authenticated-user-email": "mallory@example.com" });
+		expect(res.status).toBe(200);
+		const stored = JSON.parse(bucket._store[aliceAclKey]) as MailboxAcl;
+		expect(stored.owner).toBe("operator@example.com");
+		expect(stored.members).not.toContain("mallory@example.com");
 	});
 });

--- a/tests/routes/me.test.ts
+++ b/tests/routes/me.test.ts
@@ -1,13 +1,16 @@
 // Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
 
 /**
- * Route-level test for `GET /api/v1/me` (#204).
+ * Route-level test for `GET /api/v1/me` (#204, f17).
  *
- * The endpoint reads the Cloudflare Access-set
- * `Cf-Access-Authenticated-User-Email` header that the JWT-verifying
- * middleware in `workers/app.ts` has already vouched for. The unit test
- * scope here is the *handler* contract — given the header, return the
- * email — not the middleware (which has its own integration coverage).
+ * The endpoint decodes the signed-in identity from the `email` claim of the
+ * `cf-access-jwt-assertion` token that the JWT-verifying middleware in
+ * `workers/app.ts` has already vouched for — NEVER from the
+ * `Cf-Access-Authenticated-User-Email` header, which is decoupled from the
+ * token and forgeable on a direct-to-origin request (advisory finding f17).
+ * The unit test scope here is the *handler* contract — given the verified
+ * token, return its email claim — not the middleware (which has its own
+ * integration coverage).
  *
  * We rebuild a minimal Hono app with the same handler shape rather than
  * importing the full `workers/index.ts` graph, because that module pulls
@@ -16,20 +19,28 @@
  * mirroring the handler keeps the test fast and dependency-free; the
  * production handler lives in `workers/index.ts` next to `/api/v1/config`
  * so a follow-up that changes one and forgets the other will fail this
- * test on the contract (header → email mapping) regardless of where the
- * route is defined.
+ * test on the contract (JWT email claim → email mapping) regardless of
+ * where the route is defined.
  */
 
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
+import { callerEmailFromJwt } from "../../workers/lib/mailbox-acl";
+
+// Helper: build a fake (unsigned) JWT carrying arbitrary claims. decodeJwt
+// from jose just base64url-decodes the payload — no sig check needed here.
+function makeFakeJwt(claims: Record<string, unknown>): string {
+	const b64url = (s: string) => btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+	return `${b64url('{"alg":"none"}')}.${b64url(JSON.stringify(claims))}.`;
+}
 
 // Mirror of the production handler in workers/index.ts. Keep in sync.
 function makeApp(opts: { dev: boolean } = { dev: false }) {
 	const app = new Hono();
 	app.get("/api/v1/me", (c) => {
-		const headerEmail = c.req.header("cf-access-authenticated-user-email");
-		if (headerEmail) {
-			return c.json({ email: headerEmail });
+		const jwtEmail = callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"));
+		if (jwtEmail) {
+			return c.json({ email: jwtEmail });
 		}
 		if (opts.dev) {
 			return c.json({ email: "dev@local" });
@@ -39,27 +50,52 @@ function makeApp(opts: { dev: boolean } = { dev: false }) {
 	return app;
 }
 
-describe("GET /api/v1/me (#204)", () => {
-	it("returns the email from the Cf-Access-Authenticated-User-Email header", async () => {
+describe("GET /api/v1/me (#204, f17)", () => {
+	it("returns the email claim from the verified cf-access-jwt-assertion token", async () => {
 		const app = makeApp();
 		const res = await app.request("/api/v1/me", {
-			headers: { "cf-access-authenticated-user-email": "alice@acme.com" },
+			headers: { "cf-access-jwt-assertion": makeFakeJwt({ email: "alice@acme.com" }) },
 		});
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as { email: string };
 		expect(body.email).toBe("alice@acme.com");
 	});
 
-	it("returns 401 in production when the header is absent", async () => {
-		// The auth middleware would normally have already 403'd this case;
-		// reaching the handler without the header in production is the
-		// belt-and-suspenders branch.
+	it("ignores the forgeable cf-access-authenticated-user-email header (f17)", async () => {
+		// A forged header without a JWT email claim must NOT mint an identity.
+		const app = makeApp({ dev: false });
+		const res = await app.request("/api/v1/me", {
+			headers: {
+				"cf-access-authenticated-user-email": "victim@corp.com",
+				"cf-access-jwt-assertion": makeFakeJwt({ common_name: "svc-token" }),
+			},
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it("prefers the JWT email when a conflicting header is forged", async () => {
+		const app = makeApp({ dev: false });
+		const res = await app.request("/api/v1/me", {
+			headers: {
+				"cf-access-authenticated-user-email": "victim@corp.com",
+				"cf-access-jwt-assertion": makeFakeJwt({ email: "eve@acme.com" }),
+			},
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { email: string };
+		expect(body.email).toBe("eve@acme.com");
+	});
+
+	it("returns 401 in production when no identity can be derived", async () => {
+		// The auth middleware would normally have already 403'd a tokenless
+		// request; reaching the handler without a JWT email in production is
+		// the belt-and-suspenders branch (e.g. a service token, no email claim).
 		const app = makeApp({ dev: false });
 		const res = await app.request("/api/v1/me");
 		expect(res.status).toBe(401);
 	});
 
-	it("returns a stub identity in dev mode when no header is present", async () => {
+	it("returns a stub identity in dev mode when no token is present", async () => {
 		// `npm run dev` runs the worker without Access in front; the
 		// handler must not 401 there or the account menu shows "Loading…"
 		// forever. Stub email is stable so the dev experience is

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -70,7 +70,14 @@ import {
 	mailboxesForOrgSearch,
 	type PerMailboxSearchResult,
 } from "./lib/org-search";
-import { readMailboxAcl, writeMailboxAcl, deleteMailboxAcl, callerInAcl, callerGroupsFromJwt } from "./lib/mailbox-acl";
+import {
+	readMailboxAcl,
+	writeMailboxAcl,
+	deleteMailboxAcl,
+	callerInAcl,
+	callerGroupsFromJwt,
+	callerEmailFromJwt,
+} from "./lib/mailbox-acl";
 import { aclMemberRoutes } from "./routes/acl-members";
 import { fireYaraScan } from "./security/yaramail-signal";
 import { yaramailCallbackRoute } from "./routes/yaramail-callback";
@@ -215,28 +222,30 @@ app.delete("/api/v1/org/domains/:domain", async (c) => {
 });
 
 // Authenticated-user identity (#204). The Cloudflare Access middleware in
-// `workers/app.ts` has already verified the JWT and admitted the request;
-// the `Cf-Access-Authenticated-User-Email` header is set by Access on the
-// admitted request, so reading it here is safe — no second `jwtVerify`
-// pass and no hand-rolled crypto. The Shell sidebar account menu consumes
-// `{ email }` to render the signed-in identity and the sign-out link.
+// `workers/app.ts` has already verified the JWT signature and admitted the
+// request; identity is decoded from that VERIFIED token's `email` claim —
+// never from the `cf-access-authenticated-user-email` header, which is
+// decoupled from the JWT and forgeable on a direct-to-origin request (f17).
+// No second `jwtVerify` pass and no hand-rolled crypto. The Shell sidebar
+// account menu consumes `{ email }` to render the signed-in identity and
+// the sign-out link.
 //
 // Dev mode: the auth middleware short-circuits when `import.meta.env.DEV`
-// is true (Vite dev server has no Access in front of it), so the header
+// is true (Vite dev server has no Access in front of it), so the token
 // is absent. Mirror that branch with a stable stub identity rather than
 // returning 401 — otherwise `npm run dev` shows a broken account menu.
 app.get("/api/v1/me", (c) => {
-	const headerEmail = c.req.header("cf-access-authenticated-user-email");
-	if (headerEmail) {
-		return c.json({ email: headerEmail });
+	const jwtEmail = callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"));
+	if (jwtEmail) {
+		return c.json({ email: jwtEmail });
 	}
 	if (import.meta.env.DEV) {
 		return c.json({ email: "dev@local" });
 	}
 	// In production the Access middleware would have already 403'd a
 	// request without a verified JWT; reaching this branch implies the
-	// request was admitted but Access didn't populate the header — treat
-	// as unauthenticated rather than guess.
+	// verified token carries no `email` claim (e.g. a service token) —
+	// treat as unauthenticated rather than guess.
 	return c.json({ error: "not authenticated" }, 401);
 });
 
@@ -261,16 +270,20 @@ app.get("/api/v1/ai/text-models", async (c) => {
 // -- Mailboxes ------------------------------------------------------
 
 app.get("/api/v1/mailboxes", async (c) => {
-	const callerEmail = c.req.header("cf-access-authenticated-user-email") ?? null;
-	// Groups from the verified CF Access JWT — used for group-grant ACL checks (#295).
-	const callerGroups = callerGroupsFromJwt(c.req.header("cf-access-jwt-assertion"));
+	// Identity and groups from the VERIFIED CF Access JWT — never from the
+	// forgeable cf-access-authenticated-user-email header (f17, #295).
+	const jwtToken = c.req.header("cf-access-jwt-assertion");
+	const callerEmail = callerEmailFromJwt(jwtToken);
+	const callerGroups = callerGroupsFromJwt(jwtToken);
 	const allMailboxes = await listMailboxes(c.env.BUCKET);
 
 	// Read ACLs for all mailboxes — needed for acl_status (#241) in both branches.
 	const acls = await Promise.all(allMailboxes.map((m) => readMailboxAcl(c.env, m.id)));
 
-	// In dev mode or on pre-#27 single-user deploys (no callerEmail) show all.
-	if (!callerEmail) {
+	// Local dev only (no CF Access in front → no JWT email): show all. In
+	// production a missing JWT email (service token / stripped identity) must
+	// NOT reveal scoped mailboxes — fall through to the fail-closed filter.
+	if (!callerEmail && import.meta.env.DEV) {
 		return c.json(allMailboxes.map((m, i) => ({
 			...m,
 			name: m.id,
@@ -278,10 +291,11 @@ app.get("/api/v1/mailboxes", async (c) => {
 		})));
 	}
 
-	// Filter to mailboxes the caller is allowed to see (#27, #295).
+	// Filter to mailboxes the caller is allowed to see (#27, #295). Unscoped
+	// mailboxes (acl === null) stay visible to everyone (backwards-compat).
 	const visible = allMailboxes
 		.map((m, i) => ({ mailbox: m, acl: acls[i] }))
-		.filter(({ acl }) => callerInAcl(acl, callerEmail, callerGroups));
+		.filter(({ acl }) => callerInAcl(acl, callerEmail, callerGroups, import.meta.env.DEV));
 	return c.json(visible.map(({ mailbox, acl }) => ({
 		...mailbox,
 		name: mailbox.id,
@@ -291,8 +305,9 @@ app.get("/api/v1/mailboxes", async (c) => {
 
 // Bulk lock-down: lock every unscoped mailbox the caller can see (#294).
 app.post("/api/v1/mailboxes/bulk-lockdown", async (c) => {
+	// Owner identity from the VERIFIED CF Access JWT, not a forgeable header (f17).
 	const callerEmail =
-		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+		callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"))?.toLowerCase() ?? null;
 
 	if (!callerEmail) {
 		return c.json({ error: "CF Access email required" }, 400);
@@ -414,8 +429,10 @@ app.get("/api/v1/org/acl-overview", async (c) => {
 const ORG_SEARCH_PER_MAILBOX_CAP = 200;
 
 app.get("/api/v1/org/search", async (c) => {
+	// Identity and groups from the VERIFIED CF Access JWT — never from the
+	// forgeable cf-access-authenticated-user-email header (f17).
 	const callerEmail =
-		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+		callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"))?.toLowerCase() ?? null;
 	const callerGroups = callerGroupsFromJwt(c.req.header("cf-access-jwt-assertion"));
 
 	const searchOpts = {
@@ -435,7 +452,13 @@ app.get("/api/v1/org/search", async (c) => {
 
 	const allMailboxes = await listMailboxes(c.env.BUCKET);
 	const acls = await Promise.all(allMailboxes.map((m) => readMailboxAcl(c.env, m.id)));
-	const mailboxes = mailboxesForOrgSearch(allMailboxes, acls, callerEmail, callerGroups);
+	const mailboxes = mailboxesForOrgSearch(
+		allMailboxes,
+		acls,
+		callerEmail,
+		callerGroups,
+		import.meta.env.DEV,
+	);
 
 	const settled = await Promise.allSettled(
 		mailboxes.map(async (m) => {
@@ -922,10 +945,12 @@ app.post("/api/v1/mailboxes", async (c) => {
 	const finalSettings = { ...defaultSettings, ...cleanedSettings };
 	await c.env.BUCKET.put(key, JSON.stringify(finalSettings));
 
-	// Bootstrap owner ACL (#27). Skipped when callerEmail is absent (dev
-	// mode / no Access) — those deploys get the backwards-compat "anyone
-	// past Access can see all mailboxes" behaviour.
-	const creatorEmail = c.req.header("cf-access-authenticated-user-email");
+	// Bootstrap owner ACL (#27). Owner identity comes from the VERIFIED CF
+	// Access JWT — never from the forgeable
+	// cf-access-authenticated-user-email header (f17). Skipped when the JWT
+	// email is absent (dev mode / no Access) — those deploys get the
+	// backwards-compat "anyone past Access can see all mailboxes" behaviour.
+	const creatorEmail = callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"));
 	if (creatorEmail) {
 		const owner = creatorEmail.toLowerCase();
 		await writeMailboxAcl(c.env, email, { owner, members: [owner] });

--- a/workers/lib/mailbox-acl.ts
+++ b/workers/lib/mailbox-acl.ts
@@ -91,7 +91,11 @@ export async function deleteMailboxAcl(
  *
  * - `acl === null`: no ACL written yet → allow anyone (backwards-compat for
  *   pre-#27 mailboxes and single-user deploys).
- * - `callerEmail` falsy: CF Access not in front (local dev) → allow.
+ * - `callerEmail` falsy: FAIL CLOSED in production (f17) — a missing email
+ *   means the verified JWT carried no `email` claim (service token, or a
+ *   direct-to-origin request whose identity could not be established), and
+ *   granting access there is the cross-tenant bypass. Only local dev
+ *   (`isDev === true`, no CF Access in front) is allowed through.
  * - Otherwise: caller must appear in `acl.members` (case-insensitive) OR
  *   belong to one of the `acl.groups` listed (matched against `callerGroups`
  *   sourced from the verified CF Access JWT via `callerGroupsFromJwt`).
@@ -100,9 +104,10 @@ export function callerInAcl(
 	acl: MailboxAcl | null,
 	callerEmail: string | null | undefined,
 	callerGroups: string[] = [],
+	isDev: boolean = false,
 ): boolean {
 	if (acl === null) return true;
-	if (!callerEmail) return true;
+	if (!callerEmail) return isDev;
 	const lower = callerEmail.toLowerCase();
 	if (acl.members.some((m) => m.toLowerCase() === lower)) return true;
 	if (acl.groups?.some((g) => callerGroups.includes(g))) return true;
@@ -172,5 +177,5 @@ export async function callerAllowedForMailbox(
 	if (isDev) return true;
 	const email = callerEmailFromJwt(jwtToken);
 	if (!email) return false;
-	return callerInAcl(acl, email, callerGroupsFromJwt(jwtToken));
+	return callerInAcl(acl, email, callerGroupsFromJwt(jwtToken), isDev);
 }

--- a/workers/lib/mailbox.ts
+++ b/workers/lib/mailbox.ts
@@ -10,7 +10,12 @@
 import { createMiddleware } from "hono/factory";
 import type { MailboxDO } from "../durableObject";
 import type { Env } from "../types";
-import { readMailboxAcl, callerInAcl, callerGroupsFromJwt } from "./mailbox-acl";
+import {
+	readMailboxAcl,
+	callerInAcl,
+	callerGroupsFromJwt,
+	callerEmailFromJwt,
+} from "./mailbox-acl";
 
 export type MailboxContext = {
 	Bindings: Env;
@@ -24,9 +29,13 @@ export const requireMailbox = createMiddleware<MailboxContext>(async (c, next) =
 	if (!rawId) return c.json({ error: "Mailbox ID required" }, 400);
 	const mailboxId = decodeURIComponent(rawId);
 
-	const callerEmail = c.req.header("cf-access-authenticated-user-email") ?? null;
-	// Groups sourced from the verified CF Access JWT (already checked by the global middleware).
-	const callerGroups = callerGroupsFromJwt(c.req.header("cf-access-jwt-assertion"));
+	// Identity and groups sourced from the VERIFIED CF Access JWT (signature
+	// already checked by the global middleware in workers/app.ts) — never from
+	// the cf-access-authenticated-user-email header, which is decoupled from
+	// the token and forgeable on a direct-to-origin request (f17).
+	const jwtToken = c.req.header("cf-access-jwt-assertion");
+	const callerEmail = callerEmailFromJwt(jwtToken);
+	const callerGroups = callerGroupsFromJwt(jwtToken);
 	const key = `mailboxes/${mailboxId}.json`;
 
 	// Parallel: existence check + ACL read (#27)
@@ -36,7 +45,11 @@ export const requireMailbox = createMiddleware<MailboxContext>(async (c, next) =
 	]);
 
 	if (!obj) return c.json({ error: "Not found" }, 404);
-	if (!callerInAcl(acl, callerEmail, callerGroups)) return c.json({ error: "Forbidden" }, 403);
+	// Fail closed in production when no JWT email is present (f17); local dev
+	// (no CF Access in front → no token) keeps the legacy allow.
+	if (!callerInAcl(acl, callerEmail, callerGroups, import.meta.env.DEV)) {
+		return c.json({ error: "Forbidden" }, 403);
+	}
 
 	const ns = c.env.MAILBOX;
 	const id = ns.idFromName(mailboxId);

--- a/workers/lib/org-search.ts
+++ b/workers/lib/org-search.ts
@@ -12,14 +12,20 @@
 
 import { callerInAcl, type MailboxAcl } from "./mailbox-acl";
 
-/** Restrict org-search fan-out to mailboxes the caller is permitted to access. */
+/**
+ * Restrict org-search fan-out to mailboxes the caller is permitted to access.
+ * `callerEmail` must come from the verified CF Access JWT
+ * (`callerEmailFromJwt`); a missing email fails closed for scoped mailboxes
+ * in production (`isDev === false`) — see `callerInAcl` (f17).
+ */
 export function mailboxesForOrgSearch<T extends { id: string }>(
 	mailboxes: T[],
 	acls: Array<MailboxAcl | null>,
 	callerEmail: string | null | undefined,
 	callerGroups: string[],
+	isDev: boolean = false,
 ): T[] {
-	return mailboxes.filter((_, i) => callerInAcl(acls[i], callerEmail, callerGroups));
+	return mailboxes.filter((_, i) => callerInAcl(acls[i], callerEmail, callerGroups, isDev));
 }
 
 export type OrgSearchEmailRow = {

--- a/workers/mcp/index.ts
+++ b/workers/mcp/index.ts
@@ -22,7 +22,12 @@ import {
 } from "../lib/tools";
 import { Folders, FOLDER_TOOL_DESCRIPTION, MOVE_FOLDER_TOOL_DESCRIPTION } from "../../shared/folders";
 import type { Env } from "../types";
-import { readMailboxAcl, callerInAcl, callerGroupsFromJwt } from "../lib/mailbox-acl";
+import {
+	readMailboxAcl,
+	callerInAcl,
+	callerGroupsFromJwt,
+	callerEmailFromJwt,
+} from "../lib/mailbox-acl";
 
 /** Wrap a plain result object into MCP content format. */
 function mcpText(result: unknown) {
@@ -68,17 +73,19 @@ export class EmailMCP extends McpAgent<Env> {
 		version: "1.0.0",
 	});
 
-	// Caller email from the CF Access header on the initial connection
-	// request. Each McpAgent DO instance handles exactly one session so
-	// this instance field is safe to use across tool calls (#27).
+	// Caller identity decoded from the VERIFIED CF Access JWT on the initial
+	// connection request (the global middleware in workers/app.ts already
+	// checked the signature) — never from the forgeable
+	// cf-access-authenticated-user-email header (f17). Each McpAgent DO
+	// instance handles exactly one session so these instance fields are safe
+	// to use across tool calls (#27).
 	#callerEmail: string | null = null;
 	#callerGroups: string[] = [];
 
 	async fetch(request: Request): Promise<Response> {
-		this.#callerEmail = request.headers.get("cf-access-authenticated-user-email");
-		this.#callerGroups = callerGroupsFromJwt(
-			request.headers.get("cf-access-jwt-assertion"),
-		);
+		const jwtToken = request.headers.get("cf-access-jwt-assertion");
+		this.#callerEmail = callerEmailFromJwt(jwtToken);
+		this.#callerGroups = callerGroupsFromJwt(jwtToken);
 		return super.fetch(request);
 	}
 
@@ -97,7 +104,8 @@ export class EmailMCP extends McpAgent<Env> {
 			if (!obj) {
 				return mcpError(`Mailbox "${mailboxId}" not found. Use list_mailboxes to see available mailboxes.`);
 			}
-			if (!callerInAcl(acl, this.#callerEmail, this.#callerGroups)) {
+			// Fail closed in production when the JWT carries no email (f17).
+			if (!callerInAcl(acl, this.#callerEmail, this.#callerGroups, import.meta.env.DEV)) {
 				return mcpError(`Access denied for mailbox "${mailboxId}".`);
 			}
 			return null;
@@ -111,12 +119,15 @@ export class EmailMCP extends McpAgent<Env> {
 			async () => {
 				const all = await toolListMailboxes(env);
 				const callerEmail = this.#callerEmail;
-				if (!callerEmail) return mcpText(all);
+				// Local dev only (no CF Access → no JWT email): show all. In
+				// production a missing JWT email (service token / stripped
+				// identity) must NOT reveal scoped mailboxes (f17).
+				if (!callerEmail && import.meta.env.DEV) return mcpText(all);
 				const acls = await Promise.all(
 					(all as Array<{ id: string }>).map((m) => readMailboxAcl(env, m.id)),
 				);
 				const filtered = (all as Array<{ id: string }>).filter((_, i) =>
-					callerInAcl(acls[i], callerEmail, this.#callerGroups),
+					callerInAcl(acls[i], callerEmail, this.#callerGroups, import.meta.env.DEV),
 				);
 				return mcpText(filtered);
 			},

--- a/workers/routes/acl-members.ts
+++ b/workers/routes/acl-members.ts
@@ -6,12 +6,15 @@
  *
  * Only the mailbox owner (the email stored in `acl.owner`) may call these
  * write endpoints. A caller admitted by CF Access but not the owner receives
- * 403. The ACL blob is not a settings tier; `stripDefaultEqual` is not used.
+ * 403. Caller identity is decoded from the VERIFIED CF Access JWT
+ * (`callerEmailFromJwt`) — never from the forgeable
+ * `cf-access-authenticated-user-email` header (f17). The ACL blob is not a
+ * settings tier; `stripDefaultEqual` is not used.
  */
 
 import { Hono } from "hono";
 import { requireMailbox, type MailboxContext } from "../lib/mailbox";
-import { readMailboxAcl, writeMailboxAcl } from "../lib/mailbox-acl";
+import { readMailboxAcl, writeMailboxAcl, callerEmailFromJwt } from "../lib/mailbox-acl";
 
 export const aclMemberRoutes = new Hono<MailboxContext>();
 
@@ -25,7 +28,7 @@ aclMemberRoutes.use("*", requireMailbox);
 aclMemberRoutes.get("/", async (c) => {
 	const mailboxId = c.req.param("mailboxId")!;
 	const callerEmail =
-		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+		callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"))?.toLowerCase() ?? null;
 
 	const acl = await readMailboxAcl(c.env, mailboxId);
 	if (!acl) {
@@ -45,7 +48,7 @@ aclMemberRoutes.get("/", async (c) => {
 aclMemberRoutes.post("/", async (c) => {
 	const mailboxId = c.req.param("mailboxId")!;
 	const callerEmail =
-		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+		callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"))?.toLowerCase() ?? null;
 
 	if (!callerEmail) {
 		return c.json({ error: "CF Access email required to lock down a mailbox" }, 400);
@@ -65,7 +68,7 @@ aclMemberRoutes.post("/", async (c) => {
 aclMemberRoutes.post("/members", async (c) => {
 	const mailboxId = c.req.param("mailboxId")!;
 	const callerEmail =
-		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+		callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"))?.toLowerCase() ?? null;
 
 	const acl = await readMailboxAcl(c.env, mailboxId);
 	if (!acl || callerEmail !== acl.owner) {
@@ -98,7 +101,7 @@ aclMemberRoutes.post("/members", async (c) => {
 aclMemberRoutes.post("/transfer", async (c) => {
 	const mailboxId = c.req.param("mailboxId")!;
 	const callerEmail =
-		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+		callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"))?.toLowerCase() ?? null;
 
 	const acl = await readMailboxAcl(c.env, mailboxId);
 	if (!acl || callerEmail !== acl.owner) {
@@ -127,7 +130,7 @@ aclMemberRoutes.post("/transfer", async (c) => {
 aclMemberRoutes.delete("/members/:memberEmail", async (c) => {
 	const mailboxId = c.req.param("mailboxId")!;
 	const callerEmail =
-		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+		callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"))?.toLowerCase() ?? null;
 	const memberEmail = decodeURIComponent(c.req.param("memberEmail")!).toLowerCase();
 
 	const acl = await readMailboxAcl(c.env, mailboxId);
@@ -156,7 +159,7 @@ aclMemberRoutes.delete("/members/:memberEmail", async (c) => {
 aclMemberRoutes.post("/groups", async (c) => {
 	const mailboxId = c.req.param("mailboxId")!;
 	const callerEmail =
-		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+		callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"))?.toLowerCase() ?? null;
 
 	const acl = await readMailboxAcl(c.env, mailboxId);
 	if (!acl || callerEmail !== acl.owner) {
@@ -181,7 +184,7 @@ aclMemberRoutes.post("/groups", async (c) => {
 aclMemberRoutes.delete("/groups/:groupName", async (c) => {
 	const mailboxId = c.req.param("mailboxId")!;
 	const callerEmail =
-		c.req.header("cf-access-authenticated-user-email")?.toLowerCase() ?? null;
+		callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"))?.toLowerCase() ?? null;
 	const groupName = decodeURIComponent(c.req.param("groupName")!);
 
 	const acl = await readMailboxAcl(c.env, mailboxId);


### PR DESCRIPTION
Closes finding **f17** of advisory **GHSA-g3v6-6xph-3vx6** (cross-tenant ACL).

> **STACKED on #476** — base is `claude/ghsa-g3v6-acl`, which introduced `callerEmailFromJwt` / `callerAllowedForMailbox` / `emailAgentMailboxIdFromPath`. Merge #476 first; pre-flip this PR's base to `main` before merging #476 with `--delete-branch` (see CLAUDE.md stacked-PR note).

## Problem

Authorization identity was read from the `cf-access-authenticated-user-email` header, which is decoupled from the CF Access JWT that the global middleware (`workers/app.ts`) verifies. `callerInAcl` also failed open on a null email, so a verified-JWT caller with no email (service token, or stripped identity) bypassed every per-mailbox ACL.

## Changes

- **Identity from the verified JWT everywhere.** `callerEmailFromJwt(c.req.header("cf-access-jwt-assertion"))` replaces the header read at: `workers/lib/mailbox.ts` (`requireMailbox`), `workers/index.ts` (`/api/v1/me`, `GET /api/v1/mailboxes`, bulk-lockdown, org search, mailbox-create `creatorEmail`/owner bootstrap), `workers/mcp/index.ts` (`EmailMCP.fetch`), and all 7 sites in `workers/routes/acl-members.ts`. The email header is no longer a trust source anywhere in `workers/` (grep-verified; only comments remain). Groups continue to come from the JWT via `callerGroupsFromJwt`.
- **`callerInAcl` fails closed on a null/empty email in production.** New `isDev` parameter (default `false`); all callers pass `import.meta.env.DEV` (`mailbox.ts`, `index.ts`, `mcp/index.ts`, `lib/org-search.ts`, `callerAllowedForMailbox`). The show-all list branches (`GET /api/v1/mailboxes`, MCP `list_mailboxes`) are now dev-only, so a service token cannot enumerate scoped mailboxes.
- **Preserved:** `acl === null` backwards-compat allow (unscoped mailboxes), and local-dev behavior (no CF Access → null email → allow via the `isDev` gate).

## Acceptance tests

- Valid JWT with **no email claim** + existing ACL → **403** in production (`requireMailbox`, agent gate, MCP path); was previously allowed via fail-open.
- Forged `cf-access-authenticated-user-email` header does **not** grant access, owner rights, or list visibility when the JWT email differs or is absent (requireMailbox, acl-members owner ops, bulk-lockdown, `/api/v1/me`, mailbox creation).
- `callerInAcl(acl, null, [], false)` → `false`; `callerInAcl(acl, null, [], true)` → `true`.
- Dev mode and no-ACL paths still allow; org-search fan-out keeps unscoped mailboxes and hides scoped ones for a null caller in prod.
- Mailbox creation seeds the ACL `owner` from the JWT email (lower-cased), never from the header.

## Gates

- `npm run typecheck` → exit 0
- `npm test` → `Test Files  113 passed (113)` / `Tests  1463 passed (1463)`

Existing header-authenticated test suites were migrated to fake `cf-access-jwt-assertion` tokens (`makeFakeJwt` pattern from `tests/lib/mailbox-acl.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)