### PR TITLE
feat(webauthn): reap expired step-up challenges via hourly cron (#376)

### DIFF
--- a/tests/workers/webauthn-store.test.ts
+++ b/tests/workers/webauthn-store.test.ts
@@ -3,10 +3,11 @@
 // M1 (#376): D1-backed WebAuthn credential + challenge store. Runs in real
 // workerd so `DELETE … RETURNING` atomicity and BLOB round-tripping match prod.
 import { env } from "cloudflare:test";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
 	consumeChallenge,
 	createCredential,
+	deleteExpiredChallenges,
 	getByCredentialId,
 	listBySub,
 	putChallenge,
@@ -118,5 +119,56 @@ describe("webauthn-store: challenges (atomic single-use consume)", () => {
 		const got = await consumeChallenge(db(), "chal-reg", 1_700_000_000_000);
 		expect(got!.type).toBe("registration");
 		expect(got!.payloadHash).toBeNull();
+	});
+});
+
+describe("webauthn-store: deleteExpiredChallenges (cron reap)", () => {
+	// D1 storage persists across tests in this workers-pool suite (the other
+	// suites lean on unique keys for the same reason), and the reap is a
+	// table-wide DELETE — so to assert exact counts/snapshots we start each
+	// test from a known-empty challenges table.
+	beforeEach(async () => {
+		await db().prepare("DELETE FROM webauthn_challenges").run();
+	});
+
+	// List the challenge keys still present, so we can assert exactly which rows
+	// survived the reap rather than relying on consumeChallenge's own expiry gate.
+	async function remainingChallenges(): Promise<string[]> {
+		const { results } = await db()
+			.prepare("SELECT challenge FROM webauthn_challenges ORDER BY challenge")
+			.all<{ challenge: string }>();
+		return results.map((r) => r.challenge);
+	}
+
+	it("removes only rows with expires_at <= now, leaves live rows, returns the count", async () => {
+		const now = 1_700_000_000_000;
+		// Two already-expired (one strictly past, one exactly at `now` — the
+		// boundary consumeChallenge treats as non-consumable, so it must reap)
+		// and two still-live challenges.
+		await putChallenge(db(), { challenge: "exp-past", userSub: "u", type: "authentication", payloadHash: "h", expiresAt: now - 1 });
+		await putChallenge(db(), { challenge: "exp-boundary", userSub: "u", type: "authentication", payloadHash: "h", expiresAt: now });
+		await putChallenge(db(), { challenge: "live-1", userSub: "u", type: "authentication", payloadHash: "h", expiresAt: now + 1 });
+		await putChallenge(db(), { challenge: "live-2", userSub: "u", type: "registration", payloadHash: null, expiresAt: now + 60_000 });
+
+		const removed = await deleteExpiredChallenges(db(), now);
+		expect(removed).toBe(2);
+		expect(await remainingChallenges()).toEqual(["live-1", "live-2"]);
+
+		// Surviving live rows are still consumable.
+		expect(await consumeChallenge(db(), "live-1", now)).not.toBeNull();
+	});
+
+	it("is idempotent — a second reap with no expired rows returns 0", async () => {
+		const now = 1_700_000_000_000;
+		await putChallenge(db(), { challenge: "idem-expired", userSub: "u", type: "authentication", payloadHash: "h", expiresAt: now - 5 });
+		await putChallenge(db(), { challenge: "idem-live", userSub: "u", type: "authentication", payloadHash: "h", expiresAt: now + 5 });
+
+		expect(await deleteExpiredChallenges(db(), now)).toBe(1);
+		expect(await deleteExpiredChallenges(db(), now)).toBe(0);
+		expect(await remainingChallenges()).toEqual(["idem-live"]);
+	});
+
+	it("returns 0 against an empty table", async () => {
+		expect(await deleteExpiredChallenges(db(), 1_700_000_000_000)).toBe(0);
 	});
 });

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -10,6 +10,7 @@ import { app as apiApp, receiveEmail, receiveCatchall } from "./index";
 import { normalizeInbound } from "./providers/cf-routing";
 import { EmailMCP } from "./mcp";
 import { refreshAllFeeds } from "./intel/feeds";
+import { deleteExpiredChallenges } from "./lib/webauthn-store";
 import { webauthnRoute } from "./routes/webauthn";
 import { callerAllowedForMailbox, emailAgentMailboxIdFromPath } from "./lib/mailbox-acl";
 import {
@@ -194,5 +195,22 @@ export default {
 				(e) => console.error("intel feed refresh failed:", (e as Error).message),
 			),
 		);
+
+		// Reap expired WebAuthn step-up challenges (#376). consumeChallenge only
+		// deletes on a successful consume, so abandoned step-ups leave rows that
+		// never expire out of the table; sweep them hourly. Runs as a separate
+		// waitUntil and swallows its own error so a reap failure (or an unbound
+		// WEBAUTHN_DB in deploys without step-up configured) never breaks the
+		// feed refresh above.
+		if (env.WEBAUTHN_DB) {
+			ctx.waitUntil(
+				deleteExpiredChallenges(env.WEBAUTHN_DB, Date.now()).then(
+					(n) => {
+						if (n > 0) console.log(`webauthn: reaped ${n} expired challenges`);
+					},
+					(e) => console.error("webauthn challenge reap failed:", (e as Error).message),
+				),
+			);
+		}
 	},
 };

--- a/workers/lib/webauthn-store.ts
+++ b/workers/lib/webauthn-store.ts
@@ -173,3 +173,19 @@ export async function consumeChallenge(
 		expiresAt: Number(row.expires_at),
 	};
 }
+
+/**
+ * Reap expired challenges. `consumeChallenge` only deletes on a successful
+ * (non-expired) consume — an abandoned step-up (options requested, assertion
+ * never completed) leaves a row whose `expires_at` has passed but which nothing
+ * ever removes, so the table grows unbounded. The hourly cron calls this to
+ * delete every row with `expires_at <= now`; live rows (`expires_at > now`,
+ * still consumable) are untouched. Returns the number of rows removed.
+ */
+export async function deleteExpiredChallenges(db: D1Database, now: number): Promise<number> {
+	const { meta } = await db
+		.prepare("DELETE FROM webauthn_challenges WHERE expires_at <= ?")
+		.bind(now)
+		.run();
+	return meta.changes ?? 0;
+}


### PR DESCRIPTION
## Problem

The `webauthn_challenges` D1 table (schema in `migrations/webauthn/0001_init.sql`) accumulates dead rows. `consumeChallenge` deletes a challenge only on a successful, non-expired consume:

```sql
DELETE FROM webauthn_challenges WHERE challenge = ? AND expires_at > ? RETURNING *
```

Rows whose `expires_at` has already passed are excluded from that DELETE, so an **abandoned step-up** — the user requested options but never completed the assertion — leaves a row that is never removed. Over time the table grows unbounded.

(This was observed directly while writing the test: the suite's pre-existing expired-challenge row from an earlier test leaked into a global reap, which is exactly the leak this PR closes.)

## Change

- **`workers/lib/webauthn-store.ts`** — add `deleteExpiredChallenges(db, now)`: a table-wide `DELETE FROM webauthn_challenges WHERE expires_at <= ?` that returns `meta.changes` (rows removed). Live rows (`expires_at > now`, still consumable) are untouched. Does not change `consumeChallenge` semantics or the challenge TTL.
- **`workers/app.ts`** — wire it into the existing hourly `scheduled()` cron (`0 * * * *`) as a second `ctx.waitUntil(...)`, guarded so a reap failure is logged but never breaks `refreshAllFeeds`, and skipped cleanly if `env.WEBAUTHN_DB` is unbound.

## Tests

New cases in `tests/workers/webauthn-store.test.ts` (workers-pool / real workerd, so `DELETE` semantics match prod):

- removes only rows with `expires_at <= now` (incl. the `== now` boundary), leaves live rows, surviving rows remain consumable, returns the correct count;
- idempotent — a second reap with no expired rows returns 0;
- returns 0 against an empty table.

The reap is a table-wide DELETE and this suite's D1 storage persists across tests, so each new test starts from a known-empty challenges table via `beforeEach`.

## Verification

- `npm test` — 1626 passed (127 files) ✅
- `npm run typecheck` — clean ✅

## Out of scope

- Credential cleanup (`webauthn_credentials` rows do not expire).
- Changing `consumeChallenge` semantics or the challenge TTL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bwah19ZQSfNjMFVCeHLCvb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bwah19ZQSfNjMFVCeHLCvb)_