### PR TITLE
fix(inbound): resolve mailbox from SMTP envelope recipient, not To[0]

### DIFF
--- a/tests/routes/catchall.test.ts
+++ b/tests/routes/catchall.test.ts
@@ -121,6 +121,8 @@ async function runNormalize(
 		ownedDomains?: string[];
 		mailboxes?: string[];
 		domainSettings?: Record<string, unknown>;
+		/** SMTP envelope recipient (RCPT TO) Cloudflare matched the routing rule on. */
+		envelopeTo?: string;
 	} = {},
 ) {
 	const { normalizeInbound } = await import("../../workers/providers/cf-routing");
@@ -145,7 +147,11 @@ async function runNormalize(
 	clearOrgSettingsCache();
 
 	const bytes = rawEmailBytes(toAddresses);
-	const event = { raw: makeStream(bytes), rawSize: bytes.byteLength };
+	const event = {
+		raw: makeStream(bytes),
+		rawSize: bytes.byteLength,
+		...(opts.envelopeTo ? { to: opts.envelopeTo } : {}),
+	};
 	const env = {
 		EMAIL_ADDRESSES: opts.emailAddresses ?? [],
 		DOMAINS: opts.domains ?? "",
@@ -173,6 +179,95 @@ describe("normalizeInbound — mailbox path", () => {
 			{ emailAddresses: ["alice@acme.example"], mailboxes: [] },
 		);
 		expect(result).toBeNull();
+	});
+});
+
+describe("normalizeInbound — envelope recipient resolution", () => {
+	// Regression: a message delivered to consulting@cortech.online (envelope
+	// RCPT TO) whose visible `To:` header lists a different address first must
+	// still be routed to the consulting mailbox. Previously the mailbox was
+	// resolved from `To[0]` only, so any multi-recipient / bcc / list message
+	// where the real recipient was not the first `To:` was silently dropped.
+	it("delivers to the envelope recipient's mailbox even when it is not the first To: address", async () => {
+		const result = await runNormalize(
+			["someone-else@external.example", "consulting@cortech.online"],
+			{
+				emailAddresses: [],
+				domains: "cortech.online",
+				mailboxes: ["consulting@cortech.online"],
+				envelopeTo: "consulting@cortech.online",
+			},
+		);
+		expect(result?.kind).toBe("mailbox");
+		if (result?.kind === "mailbox") {
+			expect(result.mailboxId).toBe("consulting@cortech.online");
+		}
+	});
+
+	it("delivers to the envelope recipient even when it is absent from the To: header (bcc)", async () => {
+		const result = await runNormalize(
+			["public-list@external.example"],
+			{
+				emailAddresses: [],
+				domains: "cortech.online",
+				mailboxes: ["consulting@cortech.online"],
+				envelopeTo: "consulting@cortech.online",
+			},
+		);
+		expect(result?.kind).toBe("mailbox");
+		if (result?.kind === "mailbox") {
+			expect(result.mailboxId).toBe("consulting@cortech.online");
+		}
+	});
+
+	it("normalises envelope recipient casing/whitespace before the mailbox lookup", async () => {
+		const result = await runNormalize(
+			["someone-else@external.example"],
+			{
+				emailAddresses: [],
+				domains: "cortech.online",
+				mailboxes: ["consulting@cortech.online"],
+				envelopeTo: "  Consulting@Cortech.Online ",
+			},
+		);
+		expect(result?.kind).toBe("mailbox");
+		if (result?.kind === "mailbox") {
+			expect(result.mailboxId).toBe("consulting@cortech.online");
+		}
+	});
+
+	it("falls through to catch-all when the envelope recipient has no mailbox", async () => {
+		const result = await runNormalize(
+			["whoever@external.example"],
+			{
+				emailAddresses: [],
+				domains: "acme.example",
+				mailboxes: [],
+				envelopeTo: "probe@acme.example",
+				domainSettings: {
+					"acme.example": { catchall_intel: { enabled: true, retention_days: 30, sample_limit: 50 } },
+				},
+			},
+		);
+		expect(result?.kind).toBe("catchall");
+		if (result?.kind === "catchall") {
+			expect(result.domain).toBe("acme.example");
+		}
+	});
+
+	it("with EMAIL_ADDRESSES set: matches the envelope recipient against the allow-list", async () => {
+		const result = await runNormalize(
+			["someone-else@external.example"],
+			{
+				emailAddresses: ["consulting@cortech.online"],
+				mailboxes: ["consulting@cortech.online"],
+				envelopeTo: "consulting@cortech.online",
+			},
+		);
+		expect(result?.kind).toBe("mailbox");
+		if (result?.kind === "mailbox") {
+			expect(result.mailboxId).toBe("consulting@cortech.online");
+		}
 	});
 });
 

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -149,7 +149,10 @@ app.all("*", (c) => {
 export default {
 	fetch: app.fetch,
 	async email(
-		event: { raw: ReadableStream; rawSize: number },
+		// `to` is the SMTP envelope recipient (RCPT TO) Cloudflare Email
+		// Routing matched its rule on; normalizeInbound resolves the target
+		// mailbox from it rather than trusting the parsed `To:` header.
+		event: { raw: ReadableStream; rawSize: number; to?: string },
 		env: Env,
 		ctx: ExecutionContext,
 	) {

--- a/workers/providers/cf-routing.ts
+++ b/workers/providers/cf-routing.ts
@@ -54,23 +54,42 @@ async function streamToArrayBuffer(
  * - `null`            — silently drop (unowned domain, disabled catch-all, or
  *                       an EMAIL_ADDRESSES member whose mailbox JSON is missing).
  *
+ * The SMTP envelope recipient (`event.to`, the RCPT TO Cloudflare Email
+ * Routing matched its rule on) is authoritative and is consulted FIRST when
+ * resolving the target mailbox. The parsed `To:` header is a fallback only:
+ * it is attacker-controlled and, for multi-recipient threads / bcc / list
+ * mail, its first address is frequently NOT the address the message was
+ * actually delivered to. Keying mailbox resolution off the header alone
+ * silently dropped legitimately-routed mail whenever the real recipient was
+ * not `To[0]`.
+ *
  * Any parse/stream failure throws so CF Email Routing can retry or bounce.
  */
 export async function normalizeInbound(
-	event: { raw: ReadableStream; rawSize: number },
+	event: { raw: ReadableStream; rawSize: number; to?: string },
 	env: Env,
 ): Promise<MailboxInbound | CatchallInbound | null> {
 	const rawEmail = await streamToArrayBuffer(event.raw, event.rawSize);
 	const parsedEmail = await new PostalMime().parse(rawEmail);
 
-	if (!parsedEmail.to?.length || !parsedEmail.to[0].address) {
-		throw new Error("received email with empty to");
+	// Envelope recipient (RCPT TO) — the address Cloudflare delivered to.
+	const envelopeRecipient = event.to?.trim().toLowerCase() || undefined;
+	const headerRecipients = (parsedEmail.to ?? [])
+		.map((t) => (t as { address?: string }).address?.toLowerCase())
+		.filter((a): a is string => Boolean(a));
+
+	// Candidate recipients: envelope recipient first, then header addresses,
+	// de-duplicated. The envelope recipient wins so a multi-recipient `To:`
+	// header can never shadow the address the message was routed to.
+	const allRecipients: string[] = [];
+	for (const addr of [envelopeRecipient, ...headerRecipients]) {
+		if (addr && !allRecipients.includes(addr)) allRecipients.push(addr);
+	}
+	if (allRecipients.length === 0) {
+		throw new Error("received email with no envelope or header recipient");
 	}
 
 	const allowedAddresses = ((env.EMAIL_ADDRESSES ?? []) as string[]).map((a) => a.toLowerCase());
-	const allRecipients = parsedEmail.to
-		.map((t) => (t as { address?: string }).address?.toLowerCase())
-		.filter((a): a is string => Boolean(a));
 
 	if (allowedAddresses.length > 0) {
 		// Step 1: find a registered mailbox among allowed addresses.
@@ -88,9 +107,12 @@ export async function normalizeInbound(
 		// No address matched EMAIL_ADDRESSES — try catch-all for all recipients.
 		return resolveCatchall(allRecipients, rawEmail, parsedEmail, env);
 	} else {
-		// No EMAIL_ADDRESSES configured — single-recipient mode for registered
-		// mailboxes, then catch-all for unregistered addresses on owned domains.
-		const mailboxId = allRecipients[0];
+		// No EMAIL_ADDRESSES configured: any recipient with a provisioned
+		// mailbox is deliverable. Resolve from the envelope recipient (or, as a
+		// fallback, the first header address) before trying catch-all. Only the
+		// authoritative envelope address is used as the mailbox key so a forged
+		// `To:`/`Cc:` cannot misfile mail into another mailbox.
+		const mailboxId = envelopeRecipient ?? headerRecipients[0];
 		if (!mailboxId) throw new Error("received email with no valid recipient address");
 		if (await env.BUCKET.head(`mailboxes/${mailboxId}.json`)) {
 			return { kind: "mailbox", rawEmail: rawEmail.buffer as ArrayBuffer, parsedEmail, mailboxId };


### PR DESCRIPTION
## Summary

Inbound mail to a valid, provisioned mailbox was being **silently dropped** whenever the real recipient wasn't the first address in the message's `To:` header.

Cloudflare Email Routing calls the Worker's `email()` handler with the **SMTP envelope recipient** (RCPT TO) it matched its routing rule on. `normalizeInbound` ignored that and resolved the target mailbox solely from the parsed `To:` header's first address (`allRecipients[0]`). For multi-recipient threads, bcc'd recipients, or list mail, `To[0]` is frequently **not** the address the message was delivered to — so `head("mailboxes/<To[0]>.json")` missed the existing mailbox and the message fell through to the catch-all path, which dropped it (logging `"no recipient matches EMAIL_ADDRESSES."`).

The mailbox stays creatable, listable, and usable for *sending* the whole time, which makes the failure especially confusing: the address works in the UI but every inbound message to it vanishes.

### Observed incident
Two unrelated senders, six days apart, both delivered to `consulting@cortech.online` (envelope `rcptTo` in the Worker logs), both dropped with the identical 3-line log signature, while `EMAIL_ADDRESSES = []` and the `consulting@cortech.online` mailbox existed at the clean key. The only code path consistent with all of that is the `To[0]`-only resolution missing the envelope recipient.

## Fix

- Thread the envelope recipient (`event.to`) through the `email()` handler into `normalizeInbound`.
- Resolve the mailbox from the **envelope recipient first**, falling back to the parsed `To:` header only when no envelope recipient is available (non-CF ingestion / tests).
- In the no-allow-list branch, the envelope address is the **sole mailbox key** — it's the authoritative, non-spoofable address the message was delivered to, so a forged `To:`/`Cc:` can no longer misfile mail into another mailbox.
- Envelope recipient is trimmed + lowercased before lookup.

## Tests

`tests/routes/catchall.test.ts` gains regression coverage for:
- envelope recipient present but **not first** in `To:` (the exact incident)
- envelope recipient **absent** from `To:` (bcc)
- casing/whitespace normalisation of the envelope address
- catch-all fallback when the envelope recipient has no mailbox
- allow-list (`EMAIL_ADDRESSES` non-empty) mode matching the envelope recipient

Full suite green locally: **118 files / 1540 tests pass**, `npm run typecheck` clean.

## Note (separate, not addressed here)

The Worker logs also show `parseSettingsLenient: dropped invalid intel.hub on read (secret-name prefix invariant)` on every inbound for `cortech.online` — the domain's `intel.hub` config is being stripped on load (hub integration effectively disabled for that domain). Unrelated to this routing fix; worth a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnGM8jrbZ4s4i1Q7PcDGCq

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnGM8jrbZ4s4i1Q7PcDGCq)_