### PR TITLE
chore(intel): remove deploy-window legacy exact-key fallback (#485)

### DIFF
--- a/tests/intel/feed-refresh-hardening.test.ts
+++ b/tests/intel/feed-refresh-hardening.test.ts
@@ -10,15 +10,11 @@
  *   1. A 304 must record a fresh `last_fetched_at`, otherwise 304-ing feeds
  *      are conditionally fetched every hour forever and never get the
  *      refreshHours skip.
- *   2. While a feed's exact blob is absent (the window between deploying
- *      the blob scheme and that feed's first new-style refresh), the read
- *      path must fall back to the legacy `intel:<feed>:exact:<value>` keys
- *      so detections don't transiently degrade to unconfirmed.
- *   3. The exact blob must be deduplicated before the cap — url-kind values
+ *   2. The exact blob must be deduplicated before the cap — url-kind values
  *      repeat hostnames, which would waste roughly half the cap.
- *   4. An unparseable exact blob must degrade the hit to `confirmed: false`,
- *      not throw out of the whole lookup.
- *   5. The exact blob must be fetched lazily — only after a bloom hit — not
+ *   3. A missing or unparseable exact blob must degrade the hit to
+ *      `confirmed: false` (bloom-only), not throw out of the whole lookup.
+ *   4. The exact blob must be fetched lazily — only after a bloom hit — not
  *      eagerly for every feed on every lookup.
  */
 
@@ -174,25 +170,10 @@ describe("refreshFeed 304 handling", () => {
 	});
 });
 
-// ── Deploy-window legacy fallback ─────────────────────────────────────
+// ── Blob-absent degradation ───────────────────────────────────────────
 
-describe("legacy per-entry exact-key fallback", () => {
-	it("confirms via a legacy exact key while the exact blob is absent", async () => {
-		const member = "https://evil.example/login";
-		const bloom = createBloom(10);
-		for (const v of [member, "evil.example"]) addToBloom(bloom, v);
-		const kv = makeKv();
-		kv.store.set("intel:testfeed:bloom", serializeBloom(bloom));
-		kv.store.set(`intel:testfeed:exact:${member}`, "1");
-		const env = makeEnv({ mailboxSettings: urlFeedSettings(), kv });
-
-		const match = await checkUrlAgainstFeeds(env, MAILBOX_ID, member);
-
-		expect(match).not.toBeNull();
-		expect(match!.confirmed).toBe(true);
-	});
-
-	it("degrades to unconfirmed when neither blob nor legacy key exists", async () => {
+describe("exact-blob absence", () => {
+	it("degrades to unconfirmed when no exact data exists at all", async () => {
 		const member = "https://evil.example/login";
 		const bloom = createBloom(10);
 		for (const v of [member, "evil.example"]) addToBloom(bloom, v);

--- a/workers/intel/feeds.ts
+++ b/workers/intel/feeds.ts
@@ -41,14 +41,6 @@ function bloomKey(feedId: string) { return `intel:${feedId}:bloom`; }
 /** Single blob key holding a JSON array of up to EXACT_KEY_CAP exact-match values. */
 function exactBlobKey(feedId: string) { return `intel:${feedId}:exact-blob`; }
 /**
- * Pre-#481 per-entry confirmation key. Only read as a fallback while an
- * exact blob is absent (the window between deploying the blob scheme and
- * each feed's first new-style refresh); the keys carry a TTL and age out on
- * their own. Remove once a post-#482 refresh cycle has completed in
- * production — tracked in #485.
- */
-function legacyExactKey(feedId: string, value: string) { return `intel:${feedId}:exact:${value}`; }
-/**
  * Storage key for `ip-cidr` feeds. Bloom filters don't fit CIDR membership
  * (an IP is checked against a *range*, not an exact string) so we materialise
  * the whole list as a JSON blob and linear-scan on lookup. DROP-class feeds
@@ -414,15 +406,9 @@ export async function checkUrlAgainstFeeds(
 		for (const v of candidates) {
 			if (!checkBloom(filter, v)) continue;
 			if (exactSet === undefined) exactSet = await loadExactSet(env, feed.id);
-			if (exactSet) {
-				if (exactSet.has(v)) return { matched: true, feedId: feed.id, value: v, confirmed: true };
-			} else {
-				// No exact blob yet (pre-#482 KV state) — confirm via the
-				// legacy per-entry key so detections don't degrade between
-				// deploy and this feed's first new-style refresh.
-				const legacy = await env.BLOOM_KV.get(legacyExactKey(feed.id, v), "text");
-				if (legacy === "1") return { matched: true, feedId: feed.id, value: v, confirmed: true };
-			}
+			// No exact blob (missing or unparseable) → degrade to a bloom-only
+			// hit (`confirmed: false`) rather than throwing out of the lookup.
+			if (exactSet?.has(v)) return { matched: true, feedId: feed.id, value: v, confirmed: true };
 			if (!bloomOnly) bloomOnly = { matched: true, feedId: feed.id, value: v, confirmed: false };
 		}
 	}
@@ -431,8 +417,8 @@ export async function checkUrlAgainstFeeds(
 
 /**
  * Load a feed's exact-match blob. Returns null when the key is missing or
- * unparseable — a bloom hit then degrades to the legacy-key fallback (and
- * ultimately `confirmed: false`) instead of failing the whole lookup.
+ * unparseable — a bloom hit then degrades to `confirmed: false` (bloom-only)
+ * instead of failing the whole lookup.
  */
 async function loadExactSet(env: Env, feedId: string): Promise<Set<string> | null> {
 	const raw = await env.BLOOM_KV.get(exactBlobKey(feedId), "text");


### PR DESCRIPTION
Closes #485.

## What

Removes the temporary legacy-confirmation fallback added in #483: the read path no longer probes pre-#481 `intel:<feed>:exact:<value>` per-entry keys when a feed's `intel:<feed>:exact-blob` is absent.

The fallback only ever bridged the deploy window between shipping the blob scheme and each feed's first post-#482 refresh. Legacy keys carried a TTL of `4 × refreshHours` (≤24h) and have long since aged out — #483 merged 2026-06-12 and has been in production well over 48h — so the branch was a wasted KV read per bloom hit whenever a blob was missing.

## Changes

- `workers/intel/feeds.ts`: delete `legacyExactKey()` and its doc comment; collapse the `else` branch in `checkUrlAgainstFeeds` so a bloom hit with a missing/unparseable exact blob degrades to a bloom-only `confirmed: false` hit (never a throw). Updated the now-stale `loadExactSet` doc comment.
- `tests/intel/feed-refresh-hardening.test.ts`: delete the legacy-fallback test; keep both degradation tests (no-exact-data-at-all and unparseable-blob) — they pin the post-removal contract. Refreshed the module JSDoc / describe naming accordingly.

## Acceptance

- [x] `legacyExactKey` and the fallback branch are gone; `grep -rn "exact:" workers/intel/` shows no per-entry key reads.
- [x] Legacy-fallback test removed; both degradation tests pass.
- [x] Full suite: **1535 passing, 0 failing** (118 files); `npm run typecheck` exits 0.

## Out of scope

- #484 304/TTL blob-renewal fix (already landed as #488).
- Cleanup of expired KV keys (they age out via TTL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)