### PR TITLE
feat(mcp): add cc, bcc, and array to for MCP send/draft tools

### DIFF
--- a/tests/lib/tools-send-risk.test.ts
+++ b/tests/lib/tools-send-risk.test.ts
@@ -141,14 +141,16 @@ function makeEnv(
 // ── Helper: mint a valid confirmation token ───────────────────────────────────
 
 async function mintValidToken(
-	to: string,
+	to: string | string[],
 	subject: string,
 	body: string,
 	mailboxId: string,
 	kv: KVNamespace,
+	cc?: string | string[],
+	bcc?: string | string[],
 ): Promise<string> {
 	const jti = crypto.randomUUID();
-	const payloadHash = await computePayloadHash(to, subject, body, []);
+	const payloadHash = await computePayloadHash(to, subject, body, [], cc, bcc);
 	const token = await signConfirmationToken(
 		{ tier: 1, mailboxId, payloadHash, jti },
 		SECRET,
@@ -327,5 +329,164 @@ describe("toolSendEmail — send-risk gate", () => {
 		});
 		expect((result as { risk?: { tier: number } }).risk?.tier).toBe(2);
 		expect(sendEmail).not.toHaveBeenCalled();
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// cc / bcc / multi-recipient tests (issue #495)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("toolSendEmail — cc / bcc / multi-recipient", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("array to: sends to multiple recipients and writes correct SENT recipient", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to: ["colleague@internal.example", "colleague2@internal.example"],
+			subject: "Team update",
+			bodyHtml: "<p>Hi team</p>",
+		});
+		expect(result).toMatchObject({ status: "sent" });
+		expect(sendEmail).toHaveBeenCalledOnce();
+		const sentCall = (sendEmail as ReturnType<typeof vi.fn>).mock.calls[0][1];
+		expect(sentCall.to).toEqual(["colleague@internal.example", "colleague2@internal.example"]);
+		expect(stub._sentEmails).toHaveLength(1);
+		const row = stub._sentEmails[0] as { recipient: string };
+		expect(row.recipient).toBe("colleague@internal.example, colleague2@internal.example");
+	});
+
+	it("external cc recipient triggers tier ≥ 1 gate (cc reaches send-risk classifier)", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		// to is internal, but cc is external — should still require confirmation
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to: "colleague@internal.example",
+			cc: "external@other.com",
+			subject: "FYI",
+			bodyHtml: "<p>Looping in external</p>",
+		});
+		expect(result).toMatchObject({
+			error: "confirmation_required",
+			confirmation_required: true,
+		});
+		expect((result as { risk?: { tier: number } }).risk?.tier).toBeGreaterThanOrEqual(1);
+		expect(sendEmail).not.toHaveBeenCalled();
+	});
+
+	it("tier 0 with cc (all internal): sends and stores cc on SENT row", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to: "colleague@internal.example",
+			cc: "another@internal.example",
+			subject: "Hello",
+			bodyHtml: "<p>Hi</p>",
+		});
+		expect(result).toMatchObject({ status: "sent" });
+		expect(sendEmail).toHaveBeenCalledOnce();
+		const sentCall = (sendEmail as ReturnType<typeof vi.fn>).mock.calls[0][1];
+		expect(sentCall.cc).toBe("another@internal.example");
+		const row = stub._sentEmails[0] as { cc: string | null; bcc: string | null };
+		expect(row.cc).toBe("another@internal.example");
+		expect(row.bcc).toBeNull();
+	});
+
+	it("bcc array: passes to sendEmail and stores normalized string on SENT row", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to: "colleague@internal.example",
+			bcc: ["bcc1@internal.example", "bcc2@internal.example"],
+			subject: "Private",
+			bodyHtml: "<p>BCC test</p>",
+		});
+		expect(result).toMatchObject({ status: "sent" });
+		const sentCall = (sendEmail as ReturnType<typeof vi.fn>).mock.calls[0][1];
+		expect(sentCall.bcc).toEqual(["bcc1@internal.example", "bcc2@internal.example"]);
+		const row = stub._sentEmails[0] as { bcc: string | null };
+		expect(row.bcc).toBe("bcc1@internal.example, bcc2@internal.example");
+	});
+
+	it("tier ≥ 1 with valid token including cc/bcc: send proceeds", async () => {
+		const kv = makeKv();
+		const stub = makeStub();
+		const env = makeEnv(stub, kv);
+
+		const to = "vendor@external.com";
+		const cc = "cc@external.com";
+		const subject = "Proposal";
+		const body = "<p>See attached</p>";
+		const token = await mintValidToken(to, subject, body, MAILBOX_ID, kv, cc);
+
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to,
+			cc,
+			subject,
+			bodyHtml: body,
+			confirmationToken: token,
+		});
+		expect(result).toMatchObject({ status: "sent" });
+		expect(sendEmail).toHaveBeenCalledOnce();
+		const row = stub._sentEmails[0] as { cc: string | null };
+		expect(row.cc).toBe("cc@external.com");
+	});
+});
+
+describe("toolSendReply — cc / bcc / multi-recipient", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("reply with cc (all internal): sends and stores cc on SENT row", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolSendReply(env, MAILBOX_ID, {
+			originalEmailId: ORIGINAL_ID,
+			to: "colleague@internal.example",
+			cc: "manager@internal.example",
+			subject: "Re: Question",
+			bodyHtml: "<p>Sure!</p>",
+		});
+		expect(result).toMatchObject({ status: "sent" });
+		expect(sendEmail).toHaveBeenCalledOnce();
+		const sentCall = (sendEmail as ReturnType<typeof vi.fn>).mock.calls[0][1];
+		expect(sentCall.cc).toBe("manager@internal.example");
+		const row = stub._sentEmails[0] as { cc: string | null; bcc: string | null };
+		expect(row.cc).toBe("manager@internal.example");
+		expect(row.bcc).toBeNull();
+	});
+
+	it("reply with external cc triggers confirmation gate", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolSendReply(env, MAILBOX_ID, {
+			originalEmailId: ORIGINAL_ID,
+			to: "colleague@internal.example",
+			cc: "auditor@external.org",
+			subject: "Re: Question",
+			bodyHtml: "<p>FYI</p>",
+		});
+		expect(result).toMatchObject({
+			error: "confirmation_required",
+			confirmation_required: true,
+		});
+		expect(sendEmail).not.toHaveBeenCalled();
+	});
+
+	it("reply with array to: writes joined recipient on SENT row", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolSendReply(env, MAILBOX_ID, {
+			originalEmailId: ORIGINAL_ID,
+			to: ["colleague@internal.example", "colleague2@internal.example"],
+			subject: "Re: Question",
+			bodyHtml: "<p>Sure!</p>",
+		});
+		expect(result).toMatchObject({ status: "sent" });
+		const row = stub._sentEmails[0] as { recipient: string };
+		expect(row.recipient).toBe("colleague@internal.example, colleague2@internal.example");
 	});
 });

--- a/tests/lib/tools-send-risk.test.ts
+++ b/tests/lib/tools-send-risk.test.ts
@@ -38,7 +38,7 @@ vi.mock("../../workers/lib/mailbox-settings", async (orig) => {
 	};
 });
 
-import { toolSendReply, toolSendEmail } from "../../workers/lib/tools";
+import { toolSendReply, toolSendEmail, toolDraftEmail, toolUpdateDraft } from "../../workers/lib/tools";
 import { sendEmail } from "../../workers/email-sender";
 import {
 	signConfirmationToken,
@@ -433,6 +433,23 @@ describe("toolSendEmail — cc / bcc / multi-recipient", () => {
 		const row = stub._sentEmails[0] as { cc: string | null };
 		expect(row.cc).toBe("cc@external.com");
 	});
+
+	it("external bcc recipient triggers tier ≥ 1 gate (bcc reaches send-risk classifier)", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolSendEmail(env, MAILBOX_ID, {
+			to: "colleague@internal.example",
+			bcc: "auditor@external.org",
+			subject: "Private note",
+			bodyHtml: "<p>FYI</p>",
+		});
+		expect(result).toMatchObject({
+			error: "confirmation_required",
+			confirmation_required: true,
+		});
+		expect((result as { risk?: { tier: number } }).risk?.tier).toBeGreaterThanOrEqual(1);
+		expect(sendEmail).not.toHaveBeenCalled();
+	});
 });
 
 describe("toolSendReply — cc / bcc / multi-recipient", () => {
@@ -488,5 +505,106 @@ describe("toolSendReply — cc / bcc / multi-recipient", () => {
 		expect(result).toMatchObject({ status: "sent" });
 		const row = stub._sentEmails[0] as { recipient: string };
 		expect(row.recipient).toBe("colleague@internal.example, colleague2@internal.example");
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// toolDraftEmail — draft cc/bcc storage (issue #495)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("toolDraftEmail — cc / bcc storage", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("stores array cc (joined) and bcc on the DRAFT row, and echoes them in the return value", async () => {
+		const stub = makeStub();
+		const env = makeEnv(stub);
+		const result = await toolDraftEmail(env, MAILBOX_ID, {
+			to: "recip@internal.example",
+			cc: ["cc1@internal.example", "cc2@internal.example"],
+			bcc: "bcc@internal.example",
+			subject: "Draft with cc/bcc",
+			body: "<p>Hello</p>",
+			runVerifyDraft: false,
+		});
+		expect(result).toMatchObject({ status: "draft_saved" });
+		expect(stub._sentEmails).toHaveLength(1);
+		const row = stub._sentEmails[0] as { cc: string | null; bcc: string | null };
+		expect(row.cc).toBe("cc1@internal.example, cc2@internal.example");
+		expect(row.bcc).toBe("bcc@internal.example");
+		// cc/bcc echoed in the return draft object
+		const draft = (result as { draft?: { cc?: string; bcc?: string } }).draft;
+		expect(draft?.cc).toBe("cc1@internal.example, cc2@internal.example");
+		expect(draft?.bcc).toBe("bcc@internal.example");
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// toolUpdateDraft — cc/bcc carry-forward (issue #495)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DRAFT_ID = "draft-email-1";
+
+function makeUpdateDraftStub(initialCc: string | null, initialBcc: string | null) {
+	const savedEmails: unknown[] = [];
+	const existingDraft = {
+		id: DRAFT_ID,
+		subject: "Existing Subject",
+		sender: MAILBOX_ID.toLowerCase(),
+		recipient: "recip@internal.example",
+		cc: initialCc,
+		bcc: initialBcc,
+		date: new Date().toISOString(),
+		body: "<p>Existing body</p>",
+		read: false,
+		starred: false,
+		thread_id: DRAFT_ID,
+		message_id: "msg-draft",
+		in_reply_to: null,
+		email_references: null,
+		raw_headers: null,
+	};
+	return {
+		async checkSendRateLimit() { return null; },
+		async getEmail(id: string) { return id === DRAFT_ID ? existingDraft : null; },
+		async createEmail(_folder: unknown, email: unknown) { savedEmails.push(email); return {}; },
+		async deleteEmail(_id: string) { return {}; },
+		async consumeJti() { return true; },
+		_savedEmails: savedEmails,
+	};
+}
+
+describe("toolUpdateDraft — cc / bcc carry-forward", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("setting new cc/bcc overwrites existing values on the updated DRAFT row", async () => {
+		const stub = makeUpdateDraftStub("oldcc@internal.example", null);
+		const env = makeEnv(stub as any);
+		const result = await toolUpdateDraft(env, MAILBOX_ID, {
+			draftId: DRAFT_ID,
+			cc: "newcc@internal.example",
+			bcc: "newbcc@internal.example",
+		});
+		expect(result).toMatchObject({ status: "draft_updated" });
+		const row = stub._savedEmails[0] as { cc: string | null; bcc: string | null };
+		expect(row.cc).toBe("newcc@internal.example");
+		expect(row.bcc).toBe("newbcc@internal.example");
+	});
+
+	it("omitting cc/bcc carries old values forward from the existing draft", async () => {
+		const stub = makeUpdateDraftStub("preserved@internal.example", "preservedbcc@internal.example");
+		const env = makeEnv(stub as any);
+		const result = await toolUpdateDraft(env, MAILBOX_ID, {
+			draftId: DRAFT_ID,
+			subject: "Updated Subject",
+			// cc and bcc intentionally omitted — should keep old values
+		});
+		expect(result).toMatchObject({ status: "draft_updated" });
+		const row = stub._savedEmails[0] as { cc: string | null; bcc: string | null };
+		expect(row.cc).toBe("preserved@internal.example");
+		expect(row.bcc).toBe("preservedbcc@internal.example");
 	});
 });

--- a/workers/lib/schemas.ts
+++ b/workers/lib/schemas.ts
@@ -49,7 +49,7 @@ export interface AttachmentInfo {
 
 // ── Zod Schemas ────────────────────────────────────────────────────
 
-const RecipientFieldSchema = z.union([
+export const RecipientFieldSchema = z.union([
 	z.string().email(),
 	z.array(z.string().email()).min(1),
 ]);

--- a/workers/lib/tools.ts
+++ b/workers/lib/tools.ts
@@ -298,6 +298,8 @@ export async function toolDraftEmail(
 		message: "Draft saved to Drafts folder. Review it and confirm to send.",
 		draft: {
 			to: params.to,
+			...(params.cc ? { cc: Array.isArray(params.cc) ? params.cc.join(", ") : params.cc } : {}),
+			...(params.bcc ? { bcc: Array.isArray(params.bcc) ? params.bcc.join(", ") : params.bcc } : {}),
 			subject: params.subject,
 			body: params.isPlainText ? params.body.trim() : processedBody,
 		},

--- a/workers/lib/tools.ts
+++ b/workers/lib/tools.ts
@@ -224,6 +224,8 @@ export async function toolDraftEmail(
 	mailboxId: string,
 	params: {
 		to: string;
+		cc?: string | string[];
+		bcc?: string | string[];
 		subject: string;
 		body: string;
 		isPlainText?: boolean;
@@ -277,6 +279,8 @@ export async function toolDraftEmail(
 			subject: params.subject,
 			sender: mailboxId.toLowerCase(),
 			recipient: (params.to || "").toLowerCase(),
+			cc: params.cc ? (Array.isArray(params.cc) ? params.cc.join(", ") : params.cc).toLowerCase() : null,
+			bcc: params.bcc ? (Array.isArray(params.bcc) ? params.bcc.join(", ") : params.bcc).toLowerCase() : null,
 			date: new Date().toISOString(),
 			body: processedBody,
 			in_reply_to: params.in_reply_to || null,
@@ -308,6 +312,8 @@ export async function toolUpdateDraft(
 	params: {
 		draftId: string;
 		to?: string;
+		cc?: string | string[];
+		bcc?: string | string[];
 		subject?: string;
 		bodyHtml?: string;
 	},
@@ -331,6 +337,13 @@ export async function toolUpdateDraft(
 		return { error: "Draft verification failed — keeping existing draft unchanged. Please try again." };
 	}
 
+	const newCc = params.cc !== undefined
+		? (params.cc ? (Array.isArray(params.cc) ? params.cc.join(", ") : params.cc).toLowerCase() : null)
+		: (oldDraft.cc ?? null);
+	const newBcc = params.bcc !== undefined
+		? (params.bcc ? (Array.isArray(params.bcc) ? params.bcc.join(", ") : params.bcc).toLowerCase() : null)
+		: (oldDraft.bcc ?? null);
+
 	await stub.deleteEmail(params.draftId);
 	await stub.createEmail(
 		Folders.DRAFT,
@@ -339,6 +352,8 @@ export async function toolUpdateDraft(
 			subject: params.subject ?? oldDraft.subject,
 			sender: mailboxId.toLowerCase(),
 			recipient: (params.to ?? oldDraft.recipient).toLowerCase(),
+			cc: newCc,
+			bcc: newBcc,
 			date: new Date().toISOString(),
 			body: verifiedBody,
 			in_reply_to: oldDraft.in_reply_to || null,
@@ -426,7 +441,9 @@ export async function toolSendReply(
 	mailboxId: string,
 	params: {
 		originalEmailId: string;
-		to: string;
+		to: string | string[];
+		cc?: string | string[];
+		bcc?: string | string[];
 		subject: string;
 		bodyHtml: string;
 		/** Optional step-up confirmation token required for tier ≥ 1 sends. */
@@ -451,6 +468,8 @@ export async function toolSendReply(
 		{
 			mailboxId,
 			to: params.to,
+			cc: params.cc,
+			bcc: params.bcc,
 			subject: params.subject,
 			body: params.bodyHtml,
 		},
@@ -474,6 +493,8 @@ export async function toolSendReply(
 	if (!fromDomain) throw new Error("Invalid mailbox email address");
 	const { messageId, outgoingMessageId } = generateMessageId(fromDomain);
 
+	const toStr = Array.isArray(params.to) ? params.to.join(", ") : params.to;
+
 	// Verify and append quoted original message
 	const sanitizedBody = await verifyDraftForMailbox(env, mailboxId, params.bodyHtml);
 	if (!sanitizedBody) {
@@ -481,7 +502,7 @@ export async function toolSendReply(
 	}
 	const quotedBlock = buildQuotedReplyBlock({
 		date: originalEmail.date,
-		sender: originalEmail.sender || params.to,
+		sender: originalEmail.sender || toStr,
 		body: originalEmail.body ?? undefined,
 	});
 	const fullBodyHtml = sanitizedBody + quotedBlock;
@@ -492,6 +513,8 @@ export async function toolSendReply(
 			from: mailboxId,
 			subject: params.subject,
 			html: fullBodyHtml,
+			...(params.cc ? { cc: params.cc } : {}),
+			...(params.bcc ? { bcc: params.bcc } : {}),
 			headers: buildThreadingHeaders(originalMsgId, references),
 		});
 	} catch (e) {
@@ -505,7 +528,9 @@ export async function toolSendReply(
 			id: messageId,
 			subject: params.subject,
 			sender: mailboxId.toLowerCase(),
-			recipient: params.to.toLowerCase(),
+			recipient: toStr.toLowerCase(),
+			cc: params.cc ? (Array.isArray(params.cc) ? params.cc.join(", ") : params.cc).toLowerCase() : null,
+			bcc: params.bcc ? (Array.isArray(params.bcc) ? params.bcc.join(", ") : params.bcc).toLowerCase() : null,
 			date: new Date().toISOString(),
 			body: fullBodyHtml,
 			in_reply_to: originalMsgId,
@@ -517,7 +542,7 @@ export async function toolSendReply(
 		[],
 	);
 
-	return { status: "sent", messageId, message: `Reply sent to ${params.to}` };
+	return { status: "sent", messageId, message: `Reply sent to ${toStr}` };
 }
 
 // ── send_email ─────────────────────────────────────────────────────
@@ -535,7 +560,9 @@ export async function toolSendEmail(
 	env: Env,
 	mailboxId: string,
 	params: {
-		to: string;
+		to: string | string[];
+		cc?: string | string[];
+		bcc?: string | string[];
 		subject: string;
 		bodyHtml: string;
 		attachments?: ToolAttachment[];
@@ -561,6 +588,8 @@ export async function toolSendEmail(
 		{
 			mailboxId,
 			to: params.to,
+			cc: params.cc,
+			bcc: params.bcc,
 			subject: params.subject,
 			body: params.bodyHtml,
 			attachments: params.attachments?.map((a) => ({ filename: a.filename })),
@@ -597,6 +626,8 @@ export async function toolSendEmail(
 			from: mailboxId,
 			subject: params.subject,
 			html: sanitizedBody,
+			...(params.cc ? { cc: params.cc } : {}),
+			...(params.bcc ? { bcc: params.bcc } : {}),
 			...(cfAttachments && cfAttachments.length > 0 ? { attachments: cfAttachments } : {}),
 		});
 	} catch (e) {
@@ -615,13 +646,16 @@ export async function toolSendEmail(
 		disposition: att.disposition ?? "attachment",
 	}));
 
+	const toStrSend = Array.isArray(params.to) ? params.to.join(", ") : params.to;
 	await stub.createEmail(
 		Folders.SENT,
 		{
 			id: messageId,
 			subject: params.subject,
 			sender: mailboxId.toLowerCase(),
-			recipient: params.to.toLowerCase(),
+			recipient: toStrSend.toLowerCase(),
+			cc: params.cc ? (Array.isArray(params.cc) ? params.cc.join(", ") : params.cc).toLowerCase() : null,
+			bcc: params.bcc ? (Array.isArray(params.bcc) ? params.bcc.join(", ") : params.bcc).toLowerCase() : null,
 			date: new Date().toISOString(),
 			body: sanitizedBody,
 			in_reply_to: null,
@@ -632,5 +666,5 @@ export async function toolSendEmail(
 		sentAttachments,
 	);
 
-	return { status: "sent", messageId, message: `Email sent to ${params.to}` };
+	return { status: "sent", messageId, message: `Email sent to ${toStrSend}` };
 }

--- a/workers/mcp/index.ts
+++ b/workers/mcp/index.ts
@@ -21,6 +21,7 @@ import {
 	toolMoveEmail,
 } from "../lib/tools";
 import { Folders, FOLDER_TOOL_DESCRIPTION, MOVE_FOLDER_TOOL_DESCRIPTION } from "../../shared/folders";
+import { RecipientFieldSchema } from "../lib/schemas";
 import type { Env } from "../types";
 import {
 	readMailboxAcl,
@@ -258,10 +259,15 @@ export class EmailMCP extends McpAgent<Env> {
 			"Create a new draft email. Can be a new email or a reply draft.",
 			{
 				mailboxId: z.string().describe("The mailbox email address"),
-				to: z
-					.string()
+				to: RecipientFieldSchema
 					.optional()
-					.describe("Recipient email address (optional for early drafts)"),
+					.describe("Recipient email address (single or array, optional for early drafts)"),
+				cc: RecipientFieldSchema
+					.optional()
+					.describe("CC recipients (single email or array)"),
+				bcc: RecipientFieldSchema
+					.optional()
+					.describe("BCC recipients (single email or array)"),
 				subject: z.string().describe("Subject line"),
 				bodyHtml: z.string().describe("The HTML body of the draft"),
 				in_reply_to: z
@@ -273,11 +279,14 @@ export class EmailMCP extends McpAgent<Env> {
 					.optional()
 					.describe("Thread ID to attach this draft to (optional)"),
 			},
-			async ({ mailboxId, to, subject, bodyHtml, in_reply_to, thread_id }) => {
+			async ({ mailboxId, to, cc, bcc, subject, bodyHtml, in_reply_to, thread_id }) => {
 				const denied = await verifyMailbox(mailboxId);
 				if (denied) return denied;
+				const toStr = Array.isArray(to) ? to.join(", ") : (to || "");
 				const result = await toolDraftEmail(env, mailboxId, {
-					to: to || "",
+					to: toStr,
+					cc,
+					bcc,
 					subject,
 					body: bodyHtml,
 					isPlainText: false,
@@ -305,19 +314,27 @@ export class EmailMCP extends McpAgent<Env> {
 			{
 				mailboxId: z.string().describe("The mailbox email address"),
 				draftId: z.string().describe("The ID of the draft to update"),
-				to: z
-					.string()
+				to: RecipientFieldSchema
 					.optional()
-					.describe("Updated recipient email address"),
+					.describe("Updated recipient email address (single or array)"),
+				cc: RecipientFieldSchema
+					.optional()
+					.describe("Updated CC recipients (single email or array)"),
+				bcc: RecipientFieldSchema
+					.optional()
+					.describe("Updated BCC recipients (single email or array)"),
 				subject: z.string().optional().describe("Updated subject line"),
 				bodyHtml: z.string().optional().describe("Updated HTML body"),
 			},
-			async ({ mailboxId, draftId, to, subject, bodyHtml }) => {
+			async ({ mailboxId, draftId, to, cc, bcc, subject, bodyHtml }) => {
 				const denied = await verifyMailbox(mailboxId);
 				if (denied) return denied;
+				const toStr = Array.isArray(to) ? to.join(", ") : to;
 				const result = await toolUpdateDraft(env, mailboxId, {
 					draftId,
-					to,
+					to: toStr,
+					cc,
+					bcc,
 					subject,
 					bodyHtml,
 				});
@@ -359,7 +376,13 @@ export class EmailMCP extends McpAgent<Env> {
 				originalEmailId: z
 					.string()
 					.describe("The ID of the email being replied to"),
-				to: z.string().email().describe("Recipient email address"),
+				to: RecipientFieldSchema.describe("Recipient email address (single or array)"),
+				cc: RecipientFieldSchema
+					.optional()
+					.describe("CC recipients (single email or array)"),
+				bcc: RecipientFieldSchema
+					.optional()
+					.describe("BCC recipients (single email or array)"),
 				subject: z.string().describe("Subject line"),
 				bodyHtml: z.string().describe("The HTML body of the reply"),
 				confirmationToken: z
@@ -367,12 +390,14 @@ export class EmailMCP extends McpAgent<Env> {
 					.optional()
 					.describe("Step-up confirmation token required for tier ≥ 1 sends (external recipients, BEC keywords, etc.)"),
 			},
-			async ({ mailboxId, originalEmailId, to, subject, bodyHtml, confirmationToken }) => {
+			async ({ mailboxId, originalEmailId, to, cc, bcc, subject, bodyHtml, confirmationToken }) => {
 				const denied = await verifyMailbox(mailboxId);
 				if (denied) return denied;
 				const result = await toolSendReply(env, mailboxId, {
 					originalEmailId,
 					to,
+					cc,
+					bcc,
 					subject,
 					bodyHtml,
 					confirmationToken,
@@ -403,7 +428,13 @@ export class EmailMCP extends McpAgent<Env> {
 			"Send a new email (not a reply). Only call after getting confirmation.",
 			{
 				mailboxId: z.string().describe("The mailbox email address to send from"),
-				to: z.string().email().describe("Recipient email address"),
+				to: RecipientFieldSchema.describe("Recipient email address (single or array)"),
+				cc: RecipientFieldSchema
+					.optional()
+					.describe("CC recipients (single email or array)"),
+				bcc: RecipientFieldSchema
+					.optional()
+					.describe("BCC recipients (single email or array)"),
 				subject: z.string().describe("Subject line"),
 				bodyHtml: z.string().describe("The HTML body of the email"),
 				attachments: z
@@ -425,11 +456,13 @@ export class EmailMCP extends McpAgent<Env> {
 					.optional()
 					.describe("Step-up confirmation token required for tier ≥ 1 sends (external recipients, BEC keywords, etc.)"),
 			},
-			async ({ mailboxId, to, subject, bodyHtml, attachments, confirmationToken }) => {
+			async ({ mailboxId, to, cc, bcc, subject, bodyHtml, attachments, confirmationToken }) => {
 				const denied = await verifyMailbox(mailboxId);
 				if (denied) return denied;
 				const result = await toolSendEmail(env, mailboxId, {
 					to,
+					cc,
+					bcc,
 					subject,
 					bodyHtml,
 					...(attachments && attachments.length > 0 ? { attachments } : {}),


### PR DESCRIPTION
## Summary

- Export `RecipientFieldSchema` from `workers/lib/schemas.ts` so the MCP and HTTP API stay in lockstep on the `string | string[]` shape.
- Widen `toolSendEmail` / `toolSendReply` in `workers/lib/tools.ts` to accept `to: string | string[]` plus optional `cc` / `bcc`; thread all three into `enforceSendRiskConfirmation` (external cc/bcc recipients trigger tier escalation) and into `sendEmail`; store normalized cc/bcc strings on the SENT record, mirroring `workers/routes/send-email.ts:82`.
- Add cc/bcc to `toolDraftEmail` / `toolUpdateDraft`; update carries old draft cc/bcc when the caller omits the field.
- Update all four MCP tool definitions in `workers/mcp/index.ts` to use `RecipientFieldSchema` for `to` and expose optional `cc` / `bcc`.

Closes #495.

## Test plan

- [x] `npm test` — 1548 passing, 0 failing
- [x] `npm run typecheck` — clean
- [x] 8 new cases in `tests/lib/tools-send-risk.test.ts`: array `to` (multi-recipient), external cc triggers tier ≥ 1 gate, internal cc passes through with cc stored on SENT row, bcc array normalized on SENT row, tier ≥ 1 with token + cc proceeds, reply with cc, reply with external cc blocked, reply with array `to`.

## Choices made

- `toolUpdateDraft` treats a missing `cc`/`bcc` param as "keep old value" (same pattern as `to`, `subject`, `bodyHtml`); there is no explicit "clear cc" path since `RecipientFieldSchema` rejects empty arrays and nulls — a future issue can add that if needed.
- `create_draft` normalizes an array `to` to a comma-joined string before passing to `toolDraftEmail` (that function's `to` param is still `string` because drafts only display, never send from the MCP layer).

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ff7j147rM3AruG7x2CY1o)_