### PR TITLE
docs(intel): remove stale per-entry exact-key references from module JSDoc

### DIFF
--- a/workers/intel/bloom.ts
+++ b/workers/intel/bloom.ts
@@ -7,8 +7,8 @@
  *
  * Purpose: cheap "is this URL/domain on a known-bad list" test without
  * shipping a multi-MB list to every hot-path request. A positive match
- * still triggers a secondary exact-match lookup (`BLOOM_KV.get(exact:<value>)`)
- * before we act on it — bloom false-positives must not cause blocking.
+ * still triggers a secondary exact-blob set-membership check before we act
+ * on it — bloom false-positives must not cause blocking.
  *
  * Sizing: m = ceil(-n * ln(p) / (ln(2))^2), k = ceil((m/n) * ln(2))
  * For n = 100k entries, p = 0.01 → m ≈ 958k bits (≈120KB), k ≈ 7.

--- a/workers/intel/feeds.ts
+++ b/workers/intel/feeds.ts
@@ -10,9 +10,9 @@
  *   2. For each mailbox with `intel.feeds`, fetch each feed (If-None-Match).
  *   3. Parse entries (domain or URL, ignore `#` comments).
  *   4. Build a bloom filter and store under KV key `intel:{feedId}:bloom`.
- *   5. Also write an `intel:{feedId}:exact:<value>` marker for a subset of
- *      high-confidence entries so we can confirm a bloom hit without false
- *      positives. (Bounded to prevent runaway KV writes.)
+ *   5. Write a single `intel:{feedId}:exact-blob` JSON array capped at
+ *      EXACT_KEY_CAP entries so we can confirm a bloom hit without false
+ *      positives (one blob per feed, not one key per entry).
  *   6. Update `intel_feed_state` row on the mailbox DO.
  *
  * Lookup flow:


### PR DESCRIPTION
## Summary

- Updates the module-level JSDoc in `workers/intel/feeds.ts` to describe the blob approach (one `exact-blob` key per feed) instead of the old per-entry `exact:<value>` pattern.
- Updates the module-level JSDoc in `workers/intel/bloom.ts` to say "exact-blob set-membership check" instead of `` `BLOOM_KV.get(exact:<value>)` ``.

Closes #485.

## Context

PR #482 replaced per-entry KV exact keys with a single blob per feed but did not update the two module-level doc comments that still described the old `intel:{id}:exact:<value>` pattern. The code change itself (`legacyExactKey` / fallback branch) was never merged to `main` — PR #482 shipped the clean implementation directly — so no code removal was needed, only comment cleanup.

## Test plan

- [x] `npm test` — 1524 passing, 0 failing
- [x] `npm run typecheck` — clean
- [x] `grep -rn "exact:" workers/intel/` — no output (all per-entry key references removed)

_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_0136UhtgJor5g3H46LAxJkMT)_