### PR TITLE
fix(intel): renew feed blob TTLs on 304 so stable feeds don't go dark

### DIFF
--- a/tests/intel/feed-kv-writes.test.ts
+++ b/tests/intel/feed-kv-writes.test.ts
@@ -11,6 +11,9 @@
  *   2. refreshAllFeeds skips a feed whose last_fetched_at is within refreshHours.
  *   3. The exact-match read path still confirms values that appear in the blob
  *      and reports bloom-only hits as unconfirmed.
+ *   4. A 304 renews the required blobs' TTLs (re-put same value) instead of
+ *      letting them expire under sustained 304s, and a missing blob forces an
+ *      unconditional refetch (#484).
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -27,9 +30,11 @@ const MAILBOX_ID = "user@example.com";
 function makeCountingKv() {
 	const store = new Map<string, string | Uint8Array>();
 	const putKeys: string[] = [];
+	const putCalls: Array<{ key: string; opts?: { expirationTtl?: number } }> = [];
 	return {
 		store,
 		putKeys,
+		putCalls,
 		async get(key: string, type?: "text" | "arrayBuffer") {
 			const val = store.get(key);
 			if (val === undefined) return null;
@@ -41,9 +46,14 @@ function makeCountingKv() {
 			}
 			return val;
 		},
-		async put(key: string, value: string | Uint8Array, _opts?: unknown) {
+		async put(
+			key: string,
+			value: string | Uint8Array | ArrayBuffer,
+			opts?: { expirationTtl?: number },
+		) {
 			putKeys.push(key);
-			store.set(key, value);
+			putCalls.push({ key, opts });
+			store.set(key, value instanceof ArrayBuffer ? new Uint8Array(value) : value);
 		},
 	};
 }
@@ -77,15 +87,22 @@ function makeEnv(opts: {
 	mailboxSettings: unknown;
 	kv?: ReturnType<typeof makeCountingKv>;
 	feedState?: FeedStateRow | null;
-}): { env: Env; kv: ReturnType<typeof makeCountingKv> } {
+}): {
+	env: Env;
+	kv: ReturnType<typeof makeCountingKv>;
+	upserts: Array<{ feedId: string; data: Record<string, unknown> }>;
+} {
 	const kv = opts.kv ?? makeCountingKv();
 	const state = opts.feedState !== undefined ? opts.feedState : null;
+	const upserts: Array<{ feedId: string; data: Record<string, unknown> }> = [];
 
 	const stub = {
 		async getIntelFeedState(_feedId: string) {
 			return state;
 		},
-		async upsertIntelFeedState(_feedId: string, _data: unknown) {},
+		async upsertIntelFeedState(feedId: string, data: unknown) {
+			upserts.push({ feedId, data: data as Record<string, unknown> });
+		},
 	};
 
 	const mailboxNs = {
@@ -118,7 +135,7 @@ function makeEnv(opts: {
 		MAILBOX: mailboxNs,
 	} as unknown as Env;
 
-	return { env, kv };
+	return { env, kv, upserts };
 }
 
 function feedBody(n: number): string {
@@ -410,5 +427,208 @@ describe("exact-match read path (exact blob)", () => {
 
 		expect(result).not.toBeNull();
 		expect(result?.confirmed).toBe(false);
+	});
+});
+
+// ── Tests: blob TTL renewal under sustained 304s (#484) ──────────────────────
+
+describe("blob TTL renewal on 304 (#484)", () => {
+	function staleFetchedAt(hoursAgo: number): string {
+		return new Date(Date.now() - hoursAgo * 3600 * 1000).toISOString();
+	}
+
+	function urlFeedSettings() {
+		return {
+			intel: {
+				feeds: [
+					{
+						id: "test-feed",
+						url: "https://test.example/feed.txt",
+						kind: "url",
+						refresh_hours: 6,
+					},
+				],
+			},
+		};
+	}
+
+	/** Seed both required blobs for a url-kind feed, returning the seeded values. */
+	function seedUrlBlobs(kv: ReturnType<typeof makeCountingKv>) {
+		const bloom = createBloom(10);
+		addToBloom(bloom, "https://evil.example/phish");
+		const bloomBytes = serializeBloom(bloom);
+		const exactJson = JSON.stringify(["https://evil.example/phish"]);
+		kv.store.set("intel:test-feed:bloom", bloomBytes);
+		kv.store.set("intel:test-feed:exact-blob", exactJson);
+		return { bloomBytes, exactJson };
+	}
+
+	it("304 with blobs present re-puts bloom + exact blobs with a fresh TTL (≤ required-blob writes)", async () => {
+		vi.stubGlobal("fetch", async () => new Response(null, { status: 304 }));
+		const kv = makeCountingKv();
+		const { bloomBytes, exactJson } = seedUrlBlobs(kv);
+		const { env } = makeEnv({
+			mailboxSettings: urlFeedSettings(),
+			kv,
+			feedState: makeFeedState({
+				etag: '"abc"',
+				last_fetched_at: staleFetchedAt(8),
+				entry_count: 1,
+			}),
+		});
+
+		await refreshAllFeeds(env);
+
+		// exactly the two required blobs — no extra writes
+		expect([...kv.putKeys].sort()).toEqual([
+			"intel:test-feed:bloom",
+			"intel:test-feed:exact-blob",
+		]);
+		// every renewal put carries a fresh TTL: max(6h * 4, 86400) = 86400
+		for (const call of kv.putCalls) {
+			expect(call.opts?.expirationTtl).toBe(86400);
+		}
+		// rewrite-same-value renewal: blob contents unchanged
+		expect(kv.store.get("intel:test-feed:bloom")).toEqual(bloomBytes);
+		expect(kv.store.get("intel:test-feed:exact-blob")).toBe(exactJson);
+	});
+
+	it("304 on an ip-cidr feed re-puts the cidrs blob (write count = 1)", async () => {
+		vi.stubGlobal("fetch", async () => new Response(null, { status: 304 }));
+		const kv = makeCountingKv();
+		const cidrJson = JSON.stringify([{ n: 16909056, m: 4294901760, p: 16 }]);
+		kv.store.set("intel:spamhaus-drop:cidrs", cidrJson);
+		const { env } = makeEnv({
+			mailboxSettings: {
+				intel: {
+					// base DEFAULT_FEEDS entry supplies kind: "ip-cidr"
+					feeds: [
+						{ id: "spamhaus-drop", url: "https://test.example/drop.txt", refresh_hours: 12 },
+					],
+				},
+			},
+			kv,
+			feedState: makeFeedState({
+				feed_id: "spamhaus-drop",
+				etag: '"abc"',
+				last_fetched_at: staleFetchedAt(13),
+				entry_count: 1,
+			}),
+		});
+
+		await refreshAllFeeds(env);
+
+		expect(kv.putKeys).toEqual(["intel:spamhaus-drop:cidrs"]);
+		expect(kv.putCalls[0]?.opts?.expirationTtl).toBe(12 * 4 * 3600);
+		expect(kv.store.get("intel:spamhaus-drop:cidrs")).toBe(cidrJson);
+	});
+
+	it("304 upserts a fresh last_fetched_at preserving etag and entry_count (keeps the refreshHours gate)", async () => {
+		vi.stubGlobal("fetch", async () => new Response(null, { status: 304 }));
+		const kv = makeCountingKv();
+		seedUrlBlobs(kv);
+		const before = Date.now();
+		const { env, upserts } = makeEnv({
+			mailboxSettings: urlFeedSettings(),
+			kv,
+			feedState: makeFeedState({
+				etag: '"abc"',
+				last_fetched_at: staleFetchedAt(8),
+				entry_count: 7,
+			}),
+		});
+
+		await refreshAllFeeds(env);
+
+		expect(upserts).toHaveLength(1);
+		const data = upserts[0].data as {
+			last_fetched_at: string;
+			etag: string | null;
+			entry_count: number;
+		};
+		expect(new Date(data.last_fetched_at).getTime()).toBeGreaterThanOrEqual(before);
+		expect(data.etag).toBe('"abc"');
+		expect(data.entry_count).toBe(7);
+	});
+
+	it("missing required blob → fetch omits If-None-Match and a 200 rebuilds all blobs", async () => {
+		const captured: Array<Record<string, string>> = [];
+		vi.stubGlobal("fetch", async (_input: string | URL | Request, init?: RequestInit) => {
+			captured.push({ ...((init?.headers as Record<string, string>) ?? {}) });
+			return new Response(feedBody(5), { status: 200 });
+		});
+		const kv = makeCountingKv();
+		// bloom survives but the exact blob has TTL-expired
+		kv.store.set("intel:test-feed:bloom", serializeBloom(createBloom(10)));
+		const { env } = makeEnv({
+			mailboxSettings: urlFeedSettings(),
+			kv,
+			feedState: makeFeedState({
+				etag: '"abc"',
+				last_fetched_at: staleFetchedAt(8),
+				entry_count: 5,
+			}),
+		});
+
+		await refreshAllFeeds(env);
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0]).not.toHaveProperty("If-None-Match");
+		expect([...kv.putKeys].sort()).toEqual([
+			"intel:test-feed:bloom",
+			"intel:test-feed:exact-blob",
+		]);
+	});
+
+	it("blobs present + stored etag → If-None-Match still sent (normal conditional flow)", async () => {
+		const captured: Array<Record<string, string>> = [];
+		vi.stubGlobal("fetch", async (_input: string | URL | Request, init?: RequestInit) => {
+			captured.push({ ...((init?.headers as Record<string, string>) ?? {}) });
+			return new Response(feedBody(5), { status: 200 });
+		});
+		const kv = makeCountingKv();
+		seedUrlBlobs(kv);
+		const { env } = makeEnv({
+			mailboxSettings: urlFeedSettings(),
+			kv,
+			feedState: makeFeedState({
+				etag: '"abc"',
+				last_fetched_at: staleFetchedAt(8),
+				entry_count: 1,
+			}),
+		});
+
+		await refreshAllFeeds(env);
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0]["If-None-Match"]).toBe('"abc"');
+		// content changed → full rebuild of both blobs
+		expect([...kv.putKeys].sort()).toEqual([
+			"intel:test-feed:bloom",
+			"intel:test-feed:exact-blob",
+		]);
+	});
+
+	it("304 to an unconditional request (blobs missing) fails the refresh without marking it fresh", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.stubGlobal("fetch", async () => new Response(null, { status: 304 }));
+		const kv = makeCountingKv(); // no blobs seeded
+		const { env, upserts } = makeEnv({
+			mailboxSettings: urlFeedSettings(),
+			kv,
+			feedState: makeFeedState({
+				etag: '"abc"',
+				last_fetched_at: staleFetchedAt(8),
+				entry_count: 5,
+			}),
+		});
+
+		const result = await refreshAllFeeds(env);
+
+		// counted as failed, not refreshed; last_fetched_at stays stale → retried next run
+		expect(result.feeds).toBe(0);
+		expect(upserts).toHaveLength(0);
+		expect(kv.putKeys).toHaveLength(0);
+		expect(errorSpy).toHaveBeenCalled();
 	});
 });

--- a/workers/intel/feeds.ts
+++ b/workers/intel/feeds.ts
@@ -257,15 +257,59 @@ async function refreshFeed(
 ): Promise<{ entries: number }> {
 	const stub = getMailboxStub(env, mailboxId);
 
+	// Read the blobs this feed's lookups depend on BEFORE fetching. A 304
+	// carries no body, so the only way to renew their TTL (KV has no touch
+	// operation) is to rewrite the values just read — and if any blob has
+	// already TTL-expired, only an unconditional 200 can rebuild it.
+	const requiredBlobs: Array<{ key: string; type: "arrayBuffer" | "text" }> =
+		feed.kind === "ip-cidr"
+			? [{ key: cidrKey(feed.id), type: "text" }]
+			: [
+					{ key: bloomKey(feed.id), type: "arrayBuffer" },
+					{ key: exactBlobKey(feed.id), type: "text" },
+				];
+	const existingBlobs: Array<{ key: string; value: ArrayBuffer | string }> = [];
+	for (const blob of requiredBlobs) {
+		const value =
+			blob.type === "arrayBuffer"
+				? await env.BLOOM_KV.get(blob.key, "arrayBuffer")
+				: await env.BLOOM_KV.get(blob.key, "text");
+		if (value !== null) existingBlobs.push({ key: blob.key, value });
+	}
+	const blobsIntact = existingBlobs.length === requiredBlobs.length;
+
 	const headers: Record<string, string> = { ...(feed.headers ?? {}) };
-	if (state?.etag) headers["If-None-Match"] = state.etag;
+	// Conditional GET only while every required blob is still alive in KV — a
+	// 304 is only safe to trust if the data it vouches for hasn't expired.
+	if (state?.etag && blobsIntact) headers["If-None-Match"] = state.etag;
 
 	const res = await fetch(feed.url, { headers, signal: AbortSignal.timeout(15000) });
-	if (res.status === 304) return { entries: state?.entry_count ?? 0 };
+	const ttlSeconds = Math.max(feed.refreshHours * 3600 * 4, 86400);
+	if (res.status === 304) {
+		if (!blobsIntact) {
+			// We didn't send If-None-Match, so this 304 violates the protocol —
+			// and with blobs missing there is no body to rebuild from. Fail the
+			// refresh; last_fetched_at stays stale so the next cron run retries.
+			throw new Error(`${feed.url} returned 304 to an unconditional request`);
+		}
+		// Renew the TTLs by rewriting the just-read values, and record the
+		// refresh so the refreshHours gate keeps renewal at O(feeds) writes per
+		// interval rather than per cron run.
+		for (const { key, value } of existingBlobs) {
+			await env.BLOOM_KV.put(key, value, { expirationTtl: ttlSeconds });
+		}
+		await stub.upsertIntelFeedState(feed.id, {
+			url: feed.url,
+			last_fetched_at: new Date().toISOString(),
+			etag: state?.etag ?? null,
+			entry_count: state?.entry_count ?? 0,
+			bloom_kv_key: feed.kind === "ip-cidr" ? cidrKey(feed.id) : bloomKey(feed.id),
+		});
+		return { entries: state?.entry_count ?? 0 };
+	}
 	if (!res.ok) throw new Error(`${feed.url} returned ${res.status}`);
 
 	const body = await res.text();
-	const ttlSeconds = Math.max(feed.refreshHours * 3600 * 4, 86400);
 
 	if (feed.kind === "ip-cidr") {
 		// CIDR feeds use a separate storage path: a JSON blob of


### PR DESCRIPTION
Closes #484

## Base note

The issue suggested branching from `fix/481-bloom-kv-write-reduction` (#483) if it hadn't merged. It hasn't — but it's now `CONFLICTING`: the issues-opened routine's equivalent implementation merged to `main` as #482 first. This PR therefore branches from `main` on top of #482's implementation. Two consequences:

- Tests extend `tests/intel/feed-kv-writes.test.ts` (main's file from #482), not `tests/intel/feed-refresh-writes.test.ts` (which only exists on #483's branch).
- #482's 304 branch — unlike #483's — did **not** upsert `last_fetched_at`, so on main a stable feed was conditionally re-fetched every hourly cron run. This PR adds that upsert as part of the fix; without it, blob renewal would cost O(feeds) writes per *hour* instead of per `refreshHours` interval.

## Problem

A 304 Not Modified returned early from `refreshFeed` without rewriting any KV blob. Blob TTL is `max(refreshHours*4*3600, 86400)` — 48h for `spamhaus-drop`/`spamhaus-edrop`. A feed whose content stays stable longer than its TTL went silently dark: the bloom/exactset/cidr blobs expired, `checkUrlAgainstFeeds`/`checkIpAgainstFeeds` stopped matching, and the stored ETag kept producing 304s, so nothing recovered until upstream content actually changed.

## Changes (`workers/intel/feeds.ts`)

- **Read required blobs before the fetch.** `url`/`domain` kind → `intel:<feed>:bloom` + `intel:<feed>:exact-blob`; `ip-cidr` kind → `intel:<feed>:cidrs`.
- **Missing blob ⇒ unconditional refetch.** If any required blob is absent, `If-None-Match` is omitted so the origin returns 200 and all blobs are rebuilt. This also self-heals any other KV data loss.
- **304 with blobs intact ⇒ TTL renewal.** The just-read values are re-`put` with a fresh `expirationTtl` (KV has no touch operation; rewrite-same-value is the renewal), and `last_fetched_at` is upserted preserving `etag`/`entry_count` so the `refreshHours` gate applies to stable feeds.
- **Defensive:** a 304 to an unconditional request (blobs missing, so no body to rebuild from) throws; `refreshAllFeeds` logs it and `last_fetched_at` stays stale, so the next cron run retries instead of marking the feed fresh.

## Write volume (#481 win preserved)

A refresh now costs the same number of puts whether it's a 200 rebuild or a 304 renewal (2 for url-kind, 1 for cidr-kind), and the `last_fetched_at` upsert keeps renewals gated to once per `refreshHours` interval. Worst case with all default feeds refreshing every interval: urlhaus 48 + openphish 8 + spamhaus-drop/edrop 4 ≈ **60 writes/day** — unchanged from #482's nominal estimate, far under the ~200/day budget. The pre-fetch blob reads add ≤2 KV *reads* per refresh attempt (reads are not the constrained resource).

## Tests

**1,530 passing, 0 failing** (117 files; `npm test`), `npm run typecheck` exit 0. 6 new tests in `tests/intel/feed-kv-writes.test.ts`, written failing-first (TDD; 5 failed pre-fix, the conditional-flow guard passed by design):

- 304 with blobs present re-puts bloom + exact blobs with fresh TTL; put keys exactly equal the required blob set (write count ≤ required blobs)
- 304 on an ip-cidr feed re-puts only the cidrs blob (write count = 1, TTL = 4×refreshHours)
- 304 upserts a fresh `last_fetched_at` preserving etag/entry_count (keeps the refreshHours gate)
- missing required blob → captured fetch headers contain no `If-None-Match`, and the 200 rebuilds both blobs
- blobs present + stored etag → `If-None-Match` still sent (normal conditional flow not regressed)
- 304 to an unconditional request → refresh fails, no upsert, no puts, error logged

## Out of scope (per #484)

- Removing the legacy per-entry exact-key fallback (#485)
- TTL / `refreshHours` value changes
- `workers/intel/crowdsec-cti.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
