### PR TITLE
fix(intel): cut BLOOM_KV writes ~99% — exact-blob + refreshHours gate

### DIFF
--- a/tests/intel/feed-kv-writes.test.ts
+++ b/tests/intel/feed-kv-writes.test.ts
@@ -1,0 +1,414 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * BLOOM_KV write-reduction: exact-blob storage + refreshHours staleness gate.
+ *
+ * Validates that:
+ *   1. A url-kind feed refresh writes exactly 2 KV keys (bloom blob + exact blob)
+ *      regardless of entry count — not one key per entry.
+ *   2. refreshAllFeeds skips a feed whose last_fetched_at is within refreshHours.
+ *   3. The exact-match read path still confirms values that appear in the blob
+ *      and reports bloom-only hits as unconfirmed.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { checkUrlAgainstFeeds, refreshAllFeeds } from "../../workers/intel/feeds";
+import { addToBloom, createBloom, serializeBloom } from "../../workers/intel/bloom";
+import { clearOrgSettingsCache } from "../../workers/lib/org-settings";
+import { clearDomainSettingsCache } from "../../workers/lib/domain-settings";
+import type { Env } from "../../workers/types";
+
+const MAILBOX_ID = "user@example.com";
+
+// ── KV mock with put-call tracking ────────────────────────────────────────────
+
+function makeCountingKv() {
+	const store = new Map<string, string | Uint8Array>();
+	const putKeys: string[] = [];
+	return {
+		store,
+		putKeys,
+		async get(key: string, type?: "text" | "arrayBuffer") {
+			const val = store.get(key);
+			if (val === undefined) return null;
+			if (type === "arrayBuffer") {
+				return val instanceof Uint8Array ? val.buffer : null;
+			}
+			if (type === "text") {
+				return typeof val === "string" ? val : null;
+			}
+			return val;
+		},
+		async put(key: string, value: string | Uint8Array, _opts?: unknown) {
+			putKeys.push(key);
+			store.set(key, value);
+		},
+	};
+}
+
+// ── Feed-state factory ────────────────────────────────────────────────────────
+
+type FeedStateRow = {
+	feed_id: string;
+	url: string;
+	last_fetched_at: string | null;
+	etag: string | null;
+	entry_count: number | null;
+	bloom_kv_key: string | null;
+};
+
+function makeFeedState(overrides: Partial<FeedStateRow> = {}): FeedStateRow {
+	return {
+		feed_id: "test-feed",
+		url: "https://test.example/feed.txt",
+		last_fetched_at: null,
+		etag: null,
+		entry_count: null,
+		bloom_kv_key: null,
+		...overrides,
+	};
+}
+
+// ── Env factory ───────────────────────────────────────────────────────────────
+
+function makeEnv(opts: {
+	mailboxSettings: unknown;
+	kv?: ReturnType<typeof makeCountingKv>;
+	feedState?: FeedStateRow | null;
+}): { env: Env; kv: ReturnType<typeof makeCountingKv> } {
+	const kv = opts.kv ?? makeCountingKv();
+	const state = opts.feedState !== undefined ? opts.feedState : null;
+
+	const stub = {
+		async getIntelFeedState(_feedId: string) {
+			return state;
+		},
+		async upsertIntelFeedState(_feedId: string, _data: unknown) {},
+	};
+
+	const mailboxNs = {
+		idFromName(_name: string) {
+			return { toString: () => _name } as unknown as DurableObjectId;
+		},
+		get(_id: DurableObjectId) {
+			return stub as unknown as DurableObjectStub;
+		},
+	} as unknown as DurableObjectNamespace;
+
+	const bucket = {
+		async list(_opts: { prefix: string }) {
+			return { objects: [{ key: `mailboxes/${MAILBOX_ID}.json` }] };
+		},
+		async get(key: string) {
+			if (key !== `mailboxes/${MAILBOX_ID}.json`) return null;
+			return {
+				etag: "etag-1",
+				async json() {
+					return opts.mailboxSettings;
+				},
+			};
+		},
+	};
+
+	const env = {
+		BLOOM_KV: kv as unknown as KVNamespace,
+		BUCKET: bucket as unknown as R2Bucket,
+		MAILBOX: mailboxNs,
+	} as unknown as Env;
+
+	return { env, kv };
+}
+
+function feedBody(n: number): string {
+	return Array.from({ length: n }, (_, i) => `https://evil-${i}.example/phish`).join("\n");
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────────
+
+let savedFetch: typeof fetch;
+beforeEach(() => {
+	savedFetch = globalThis.fetch;
+	clearOrgSettingsCache();
+	clearDomainSettingsCache();
+});
+afterEach(() => {
+	globalThis.fetch = savedFetch;
+	vi.restoreAllMocks();
+});
+
+// ── Tests: write count ────────────────────────────────────────────────────────
+
+describe("BLOOM_KV write count — url-kind feed", () => {
+	it("performs exactly 2 BLOOM_KV.put calls per refresh (bloom blob + exact blob)", async () => {
+		vi.stubGlobal("fetch", async () => new Response(feedBody(2500), { status: 200 }));
+
+		const { env, kv } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [{ id: "test-feed", url: "https://test.example/feed.txt", kind: "url" }],
+				},
+			},
+		});
+
+		await refreshAllFeeds(env);
+
+		expect(kv.putKeys).toHaveLength(2);
+		expect(kv.putKeys.some((k) => k === "intel:test-feed:bloom")).toBe(true);
+		expect(kv.putKeys.some((k) => k === "intel:test-feed:exact-blob")).toBe(true);
+	});
+
+	it("exact blob is a JSON array capped at EXACT_KEY_CAP entries", async () => {
+		vi.stubGlobal("fetch", async () => new Response(feedBody(2500), { status: 200 }));
+
+		const { env, kv } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [{ id: "test-feed", url: "https://test.example/feed.txt", kind: "url" }],
+				},
+			},
+		});
+
+		await refreshAllFeeds(env);
+
+		const raw = kv.store.get("intel:test-feed:exact-blob");
+		expect(typeof raw).toBe("string");
+		const parsed = JSON.parse(raw as string) as unknown[];
+		expect(Array.isArray(parsed)).toBe(true);
+		expect(parsed.length).toBeLessThanOrEqual(2000);
+	});
+
+	it("small feed (fewer entries than cap) still uses exact-blob, not per-entry keys", async () => {
+		vi.stubGlobal("fetch", async () => new Response(feedBody(5), { status: 200 }));
+
+		const { env, kv } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [{ id: "small-feed", url: "https://test.example/small.txt", kind: "url" }],
+				},
+			},
+		});
+
+		await refreshAllFeeds(env);
+
+		// Still exactly 2 — no per-entry keys
+		expect(kv.putKeys).toHaveLength(2);
+		const perEntryKeys = kv.putKeys.filter((k) => k.startsWith("intel:small-feed:exact:"));
+		expect(perEntryKeys).toHaveLength(0);
+	});
+});
+
+// ── Tests: refreshHours staleness gate ───────────────────────────────────────
+
+describe("refreshHours staleness gate", () => {
+	it("skips a feed whose last_fetched_at is within refreshHours", async () => {
+		const fetchUrls: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			async (input: string | URL | Request) => {
+				fetchUrls.push(typeof input === "string" ? input : input.toString());
+				return new Response(feedBody(5), { status: 200 });
+			},
+		);
+
+		// refreshHours = 6; last fetched 2 h ago → still fresh
+		const { env } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [
+						{
+							id: "test-feed",
+							url: "https://test.example/feed.txt",
+							kind: "url",
+							refresh_hours: 6,
+						},
+					],
+				},
+			},
+			feedState: makeFeedState({
+				last_fetched_at: new Date(Date.now() - 2 * 3600 * 1000).toISOString(),
+				entry_count: 10,
+			}),
+		});
+
+		const result = await refreshAllFeeds(env);
+
+		expect(fetchUrls).toHaveLength(0);
+		expect(result.feeds).toBe(0);
+	});
+
+	it("fetches a feed whose last_fetched_at is beyond refreshHours", async () => {
+		const fetchUrls: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			async (input: string | URL | Request) => {
+				fetchUrls.push(typeof input === "string" ? input : input.toString());
+				return new Response(feedBody(5), { status: 200 });
+			},
+		);
+
+		// refreshHours = 6; last fetched 8 h ago → stale
+		const { env } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [
+						{
+							id: "test-feed",
+							url: "https://test.example/feed.txt",
+							kind: "url",
+							refresh_hours: 6,
+						},
+					],
+				},
+			},
+			feedState: makeFeedState({
+				last_fetched_at: new Date(Date.now() - 8 * 3600 * 1000).toISOString(),
+			}),
+		});
+
+		await refreshAllFeeds(env);
+
+		expect(fetchUrls).toHaveLength(1);
+	});
+
+	it("fetches a feed with no prior state (first run)", async () => {
+		const fetchUrls: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			async (input: string | URL | Request) => {
+				fetchUrls.push(typeof input === "string" ? input : input.toString());
+				return new Response(feedBody(5), { status: 200 });
+			},
+		);
+
+		const { env } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [{ id: "test-feed", url: "https://test.example/feed.txt", kind: "url" }],
+				},
+			},
+			feedState: null,
+		});
+
+		await refreshAllFeeds(env);
+
+		expect(fetchUrls).toHaveLength(1);
+	});
+
+	it("feeds with no last_fetched_at (state row exists but field is null) are treated as first run", async () => {
+		const fetchUrls: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			async (input: string | URL | Request) => {
+				fetchUrls.push(typeof input === "string" ? input : input.toString());
+				return new Response(feedBody(5), { status: 200 });
+			},
+		);
+
+		const { env } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [{ id: "test-feed", url: "https://test.example/feed.txt", kind: "url" }],
+				},
+			},
+			feedState: makeFeedState({ last_fetched_at: null }),
+		});
+
+		await refreshAllFeeds(env);
+
+		expect(fetchUrls).toHaveLength(1);
+	});
+});
+
+// ── Tests: exact-match read path ──────────────────────────────────────────────
+
+describe("exact-match read path (exact blob)", () => {
+	it("value present in exact blob → confirmed: true", async () => {
+		const { env, kv } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [{ id: "test-feed", url: "https://test.example/feed.txt", kind: "url" }],
+				},
+			},
+		});
+
+		const testUrl = "https://evil.example/phish";
+		const host = new URL(testUrl).hostname;
+
+		const bloom = createBloom(10);
+		addToBloom(bloom, testUrl);
+		addToBloom(bloom, host);
+		kv.store.set("intel:test-feed:bloom", serializeBloom(bloom));
+		kv.store.set("intel:test-feed:exact-blob", JSON.stringify([testUrl, host]));
+
+		const result = await checkUrlAgainstFeeds(env, MAILBOX_ID, testUrl);
+
+		expect(result).not.toBeNull();
+		expect(result?.confirmed).toBe(true);
+		expect(result?.value).toBe(testUrl);
+	});
+
+	it("bloom hit but value absent from exact blob → confirmed: false", async () => {
+		const { env, kv } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [{ id: "test-feed", url: "https://test.example/feed.txt", kind: "url" }],
+				},
+			},
+		});
+
+		const testUrl = "https://evil.example/phish";
+
+		const bloom = createBloom(10);
+		addToBloom(bloom, testUrl);
+		kv.store.set("intel:test-feed:bloom", serializeBloom(bloom));
+		// exact blob is empty — simulates a bloom false positive or a value above the cap
+		kv.store.set("intel:test-feed:exact-blob", JSON.stringify([]));
+
+		const result = await checkUrlAgainstFeeds(env, MAILBOX_ID, testUrl);
+
+		expect(result).not.toBeNull();
+		expect(result?.confirmed).toBe(false);
+	});
+
+	it("URL not in bloom → null", async () => {
+		const { env, kv } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [{ id: "test-feed", url: "https://test.example/feed.txt", kind: "url" }],
+				},
+			},
+		});
+
+		const bloom = createBloom(10);
+		kv.store.set("intel:test-feed:bloom", serializeBloom(bloom));
+		kv.store.set("intel:test-feed:exact-blob", JSON.stringify([]));
+
+		const result = await checkUrlAgainstFeeds(env, MAILBOX_ID, "https://safe.example/ok");
+
+		expect(result).toBeNull();
+	});
+
+	it("no exact blob in KV → bloom hit falls back to confirmed: false gracefully", async () => {
+		const { env, kv } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [{ id: "test-feed", url: "https://test.example/feed.txt", kind: "url" }],
+				},
+			},
+		});
+
+		const testUrl = "https://evil.example/phish";
+
+		const bloom = createBloom(10);
+		addToBloom(bloom, testUrl);
+		kv.store.set("intel:test-feed:bloom", serializeBloom(bloom));
+		// no exact-blob key at all
+
+		const result = await checkUrlAgainstFeeds(env, MAILBOX_ID, testUrl);
+
+		expect(result).not.toBeNull();
+		expect(result?.confirmed).toBe(false);
+	});
+});

--- a/workers/intel/feeds.ts
+++ b/workers/intel/feeds.ts
@@ -35,10 +35,11 @@ import { getMailboxStub, listMailboxes } from "../lib/email-helpers";
 import { hostAllowed } from "../lib/host-allowlist";
 import { resolveMailboxSettings } from "../lib/mailbox-settings";
 
-const EXACT_KEY_CAP = 2000; // per-feed cap — we only fast-path confirm up to this many
+const EXACT_KEY_CAP = 2000; // per-feed cap — exact blob stores at most this many entries
 
 function bloomKey(feedId: string) { return `intel:${feedId}:bloom`; }
-function exactKey(feedId: string, value: string) { return `intel:${feedId}:exact:${value}`; }
+/** Single blob key holding a JSON array of up to EXACT_KEY_CAP exact-match values. */
+function exactBlobKey(feedId: string) { return `intel:${feedId}:exact-blob`; }
 /**
  * Storage key for `ip-cidr` feeds. Bloom filters don't fit CIDR membership
  * (an IP is checked against a *range*, not an exact string) so we materialise
@@ -226,7 +227,16 @@ export async function refreshAllFeeds(env: Env): Promise<{ feeds: number; entrie
 			// materialised out-of-band.
 			if (!feed.url) continue;
 			try {
-				const refreshed = await refreshFeed(env, mailboxId, feed);
+				const stub = getMailboxStub(env, mailboxId);
+				const state = await stub.getIntelFeedState(feed.id);
+				// Honor refreshHours: skip if the feed was fetched more recently than
+				// its configured interval. A null/absent last_fetched_at is treated as
+				// a first run and always triggers a fetch.
+				if (state?.last_fetched_at) {
+					const elapsedMs = Date.now() - new Date(state.last_fetched_at).getTime();
+					if (elapsedMs < feed.refreshHours * 3600 * 1000) continue;
+				}
+				const refreshed = await refreshFeed(env, mailboxId, feed, state);
 				feeds++;
 				entries += refreshed.entries;
 			} catch (e) {
@@ -237,13 +247,15 @@ export async function refreshAllFeeds(env: Env): Promise<{ feeds: number; entrie
 	return { feeds, entries };
 }
 
+type FeedState = Awaited<ReturnType<ReturnType<typeof getMailboxStub>["getIntelFeedState"]>>;
+
 async function refreshFeed(
 	env: Env,
 	mailboxId: string,
 	feed: FeedDefinition,
+	state: FeedState,
 ): Promise<{ entries: number }> {
 	const stub = getMailboxStub(env, mailboxId);
-	const state = await stub.getIntelFeedState(feed.id);
 
 	const headers: Record<string, string> = { ...(feed.headers ?? {}) };
 	if (state?.etag) headers["If-None-Match"] = state.etag;
@@ -289,19 +301,12 @@ async function refreshFeed(
 		expirationTtl: ttlSeconds,
 	});
 
-	// Write a bounded subset of exact-match markers for secondary confirmation.
+	// Write a bounded subset of exact-match values as a single JSON blob.
+	// This reduces KV writes from O(entries) to O(1) per feed per refresh.
 	const exactSlice = values.slice(0, EXACT_KEY_CAP);
-	const writes: Promise<void>[] = [];
-	for (const v of exactSlice) {
-		writes.push(
-			env.BLOOM_KV
-				.put(exactKey(feed.id, v), "1", {
-					expirationTtl: feed.refreshHours * 3600 * 4,
-				})
-				.catch(() => {}), // isolated; individual failures shouldn't abort refresh
-		);
-	}
-	await Promise.all(writes);
+	await env.BLOOM_KV.put(exactBlobKey(feed.id), JSON.stringify(exactSlice), {
+		expirationTtl: ttlSeconds,
+	});
 
 	await stub.upsertIntelFeedState(feed.id, {
 		url: feed.url,
@@ -348,10 +353,14 @@ export async function checkUrlAgainstFeeds(
 		const filter = deserializeBloom(serialized);
 		if (!filter) continue;
 		const candidates = feed.kind === "domain" ? [host] : [fullUrl, host];
+		// Fetch the exact-match blob once per feed, not once per candidate.
+		const exactBlobRaw = await env.BLOOM_KV.get(exactBlobKey(feed.id), "text");
+		const exactSet = new Set<string>(
+			exactBlobRaw ? (JSON.parse(exactBlobRaw) as string[]) : [],
+		);
 		for (const v of candidates) {
 			if (!checkBloom(filter, v)) continue;
-			const exact = await env.BLOOM_KV.get(exactKey(feed.id, v), "text");
-			if (exact === "1") return { matched: true, feedId: feed.id, value: v, confirmed: true };
+			if (exactSet.has(v)) return { matched: true, feedId: feed.id, value: v, confirmed: true };
 			if (!bloomOnly) bloomOnly = { matched: true, feedId: feed.id, value: v, confirmed: false };
 		}
 	}


### PR DESCRIPTION
## Summary

- Replace per-entry exact-key KV writes (up to 2,001/feed/run) with 2 puts: the bloom blob + a single `intel:{id}:exact-blob` JSON array capped at `EXACT_KEY_CAP` (2,000) entries.
- Add a staleness gate in `refreshAllFeeds`: each feed is skipped when `now − last_fetched_at < refreshHours × 3600 s`, honouring per-feed refresh intervals (urlhaus: 1h, openphish: 6h, spamhaus: 12h) rather than fetching every feed on every cron run.
- Update the read path in `checkUrlAgainstFeeds` to load the exact blob once per feed and check `Set` membership — no per-candidate `KV.get`.

Closes #481.

## Cost math

| Before | After |
|--------|-------|
| ~2,001 writes/feed/run × 4 feeds × 24 runs/day ≈ 192k writes/day | ≤ 2 writes/feed refreshed × 4 feeds × (refreshed at most once per `refreshHours`) ≈ ≤ 8–32 writes/day |
| ~1.5M writes/month (KV overage billing) | < 200 writes/day |

**To verify post-deploy:** query `kvOperationsAdaptiveGroups` for namespace `ebaf7dd6b5514eeba2ea319cdb587f78` grouped by `date`/`actionType` — daily write count should drop below ~200 within 24h of deployment.

## Test plan

- [x] `npm test` — 1524 passing, 0 failing (includes 11 new tests in `tests/intel/feed-kv-writes.test.ts`)
- [x] `npm run typecheck` — clean
- New tests assert: exactly 2 `BLOOM_KV.put` calls for a 2,500-entry feed; exact blob is a capped JSON array; staleness skip/fetch transitions (fresh, stale, first-run, null `last_fetched_at`); read-path confirmed/unconfirmed/null outcomes.

## Choices made

- `exactBlobKey` uses suffix `exact-blob` (not `exact:`) so old per-entry keys `intel:{id}:exact:{value}` that carry their own `expirationTtl` age out on their own — no migration needed (per issue constraint).
- The exact-blob TTL uses the same `ttlSeconds = max(refreshHours × 4 × 3600, 86400)` formula as the bloom blob (previously the per-entry keys used `refreshHours × 4 × 3600` without the 86400 floor; unified for simplicity).
- `FeedState` type derived via `Awaited<ReturnType<...>>` from the DO method signature rather than duplicating the drizzle row type.

https://claude.ai/code/session_01UhAE8GSzdztSYNVtGf2H2x

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhAE8GSzdztSYNVtGf2H2x)_