### PR TITLE
🎨 Palette: Add aria-controls to FolderNav expand/collapse

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-05-21 - Add aria-expanded and aria-controls to collapsibles
 **Learning:** Collapsible regions (like the thread message or security verdict panels) in this application were missing ARIA roles for screen reader state mapping. The buttons needed `aria-expanded` and `aria-controls`.
 **Action:** When implementing or modifying expand/collapse UI patterns, ensure that toggle buttons are wired up with `aria-expanded` representing the boolean state, and `aria-controls` correctly tied to an explicit `id` on the content wrapper.
+## 2026-06-18 - Missing aria-controls on dynamic fragment wrappers
+**Learning:** React fragments (`<>...</>`) cannot accept DOM attributes, making it impossible to attach an `id` for `aria-controls`. The folder list in `Shell.tsx` had `aria-expanded` on the toggle button but lacked `aria-controls` because the expanded content was wrapped in a fragment.
+**Action:** Always verify that conditionally expanded content is wrapped in an actual DOM element (like `<div>`) with a unique `id` so that `aria-controls` on the toggle button can correctly point to it.

--- a/app/components/phishsoc/Shell.tsx
+++ b/app/components/phishsoc/Shell.tsx
@@ -226,6 +226,8 @@ function FolderNav({ mailboxId, folders, base }: FolderNavProps) {
 	const favorites = sorted.filter((f) => prefs.favorites.includes(f.id));
 	const rest = sorted.filter((f) => !prefs.favorites.includes(f.id));
 
+	const contentId = "folder-list-content";
+
 	return (
 		<>
 			{/* Collapsible section header */}
@@ -234,6 +236,7 @@ function FolderNav({ mailboxId, folders, base }: FolderNavProps) {
 				onClick={toggleCollapsed}
 				className="w-full flex items-center gap-1 px-3 pt-4 pb-1.5 text-[10.5px] uppercase tracking-[0.08em] text-ink-3 hover:text-ink-2 transition-colors"
 				aria-expanded={!prefs.collapsed}
+				aria-controls={contentId}
 			>
 				<span className="flex-1 text-left">Folders</span>
 				{prefs.collapsed ? (
@@ -244,7 +247,7 @@ function FolderNav({ mailboxId, folders, base }: FolderNavProps) {
 			</button>
 
 			{!prefs.collapsed && (
-				<>
+				<div id={contentId} className="flex flex-col">
 					{/* Favorites pinned at top */}
 					{favorites.map((folder) => (
 						<FolderNavItem
@@ -265,7 +268,7 @@ function FolderNav({ mailboxId, folders, base }: FolderNavProps) {
 							onToggleFavorite={toggleFavorite}
 						/>
 					))}
-				</>
+				</div>
 			)}
 		</>
 	);


### PR DESCRIPTION
💡 What: Added `aria-controls` to the toggle button for the folder list in the Shell navigation sidebar. Wrapped the conditionally-rendered folder items in a `<div id="folder-list-content">` since React Fragments cannot accept an `id`.
🎯 Why: Screen reader users need explicit associations between expand/collapse toggle buttons and the content they control. The button had `aria-expanded` but lacked the corresponding target link.
♿ Accessibility: Ensures WCAG compliance for collapsible UI patterns.

---
*PR created automatically by Jules for task [18340793663841324833](https://jules.google.com/task/18340793663841324833) started by @schmug*