### PR TITLE
fix(classification): handle non-string ai.run response — fixes TypeError on every email

### DIFF
--- a/test/security/classification.test.ts
+++ b/test/security/classification.test.ts
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
 	__setClassifier,
 	classifyEmail,
+	parseClassifierOutput,
 	sanitizeForClassifier,
 	scoreClassification,
 	type ClassificationResult,
@@ -357,5 +358,90 @@ describe("scoreClassification — unavailable contributes 0", () => {
 	it("safe verdict still contributes 0 with no reasons", () => {
 		const result: ClassificationResult = { label: "safe", confidence: 1, reasoning: "" };
 		expect(scoreClassification(result)).toMatchObject({ score: 0, reasons: [], confidence: 1 });
+	});
+});
+
+describe("parseClassifierOutput — non-string coercion (issue #500)", () => {
+	it("accepts a string and parses the JSON verdict normally", () => {
+		const result = parseClassifierOutput('{"label":"phishing","confidence":0.9,"reasoning":"credential harvest"}');
+		expect(result.label).toBe("phishing");
+		expect(result.confidence).toBe(0.9);
+	});
+
+	it("accepts an object (Workers AI auto-parsed JSON) and extracts the label", () => {
+		// @cf/meta/llama-3.1-8b-instruct-fast returns response.response as a parsed
+		// JSON object rather than a raw string, causing raw.trim() to throw. This test
+		// pins the fix: stringify the object and parse the embedded JSON block.
+		const parsedByWorkersAI = { label: "phishing", confidence: 0.92, reasoning: "credential-harvest pattern" };
+		const result = parseClassifierOutput(parsedByWorkersAI);
+		expect(result.label).toBe("phishing");
+		expect(result.confidence).toBe(0.92);
+		expect(result.reasoning).toContain("credential-harvest");
+	});
+
+	it("accepts null → returns suspicious (graceful degradation)", () => {
+		const result = parseClassifierOutput(null);
+		expect(result.label).toBe("suspicious");
+	});
+
+	it("accepts undefined → returns suspicious (graceful degradation)", () => {
+		const result = parseClassifierOutput(undefined);
+		expect(result.label).toBe("suspicious");
+	});
+
+	it("accepts a non-JSON object → returns suspicious, does not throw", () => {
+		expect(() => parseClassifierOutput({ unexpected: true })).not.toThrow();
+		expect(parseClassifierOutput({ unexpected: true }).label).toBe("suspicious");
+	});
+});
+
+describe("classifyEmail — ai.run object response regression (issue #500)", () => {
+	// Regression: ai.run returns response.response as a parsed JSON object
+	// (truthy, non-string) rather than a raw string. Prior code called raw.trim()
+	// and threw TypeError on every email. Fix: parseClassifierOutput coerces.
+	function makeMockAiWithObjectResponse(responseObj: unknown): Ai {
+		return {
+			run(_model: string, _params: unknown) {
+				return Promise.resolve({ response: responseObj });
+			},
+		} as unknown as Ai;
+	}
+
+	afterEach(() => {
+		__setClassifier(null);
+	});
+
+	it("returns a real label when ai.run yields response.response as a parsed object", async () => {
+		const ai = makeMockAiWithObjectResponse({
+			label: "phishing",
+			confidence: 0.9,
+			reasoning: "credential-harvest link detected",
+		});
+		const result = await classifyEmail(ai, baseInput);
+		expect(result.label).toBe("phishing");
+		expect(result.label).not.toBe("error");
+		expect(result.confidence).toBe(0.9);
+	});
+
+	it("returns safe when ai.run yields a safe verdict object", async () => {
+		const ai = makeMockAiWithObjectResponse({
+			label: "safe",
+			confidence: 0.98,
+			reasoning: "routine correspondence",
+		});
+		const result = await classifyEmail(ai, baseInput);
+		expect(result.label).toBe("safe");
+	});
+
+	it("does not emit llm_error when ai.run returns a parseable object response", async () => {
+		const ai = makeMockAiWithObjectResponse({
+			label: "spam",
+			confidence: 0.75,
+			reasoning: "bulk marketing",
+		});
+		const result = await classifyEmail(ai, baseInput);
+		expect(result.label).not.toBe("error");
+		const { reasons } = scoreClassification(result);
+		expect(reasons).not.toContain("llm_error");
 	});
 });

--- a/workers/security/classification.ts
+++ b/workers/security/classification.ts
@@ -192,9 +192,9 @@ ${sanitizedBody}
 			new Promise((_, reject) =>
 				setTimeout(() => reject(new Error("classify-timeout")), 5000),
 			),
-		])) as { response?: string };
+		])) as { response?: unknown };
 
-		return parseClassifierOutput(response?.response ?? "");
+		return parseClassifierOutput((response as { response?: unknown })?.response);
 	} catch (e) {
 		// Capture the real error text regardless of whether e is an Error
 		// instance — Workers AI can throw plain strings or Response objects.
@@ -222,8 +222,19 @@ ${sanitizedBody}
 	}
 }
 
-function parseClassifierOutput(raw: string): ClassificationResult {
-	const trimmed = raw.trim();
+export function parseClassifierOutput(raw: unknown): ClassificationResult {
+	// Workers AI may return a parsed-JSON object in `response.response` rather
+	// than a raw string (observed with @cf/meta/llama-3.1-8b-instruct-fast).
+	// Coerce to string before trimming so we never hit "raw.trim is not a function".
+	let rawStr: string;
+	if (typeof raw === "string") {
+		rawStr = raw;
+	} else if (raw != null) {
+		rawStr = typeof raw === "object" ? JSON.stringify(raw) : String(raw);
+	} else {
+		rawStr = "";
+	}
+	const trimmed = rawStr.trim();
 	// Try to locate the first { ... } block if the model wrapped it.
 	const match = trimmed.match(/\{[\s\S]*\}/);
 	if (!match) {


### PR DESCRIPTION
## Summary

- `parseClassifierOutput` now accepts `unknown` instead of `string`; objects are coerced via `JSON.stringify` so the embedded JSON block is still found and parsed even when Workers AI returns a pre-parsed object in `response.response`.
- Drops the false `as { response?: string }` cast at the `classifyEmail` call site.
- Exports `parseClassifierOutput` for direct unit testing.

Closes #500.

## Root cause

`@cf/meta/llama-3.1-8b-instruct-fast` returns `response.response` as a parsed JSON object (truthy, non-string). The `?? ""` fallback never fires (truthy objects pass it), so `parseClassifierOutput` received the object, called `.trim()` on it, and threw `TypeError: raw.trim is not a function` on every email. The catch block surfaced this as `classification.label = "error"`.

## Test plan

- [x] `npm test` — 1572 passing, 0 failing
- [x] `npm run typecheck` — clean
- [x] Unit tests: `parseClassifierOutput` with object input, null, undefined, non-JSON object
- [x] Regression tests: `classifyEmail` with `ai.run` mocked to return `{ response: <parsedObject> }` → asserts real label, not `error`, no `llm_error` signal


---
_Generated by [Claude Code](https://claude.ai/code/session_01WciPia8cqsJbzpav9gPciB)_