### PR TITLE
fix(send): clean 400 on invalid recipients instead of 500

### DIFF
--- a/app/hooks/useComposeForm.ts
+++ b/app/hooks/useComposeForm.ts
@@ -229,10 +229,14 @@ export function useComposeForm(mailboxId?: string, _folder?: string) {
 		const timer = setTimeout(async () => {
 			setIsPreflighting(true);
 			try {
+				// Normalise the same way the send path does so the live risk
+				// preview validates the exact payload the send will use — a
+				// multi-address Cc/Bcc must be sent as an array, not a raw
+				// comma-joined string (which fails per-address email validation).
 				const result = await api.preflightEmail(mailboxId, {
-					to,
-					cc: cc || undefined,
-					bcc: bcc || undefined,
+					to: toEmailListValue(splitEmailList(to)),
+					cc: toEmailListValue(splitEmailList(cc)),
+					bcc: toEmailListValue(splitEmailList(bcc)),
 					from: mailboxId,
 					subject: latestSubjectRef.current || ".",
 					text: htmlToPlainText(latestBodyRef.current) || " ",
@@ -276,7 +280,7 @@ export function useComposeForm(mailboxId?: string, _folder?: string) {
 		e.preventDefault(); if (isSending) return; setError(null);
 		if (!currentMailbox || !mailboxId) { setError("No mailbox selected."); return; }
 		const toRecipients = splitEmailList(to);
-		if (toRecipients.length === 0) { setError("Add at least one recipient."); return; }
+		if (toRecipients.length === 0) { setError("Add a To: recipient."); return; }
 
 		const sendTier = preflight?.tier ?? 0;
 		if (sendTier >= 2) {

--- a/tests/frontend/compose-send-risk.test.tsx
+++ b/tests/frontend/compose-send-risk.test.tsx
@@ -218,6 +218,35 @@ describe("Composer send-risk UI (#263)", () => {
 		});
 	});
 
+	// ── Regression: preflight normalises multi-address Cc/Bcc to arrays ───────
+	// A comma-joined Bcc string fails per-address email validation server-side
+	// (ZodError → 500); the live preview must send the same array the send does.
+
+	describe("Preflight recipient normalisation", () => {
+		it("sends a multi-address Bcc as an array, not a comma-joined string", async () => {
+			preflightMock.mockResolvedValue({ tier: 0, reasons: [] });
+			const user = userEvent.setup();
+			renderPanel();
+
+			await user.type(
+				screen.getByPlaceholderText(/recipient@example.com/i),
+				"primary@example.com",
+			);
+			await user.click(screen.getByRole("button", { name: /cc \/ bcc/i }));
+			await user.type(
+				screen.getByLabelText(/^BCC$/i),
+				"one@example.com, two@example.com",
+			);
+
+			await waitFor(() => expect(preflightMock).toHaveBeenCalled(), { timeout: 2000 });
+
+			const lastCall = preflightMock.mock.calls.at(-1);
+			const payload = lastCall?.[1] as { to: unknown; bcc: unknown };
+			expect(payload.to).toBe("primary@example.com");
+			expect(payload.bcc).toEqual(["one@example.com", "two@example.com"]);
+		});
+	});
+
 	// ── Acceptance: preflight network failure does not block send ────────────
 
 	describe("Preflight network failure fallback", () => {

--- a/tests/lib/send-email-validation.test.ts
+++ b/tests/lib/send-email-validation.test.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Unit tests for describeRecipientValidationError — the helper that turns a
+ * SendEmailRequestSchema ZodError into a clear, user-facing message so that
+ * invalid recipient input surfaces as a friendly 400 instead of an opaque 500.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	SendEmailRequestSchema,
+	describeRecipientValidationError,
+} from "../../workers/lib/schemas";
+
+function messageFor(body: Record<string, unknown>): string {
+	const parsed = SendEmailRequestSchema.safeParse(body);
+	expect(parsed.success).toBe(false);
+	if (parsed.success) throw new Error("expected validation failure");
+	return describeRecipientValidationError(parsed.error);
+}
+
+const VALID = {
+	to: "alice@example.com",
+	from: "me@example.com",
+	subject: "hi",
+	text: "body",
+};
+
+describe("describeRecipientValidationError", () => {
+	it("asks for a To: recipient when to is missing", () => {
+		const body = { ...VALID } as Record<string, unknown>;
+		delete body.to;
+		expect(messageFor(body)).toMatch(/to:/i);
+	});
+
+	it("asks for a To: recipient when to is an invalid email", () => {
+		expect(messageFor({ ...VALID, to: "nope" })).toMatch(/to:/i);
+	});
+
+	it("names bcc when only bcc is a malformed email", () => {
+		const msg = messageFor({ ...VALID, bcc: "not-an-email" });
+		expect(msg).toMatch(/bcc/i);
+		expect(msg).not.toMatch(/to:/i);
+	});
+
+	it("names cc when only cc is a malformed email", () => {
+		const msg = messageFor({ ...VALID, cc: "not-an-email" });
+		expect(msg).toMatch(/cc/i);
+	});
+
+	it("passes through the body requirement when neither html nor text is given", () => {
+		const body = { to: "alice@example.com", from: "me@example.com", subject: "hi" };
+		expect(messageFor(body)).toMatch(/html|text/i);
+	});
+});

--- a/tests/routes/send-email.test.ts
+++ b/tests/routes/send-email.test.ts
@@ -231,3 +231,88 @@ describe("POST /emails/preflight", () => {
 		expect(json.tier).toBe(2);
 	});
 });
+
+// ── Validation errors return 400, never 500 (issue: CC/BCC-only 500) ────────────
+
+describe("invalid recipient input → 400 (never 500)", () => {
+	it("POST /emails with a malformed bcc returns 400 with a clear message", async () => {
+		const createEmailCalls: unknown[] = [];
+		currentStub = makeStub({
+			createEmail: async (...args: unknown[]) => { createEmailCalls.push(args); return {}; },
+		});
+		const { fetch } = makeApp();
+		const res = await fetch(
+			`/api/v1/mailboxes/${encodeURIComponent(MAILBOX_ID)}/emails`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(sendBody({ bcc: "not-an-email" })),
+			},
+		);
+		expect(res.status).toBe(400);
+		const json = await res.json() as { error: string };
+		expect(json.error).toMatch(/bcc/i);
+		// Nothing was stored for an invalid send.
+		expect(createEmailCalls).toHaveLength(0);
+	});
+
+	it("POST /emails with no To: returns 400 asking for a To: recipient", async () => {
+		const { fetch } = makeApp();
+		const body = sendBody();
+		delete (body as Record<string, unknown>).to;
+		const res = await fetch(
+			`/api/v1/mailboxes/${encodeURIComponent(MAILBOX_ID)}/emails`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(body),
+			},
+		);
+		expect(res.status).toBe(400);
+		const json = await res.json() as { error: string };
+		expect(json.error).toMatch(/to:/i);
+	});
+
+	it("POST /emails/preflight with a malformed bcc returns 400, not 500", async () => {
+		const { fetch } = makeApp();
+		const res = await fetch(
+			`/api/v1/mailboxes/${encodeURIComponent(MAILBOX_ID)}/emails/preflight`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(sendBody({ bcc: "not-an-email" })),
+			},
+		);
+		expect(res.status).toBe(400);
+		const json = await res.json() as { error: string };
+		expect(json.error).toMatch(/bcc/i);
+	});
+
+	it("POST /emails with a valid array bcc still succeeds (202)", async () => {
+		const { fetch } = makeApp();
+		const res = await fetch(
+			`/api/v1/mailboxes/${encodeURIComponent(MAILBOX_ID)}/emails`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(
+					sendBody({ bcc: ["one@internal.example", "two@internal.example"] }),
+				),
+			},
+		);
+		expect(res.status).toBe(202);
+	});
+
+	it("POST /emails with malformed JSON returns 400, not 500", async () => {
+		const { fetch } = makeApp();
+		const res = await fetch(
+			`/api/v1/mailboxes/${encodeURIComponent(MAILBOX_ID)}/emails`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: "{ not json",
+			},
+		);
+		expect(res.status).toBe(400);
+	});
+});

--- a/workers/lib/schemas.ts
+++ b/workers/lib/schemas.ts
@@ -95,3 +95,50 @@ export const SendEmailResponseSchema = z.object({
 	id: z.string(),
 	status: z.string(),
 });
+
+/**
+ * Turn a {@link SendEmailRequestSchema} validation failure into a short,
+ * user-facing message. Send/preflight/reply/forward handlers use this to
+ * return a clear 400 instead of letting a raw `ZodError` bubble up as a 500
+ * when a recipient field is missing or malformed (e.g. a partial address or a
+ * comma-joined string typed into To:/Cc:/Bcc:).
+ */
+export function describeRecipientValidationError(error: z.ZodError): string {
+	const issues = error.issues;
+	const offending = (["to", "cc", "bcc"] as const).filter((field) =>
+		issues.some((issue) => issue.path[0] === field),
+	);
+
+	// A missing or invalid To: is the most common cause; call it out explicitly
+	// since To: is required (Cc/Bcc-only sends are intentionally blocked).
+	if (offending.includes("to")) {
+		const others = offending.filter((field) => field !== "to");
+		const tail = others.length ? ` Also check: ${others.join(", ")}.` : "";
+		return `A valid To: recipient is required.${tail}`;
+	}
+	if (offending.length > 0) {
+		return `Invalid email address in: ${offending.join(", ")}. Use comma-separated addresses.`;
+	}
+
+	// Top-level refine (e.g. "Either 'html' or 'text' must be provided").
+	const topLevel = issues.find((issue) => issue.path.length === 0);
+	if (topLevel) return topLevel.message;
+
+	return issues[0]?.message ?? "Invalid request payload.";
+}
+
+/**
+ * Validate a raw request body against {@link SendEmailRequestSchema}, returning
+ * either the parsed payload or a clear error message. Shared by the send,
+ * preflight, reply, and forward handlers so a malformed recipient yields a 400
+ * with a useful message rather than an unhandled `ZodError` (HTTP 500).
+ */
+export function parseSendEmailRequest(
+	raw: unknown,
+):
+	| { ok: true; data: z.infer<typeof SendEmailRequestSchema> }
+	| { ok: false; error: string } {
+	const parsed = SendEmailRequestSchema.safeParse(raw);
+	if (parsed.success) return { ok: true, data: parsed.data };
+	return { ok: false, error: describeRecipientValidationError(parsed.error) };
+}

--- a/workers/routes/reply-forward.ts
+++ b/workers/routes/reply-forward.ts
@@ -14,7 +14,7 @@ import {
 	buildThreadingHeaders,
 	resolveOriginalEmail,
 } from "../lib/email-helpers";
-import { SendEmailRequestSchema } from "../lib/schemas";
+import { parseSendEmailRequest } from "../lib/schemas";
 import { enforceSendRiskConfirmation } from "../lib/send-risk-gate";
 import { resolveCreatedByFromDraft } from "../lib/send-risk-draft";
 import { Folders } from "../../shared/folders";
@@ -26,8 +26,9 @@ type RateLimitStub = { checkSendRateLimit: () => Promise<string | null> };
 export async function handleReplyEmail(c: AppContext) {
 	const mailboxId = c.req.param("mailboxId") ?? "";
 	const id = c.req.param("id") ?? "";
-	const body = SendEmailRequestSchema.parse(await c.req.json());
-	const { to, cc, bcc, from, subject, html, text, attachments, draft_id } = body;
+	const parsed = parseSendEmailRequest(await c.req.json().catch(() => null));
+	if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+	const { to, cc, bcc, from, subject, html, text, attachments, draft_id } = parsed.data;
 
 	const stub = c.var.mailboxStub;
 	const createdBy = await resolveCreatedByFromDraft(stub, draft_id);
@@ -134,8 +135,9 @@ export async function handleReplyEmail(c: AppContext) {
 export async function handleForwardEmail(c: AppContext) {
 	const mailboxId = c.req.param("mailboxId") ?? "";
 	const id = c.req.param("id") ?? "";
-	const body = SendEmailRequestSchema.parse(await c.req.json());
-	const { to, cc, bcc, from, subject, html, text, attachments, draft_id } = body;
+	const parsed = parseSendEmailRequest(await c.req.json().catch(() => null));
+	if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+	const { to, cc, bcc, from, subject, html, text, attachments, draft_id } = parsed.data;
 
 	const stub = c.var.mailboxStub;
 	const createdBy = await resolveCreatedByFromDraft(stub, draft_id);

--- a/workers/routes/send-email.ts
+++ b/workers/routes/send-email.ts
@@ -14,7 +14,7 @@ import {
 	generateMessageId,
 	buildThreadingHeaders,
 } from "../lib/email-helpers";
-import { SendEmailRequestSchema } from "../lib/schemas";
+import { parseSendEmailRequest } from "../lib/schemas";
 import { classifySend } from "../security/send-risk";
 import { enforceSendRiskConfirmation } from "../lib/send-risk-gate";
 import { resolveCreatedByFromDraft } from "../lib/send-risk-draft";
@@ -27,8 +27,9 @@ sendEmailRoutes.use("*", requireMailbox);
 
 sendEmailRoutes.post("/emails/preflight", async (c) => {
 	const mailboxId = c.req.param("mailboxId")!;
-	const body = SendEmailRequestSchema.parse(await c.req.json());
-	const { to, cc, bcc, subject, html, text, attachments, draft_id } = body;
+	const parsed = parseSendEmailRequest(await c.req.json().catch(() => null));
+	if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+	const { to, cc, bcc, subject, html, text, attachments, draft_id } = parsed.data;
 	const createdBy = await resolveCreatedByFromDraft(c.var.mailboxStub, draft_id);
 	const risk = classifySend({
 		to, cc, bcc, subject,
@@ -42,8 +43,9 @@ sendEmailRoutes.post("/emails/preflight", async (c) => {
 
 sendEmailRoutes.post("/emails", async (c) => {
 	const mailboxId = c.req.param("mailboxId")!;
-	const body = SendEmailRequestSchema.parse(await c.req.json());
-	const { to, cc, bcc, from, subject, html, text, attachments, in_reply_to, references, thread_id, draft_id } = body;
+	const parsed = parseSendEmailRequest(await c.req.json().catch(() => null));
+	if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+	const { to, cc, bcc, from, subject, html, text, attachments, in_reply_to, references, thread_id, draft_id } = parsed.data;
 
 	let toStr: string, fromEmail: string, fromDomain: string;
 	try {


### PR DESCRIPTION
## Problem

Sending an email — or just typing in the composer — with only a Cc/Bcc, or with a malformed recipient field, returned an **HTTP 500** on `POST /api/v1/mailboxes/:id/emails/preflight` (and `/emails`):

```json
[{ "validation": "email", "code": "invalid_string", "message": "Invalid email", "path": ["to"] },
 { "validation": "email", "code": "invalid_string", "message": "Invalid email", "path": ["bcc"] }]
```

The reporter confirmed it fired even with a **valid** `bugs@cortech.online` in To: — so it isn't really about the missing To:, it's the **Cc/Bcc field content failing validation** and `.parse()` turning that into a 500.

## Root cause

1. The four send-family handlers (`/emails`, `/emails/preflight`, reply, forward) used `SendEmailRequestSchema.parse()`, which **throws** a `ZodError`. There is no `onError` handler in the Hono app, so any validation failure became an unhandled exception → **500**.
2. The composer's debounced preflight sent the **raw, unsplit** `to`/`cc`/`bcc` strings ([`useComposeForm.ts`](app/hooks/useComposeForm.ts)). A legitimate two-address Bcc (`"a@x.com, b@y.com"`) is neither a valid single email nor an array, so it failed validation — reproducing the 500 during normal typing even with a valid To:.

## Decision

Per discussion, **Cc/Bcc-only sends stay blocked by design** — the Cloudflare Email Service binding lists `to` as a required field (`E_FIELD_MISSING`), so a truly To-less message would be rejected at delivery (and the send is fire-and-forget, so the user would falsely see "sent"). The fix is to **never 500**: return a clear 400 instead, and stop legitimate multi-recipient input from failing.

## Changes

- **`workers/lib/schemas.ts`** — `parseSendEmailRequest()` (safeParse wrapper) + `describeRecipientValidationError()` mapping a recipient `ZodError` to a friendly message (`"A valid To: recipient is required."` / `"Invalid email address in: bcc."`).
- **`workers/routes/send-email.ts`**, **`workers/routes/reply-forward.ts`** — route send/preflight/reply/forward through the helper; invalid input *and* malformed JSON now return `400 {error}` instead of 500. The `{error}` surfaces directly in the composer toast via `ApiError`.
- **`app/hooks/useComposeForm.ts`** — normalise the preflight payload with `toEmailListValue(splitEmailList(...))` (matches the send path), and tighten the empty-To guard message to `"Add a To: recipient."`.

## Tests

- Route tests: 400-not-500 for malformed bcc, missing to, and malformed JSON; valid send still 202 / preflight still 200; nothing stored on a rejected send.
- Unit test for the message helper.
- Frontend regression test: a multi-address Bcc is sent to preflight as an **array**, not a comma-joined string.

**Gates:** `npm test` → 1598 passing, 0 failing (120 files). `npm run typecheck` → clean (tsc exit 0).

## Out of scope / possible follow-up

Other endpoints that still use `.parse()` on request bodies (`POST /mailboxes`, the draft endpoint in `workers/index.ts`) share the same 500-on-bad-input footgun. Not touched here to keep the change focused; happy to file a follow-up issue to route them through the same safe-parse pattern (or add a global `onError` ZodError→400 handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)