### PR TITLE
fix(confirm-token): treat rowsWritten > 0 as successful jti consume

### DIFF
--- a/tests/durableObject/consume-jti.test.ts
+++ b/tests/durableObject/consume-jti.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Unit tests for `MailboxDO.consumeJti` (issue #461 / PR #468 regression).
+ *
+ * In Cloudflare DO SQLite, `cursor.rowsWritten` counts rows written to
+ * indexes as well as tables. `consumed_jti` declares `jti TEXT PRIMARY KEY`,
+ * which SQLite backs with an implicit unique index — so a successful
+ * first-time INSERT reports rowsWritten === 2, not 1. Measured empirically
+ * against workerd (wrangler dev --local, 2026-06-11):
+ *
+ *   INSERT OR IGNORE ... (new jti)        → rowsWritten === 2
+ *   INSERT OR IGNORE ... (duplicate jti)  → rowsWritten === 0
+ *   control: INTEGER PRIMARY KEY insert   → rowsWritten === 1
+ *
+ * The shipped check `rowsWritten === 1` therefore rejected EVERY legitimate
+ * consume, 401-ing all Tier ≥ 1 sends. The fix treats any written row as a
+ * successful consume (`> 0`); a replayed jti still reports 0.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+// Mock cloudflare:workers — MailboxDO extends DurableObject from this module,
+// but consumeJti only touches `this.ctx.storage.sql.exec`.
+vi.mock("cloudflare:workers", () => ({
+	DurableObject: class {
+		ctx: unknown;
+		env: unknown;
+		constructor(state: unknown, env: unknown) { this.ctx = state; this.env = env; }
+	},
+}));
+
+import { MailboxDO } from "../../workers/durableObject/index";
+
+/**
+ * Builds a MailboxDO whose sql.exec mimics workerd's measured rowsWritten
+ * accounting for the consumed_jti table (see header comment). The
+ * constructor (drizzle + migrations) is bypassed — consumeJti needs only
+ * `ctx.storage.sql`.
+ */
+function makeDO() {
+	const consumed = new Set<string>();
+	const sql = {
+		exec: (query: string, ...bindings: unknown[]) => {
+			if (!/INSERT OR IGNORE INTO consumed_jti/.test(query)) {
+				throw new Error(`unexpected query: ${query}`);
+			}
+			const jti = bindings[0] as string;
+			if (consumed.has(jti)) return { rowsWritten: 0 };
+			consumed.add(jti);
+			// 2 = table row + implicit `jti TEXT PRIMARY KEY` unique index row.
+			return { rowsWritten: 2 };
+		},
+	};
+	const mailboxDO = Object.create(MailboxDO.prototype) as MailboxDO;
+	(mailboxDO as unknown as { ctx: unknown }).ctx = { storage: { sql } };
+	return mailboxDO;
+}
+
+describe("MailboxDO.consumeJti — workerd rowsWritten accounting (PR #468 regression)", () => {
+	it("returns true on first consume even though the PK index makes rowsWritten 2", async () => {
+		const mailboxDO = makeDO();
+		await expect(mailboxDO.consumeJti("jti-1")).resolves.toBe(true);
+	});
+
+	it("returns false when the jti was already consumed (replay)", async () => {
+		const mailboxDO = makeDO();
+		await mailboxDO.consumeJti("jti-1");
+		await expect(mailboxDO.consumeJti("jti-1")).resolves.toBe(false);
+	});
+
+	it("consumes distinct jtis independently", async () => {
+		const mailboxDO = makeDO();
+		await expect(mailboxDO.consumeJti("jti-a")).resolves.toBe(true);
+		await expect(mailboxDO.consumeJti("jti-b")).resolves.toBe(true);
+		await expect(mailboxDO.consumeJti("jti-a")).resolves.toBe(false);
+	});
+});

--- a/workers/durableObject/index.ts
+++ b/workers/durableObject/index.ts
@@ -2187,15 +2187,20 @@ export class MailboxDO extends DurableObject<Env> {
 	 * (this call wins the race), false if it was already consumed.
 	 *
 	 * INSERT OR IGNORE on a PRIMARY KEY is an atomic test-and-set in DO SQLite:
-	 * the DO serializes all JS execution, so rowsWritten === 1 means exactly
-	 * one caller consumed the token.
+	 * the DO serializes all JS execution, so only one caller's INSERT writes.
+	 *
+	 * rowsWritten counts index rows too: `jti TEXT PRIMARY KEY` carries an
+	 * implicit unique index, so a successful insert reports rowsWritten === 2
+	 * (measured against workerd). An ignored duplicate reports 0 — so the
+	 * consume test is "wrote anything", NOT `=== 1`, which rejected every
+	 * legitimate consume and 401'd all Tier ≥ 1 sends.
 	 */
 	async consumeJti(jti: string): Promise<boolean> {
 		const cursor = this.ctx.storage.sql.exec(
 			`INSERT OR IGNORE INTO consumed_jti (jti) VALUES (?1)`,
 			jti,
 		);
-		return cursor.rowsWritten === 1;
+		return cursor.rowsWritten > 0;
 	}
 
 	/** List RUF records, optionally filtered by domain. Newest first, max 200. */

--- a/workers/durableObject/migrations.ts
+++ b/workers/durableObject/migrations.ts
@@ -530,7 +530,8 @@ export const mailboxMigrations: Migration[] = [
 		// KV has no compare-and-swap, so the previous get-then-delete was a
 		// non-atomic race. The DO serializes all JS execution, so an
 		// INSERT OR IGNORE with a PRIMARY KEY constraint is the atomic gate:
-		// only the request whose INSERT creates a row (rowsWritten === 1) may proceed.
+		// only the request whose INSERT creates a row (rowsWritten > 0; the TEXT
+		// PRIMARY KEY's implicit index makes a successful insert report 2) may proceed.
 		// The KV get-check is still used to verify the token was legitimately issued.
 		name: "25_consumed_jti",
 		sql: `


### PR DESCRIPTION
## Problem

Since #468 (abe1d9b, merged 2026-06-10) **every Tier ≥ 1 send fails** with `invalid or expired confirmation token`, even with a freshly minted step-up token (reported live on inbox.cortech.online, 2026-06-11).

## Root cause

`MailboxDO.consumeJti` decides "newly consumed" with `cursor.rowsWritten === 1`. But DO SQLite's `rowsWritten` counts **index writes too**, and migration 25 created `consumed_jti` with `jti TEXT PRIMARY KEY` — backed by an implicit unique index. Measured against real workerd (`wrangler dev --local`, scratch DO running the exact DDL + statement):

| Statement | rowsWritten |
|---|---|
| `INSERT OR IGNORE` (new jti) | **2** (table row + implicit PK index row) |
| `INSERT OR IGNORE` (duplicate jti) | 0 |
| control: insert into `INTEGER PRIMARY KEY` table | 1 |

So the success path reports 2, `=== 1` is false, `verifyConfirmationToken` returns null, and `enforceSendRiskConfirmation` 401s the send (`workers/lib/send-risk-gate.ts:86`). Retrying with a new token fails identically — a deterministic, total regression of step-up sends.

CI never caught it because every test mocks the `consumeJti` callback (`tests/lib/confirm-token.test.ts`, `tests/routes/confirm.test.ts`, …) and the suite runs in vitest's Node pool — the real method never executes against SQLite accounting.

## Fix

`rowsWritten > 0` = consumed. A replayed jti writes nothing (0) and stays rejected, so the one-shot/replay guarantee from #461 is unchanged. Comments on the method and migration 25 now document the index-write accounting so `=== 1` doesn't get reintroduced.

## Tests

- New `tests/durableObject/consume-jti.test.ts` exercises the **real** `MailboxDO.consumeJti` (via `Object.create` + stubbed `ctx.storage.sql`) against the empirically measured cursor semantics: first consume → true, replay → false, distinct jtis independent. Written first and confirmed failing (2/3) against the shipped code.
- Full gates: `npm test` — **1467 passing, 0 failing (115 files)**; `npm run typecheck` clean.

## Follow-up (not in this PR)

The send outage was only half of the report — the `ERR_TOO_MANY_REDIRECTS` loop on the main hostname is the documented shared-hostname Access caveat (`docs/step-up-auth.md` §4, #287): verify the step-up Access app's session duration is not "expire immediately".

A `@cloudflare/vitest-pool-workers` harness for `MailboxDO` would catch this class of runtime-semantics bug for real; can file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)