### PR TITLE
fix: renew KV blob TTL on 304 and force refetch when blobs are missing

### DIFF
--- a/tests/intel/feed-kv-writes.test.ts
+++ b/tests/intel/feed-kv-writes.test.ts
@@ -25,7 +25,7 @@ const MAILBOX_ID = "user@example.com";
 // ── KV mock with put-call tracking ────────────────────────────────────────────
 
 function makeCountingKv() {
-	const store = new Map<string, string | Uint8Array>();
+	const store = new Map<string, string | Uint8Array | ArrayBuffer>();
 	const putKeys: string[] = [];
 	return {
 		store,
@@ -34,6 +34,7 @@ function makeCountingKv() {
 			const val = store.get(key);
 			if (val === undefined) return null;
 			if (type === "arrayBuffer") {
+				if (val instanceof ArrayBuffer) return val;
 				return val instanceof Uint8Array ? val.buffer : null;
 			}
 			if (type === "text") {
@@ -41,7 +42,7 @@ function makeCountingKv() {
 			}
 			return val;
 		},
-		async put(key: string, value: string | Uint8Array, _opts?: unknown) {
+		async put(key: string, value: string | Uint8Array | ArrayBuffer, _opts?: unknown) {
 			putKeys.push(key);
 			store.set(key, value);
 		},
@@ -410,5 +411,222 @@ describe("exact-match read path (exact blob)", () => {
 
 		expect(result).not.toBeNull();
 		expect(result?.confirmed).toBe(false);
+	});
+});
+
+// ── Tests: 304 TTL renewal — url-kind feed ────────────────────────────────────
+
+describe("304 TTL renewal — url-kind feed", () => {
+	it("304 with blobs present re-puts bloom and exact-blob (TTL renewed)", async () => {
+		vi.stubGlobal("fetch", async () => new Response(null, { status: 304 }));
+
+		const { env, kv } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [{ id: "test-feed", url: "https://test.example/feed.txt", kind: "url" }],
+				},
+			},
+			feedState: makeFeedState({
+				last_fetched_at: new Date(Date.now() - 8 * 3600 * 1000).toISOString(),
+				etag: '"abc123"',
+				entry_count: 5,
+			}),
+		});
+
+		// Pre-seed blobs so blobsPresent === true
+		const bloom = createBloom(5);
+		addToBloom(bloom, "https://evil.example/phish");
+		kv.store.set("intel:test-feed:bloom", serializeBloom(bloom));
+		kv.store.set("intel:test-feed:exact-blob", JSON.stringify(["https://evil.example/phish"]));
+
+		await refreshAllFeeds(env);
+
+		// Exactly 2 puts — bloom + exact-blob renewed, no extra writes
+		expect(kv.putKeys).toHaveLength(2);
+		expect(kv.putKeys).toContain("intel:test-feed:bloom");
+		expect(kv.putKeys).toContain("intel:test-feed:exact-blob");
+	});
+
+	it("304 write count is exactly the number of required blobs (≤ 2)", async () => {
+		vi.stubGlobal("fetch", async () => new Response(null, { status: 304 }));
+
+		const { env, kv } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [{ id: "test-feed", url: "https://test.example/feed.txt", kind: "url" }],
+				},
+			},
+			feedState: makeFeedState({
+				last_fetched_at: new Date(Date.now() - 8 * 3600 * 1000).toISOString(),
+				etag: '"abc123"',
+				entry_count: 5,
+			}),
+		});
+
+		const bloom = createBloom(5);
+		addToBloom(bloom, "https://evil.example/phish");
+		kv.store.set("intel:test-feed:bloom", serializeBloom(bloom));
+		kv.store.set("intel:test-feed:exact-blob", JSON.stringify(["https://evil.example/phish"]));
+
+		await refreshAllFeeds(env);
+
+		expect(kv.putKeys.length).toBeLessThanOrEqual(2);
+	});
+});
+
+// ── Tests: 304 TTL renewal — ip-cidr feed ────────────────────────────────────
+
+describe("304 TTL renewal — ip-cidr feed", () => {
+	it("304 with cidr blob present re-puts cidr blob", async () => {
+		vi.stubGlobal("fetch", async () => new Response(null, { status: 304 }));
+
+		const { env, kv } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [
+						{
+							id: "test-cidr-feed",
+							url: "https://test.example/drop.txt",
+							kind: "ip-cidr",
+							refresh_hours: 12,
+						},
+					],
+				},
+			},
+			feedState: makeFeedState({
+				feed_id: "test-cidr-feed",
+				url: "https://test.example/drop.txt",
+				last_fetched_at: new Date(Date.now() - 14 * 3600 * 1000).toISOString(),
+				etag: '"drop-etag"',
+				entry_count: 3,
+			}),
+		});
+
+		const cidrData = JSON.stringify([{ n: 16843008, m: 4294967040, p: 24 }]);
+		kv.store.set("intel:test-cidr-feed:cidrs", cidrData);
+
+		await refreshAllFeeds(env);
+
+		expect(kv.putKeys).toHaveLength(1);
+		expect(kv.putKeys).toContain("intel:test-cidr-feed:cidrs");
+	});
+});
+
+// ── Tests: missing blob forces unconditional refetch ─────────────────────────
+
+describe("missing blob forces unconditional refetch", () => {
+	it("missing bloom blob omits If-None-Match and 200 rebuilds url-kind blobs", async () => {
+		let capturedInit: RequestInit | undefined;
+		vi.stubGlobal(
+			"fetch",
+			async (input: string | URL | Request, init?: RequestInit) => {
+				capturedInit = init;
+				return new Response(feedBody(5), { status: 200, headers: { ETag: '"new-etag"' } });
+			},
+		);
+
+		const { env, kv } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [{ id: "test-feed", url: "https://test.example/feed.txt", kind: "url" }],
+				},
+			},
+			feedState: makeFeedState({
+				last_fetched_at: new Date(Date.now() - 8 * 3600 * 1000).toISOString(),
+				etag: '"stale-etag"',
+				entry_count: 5,
+			}),
+		});
+
+		// No blobs in KV — simulates TTL expiry
+
+		await refreshAllFeeds(env);
+
+		// If-None-Match must be absent
+		const sentHeaders = capturedInit?.headers as Record<string, string> | undefined;
+		expect(sentHeaders?.["If-None-Match"]).toBeUndefined();
+
+		// Full rebuild: bloom + exact-blob written
+		expect(kv.putKeys).toContain("intel:test-feed:bloom");
+		expect(kv.putKeys).toContain("intel:test-feed:exact-blob");
+	});
+
+	it("missing cidr blob omits If-None-Match and 200 rebuilds cidr blob", async () => {
+		let capturedInit: RequestInit | undefined;
+		vi.stubGlobal(
+			"fetch",
+			async (input: string | URL | Request, init?: RequestInit) => {
+				capturedInit = init;
+				return new Response("10.0.0.0/8 ; SBL1\n192.168.0.0/16 ; SBL2\n", {
+					status: 200,
+					headers: { ETag: '"new-cidr-etag"' },
+				});
+			},
+		);
+
+		const { env, kv } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [
+						{
+							id: "test-cidr-feed",
+							url: "https://test.example/drop.txt",
+							kind: "ip-cidr",
+							refresh_hours: 12,
+						},
+					],
+				},
+			},
+			feedState: makeFeedState({
+				feed_id: "test-cidr-feed",
+				url: "https://test.example/drop.txt",
+				last_fetched_at: new Date(Date.now() - 14 * 3600 * 1000).toISOString(),
+				etag: '"stale-cidr-etag"',
+				entry_count: 2,
+			}),
+		});
+
+		// No cidr blob in KV — simulates TTL expiry
+
+		await refreshAllFeeds(env);
+
+		const sentHeaders = capturedInit?.headers as Record<string, string> | undefined;
+		expect(sentHeaders?.["If-None-Match"]).toBeUndefined();
+
+		expect(kv.putKeys).toContain("intel:test-cidr-feed:cidrs");
+	});
+
+	it("blobs present + etag → If-None-Match is sent (no regression)", async () => {
+		let capturedInit: RequestInit | undefined;
+		vi.stubGlobal(
+			"fetch",
+			async (input: string | URL | Request, init?: RequestInit) => {
+				capturedInit = init;
+				return new Response(null, { status: 304 });
+			},
+		);
+
+		const { env, kv } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					feeds: [{ id: "test-feed", url: "https://test.example/feed.txt", kind: "url" }],
+				},
+			},
+			feedState: makeFeedState({
+				last_fetched_at: new Date(Date.now() - 8 * 3600 * 1000).toISOString(),
+				etag: '"present-etag"',
+				entry_count: 5,
+			}),
+		});
+
+		const bloom = createBloom(5);
+		addToBloom(bloom, "https://evil.example/phish");
+		kv.store.set("intel:test-feed:bloom", serializeBloom(bloom));
+		kv.store.set("intel:test-feed:exact-blob", JSON.stringify(["https://evil.example/phish"]));
+
+		await refreshAllFeeds(env);
+
+		const sentHeaders = capturedInit?.headers as Record<string, string> | undefined;
+		expect(sentHeaders?.["If-None-Match"]).toBe('"present-etag"');
 	});
 });

--- a/workers/intel/feeds.ts
+++ b/workers/intel/feeds.ts
@@ -256,16 +256,55 @@ async function refreshFeed(
 	state: FeedState,
 ): Promise<{ entries: number }> {
 	const stub = getMailboxStub(env, mailboxId);
+	const ttlSeconds = Math.max(feed.refreshHours * 3600 * 4, 86400);
+
+	// Read required blobs before the conditional GET. A missing blob means the
+	// TTL already elapsed — force a 200 by omitting If-None-Match so the
+	// origin returns fresh content and the blobs are fully rebuilt.
+	let existingCidrs: string | null = null;
+	let existingBloom: ArrayBuffer | null = null;
+	let existingExact: string | null = null;
+	if (feed.kind === "ip-cidr") {
+		existingCidrs = await env.BLOOM_KV.get(cidrKey(feed.id), "text");
+	} else {
+		existingBloom = await env.BLOOM_KV.get(bloomKey(feed.id), "arrayBuffer");
+		existingExact = await env.BLOOM_KV.get(exactBlobKey(feed.id), "text");
+	}
+	const blobsPresent =
+		feed.kind === "ip-cidr"
+			? existingCidrs !== null
+			: existingBloom !== null && existingExact !== null;
 
 	const headers: Record<string, string> = { ...(feed.headers ?? {}) };
-	if (state?.etag) headers["If-None-Match"] = state.etag;
+	// Only attach If-None-Match when blobs are present — a 304 is useless
+	// when there is nothing in KV to keep alive.
+	if (state?.etag && blobsPresent) headers["If-None-Match"] = state.etag;
 
 	const res = await fetch(feed.url, { headers, signal: AbortSignal.timeout(15000) });
-	if (res.status === 304) return { entries: state?.entry_count ?? 0 };
+
+	if (res.status === 304) {
+		// Re-put each blob with a fresh TTL so a stable (never-200) feed
+		// doesn't go dark once the original TTL elapses. KV has no touch
+		// operation; rewriting the same value is the only renewal mechanism.
+		if (feed.kind === "ip-cidr") {
+			await env.BLOOM_KV.put(cidrKey(feed.id), existingCidrs!, { expirationTtl: ttlSeconds });
+		} else {
+			await env.BLOOM_KV.put(bloomKey(feed.id), existingBloom!, { expirationTtl: ttlSeconds });
+			await env.BLOOM_KV.put(exactBlobKey(feed.id), existingExact!, { expirationTtl: ttlSeconds });
+		}
+		await stub.upsertIntelFeedState(feed.id, {
+			url: feed.url,
+			last_fetched_at: new Date().toISOString(),
+			etag: state?.etag ?? null,
+			entry_count: state?.entry_count ?? 0,
+			bloom_kv_key: feed.kind === "ip-cidr" ? cidrKey(feed.id) : bloomKey(feed.id),
+		});
+		return { entries: state?.entry_count ?? 0 };
+	}
+
 	if (!res.ok) throw new Error(`${feed.url} returned ${res.status}`);
 
 	const body = await res.text();
-	const ttlSeconds = Math.max(feed.refreshHours * 3600 * 4, 86400);
 
 	if (feed.kind === "ip-cidr") {
 		// CIDR feeds use a separate storage path: a JSON blob of


### PR DESCRIPTION
## Summary

- **304 TTL renewal**: `refreshFeed` now reads the required blobs before the conditional GET. On 304, it re-puts each blob with a fresh `expirationTtl` (KV has no touch operation) and upserts `last_fetched_at`, preventing a stable feed from going silently dark after its blob TTL elapses.
- **Missing-blob self-healing**: If any required blob is absent (TTL already expired), `If-None-Match` is omitted so the origin returns a 200 and fully rebuilds the blobs, recovering from data loss without manual intervention.
- **ip-cidr feeds covered**: Both `url`/`domain` (bloom + exact-blob) and `ip-cidr` (cidrs blob) paths get the same treatment.

Closes #484.

## Test plan

- [x] `npm test` — 1530 passing, 0 failing
- [x] `npm run typecheck` — clean
- [ ] Three new describe blocks in `tests/intel/feed-kv-writes.test.ts`:
  - `304 TTL renewal — url-kind feed`: asserts bloom and exact-blob re-put (put-count = 2)
  - `304 TTL renewal — ip-cidr feed`: asserts cidr blob re-put (put-count = 1)
  - `missing blob forces unconditional refetch`: asserts `If-None-Match` absent in captured fetch headers for both url and ip-cidr kinds; asserts full rebuild on 200
  - Regression guard: blobs present + etag → `If-None-Match` is still sent

## Choices made

- `entry_count` in the 304 `upsertIntelFeedState` call falls back to `0` (not `null`) to satisfy the schema's `number` type; the entry count hasn't changed so the prior value from `state?.entry_count` (already an integer) is used when available.
- `last_fetched_at` is upserted on 304 so the `refreshHours` skip stays accurate for the next cron run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT5wxgqe9XqL7EDpyFYKnd)_