### PR TITLE
fix(security): surface LLM classifier errors in verdict JSON; add label='error' for ai.run failures

### DIFF
--- a/app/components/email-panel/SecurityVerdictPanel.tsx
+++ b/app/components/email-panel/SecurityVerdictPanel.tsx
@@ -185,7 +185,7 @@ function ClassifierChip({
 	const color =
 		label === "phishing" || label === "bec"
 			? "text-danger"
-			: label === "suspicious"
+			: label === "suspicious" || label === "error"
 				? "text-suspect"
 				: label === "spam"
 					? "text-ink-3"

--- a/test/security/classification.test.ts
+++ b/test/security/classification.test.ts
@@ -68,14 +68,19 @@ describe("classifyEmail — narrowed Rule 5 (issue #28)", () => {
 		expect(result.label).toBe("unavailable");
 	});
 
-	it("non-timeout error (e.g. binding misconfigured) → still fails closed to suspicious", async () => {
+	it("non-timeout error (e.g. binding misconfigured) → label=error, reasoning embeds the actual error", async () => {
 		__setClassifier(async () => {
 			throw new Error("AI binding not bound");
 		});
 		const result = await classifyEmail(FAKE_AI, baseInput);
-		// Rule 5 only narrows the timeout/abort path. A generic thrown error
-		// stays fail-closed because we genuinely don't know what happened.
-		expect(result.label).toBe("suspicious");
+		// Non-timeout errors use label="error" so operators can distinguish a
+		// broken classifier from a genuine suspicious verdict (issue #496).
+		// Security posture is unchanged: scoreClassification maps "error" to the
+		// same +20 weight as "suspicious".
+		expect(result.label).toBe("error");
+		// The real ai.run error is embedded in reasoning for verdict-level
+		// visibility without requiring wrangler tail access.
+		expect(result.reasoning).toContain("AI binding not bound");
 	});
 
 	it("parse-fail (model returns garbage) → returns suspicious, NOT unavailable", async () => {
@@ -94,12 +99,15 @@ describe("classifyEmail — narrowed Rule 5 (issue #28)", () => {
 		expect(result.label).not.toBe("unavailable");
 	});
 
-	it("legacy mode (skipOnTimeout=false) → timeout reverts to fail-closed suspicious", async () => {
+	it("legacy mode (skipOnTimeout=false) → timeout treated as error, label=error, fail-closed", async () => {
 		__setClassifier(async () => {
 			throw new Error("classify-timeout");
 		});
 		const result = await classifyEmail(FAKE_AI, baseInput, { skipOnTimeout: false });
-		expect(result.label).toBe("suspicious");
+		// When skip_on_timeout is false, the timeout is not treated specially —
+		// it falls through to the generic error path. Label is "error" (same score
+		// weight as suspicious, fail-closed) rather than the old "suspicious".
+		expect(result.label).toBe("error");
 		expect(result.confidence).toBeLessThan(0.5);
 	});
 
@@ -258,6 +266,52 @@ describe("classifyEmail — prompt-injection hardening (issue #459)", () => {
 		const trustedSection = userMsg.slice(0, fenceStart);
 		expect(trustedSection).toContain("SENDER: alice@example.com");
 		expect(trustedSection).toContain("AUTH: spf=pass");
+	});
+});
+
+describe("scoreClassification — error label (issue #496)", () => {
+	it("error → same score weight as suspicious, reason 'llm_error'", () => {
+		const result: ClassificationResult = {
+			label: "error",
+			confidence: 0.3,
+			reasoning: "classifier error: AI binding not bound",
+		};
+		const { score, reasons, contributions } = scoreClassification(result);
+		// Fail-closed at same weight as suspicious: 30 * (0.5 + 0.5 * 0.3) = 19.5 → 20
+		expect(score).toBe(20);
+		expect(reasons).toEqual(["llm_error"]);
+		expect(contributions[0].rule).toBe("classifier_error");
+	});
+
+	it("error score is independent of confidence value in terms of signal tag", () => {
+		const result: ClassificationResult = {
+			label: "error",
+			confidence: 0.9,
+			reasoning: "classifier error: quota exceeded",
+		};
+		const { score, reasons } = scoreClassification(result);
+		// Higher confidence still maps to llm_error, score scales with confidence
+		expect(score).toBeGreaterThan(20);
+		expect(reasons).toEqual(["llm_error"]);
+	});
+
+	it("error label is distinct from suspicious — scoreClassification does not conflate them", () => {
+		const errResult: ClassificationResult = {
+			label: "error",
+			confidence: 0.3,
+			reasoning: "classifier error: binding not found",
+		};
+		const susResult: ClassificationResult = {
+			label: "suspicious",
+			confidence: 0.3,
+			reasoning: "uncertain signals",
+		};
+		const err = scoreClassification(errResult);
+		const sus = scoreClassification(susResult);
+		// Same score (fail-closed), different signal tags — this is the observability fix
+		expect(err.score).toBe(sus.score);
+		expect(err.reasons).toEqual(["llm_error"]);
+		expect(sus.reasons[0]).toMatch(/classifier: suspicious/);
 	});
 });
 

--- a/test/security/run-pipeline.test.ts
+++ b/test/security/run-pipeline.test.ts
@@ -288,8 +288,12 @@ describe("LLM timeout — narrowed Rule 5 (issue #28)", () => {
 		expect(result.verdict?.signals).toContain("llm_unavailable");
 	});
 
-	it("legacy mode (skip_on_timeout=false) → timeout reverts to fail-closed suspicious", async () => {
+	it("legacy mode (skip_on_timeout=false) → timeout treated as error, fail-closed at suspicious weight", async () => {
 		// Backward-compat for operators who explicitly want the old behavior.
+		// With skip_on_timeout=false the timeout is NOT treated specially and
+		// falls through to the generic non-timeout error path (issue #496).
+		// Label is "error" (observable, distinguishable from a real verdict)
+		// and score weight is identical to suspicious — security posture unchanged.
 		__setClassifier(async () => {
 			throw new Error("classify-timeout");
 		});
@@ -305,11 +309,12 @@ describe("LLM timeout — narrowed Rule 5 (issue #28)", () => {
 		const result = await runSecurityPipeline({
 			env, mailboxId: MAILBOX, messageId: "m-legacy", targetFolder: "inbox", parsedEmail: parsed,
 		});
-		// With the old fail-closed behavior, the classifier contributes at the
-		// `suspicious` weight; combined with a clean email's other signals
-		// (≈0), 30*(0.5+0.5*0.3)≈10 sits below the tag threshold but the
-		// classifier label itself must read `suspicious`, not `unavailable`.
-		expect(result.verdict?.classification.label).toBe("suspicious");
+		// Label is "error" (not "suspicious") so operators can distinguish a
+		// broken classifier from a genuine verdict. The score contribution is
+		// the same so the pipeline action (allow, tag, etc.) is unchanged.
+		expect(result.verdict?.classification.label).toBe("error");
+		// llm_error is emitted instead of "classifier: suspicious (30%)"
+		expect(result.verdict?.signals).toContain("llm_error");
 		expect(result.verdict?.signals).not.toContain("llm_unavailable");
 	});
 

--- a/workers/security/classification.ts
+++ b/workers/security/classification.ts
@@ -32,7 +32,18 @@ export type ClassificationLabel =
 	 *
 	 * Issue: https://github.com/schmug/PhishSOC/issues/28
 	 */
-	| "unavailable";
+	| "unavailable"
+	/**
+	 * `ai.run()` threw a non-timeout error (binding misconfigured, model
+	 * quota, unexpected throw shape). Fail-closed at the same score weight as
+	 * `suspicious` so the security posture is unchanged, but tagged as
+	 * `"error"` so operators can distinguish a broken classifier from a
+	 * genuine suspicious verdict. The actual error message is embedded in
+	 * `reasoning` so it is visible in the verdict JSON without log access.
+	 *
+	 * Issue: https://github.com/schmug/PhishSOC/issues/496
+	 */
+	| "error";
 
 export interface ClassificationResult {
 	label: ClassificationLabel;
@@ -185,7 +196,9 @@ ${sanitizedBody}
 
 		return parseClassifierOutput(response?.response ?? "");
 	} catch (e) {
-		const message = (e as Error).message;
+		// Capture the real error text regardless of whether e is an Error
+		// instance — Workers AI can throw plain strings or Response objects.
+		const message = e instanceof Error ? e.message : String(e);
 		if (isClassifierTimeout(e) && skipOnTimeout) {
 			// Rule 5 narrowed (issue #28): timeout/abort no longer fails closed
 			// to `suspicious`. Instead the classifier signals "unavailable" and
@@ -198,11 +211,14 @@ ${sanitizedBody}
 			console.warn("classifyEmail timeout — skipping classifier contribution:", message);
 			return { label: "unavailable", confidence: 0, reasoning: "classifier timeout" };
 		}
-		// Fail closed: unparsable / non-timeout failures → suspicious.
-		// We do NOT quarantine solely on classifier failure; the verdict
-		// aggregator combines with auth / URL / reputation signals.
+		// Fail closed: non-timeout thrown error (binding misconfigured, quota,
+		// unexpected throw shape). Label is "error" rather than "suspicious" so
+		// operators can distinguish a broken classifier from a genuine verdict.
+		// Score weight is identical to `suspicious` — security posture unchanged.
+		// The real error message is embedded in `reasoning` so it surfaces in
+		// the verdict JSON without requiring log access (issue #496).
 		console.error("classifyEmail failed:", message);
-		return { label: "suspicious", confidence: 0.3, reasoning: "classifier unavailable" };
+		return { label: "error", confidence: 0.3, reasoning: `classifier error: ${message}` };
 	}
 }
 
@@ -266,7 +282,21 @@ export function scoreClassification(result: ClassificationResult): {
 			contributions: [{ scorer: "classification", rule: "classifier_unavailable", weight: 0, reason: "llm_unavailable" }],
 		};
 	}
-	const map: Record<Exclude<ClassificationLabel, "unavailable">, number> = {
+	if (result.label === "error") {
+		// Fail-closed: ai.run() threw a non-timeout error (issue #496).
+		// Same score weight as `suspicious` so the security posture is unchanged,
+		// but tagged `llm_error` so the signal is observable in verdict.signals
+		// and the stage trace without being confused with a real verdict.
+		const base = 30; // matches map["suspicious"] below
+		const scaled = Math.round(base * (0.5 + 0.5 * result.confidence));
+		return {
+			score: scaled,
+			reasons: ["llm_error"],
+			confidence: result.confidence,
+			contributions: [{ scorer: "classification", rule: "classifier_error", weight: scaled, reason: "llm_error" }],
+		};
+	}
+	const map: Record<Exclude<ClassificationLabel, "unavailable" | "error">, number> = {
 		safe: 0, spam: 20, suspicious: 30, bec: 45, phishing: 50,
 	};
 	const base = map[result.label];


### PR DESCRIPTION
## Summary

- **`label: "error"` for non-timeout `ai.run()` failures.** Previously every thrown exception from the classifier returned `{ label: "suspicious", reasoning: "classifier unavailable" }` — indistinguishable from a genuine LLM verdict. This was silently swallowed to `console.error` only. Now the catch block returns `{ label: "error", reasoning: "classifier error: <real message>" }`, embedding the actual `ai.run` error in the verdict JSON so it is readable via `get_email` / the API without requiring `wrangler tail` access.
- **`scoreClassification` maps `"error"` to the same +20 weight as `"suspicious"`** (fail-closed security posture is unchanged), but emits `"llm_error"` as the verdict signal and stage-trace reason — distinguishable from both `"classifier: suspicious (30%)"` (real verdict) and `"llm_unavailable"` (timeout).
- **Error capture fix:** `(e as Error).message` → `e instanceof Error ? e.message : String(e)` so plain-string or Response-typed throws from the Workers AI binding are also captured.
- **UI:** `ClassifierChip` colors `"error"` as amber (`text-suspect`) rather than the default green, matching the fail-closed intent.

Closes #496.

## Root-cause note

The model `@cf/meta/llama-3.1-8b-instruct-fast` is confirmed active (Cloudflare's May 2026 deprecation doc explicitly lists `-fast` variants as **not** deprecated). The exact `ai.run` error cannot be read without `wrangler tail` access from this environment. **After this PR lands:** send a test email and read `security_verdict.classification.reasoning` from `get_email` — it will now contain `"classifier error: <real error>"`. The fix for the actual error follows from that string (likely a binding/quota/account issue).

## Test plan
- [x] `npm test` — 1543 passing, 0 failing
- [x] `npm run typecheck` — 0 errors
- [x] 3 existing tests updated to expect `label: "error"` for non-timeout failures
- [x] 3 new `scoreClassification` tests for `label: "error"` (score weight, `llm_error` signal, distinctness from `"suspicious"`)

## Choices made

- `"error"` label uses the same confidence (0.3) and score weight as the old `"suspicious"` path — security posture is identical, only observability is improved.
- `ClassifierChip` renders `"error"` as amber (same as `"suspicious"`) since it represents a fail-closed conservative state.
- `parseClassifierOutput` parse-failures (model returns garbage JSON) continue to use `label: "suspicious"` — those are already distinguishable via their `reasoning` field (`"classifier output not JSON"` / `"classifier output malformed"`); changing them is out of scope per the issue constraints.

## Deferred

- Actual root cause (`wrangler tail` log line) — requires runtime access. After this PR, the error will surface in `classification.reasoning` in the verdict JSON.
- Narrowing `SECURITY_SPEC.md` Rule 5 comment if applicable (per CLAUDE.md convention, spec edits follow the code change in a separate `docs:` PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrmUFgpg54EkWU3cyG7psa)_