### PR TITLE
security(inbound): file each copy into its own envelope recipient's mailbox (GHSA-6jgg-fp96-7x3x)

### DIFF
--- a/tests/routes/catchall.test.ts
+++ b/tests/routes/catchall.test.ts
@@ -68,19 +68,33 @@ describe("catchall_intel — stripDefaultEqual", () => {
 // 2. normalizeInbound — discriminated union
 // ---------------------------------------------------------------------------
 
-// Minimal PostalMime-shaped email builder
-function rawEmailBytes(to: string[], from = "sender@attacker.example"): Uint8Array {
-	const toHeader = to.map((a) => `To: ${a}`).join("\r\n");
-	const raw = [
-		`From: ${from}`,
-		toHeader,
-		"Subject: test",
-		"MIME-Version: 1.0",
-		"Content-Type: text/plain",
-		"",
-		"body",
-	].join("\r\n");
-	return new TextEncoder().encode(raw);
+// Minimal PostalMime-shaped email builder.
+//
+// `receivedLines` (full `Received:` header values, top-first) and the
+// `receivedFor` convenience let a test reproduce the per-RCPT delivery that
+// Cloudflare Email Routing performs: a `Received: ... for <addr>;` line stamped
+// at the trust boundary. `cc` addresses land in `parsedEmail.cc`, NOT
+// `parsedEmail.to`, mirroring how a cc/bcc copy carries no `To:`-header trace
+// of its real envelope recipient.
+function rawEmailBytes(
+	to: string[],
+	from = "sender@attacker.example",
+	opts: { cc?: string[]; receivedFor?: string; receivedLines?: string[] } = {},
+): Uint8Array {
+	const received = opts.receivedLines
+		? [...opts.receivedLines]
+		: opts.receivedFor
+			? [`from mx.example by route.mx.cloudflare.net with ESMTPS id deadbeef for <${opts.receivedFor}>; Wed, 18 Jun 2026 12:00:00 +0000`]
+			: [];
+	const lines: string[] = [];
+	// Received headers are prepended at each hop; the FIRST line is the
+	// most-recent (top) hop — the one Cloudflare stamps for this delivery.
+	for (const r of received) lines.push(`Received: ${r}`);
+	lines.push(`From: ${from}`);
+	for (const a of to) lines.push(`To: ${a}`);
+	for (const a of opts.cc ?? []) lines.push(`Cc: ${a}`);
+	lines.push("Subject: test", "MIME-Version: 1.0", "Content-Type: text/plain", "", "body");
+	return new TextEncoder().encode(lines.join("\r\n"));
 }
 
 function makeStream(bytes: Uint8Array): ReadableStream {
@@ -123,6 +137,12 @@ async function runNormalize(
 		domainSettings?: Record<string, unknown>;
 		/** SMTP envelope recipient (RCPT TO) Cloudflare matched the routing rule on. */
 		envelopeTo?: string;
+		/** Cc addresses (land in parsedEmail.cc, not .to). */
+		cc?: string[];
+		/** Convenience: a CF-style top `Received: ... for <receivedFor>;` line. */
+		receivedFor?: string;
+		/** Full `Received:` header values, top-first, for multi-hop scenarios. */
+		receivedLines?: string[];
 	} = {},
 ) {
 	const { normalizeInbound } = await import("../../workers/providers/cf-routing");
@@ -146,7 +166,11 @@ async function runNormalize(
 	const { clearOrgSettingsCache } = await import("../../workers/lib/org-settings");
 	clearOrgSettingsCache();
 
-	const bytes = rawEmailBytes(toAddresses);
+	const bytes = rawEmailBytes(toAddresses, undefined, {
+		cc: opts.cc,
+		receivedFor: opts.receivedFor,
+		receivedLines: opts.receivedLines,
+	});
 	const event = {
 		raw: makeStream(bytes),
 		rawSize: bytes.byteLength,
@@ -267,6 +291,184 @@ describe("normalizeInbound — envelope recipient resolution", () => {
 		expect(result?.kind).toBe("mailbox");
 		if (result?.kind === "mailbox") {
 			expect(result.mailboxId).toBe("consulting@cortech.online");
+		}
+	});
+});
+
+describe("normalizeInbound — per-RCPT delivery via top Received header (GHSA-6jgg-fp96-7x3x)", () => {
+	// Cloudflare Email Routing invokes email() once per SMTP envelope recipient
+	// (RCPT TO). On the CF Email Sending → CF Email Routing cc/bcc/multi-recipient
+	// path, event.to is NOT the distinct envelope recipient and collapses to the
+	// To: header's first address, so a copy delivered for B was misfiled into A
+	// (cc/bcc/secondary recipients silently lost mail; the bcc copy landing in A
+	// is a cross-mailbox disclosure). The authoritative per-copy RCPT survives in
+	// the TOP `Received: ... for <addr>` header Cloudflare stamps.
+
+	it("To: A, Cc: B — the copy delivered for B is filed to B, not A", async () => {
+		const result = await runNormalize(
+			["support@cortech.online"],
+			{
+				emailAddresses: [],
+				domains: "cortech.online",
+				mailboxes: ["support@cortech.online", "inbox@cortech.online"],
+				cc: ["inbox@cortech.online"],
+				receivedFor: "inbox@cortech.online",
+				// event.to collapses to the To: header's first address on this path.
+				envelopeTo: "support@cortech.online",
+			},
+		);
+		expect(result?.kind).toBe("mailbox");
+		if (result?.kind === "mailbox") {
+			expect(result.mailboxId).toBe("inbox@cortech.online");
+		}
+	});
+
+	it("To: A, Cc: B — the copy delivered for A is still filed to A", async () => {
+		const result = await runNormalize(
+			["support@cortech.online"],
+			{
+				emailAddresses: [],
+				domains: "cortech.online",
+				mailboxes: ["support@cortech.online", "inbox@cortech.online"],
+				cc: ["inbox@cortech.online"],
+				receivedFor: "support@cortech.online",
+				envelopeTo: "support@cortech.online",
+			},
+		);
+		expect(result?.kind).toBe("mailbox");
+		if (result?.kind === "mailbox") {
+			expect(result.mailboxId).toBe("support@cortech.online");
+		}
+	});
+
+	it("To: A, Bcc: C — the copy delivered for C is filed to C; A never receives it", async () => {
+		// The bcc recipient is absent from To:/Cc: entirely; the only signal that
+		// this copy belongs to C is the top Received header.
+		const result = await runNormalize(
+			["support@cortech.online"],
+			{
+				emailAddresses: [],
+				domains: "cortech.online",
+				mailboxes: ["support@cortech.online", "gh4all@cortech.online"],
+				receivedFor: "gh4all@cortech.online",
+				envelopeTo: "support@cortech.online",
+			},
+		);
+		expect(result?.kind).toBe("mailbox");
+		if (result?.kind === "mailbox") {
+			expect(result.mailboxId).toBe("gh4all@cortech.online");
+		}
+	});
+
+	it("To: [A, B] — the copy delivered for the second To address is filed to it", async () => {
+		const result = await runNormalize(
+			["support@cortech.online", "steptest@cortech.online"],
+			{
+				emailAddresses: [],
+				domains: "cortech.online",
+				mailboxes: ["support@cortech.online", "steptest@cortech.online"],
+				receivedFor: "steptest@cortech.online",
+				envelopeTo: "support@cortech.online",
+			},
+		);
+		expect(result?.kind).toBe("mailbox");
+		if (result?.kind === "mailbox") {
+			expect(result.mailboxId).toBe("steptest@cortech.online");
+		}
+	});
+
+	it("files into the envelope recipient (top Received) even when the To: header names a different provisioned mailbox", async () => {
+		const result = await runNormalize(
+			["x@cortech.online"],
+			{
+				emailAddresses: [],
+				domains: "cortech.online",
+				mailboxes: ["x@cortech.online", "y@cortech.online"],
+				receivedFor: "y@cortech.online",
+				envelopeTo: "x@cortech.online",
+			},
+		);
+		expect(result?.kind).toBe("mailbox");
+		if (result?.kind === "mailbox") {
+			expect(result.mailboxId).toBe("y@cortech.online");
+		}
+	});
+
+	it("fails closed (drops) when the envelope recipient has no mailbox even though the To: header names one", async () => {
+		// Delivered for y@ (no mailbox, catch-all disabled); To: x@ (provisioned).
+		// Must NOT misfile into x@.
+		const result = await runNormalize(
+			["x@cortech.online"],
+			{
+				emailAddresses: [],
+				domains: "cortech.online",
+				mailboxes: ["x@cortech.online"],
+				receivedFor: "y@cortech.online",
+				envelopeTo: "x@cortech.online",
+				domainSettings: { "cortech.online": {} },
+			},
+		);
+		expect(result).toBeNull();
+	});
+
+	it("EMAIL_ADDRESSES allow-list: the copy for B is matched against B, not the To: header A", async () => {
+		const result = await runNormalize(
+			["support@cortech.online"],
+			{
+				emailAddresses: ["support@cortech.online", "inbox@cortech.online"],
+				mailboxes: ["support@cortech.online", "inbox@cortech.online"],
+				cc: ["inbox@cortech.online"],
+				receivedFor: "inbox@cortech.online",
+				envelopeTo: "support@cortech.online",
+			},
+		);
+		expect(result?.kind).toBe("mailbox");
+		if (result?.kind === "mailbox") {
+			expect(result.mailboxId).toBe("inbox@cortech.online");
+		}
+	});
+
+	it("uses only the TOP Received header's for-clause; a forged lower Received cannot redirect delivery", async () => {
+		const result = await runNormalize(
+			["x@cortech.online"],
+			{
+				emailAddresses: [],
+				domains: "cortech.online",
+				mailboxes: ["x@cortech.online", "real@cortech.online", "attacker@cortech.online"],
+				receivedLines: [
+					// TOP — stamped by Cloudflare for the actual RCPT.
+					"from mx by route.mx.cloudflare.net with ESMTPS id aa for <real@cortech.online>; Wed, 18 Jun 2026 12:00:00 +0000",
+					// LOWER — forged upstream to try to grab attacker@'s mailbox.
+					"from evil by relay.example with ESMTP id bb for <attacker@cortech.online>; Wed, 18 Jun 2026 11:59:00 +0000",
+				],
+				envelopeTo: "x@cortech.online",
+			},
+		);
+		expect(result?.kind).toBe("mailbox");
+		if (result?.kind === "mailbox") {
+			expect(result.mailboxId).toBe("real@cortech.online");
+		}
+	});
+
+	it("falls back to event.to when the top Received has no for-clause, ignoring a lower Received for-clause", async () => {
+		const result = await runNormalize(
+			["x@cortech.online"],
+			{
+				emailAddresses: [],
+				domains: "cortech.online",
+				mailboxes: ["x@cortech.online", "attacker@cortech.online"],
+				receivedLines: [
+					// TOP — no `for` clause (some CF paths omit it).
+					"from mx by route.mx.cloudflare.net with ESMTPS id aa; Wed, 18 Jun 2026 12:00:00 +0000",
+					// LOWER — forged for attacker@.
+					"from evil by relay.example with ESMTP id bb for <attacker@cortech.online>; Wed, 18 Jun 2026 11:59:00 +0000",
+				],
+				envelopeTo: "x@cortech.online",
+			},
+		);
+		expect(result?.kind).toBe("mailbox");
+		if (result?.kind === "mailbox") {
+			expect(result.mailboxId).toBe("x@cortech.online");
 		}
 	});
 });

--- a/workers/providers/cf-routing.ts
+++ b/workers/providers/cf-routing.ts
@@ -46,22 +46,70 @@ async function streamToArrayBuffer(
 }
 
 /**
+ * Extract the RCPT TO address from the TOP `Received:` header's RFC 5321
+ * `for <addr>` clause.
+ *
+ * Cloudflare Email Routing invokes `email()` once per SMTP envelope recipient
+ * and prepends a `Received:` line stamped with the actual recipient of THIS
+ * delivery (`for <addr>;`) before invoking the Worker. Because headers are
+ * prepended at each hop, the first `Received:` header in the parsed list is the
+ * one Cloudflare added at the trust boundary — the only one an upstream sender
+ * cannot forge. We read the `for` clause from that header ONLY; a `for` clause
+ * on any lower (older, attacker-reachable) Received line is ignored, so a
+ * forged `Received: ... for <victim@owned>` cannot redirect delivery.
+ *
+ * Returns the lowercased address, or undefined when the top Received header is
+ * absent or carries no `for` clause.
+ */
+export function topReceivedForAddress(headers: unknown): string | undefined {
+	if (!Array.isArray(headers)) return undefined;
+	let topReceived: string | undefined;
+	for (const h of headers) {
+		if (!h || typeof h !== "object") continue;
+		const rec = h as { key?: unknown; name?: unknown; value?: unknown };
+		const key = rec.key ?? rec.name;
+		if (typeof key !== "string" || key.toLowerCase() !== "received") continue;
+		if (typeof rec.value !== "string") continue;
+		topReceived = rec.value;
+		break; // first Received header = most-recent hop = Cloudflare's
+	}
+	if (!topReceived) return undefined;
+	// RFC 5321 `for <addr>` clause. Require an '@' so a bare hostname token
+	// (e.g. "for relay.example") is never mistaken for an address; tolerate
+	// optional angle brackets; stop at whitespace, ';' or '>'.
+	const m = /\bfor\s+<?([^\s<>;]+@[^\s<>;]+)>?/i.exec(topReceived);
+	return m?.[1]?.toLowerCase();
+}
+
+/**
  * Normalise a CF Email Routing event into a discriminated-union inbound value.
  *
  * - `MailboxInbound`  — recipient matched a registered mailbox.
  * - `CatchallInbound` — no registered mailbox, but recipient is on an owned
  *                       domain with `catchall_intel.enabled`.
  * - `null`            — silently drop (unowned domain, disabled catch-all, or
- *                       an EMAIL_ADDRESSES member whose mailbox JSON is missing).
+ *                       an envelope recipient whose mailbox JSON is missing).
  *
- * The SMTP envelope recipient (`event.to`, the RCPT TO Cloudflare Email
- * Routing matched its rule on) is authoritative and is consulted FIRST when
- * resolving the target mailbox. The parsed `To:` header is a fallback only:
- * it is attacker-controlled and, for multi-recipient threads / bcc / list
- * mail, its first address is frequently NOT the address the message was
- * actually delivered to. Keying mailbox resolution off the header alone
- * silently dropped legitimately-routed mail whenever the real recipient was
- * not `To[0]`.
+ * Mailbox selection is keyed strictly off the authoritative SMTP envelope
+ * recipient (the RCPT TO of this per-copy delivery), resolved as:
+ *
+ *   1. the TOP `Received: ... for <addr>` header Cloudflare stamps, then
+ *   2. `event.to`.
+ *
+ * The top Received header wins because, on the Cloudflare Email Sending →
+ * Cloudflare Email Routing cc/bcc/multi-recipient path, `event.to` is NOT the
+ * distinct envelope recipient and collapses to the `To:` header's first
+ * address — so a copy delivered for B was misfiled into A, silently losing
+ * cc/bcc/secondary mail and (for bcc) disclosing it cross-mailbox
+ * (GHSA-6jgg-fp96-7x3x).
+ *
+ * The parsed `To:`/`Cc:` headers are attacker-controlled and are NEVER used to
+ * SELECT a provisioned mailbox: when the envelope recipient is known but has no
+ * mailbox, we fail closed (catch-all for its own domain, else drop) rather than
+ * misfile into a different mailbox named by the header. Header addresses are
+ * consulted only as a last resort when no envelope recipient is available at
+ * all (the single-recipient / no-Received legacy path) and for catch-all domain
+ * scanning in that same case.
  *
  * Any parse/stream failure throws so CF Email Routing can retry or bounce.
  */
@@ -72,15 +120,19 @@ export async function normalizeInbound(
 	const rawEmail = await streamToArrayBuffer(event.raw, event.rawSize);
 	const parsedEmail = await new PostalMime().parse(rawEmail);
 
-	// Envelope recipient (RCPT TO) — the address Cloudflare delivered to.
-	const envelopeRecipient = event.to?.trim().toLowerCase() || undefined;
+	// Authoritative envelope recipient (RCPT TO) for this per-copy delivery:
+	// the Cloudflare-stamped top `Received: ... for <addr>` wins over event.to.
+	const eventTo = event.to?.trim().toLowerCase() || undefined;
+	const receivedFor = topReceivedForAddress(parsedEmail.headers);
+	const envelopeRecipient = receivedFor ?? eventTo;
+
 	const headerRecipients = (parsedEmail.to ?? [])
 		.map((t) => (t as { address?: string }).address?.toLowerCase())
 		.filter((a): a is string => Boolean(a));
 
-	// Candidate recipients: envelope recipient first, then header addresses,
-	// de-duplicated. The envelope recipient wins so a multi-recipient `To:`
-	// header can never shadow the address the message was routed to.
+	// Candidate recipients for catch-all / allow-list scanning when no
+	// authoritative envelope recipient is available: envelope recipient first,
+	// then header addresses, de-duplicated.
 	const allRecipients: string[] = [];
 	for (const addr of [envelopeRecipient, ...headerRecipients]) {
 		if (addr && !allRecipients.includes(addr)) allRecipients.push(addr);
@@ -89,14 +141,37 @@ export async function normalizeInbound(
 		throw new Error("received email with no envelope or header recipient");
 	}
 
+	const mkMailbox = (mailboxId: string): MailboxInbound => ({
+		kind: "mailbox",
+		rawEmail: rawEmail.buffer as ArrayBuffer,
+		parsedEmail,
+		mailboxId,
+	});
+
 	const allowedAddresses = ((env.EMAIL_ADDRESSES ?? []) as string[]).map((a) => a.toLowerCase());
 
 	if (allowedAddresses.length > 0) {
-		// Step 1: find a registered mailbox among allowed addresses.
+		if (envelopeRecipient) {
+			// Envelope recipient is authoritative: match it against the allow-list
+			// and select strictly from it. Never file a copy delivered for one
+			// RCPT into a different mailbox because that address appears in To:/Cc:.
+			if (allowedAddresses.includes(envelopeRecipient)) {
+				if (await env.BUCKET.head(`mailboxes/${envelopeRecipient}.json`)) {
+					return mkMailbox(envelopeRecipient);
+				}
+				// Allowed but no mailbox JSON — fail closed (today's drop).
+				console.log("Ignoring email: envelope recipient is registered but has no mailbox.");
+				return null;
+			}
+			// Envelope recipient is not allow-listed — try catch-all for ITS domain.
+			return resolveCatchall([envelopeRecipient], rawEmail, parsedEmail, env);
+		}
+		// No authoritative envelope recipient (single-recipient / no-Received
+		// legacy path): fall back to scanning header addresses.
 		const registered = allRecipients.filter((addr) => allowedAddresses.includes(addr));
 		for (const addr of registered) {
 			if (await env.BUCKET.head(`mailboxes/${addr}.json`)) {
-				return { kind: "mailbox", rawEmail: rawEmail.buffer as ArrayBuffer, parsedEmail, mailboxId: addr };
+				return mkMailbox(addr);
 			}
 		}
 		if (registered.length > 0) {
@@ -107,15 +182,24 @@ export async function normalizeInbound(
 		// No address matched EMAIL_ADDRESSES — try catch-all for all recipients.
 		return resolveCatchall(allRecipients, rawEmail, parsedEmail, env);
 	} else {
-		// No EMAIL_ADDRESSES configured: any recipient with a provisioned
-		// mailbox is deliverable. Resolve from the envelope recipient (or, as a
-		// fallback, the first header address) before trying catch-all. Only the
-		// authoritative envelope address is used as the mailbox key so a forged
-		// `To:`/`Cc:` cannot misfile mail into another mailbox.
-		const mailboxId = envelopeRecipient ?? headerRecipients[0];
+		// No EMAIL_ADDRESSES configured: any recipient with a provisioned mailbox
+		// is deliverable.
+		if (envelopeRecipient) {
+			// Select strictly from the authoritative envelope recipient so a forged
+			// `To:`/`Cc:` cannot misfile mail into another mailbox. If it has no
+			// mailbox, fail closed to catch-all for ITS own domain — never a
+			// header address's mailbox or domain.
+			if (await env.BUCKET.head(`mailboxes/${envelopeRecipient}.json`)) {
+				return mkMailbox(envelopeRecipient);
+			}
+			return resolveCatchall([envelopeRecipient], rawEmail, parsedEmail, env);
+		}
+		// No authoritative envelope recipient: single-recipient / no-Received
+		// legacy path — resolve from the first header address, then catch-all.
+		const mailboxId = headerRecipients[0];
 		if (!mailboxId) throw new Error("received email with no valid recipient address");
 		if (await env.BUCKET.head(`mailboxes/${mailboxId}.json`)) {
-			return { kind: "mailbox", rawEmail: rawEmail.buffer as ArrayBuffer, parsedEmail, mailboxId };
+			return mkMailbox(mailboxId);
 		}
 		return resolveCatchall(allRecipients, rawEmail, parsedEmail, env);
 	}


### PR DESCRIPTION
## Summary

Inbound mail routing now files **every copy of a multi-recipient message into its own envelope recipient's mailbox**, closing a cross-mailbox disclosure on the Cloudflare Email Sending → Cloudflare Email Routing path.

Refs **GHSA-6jgg-fp96-7x3x** (developed in the open at the repo owner's request).

## The bug

Cloudflare Email Routing invokes the Worker `email()` handler **once per SMTP envelope recipient (RCPT TO)**. `normalizeInbound()` resolved the target mailbox from `event.to` with a `To[0]` fallback. Empirically, on the CF Email Sending → CF Email Routing cc/bcc/multi-recipient path, `event.to` is **not** the distinct envelope recipient and collapses to the `To:` header's first address — so the resolver never saw the real recipient (which survives only in the top `Received: ... for <X>` header it didn't read).

Result, reproduced live on prod (`inbox.cortech.online`, 2026-06-18):

| Case | Sent | Misfiled outcome |
| --- | --- | --- |
| cc | To `support@`, Cc `inbox@` | both copies stored in `support@`; `inbox@` got nothing |
| bcc | To `support@`, Bcc `gh4all@` | the `for <gh4all@>` copy stored in `support@`; `gh4all@` got nothing |
| multi-To | To `[support@, steptest@]` | both filed to `support@`; `steptest@` got nothing |

Each provisioned mailbox is a distinct security authority (per-mailbox ACLs), so a copy delivered for B landing readable in A is a **cross-mailbox disclosure** — and the bcc case defeats bcc privacy. The send side was already correct; the defect was purely inbound resolution.

## The fix (`workers/providers/cf-routing.ts`)

- Resolve the authoritative per-copy envelope recipient from the **TOP `Received: ... for <addr>` header** Cloudflare stamps at the trust boundary, falling back to `event.to`. New exported helper `topReceivedForAddress()`.
- **Select the mailbox strictly from that envelope recipient.** The attacker-controlled `To:`/`Cc:` headers are never used to *select* a provisioned mailbox.
- **Fail closed:** when the envelope recipient has no mailbox, fall through to catch-all *for its own domain* (or drop+log) — never misfile into a different mailbox named by the header.
- **Trust boundary:** only the *topmost* `Received` header is read, so a forged lower `Received: ... for <victim@owned>` cannot redirect delivery.
- Single-recipient / no-`Received` behavior is unchanged; `resolveCatchall` and the EMAIL_ADDRESSES-empty branch are preserved.

No `app.ts` change is needed — the raw stream already carries the `Received` header, and `normalizeInbound` parses it.

## Tests (TDD — written failing first)

New regression tests in `tests/routes/catchall.test.ts` (mirroring the existing `normalizeInbound` suite), all green:

- `To: A, Cc: B` → copy for B files to B, copy for A files to A
- `To: A, Bcc: C` → copy for C files to C; A never receives it
- `To: [A, B]` → copy for the second To address files to it
- envelope recipient with no mailbox + `To:` names a provisioned mailbox → **drops**, never misfiles
- EMAIL_ADDRESSES allow-list: copy for B matched against B, not `To[0]`
- top-vs-lower `Received` trust boundary (forged lower `for` ignored; top with no `for` falls back to `event.to`)

## Verification

- `npm test` — **1549 passing, 0 failing** (118 files)
- `npm run typecheck` — exit 0

## Out of scope

- MCP cc/bcc/multi-recipient tool gap (#495)
- LLM "classifier unavailable" (#496)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
