### PR TITLE
feat(security): alert operators on first-passkey (TOFU) enrollment

### DIFF
--- a/docs/step-up-auth.md
+++ b/docs/step-up-auth.md
@@ -89,6 +89,7 @@ the token is minted.
 |---|---|
 | `CONFIRMATION_TOKEN_SECRET` | HS256 signing key for the one-shot confirm JWT (`openssl rand -hex 32`) |
 | `TEAM_DOMAIN` / `POLICY_AUD` | Main Cloudflare Access app (unchanged) |
+| `SECURITY_ALERT_WEBHOOK_URL` | **Optional.** Out-of-band webhook for first-passkey (TOFU) enrollment alerts (see §6). When set, a first-key registration POSTs the `webauthn.first_key_registered` audit payload here. When unset, only the `console.log` audit line is emitted. |
 
 > The legacy `STEP_UP_AUD` secret is **no longer used** and should be deleted (see
 > the runbook below).
@@ -164,6 +165,55 @@ to enroll and assert.
 
 Replay the same `x-confirmation-token` on a second send → **401** (`jti` consumed).
 Replay the same WebAuthn assertion → **401** (challenge consumed by `DELETE … RETURNING`).
+
+---
+
+## 6. First-key (TOFU) enrollment alert
+
+The **first** passkey a `sub` enrolls is the highest-risk moment in the whole
+step-up: whoever lands that first credential can thereafter mint confirm tokens
+for that identity's risky sends. There is no prior key to step up against, so the
+first enrollment is trust-on-first-use. To make a surreptitious first-key
+registration *actively* detectable — not just retrospectively greppable —
+`register/verify` does two things on the first key only:
+
+1. **Audit line (always).** Emits the structured
+   `webauthn.first_key_registered` log (`sub`, `email`, `credentialId`,
+   `aaguid`) for retrospective search. This is unconditional.
+2. **Operator notification (when configured).** If the optional
+   `SECURITY_ALERT_WEBHOOK_URL` secret is set, POSTs that same audit payload to
+   the webhook as `application/json`, so the event reaches a pager / SOC channel
+   in real time.
+
+```bash
+wrangler secret put SECURITY_ALERT_WEBHOOK_URL
+# e.g. a Slack/PagerDuty/Sentry inbound webhook, or your own collector
+```
+
+Example payload:
+
+```json
+{
+  "event": "webauthn.first_key_registered",
+  "sub": "a1b2c3d4-…",
+  "email": "operator@example.com",
+  "credentialId": "…",
+  "aaguid": "00000000-0000-0000-0000-000000000000"
+}
+```
+
+**Fire-and-forget by contract.** The notification is dispatched via
+`ctx.waitUntil(...)` (see `workers/lib/security-alert.ts`) and every failure — a
+down endpoint, a timeout (10 s cap), a non-2xx response, or a malformed URL — is
+caught and logged, never propagated. Enrollment still returns
+`{ verified: true }` and the credential is still stored even if the webhook
+throws. Only **first-key** registrations notify; adding a 2nd+ key (which already
+requires a fresh existing-key assertion) does not. When the secret is unset the
+dispatch no-ops and only the audit line is emitted.
+
+> This alert is the operator notification channel referenced by the rollout
+> (§3) and decommissioning runbook (§4) "watch for `webauthn.first_key_registered`"
+> steps — wire the webhook before broad enrollment so the first keys are seen live.
 
 ---
 

--- a/tests/workers/webauthn-register.test.ts
+++ b/tests/workers/webauthn-register.test.ts
@@ -32,7 +32,7 @@ function makeKv() {
 	};
 }
 
-function makeApp(identity: AccessIdentity | null) {
+function makeApp(identity: AccessIdentity | null, opts: { alertWebhookUrl?: string } = {}) {
 	const app = new Hono();
 	app.use("*", async (c, next) => {
 		if (identity) c.set("accessIdentity", identity);
@@ -45,16 +45,32 @@ function makeApp(identity: AccessIdentity | null) {
 		RP_ORIGIN,
 		CONFIRMATION_TOKEN_SECRET: SECRET,
 		BLOOM_KV: makeKv(),
+		// Only present when a test opts in; absent → the first-key alert dispatch
+		// no-ops (no webhook configured) exactly as it does on an unconfigured deploy.
+		...(opts.alertWebhookUrl ? { SECURITY_ALERT_WEBHOOK_URL: opts.alertWebhookUrl } : {}),
 	};
+	// Provide a real ExecutionContext so the handler's fire-and-forget
+	// `ctx.waitUntil(...)` dispatch exercises the production path. Scheduled
+	// promises are collected so a test can await them before asserting.
+	const scheduled: Promise<unknown>[] = [];
+	const executionCtx = {
+		waitUntil: (p: Promise<unknown>) => {
+			scheduled.push(Promise.resolve(p));
+		},
+		passThroughOnException: () => {},
+	} as unknown as ExecutionContext;
 	const call = (path: string, body: unknown) =>
 		app.request(
 			path,
 			{ method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) },
 			env,
+			executionCtx,
 		);
 	return {
 		regOptions: (body: unknown = {}) => call("/api/v1/webauthn/register/options", body),
 		regVerify: (body: unknown) => call("/api/v1/webauthn/register/verify", body),
+		/** Await every promise the handler scheduled via `ctx.waitUntil(...)`. */
+		settleAlerts: () => Promise.allSettled(scheduled),
 	};
 }
 
@@ -209,5 +225,143 @@ describe("register — adding a 2nd key requires an existing-key assertion", () 
 		expect(creds.map((c) => c.credentialId).sort()).toEqual(
 			[existing.credentialId, newKey.credentialId].sort(),
 		);
+	});
+});
+
+describe("register — first-key operator notification (TOFU alert)", () => {
+	// A surreptitious first-key registration is the highest-risk window: the
+	// console.log audit line is forensic, not an alert. register/verify dispatches
+	// the same audit payload to SECURITY_ALERT_WEBHOOK_URL — fire-and-forget, so a
+	// down/slow/throwing webhook can never block or fail the enrollment.
+	const WEBHOOK_URL = "https://soc-alerts.example.test/first-key";
+	const WEBHOOK_HOST = "soc-alerts.example.test";
+
+	// Hostname is PARSED (never substring-matched) per the CodeQL gate — both in
+	// the mock dispatcher and in the assertions below.
+	function hostOf(input: unknown): string | null {
+		const url = input instanceof Request ? input.url : typeof input === "string" ? input : String(input);
+		try {
+			return new URL(url).hostname;
+		} catch {
+			return null;
+		}
+	}
+
+	/** Spy on fetch; route only the webhook host to `handler`, pass everything
+	 *  else through (the register flow itself makes no outbound requests). */
+	function spyWebhookFetch(handler: (init?: RequestInit) => Response) {
+		const realFetch = globalThis.fetch;
+		return vi
+			.spyOn(globalThis, "fetch")
+			.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+				if (hostOf(input) === WEBHOOK_HOST) return handler(init);
+				return realFetch(input as RequestInfo | URL, init);
+			});
+	}
+
+	function webhookCalls(spy: ReturnType<typeof spyWebhookFetch>) {
+		return spy.mock.calls.filter((c) => hostOf(c[0]) === WEBHOOK_HOST);
+	}
+
+	async function enrollFirstKey(app: ReturnType<typeof makeApp>) {
+		const auth = await createTestAuthenticator();
+		const opt = (await (await app.regOptions()).json()) as {
+			registration: { challenge: string };
+		};
+		const attestation = await auth.register({
+			challenge: opt.registration.challenge,
+			rpId: RP_ID,
+			origin: RP_ORIGIN,
+		});
+		return app.regVerify({ attestation });
+	}
+
+	it("dispatches the notification with the audit payload on first-key registration", async () => {
+		const app = makeApp({ sub: "notify-first", email: "op@example.com" }, { alertWebhookUrl: WEBHOOK_URL });
+		const fetchSpy = spyWebhookFetch(() => new Response(null, { status: 200 }));
+
+		const verRes = await enrollFirstKey(app);
+		await app.settleAlerts();
+
+		expect(verRes.status).toBe(200);
+		const ver = (await verRes.json()) as { verified: boolean; firstKey: boolean };
+		expect(ver.verified).toBe(true);
+		expect(ver.firstKey).toBe(true);
+
+		const calls = webhookCalls(fetchSpy);
+		expect(calls).toHaveLength(1);
+		// The notification carries the same structured audit payload as the log line.
+		const body = JSON.parse(String((calls[0][1] as RequestInit).body)) as {
+			event: string;
+			sub: string;
+			email: string;
+		};
+		expect(body.event).toBe("webauthn.first_key_registered");
+		expect(body.sub).toBe("notify-first");
+		expect(body.email).toBe("op@example.com");
+	});
+
+	it("does NOT dispatch the notification when adding a 2nd key", async () => {
+		const sub = "notify-2nd";
+		const existing = await createTestAuthenticator();
+		await createCredential(testEnv.WEBAUTHN_DB, {
+			credentialId: existing.credentialId,
+			userSub: sub,
+			publicKey: existing.cosePublicKey,
+			counter: 0,
+			transports: ["internal"],
+			aaguid: null,
+			createdAt: 1_700_000_000_000,
+		});
+		const app = makeApp({ sub, email: "op@example.com" }, { alertWebhookUrl: WEBHOOK_URL });
+		const fetchSpy = spyWebhookFetch(() => new Response(null, { status: 200 }));
+
+		// Full add-2nd-key handshake: step-up assertion → registration options → store.
+		const phase1 = (await (await app.regOptions()).json()) as {
+			authentication: { challenge: string };
+		};
+		const stepUpAssertion = await existing.assert({
+			challenge: phase1.authentication.challenge,
+			rpId: RP_ID,
+			origin: RP_ORIGIN,
+			counter: 1,
+		});
+		const phase2 = (await (await app.regOptions({ stepUpAssertion })).json()) as {
+			registration: { challenge: string };
+		};
+		const newKey = await createTestAuthenticator();
+		const attestation = await newKey.register({
+			challenge: phase2.registration.challenge,
+			rpId: RP_ID,
+			origin: RP_ORIGIN,
+		});
+		const verRes = await app.regVerify({ attestation });
+		await app.settleAlerts();
+
+		expect(verRes.status).toBe(200);
+		const ver = (await verRes.json()) as { firstKey: boolean };
+		expect(ver.firstKey).toBe(false);
+		expect(webhookCalls(fetchSpy)).toHaveLength(0);
+	});
+
+	it("still completes enrollment (200, credential stored) when the notifier rejects", async () => {
+		const sub = "notify-throws";
+		const app = makeApp({ sub, email: "op@example.com" }, { alertWebhookUrl: WEBHOOK_URL });
+		const fetchSpy = spyWebhookFetch(() => {
+			throw new Error("alert webhook unreachable");
+		});
+
+		const verRes = await enrollFirstKey(app);
+		await app.settleAlerts();
+
+		expect(verRes.status).toBe(200);
+		const ver = (await verRes.json()) as { verified: boolean; firstKey: boolean };
+		expect(ver.verified).toBe(true);
+		expect(ver.firstKey).toBe(true);
+		// The dispatch was attempted (and its rejection swallowed) — enrollment held.
+		expect(webhookCalls(fetchSpy)).toHaveLength(1);
+
+		const creds = await listBySub(testEnv.WEBAUTHN_DB, sub);
+		expect(creds).toHaveLength(1);
 	});
 });

--- a/workers/lib/security-alert.ts
+++ b/workers/lib/security-alert.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+
+/**
+ * Out-of-band operator security alerts.
+ *
+ * A surreptitious first-passkey (TOFU) enrollment is the highest-risk window in
+ * the WebAuthn step-up (#376): whoever lands the first credential for a `sub`
+ * can mint confirm tokens for that identity's risky sends. The structured
+ * `webauthn.first_key_registered` audit line is a forensic record, not an alert
+ * — nobody is paged by a `console.log`. This module fans security events out to
+ * an operator-configured webhook so they are *actively* detectable.
+ *
+ * Fire-and-forget by contract: a webhook that is slow, down, or misconfigured
+ * MUST NOT block or fail the action it is reporting on. Every failure (a
+ * synchronous throw constructing the request, an async network rejection, or a
+ * non-2xx response) is caught and logged here — it never surfaces to the caller.
+ * When an execution context is reachable the request is scheduled with
+ * `waitUntil` so it outlives the handler's response; otherwise it is still
+ * issued, pre-`catch`ed so it cannot become an unhandled rejection.
+ */
+
+import type { Env } from "../types";
+
+/** Minimal execution-context shape — only `waitUntil` is needed here. */
+export interface AlertExecutionContext {
+	waitUntil(promise: Promise<unknown>): void;
+}
+
+/** Webhook request timeout — bounded so a hung endpoint can't pin a request. */
+const ALERT_WEBHOOK_TIMEOUT_MS = 10_000;
+
+/**
+ * POST `payload` (JSON) to the configured `SECURITY_ALERT_WEBHOOK_URL`, if any.
+ *
+ * No-ops silently when the webhook is unconfigured. Never throws and never
+ * rejects into the caller. When `ctx` is supplied the request is scheduled with
+ * `waitUntil`; otherwise the request is still issued fire-and-forget.
+ *
+ * @param env      Worker env — read for the optional `SECURITY_ALERT_WEBHOOK_URL`.
+ * @param ctx      Execution context (for `waitUntil`); `undefined` is tolerated.
+ * @param payload  Any JSON-serialisable alert body.
+ */
+export function dispatchSecurityAlert(
+	env: Pick<Env, "SECURITY_ALERT_WEBHOOK_URL">,
+	ctx: AlertExecutionContext | undefined,
+	payload: unknown,
+): void {
+	const url = env.SECURITY_ALERT_WEBHOOK_URL;
+	if (!url) return;
+
+	try {
+		const request = fetch(url, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify(payload),
+			signal: AbortSignal.timeout(ALERT_WEBHOOK_TIMEOUT_MS),
+		})
+			.then((res) => {
+				if (!res.ok) {
+					console.error(`security alert webhook returned ${res.status}`);
+				}
+			})
+			.catch((err: unknown) => {
+				console.error(
+					"security alert webhook failed:",
+					err instanceof Error ? err.message : String(err),
+				);
+			});
+		ctx?.waitUntil(request);
+	} catch (err: unknown) {
+		// A synchronous failure (e.g. fetch/AbortSignal construction) must not
+		// propagate into the handler that is reporting the event.
+		console.error(
+			"security alert webhook dispatch error:",
+			err instanceof Error ? err.message : String(err),
+		);
+	}
+}

--- a/workers/routes/webauthn.ts
+++ b/workers/routes/webauthn.ts
@@ -43,6 +43,7 @@ import {
 	type AccessVariables,
 } from "../lib/access-identity";
 import { computePayloadHash, signConfirmationToken } from "../lib/confirm-token";
+import { dispatchSecurityAlert, type AlertExecutionContext } from "../lib/security-alert";
 import {
 	consumeChallenge,
 	createCredential,
@@ -365,17 +366,29 @@ webauthnRoute.post("/register/verify", async (c) => {
 	});
 
 	if (firstKey) {
-		// Audit the TOFU enrollment so a surreptitious first-key registration is
-		// detectable. Operator notification channel is tracked in the #376 runbook.
-		console.log(
-			JSON.stringify({
-				event: "webauthn.first_key_registered",
-				sub: identity.sub,
-				email: identity.email,
-				credentialId: info.credential.id,
-				aaguid: info.aaguid,
-			}),
-		);
+		// The TOFU enrollment is the highest-risk window in the step-up, so it gets
+		// BOTH a forensic audit line AND an active out-of-band notification.
+		const auditEvent = {
+			event: "webauthn.first_key_registered",
+			sub: identity.sub,
+			email: identity.email,
+			credentialId: info.credential.id,
+			aaguid: info.aaguid,
+		};
+		// Forensic audit line (kept as-is) for retrospective log search.
+		console.log(JSON.stringify(auditEvent));
+		// Active operator notification — a console line is not an alert. Dispatched
+		// fire-and-forget via the execution context's waitUntil; a failed/slow/
+		// missing webhook MUST NOT block or fail this enrollment, so the response
+		// below still returns { verified: true } regardless. No-ops when the
+		// SECURITY_ALERT_WEBHOOK_URL operator secret is unset.
+		let alertCtx: AlertExecutionContext | undefined;
+		try {
+			alertCtx = c.executionCtx;
+		} catch {
+			alertCtx = undefined;
+		}
+		dispatchSecurityAlert(c.env, alertCtx, auditEvent);
 	}
 
 	return c.json({ verified: true, credentialId: info.credential.id, firstKey });

--- a/workers/types.ts
+++ b/workers/types.ts
@@ -32,6 +32,17 @@ export interface Env extends Cloudflare.Env {
 	 */
 	YARAMAIL_CALLBACK_SECRET?: string;
 	/**
+	 * Optional operator webhook for out-of-band security alerts (issue #376).
+	 * When set, a first-passkey (TOFU) enrollment in `register/verify` POSTs the
+	 * `webauthn.first_key_registered` audit payload here so the highest-risk
+	 * step-up window is actively detectable, not just logged. Dispatch is
+	 * fire-and-forget — a failed send never blocks or fails enrollment. When
+	 * unset, the dispatch no-ops (the `console.log` audit line still fires).
+	 * Set with `wrangler secret put SECURITY_ALERT_WEBHOOK_URL` (kept out of
+	 * `wrangler.jsonc` vars so it doesn't widen the generated `Cloudflare.Env`).
+	 */
+	SECURITY_ALERT_WEBHOOK_URL?: string;
+	/**
 	 * Comma-separated hostname allowlist for the community-hub URL
 	 * (GHSA-jfj6-w954-96vg f29). A `HUB_SECRET_*` API key is only resolved
 	 * and sent when `intel.hub.url` is https AND its hostname is on this

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -22,6 +22,12 @@
 		// hostname or every assertion is rejected.
 		"RP_ID": "inbox.cortech.online",
 		"RP_ORIGIN": "https://inbox.cortech.online"
+		// Operator security-alert webhook for first-passkey (TOFU) enrollment
+		// (issue #376) is set as a SECRET, not a var here — a literal var would
+		// widen the generated `Cloudflare.Env` and break `Env extends Cloudflare.Env`
+		// (see workers/types.ts). Configure with:
+		//   wrangler secret put SECURITY_ALERT_WEBHOOK_URL
+		// When unset, the first-key alert dispatch no-ops (the audit log still fires).
 	},
 	"send_email": [
 		{


### PR DESCRIPTION
## Summary

The **first** WebAuthn credential a user enrolls is the highest-risk window in the app-layer step-up (#376): whoever lands it can thereafter mint one-shot confirm tokens for that identity's risky sends. There is no prior key to step up against, so first-key enrollment is trust-on-first-use.

Until now, `workers/routes/webauthn.ts` (`POST /register/verify`) only emitted a structured `console.log` audit line on the first key. A console line is forensic, not an alert — nobody is paged by it. This PR adds an **active, out-of-band operator notification** so a surreptitious first-key registration is detectable in real time.

## What changed

- **New `workers/lib/security-alert.ts`** — `dispatchSecurityAlert(env, ctx, payload)`: POSTs a JSON payload to an operator webhook, fire-and-forget. No-ops when unconfigured; catches **every** failure (down / slow / non-2xx / malformed URL / sync throw) and logs it — never propagates.
- **`register/verify`** — on `firstKey === true` only, builds the audit payload once, keeps the existing `console.log` line **byte-identical**, then dispatches the same payload via `ctx.waitUntil(...)`. The execution context is read defensively (`try/catch`) so the path is robust even where `c.executionCtx` isn't present.
- **New optional `SECURITY_ALERT_WEBHOOK_URL`** secret in `workers/types.ts` `Env` + documented in `wrangler.jsonc` (as a `wrangler secret put`, not a var — a literal var would widen the generated `Cloudflare.Env` and break `Env extends Cloudflare.Env`).
- **`docs/step-up-auth.md`** — new §6 operator runbook for the first-key alert (config, payload shape, fire-and-forget contract) + a Secrets-table row.

## Why a webhook, not the `EMAIL` binding

Per the task, I checked the existing channels first. The `EMAIL` send binding would need a verified destination address *and* a separate operator-address config that doesn't exist yet; `workers/intel/catchall-alert.ts` is a pure compute layer that explicitly never sends. A configurable webhook is the task's documented fallback and reuses the repo's established fire-and-forget pattern (`fireYaraScan` in `workers/security/yaramail-signal.ts`: `ctx.waitUntil(fetch(...).catch(...))`).

## Guarantees (acceptance criteria)

- ✅ Notification dispatched on **first-key only** — never on 2nd+ keys.
- ✅ Enrollment still returns **HTTP 200** with the credential stored when the notifier throws/rejects.
- ✅ Config via env var, documented in the `docs/step-up-auth.md` operator runbook.
- ✅ `console.log` audit line unchanged; schema and 2nd-key flow untouched (out of scope: AAGUID pinning #506, admin recovery #507).

## Tests (TDD, workers pool — real `workerd`)

Added to `tests/workers/webauthn-register.test.ts`:
1. Notification dispatched with the audit payload on first-key registration.
2. **Not** dispatched when adding a 2nd key.
3. Enrollment still 200 + credential stored when the notifier **rejects**.

Mock fetch routes by **parsed** `new URL(x).hostname` (never `.startsWith`/`.includes`) per the CodeQL gate.

`npm test` → 127 files / 1626 tests pass. `npm run typecheck` → clean.

> Depends on #508 / #376 (already on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgXc9zH1rHew59552xRADp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgXc9zH1rHew59552xRADp)_