### PR TITLE
fix(security): parse non-string Workers AI classifier responses (#500)

### DIFF
--- a/test/security/classification.test.ts
+++ b/test/security/classification.test.ts
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
 	__setClassifier,
 	classifyEmail,
+	parseClassifierOutput,
 	sanitizeForClassifier,
 	scoreClassification,
 	type ClassificationResult,
@@ -123,6 +124,91 @@ describe("classifyEmail — narrowed Rule 5 (issue #28)", () => {
 		const result = await classifyEmail(FAKE_AI, baseInput);
 		expect(result.label).toBe("suspicious");
 		expect(result.confidence).toBe(0.85);
+	});
+});
+
+describe("classifyEmail — non-string ai.run response shape (issue #500)", () => {
+	afterEach(() => {
+		__setClassifier(null);
+	});
+
+	it("regression: ai.run returns the verdict as a parsed OBJECT under .response → real label, not 'error'", async () => {
+		// Live prod (2026-06-18, after #498) showed every email returning
+		// label='error' with "raw.trim is not a function". The root cause is
+		// that @cf/meta/llama-3.1-8b-instruct-fast returns `response` as an
+		// already-parsed object, not a JSON string. The old code cast it to
+		// `{ response?: string }` and called `.trim()` on the object.
+		const ai = {
+			run() {
+				return Promise.resolve({
+					response: { label: "phishing", confidence: 0.92, reasoning: "credential-harvest link" },
+				});
+			},
+		} as unknown as Ai;
+
+		const result = await classifyEmail(ai, baseInput);
+		expect(result.label).toBe("phishing");
+		expect(result.label).not.toBe("error");
+		expect(result.confidence).toBe(0.92);
+	});
+
+	it("classic string `.response` shape still classifies (no regression)", async () => {
+		const ai = {
+			run() {
+				return Promise.resolve({
+					response: '{"label":"safe","confidence":0.95,"reasoning":"routine"}',
+				});
+			},
+		} as unknown as Ai;
+
+		const result = await classifyEmail(ai, baseInput);
+		expect(result.label).toBe("safe");
+		expect(result.confidence).toBe(0.95);
+	});
+
+	it("a successful (non-throwing) response never produces label='error'", async () => {
+		// Fail-closed 'error' is reserved for genuine ai.run throws. A
+		// successful call with an odd shape must degrade to a real parsed label
+		// (or 'suspicious' fallback), never 'error'.
+		const ai = {
+			run() {
+				return Promise.resolve({
+					response: { label: "bec", confidence: 0.8, reasoning: "wire-transfer request" },
+				});
+			},
+		} as unknown as Ai;
+
+		const result = await classifyEmail(ai, baseInput);
+		expect(result.label).not.toBe("error");
+		expect(result.label).toBe("bec");
+	});
+});
+
+describe("parseClassifierOutput — non-string hardening (issue #500)", () => {
+	it("does not throw on an object verdict; extracts the label", () => {
+		const result = parseClassifierOutput({
+			label: "phishing",
+			confidence: 0.9,
+			reasoning: "fake login page",
+		});
+		expect(result.label).toBe("phishing");
+		expect(result.confidence).toBe(0.9);
+	});
+
+	it("does not throw on a bare non-string (number) — degrades to suspicious", () => {
+		const result = parseClassifierOutput(12345 as unknown as string);
+		expect(result.label).toBe("suspicious");
+	});
+
+	it("does not throw on null/undefined — degrades to suspicious", () => {
+		expect(parseClassifierOutput(null as unknown as string).label).toBe("suspicious");
+		expect(parseClassifierOutput(undefined as unknown as string).label).toBe("suspicious");
+	});
+
+	it("still parses a plain JSON string (existing behavior preserved)", () => {
+		const result = parseClassifierOutput('{"label":"spam","confidence":0.6,"reasoning":"bulk"}');
+		expect(result.label).toBe("spam");
+		expect(result.confidence).toBe(0.6);
 	});
 });
 

--- a/workers/security/classification.ts
+++ b/workers/security/classification.ts
@@ -177,7 +177,14 @@ ${sanitizedBody}
 			return await overrideClassifier(ai, input);
 		}
 
-		const response = (await Promise.race([
+		// NOTE: the result is intentionally typed `unknown`. The old
+		// `as { response?: string }` cast was a lie — at runtime
+		// @cf/meta/llama-3.1-8b-instruct-fast returns the model's verdict as an
+		// already-parsed object under `.response`, not a JSON string, so every
+		// email tripped `raw.trim is not a function` and fell into the
+		// fail-closed `error` path (issue #500). `extractClassifierText`
+		// normalizes the shape before parsing.
+		const response: unknown = await Promise.race([
 			ai.run(
 				model as Parameters<typeof ai.run>[0],
 				{
@@ -192,9 +199,9 @@ ${sanitizedBody}
 			new Promise((_, reject) =>
 				setTimeout(() => reject(new Error("classify-timeout")), 5000),
 			),
-		])) as { response?: string };
+		]);
 
-		return parseClassifierOutput(response?.response ?? "");
+		return parseClassifierOutput(extractClassifierText(response));
 	} catch (e) {
 		// Capture the real error text regardless of whether e is an Error
 		// instance — Workers AI can throw plain strings or Response objects.
@@ -222,8 +229,70 @@ ${sanitizedBody}
 	}
 }
 
-function parseClassifierOutput(raw: string): ClassificationResult {
-	const trimmed = raw.trim();
+/**
+ * Coerce any value to a string without throwing. Workers AI responses are
+ * always JSON-serializable, but guard `JSON.stringify` anyway (BigInt /
+ * circular refs throw) so a successful-but-exotic shape degrades gracefully
+ * instead of crashing into the fail-closed `error` path.
+ */
+function safeStringify(value: unknown): string {
+	try {
+		return JSON.stringify(value) ?? "";
+	} catch {
+		return "";
+	}
+}
+
+/**
+ * Normalize the Workers AI `ai.run` return value to the model's text output.
+ *
+ * The documented/typed shape is `{ response: string }`, but at runtime
+ * @cf/meta/llama-3.1-8b-instruct-fast returns `response` as an already-parsed
+ * object (the verdict JSON the prompt asked for), which the old code passed
+ * straight into `raw.trim()` and threw on (issue #500). This handles every
+ * plausible successful shape and returns "" for anything unrecognized so the
+ * downstream parser can degrade to `suspicious` rather than fail closed.
+ *
+ * Exported as a test seam (same pattern as `sanitizeForClassifier`).
+ */
+export function extractClassifierText(response: unknown): string {
+	if (typeof response === "string") return response;
+	if (response && typeof response === "object") {
+		const obj = response as Record<string, unknown>;
+		// Standard Workers AI text-generation shape: `{ response: ... }`.
+		if ("response" in obj) {
+			const inner = obj.response;
+			if (typeof inner === "string") return inner;
+			// `response` arrived as a parsed object (the #500 root cause) — or
+			// any other non-string. Re-serialize so the JSON-block matcher in
+			// parseClassifierOutput can recover the verdict.
+			if (inner != null) return safeStringify(inner);
+		}
+		// OpenAI-compatible chat-completion shape, in case a future model maps
+		// onto it: `{ choices: [{ message: { content: string } }] }`.
+		const choices = obj.choices;
+		if (Array.isArray(choices) && choices.length > 0) {
+			const content = (choices[0] as { message?: { content?: unknown } })?.message?.content;
+			if (typeof content === "string") return content;
+		}
+	}
+	return "";
+}
+
+/**
+ * Parse the classifier's text output into a structured verdict.
+ *
+ * Accepts `unknown`: a successful `ai.run` call can hand back a non-string
+ * (issue #500), and a hard `raw.trim()` on it would throw and be misreported
+ * as a classifier `error`. Coerce non-strings via JSON serialization so an
+ * embedded verdict object is still recovered, and so a future shape change
+ * degrades to `suspicious` instead of crashing.
+ *
+ * Exported as a test seam (same pattern as `sanitizeForClassifier`).
+ */
+export function parseClassifierOutput(raw: unknown): ClassificationResult {
+	const text = typeof raw === "string" ? raw : raw == null ? "" : safeStringify(raw);
+	const trimmed = text.trim();
 	// Try to locate the first { ... } block if the model wrapped it.
 	const match = trimmed.match(/\{[\s\S]*\}/);
 	if (!match) {


### PR DESCRIPTION
Closes #500.

## Problem

After #498 surfaced classifier errors, **every** inbound email returned:

```json
{ "label": "error", "confidence": 0.3, "reasoning": "classifier error: raw.trim is not a function" }
```

with an `llm_error` signal — the LLM stage contributed a fail-closed score on every message instead of a real content-derived verdict.

## Root cause (confirmed by reproduction)

`classifyEmail` cast the `ai.run` result with `as { response?: string }` and passed `response?.response ?? ""` into `parseClassifierOutput`, whose first line is `raw.trim()`.

For `.trim()` to throw, `response.response` must be a **truthy non-string** (if it were missing/null, `?? ""` would yield `""` and `.trim()` would succeed). At runtime `@cf/meta/llama-3.1-8b-instruct-fast` returns its verdict as an **already-parsed object** under `.response`, not the JSON string the cast claimed — input-independent, matching the identical error on all five live samples. The cast hid the real shape from the type checker, so a *successful* response was misreported as a fail-closed classifier `error`.

A new test reproduces the exact failure (`classifyEmail failed: raw.trim is not a function` → `label='error'`) before the fix.

## Fix

- Drop the false `as { response?: string }` cast; type the `ai.run` result `unknown`.
- Add `extractClassifierText(response)` — unwraps the Workers AI envelope across plausible successful shapes (string `.response`, **object `.response`** ← the #500 case, OpenAI-style `choices[].message.content`) and returns `""` for anything unrecognized.
- Harden `parseClassifierOutput` to accept `unknown` and coerce non-strings via JSON serialization, so an embedded verdict object is still recovered and a *future* shape change degrades to `suspicious` instead of crashing.
- **Fail-closed semantics preserved**: a genuine `ai.run` throw still returns `label="error"`; only a *successful* non-string response is now parsed. No security posture change.

## Tests (TDD — failing first, then fix)

- **Regression (AC3):** mocks `ai.run` returning the real object shape `{ response: { label, confidence, reasoning } }` and asserts a real parsed label (`phishing`/`bec`), not `error`.
- **`parseClassifierOutput` hardening (AC2):** feeds it the object verdict (extracts the label, no throw) and bare non-strings (number / null / undefined → degrades to `suspicious`, no throw).
- No-regression: classic string `.response` shape still parses.

```
npm test       → 1571 passing, 0 failing (118 files)
npm run typecheck → exit 0
```

## Out of scope / follow-up

The same `response?.response` assumption exists in `workers/lib/ai.ts` (`isPromptInjection`, `verifyDraft`, `summarizeCase`) — same root cause, different symptoms (blocked auto-drafts / blank drafts / null case summaries). Left untouched per the issue's "don't change unrelated pipeline stages"; will flag a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)