### PR TITLE
fix(intel): match url feeds on full URL only, not derived apex host

### DIFF
--- a/tests/intel/feed-refresh-hardening.test.ts
+++ b/tests/intel/feed-refresh-hardening.test.ts
@@ -228,10 +228,10 @@ describe("exact-blob read robustness", () => {
 
 describe("exact-blob dedupe", () => {
 	it("deduplicates values so the cap covers more unique entries", async () => {
-		// Two URLs on the same host parse to [urlA, host, urlB, host] — the
-		// blob should store each value once so the 2000-entry cap isn't
-		// wasted on repeated hostnames.
-		mockFetch("https://x.example/a\nhttps://x.example/b\n");
+		// url feeds store the full URL only (no derived apex host), and a
+		// duplicate line collapses to a single entry so the 2000-entry cap
+		// isn't wasted on repeats.
+		mockFetch("https://x.example/a\nhttps://x.example/b\nhttps://x.example/a\n");
 		const kv = makeKv();
 		const env = makeEnv({ mailboxSettings: urlFeedSettings(), kv });
 
@@ -240,7 +240,7 @@ describe("exact-blob dedupe", () => {
 		const blob = await kv.get("intel:testfeed:exact-blob");
 		const parsed = JSON.parse(blob as string) as string[];
 		expect(parsed.sort()).toEqual(
-			["https://x.example/a", "https://x.example/b", "x.example"].sort(),
+			["https://x.example/a", "https://x.example/b"].sort(),
 		);
 	});
 });

--- a/tests/intel/feed-url-host-fp.test.ts
+++ b/tests/intel/feed-url-host-fp.test.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+/**
+ * Regression: a `url`-kind feed (URLhaus, OpenPhish) must NOT cause a legit
+ * URL to match merely because it shares an apex host with a listed malicious
+ * URL.
+ *
+ * URLhaus is a list of *specific malicious URLs*, and malware is frequently
+ * hosted ON shared, high-reputation hosts (github.com, drive.google.com,
+ * raw.githubusercontent.com, pastebin.com, …). Deriving the bare hostname
+ * from each URL entry and matching on it collapses every such entry to its
+ * apex, so any later email linking to that apex gets a CONFIRMED intel hit →
+ * `hard_block` (score 100, classifier skipped). That is exactly how a
+ * legitimate `https://github.com/<user>/<repo>` link in a SerpApi support
+ * reply got blocked as "phishing".
+ *
+ * Contract: `url` feeds match the full URL only. Host-level matching is the
+ * job of `domain`-kind feeds.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	checkUrlAgainstFeeds,
+	parseFeedBody,
+	refreshAllFeeds,
+} from "../../workers/intel/feeds";
+import { clearOrgSettingsCache } from "../../workers/lib/org-settings";
+import { clearDomainSettingsCache } from "../../workers/lib/domain-settings";
+import type { Env } from "../../workers/types";
+
+const MAILBOX_ID = "user@example.com";
+
+// ── Minimal KV / BUCKET / MAILBOX harness (mirrors feed-kv-writes.test.ts) ──
+
+function makeKv() {
+	const store = new Map<string, string | Uint8Array>();
+	return {
+		store,
+		async get(key: string, type?: "text" | "arrayBuffer") {
+			const val = store.get(key);
+			if (val === undefined) return null;
+			if (type === "arrayBuffer") return val instanceof Uint8Array ? val.buffer : null;
+			if (type === "text") return typeof val === "string" ? val : null;
+			return val;
+		},
+		async put(key: string, value: string | Uint8Array | ArrayBuffer) {
+			store.set(key, value instanceof ArrayBuffer ? new Uint8Array(value) : value);
+		},
+	};
+}
+
+function makeEnv(mailboxSettings: unknown): Env {
+	const kv = makeKv();
+	const stub = {
+		async getIntelFeedState() {
+			return null;
+		},
+		async upsertIntelFeedState() {},
+	};
+	const mailboxNs = {
+		idFromName(name: string) {
+			return { toString: () => name } as unknown as DurableObjectId;
+		},
+		get() {
+			return stub as unknown as DurableObjectStub;
+		},
+	} as unknown as DurableObjectNamespace;
+	const bucket = {
+		async list() {
+			return { objects: [{ key: `mailboxes/${MAILBOX_ID}.json` }] };
+		},
+		async get(key: string) {
+			if (key !== `mailboxes/${MAILBOX_ID}.json`) return null;
+			return { etag: "etag-1", async json() { return mailboxSettings; } };
+		},
+	};
+	return {
+		BLOOM_KV: kv as unknown as KVNamespace,
+		BUCKET: bucket as unknown as R2Bucket,
+		MAILBOX: mailboxNs,
+	} as unknown as Env;
+}
+
+const URL_FEED_SETTINGS = {
+	intel: {
+		feeds: [{ id: "urlhaus", url: "https://test.example/urlhaus.txt", kind: "url" }],
+	},
+};
+
+// A URLhaus-shaped body: a malicious URL hosted on github.com, plus a
+// dedicated-host phishing URL.
+const FEED_BODY = [
+	"https://github.com/evil-actor/malware-dropper",
+	"https://evil.example/login",
+].join("\n");
+
+beforeEach(() => {
+	clearOrgSettingsCache();
+	clearDomainSettingsCache();
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ── parseFeedBody: url entries never contribute a bare host ──────────────────
+
+describe("parseFeedBody — url kind keeps full URLs, never derives bare host", () => {
+	it("does not emit the apex host for a url-kind entry", () => {
+		const values = parseFeedBody("https://github.com/evil-actor/malware-dropper", "url");
+		expect(values).toContain("https://github.com/evil-actor/malware-dropper");
+		expect(values).not.toContain("github.com");
+	});
+
+	it("domain kind still normalizes to the bare host", () => {
+		expect(parseFeedBody("github.com", "domain")).toEqual(["github.com"]);
+	});
+});
+
+// ── checkUrlAgainstFeeds: shared-apex links are not collateral-blocked ────────
+
+describe("url-feed lookup — shared apex host is not a false positive", () => {
+	it("a legit github.com link does NOT match a URLhaus entry hosted on github.com", async () => {
+		vi.stubGlobal("fetch", async () => new Response(FEED_BODY, { status: 200 }));
+		const env = makeEnv(URL_FEED_SETTINGS);
+		await refreshAllFeeds(env);
+
+		const result = await checkUrlAgainstFeeds(
+			env,
+			MAILBOX_ID,
+			"https://github.com/rpanigrahi222/intruth-factcheck",
+		);
+		expect(result).toBeNull();
+	});
+
+	it("the exact listed malicious URL still produces a confirmed hit", async () => {
+		vi.stubGlobal("fetch", async () => new Response(FEED_BODY, { status: 200 }));
+		const env = makeEnv(URL_FEED_SETTINGS);
+		await refreshAllFeeds(env);
+
+		const result = await checkUrlAgainstFeeds(
+			env,
+			MAILBOX_ID,
+			"https://github.com/evil-actor/malware-dropper",
+		);
+		expect(result?.confirmed).toBe(true);
+		expect(result?.value).toBe("https://github.com/evil-actor/malware-dropper");
+	});
+});

--- a/workers/intel/feeds.ts
+++ b/workers/intel/feeds.ts
@@ -140,7 +140,7 @@ function resolveFeeds(env: Env, settings: MailboxIntelSettings): FeedDefinition[
 	return [...defaults, ...user];
 }
 
-function parseFeedBody(body: string, kind: "domain" | "url"): string[] {
+export function parseFeedBody(body: string, kind: "domain" | "url"): string[] {
 	const lines = body.split(/\r?\n/);
 	const out: string[] = [];
 	for (const raw of lines) {
@@ -149,9 +149,12 @@ function parseFeedBody(body: string, kind: "domain" | "url"): string[] {
 		if (kind === "domain") {
 			out.push(normalizeDomain(line));
 		} else {
+			// `url` feeds (URLhaus, OpenPhish) list specific malicious URLs.
+			// Do NOT also derive the bare host: that would collapse e.g.
+			// `https://github.com/evil/x` to `github.com` and later flag every
+			// legitimate github.com link as a confirmed hit → hard_block. Match
+			// the full URL only; host-level blocking is the job of `domain` feeds.
 			out.push(line);
-			const host = safeHostname(line);
-			if (host) out.push(normalizeDomain(host));
 		}
 	}
 	return out;
@@ -373,9 +376,13 @@ export interface FeedMatch {
 }
 
 /**
- * Check a URL's hostname and full URL against all configured feeds.
- * Returns the first confirmed match, or the first bloom-only hit if no
- * exact confirmations are available.
+ * Check a URL against all configured feeds: the bare hostname for `domain`
+ * feeds, the full URL for `url` feeds. Returns the first confirmed match, or
+ * the first bloom-only hit if no exact confirmations are available.
+ *
+ * `url` feeds are matched on the full URL only — never on the apex host — so a
+ * URLhaus/OpenPhish entry hosted on a shared host (github.com, drive.google.com,
+ * …) cannot collateral-block every legitimate link to that host.
  */
 export async function checkUrlAgainstFeeds(
 	env: Env,
@@ -398,7 +405,11 @@ export async function checkUrlAgainstFeeds(
 		if (!serialized) continue;
 		const filter = deserializeBloom(serialized);
 		if (!filter) continue;
-		const candidates = feed.kind === "domain" ? [host] : [fullUrl, host];
+		// `domain` feeds match the bare host; `url` feeds match the full URL
+		// only. parseFeedBody no longer stores apex hosts for url feeds, so
+		// matching `host` here would never confirm and would only risk a
+		// shared-host false positive (e.g. github.com).
+		const candidates = feed.kind === "domain" ? [host] : [fullUrl];
 		// The exact blob is ~200 KB and this runs per URL on the security
 		// pipeline's hot path — fetch it lazily on the first bloom hit, at
 		// most once per feed.


### PR DESCRIPTION
Closes #513

## What

`url`-kind threat-intel feeds (URLhaus, OpenPhish) now match on the **full URL only**. Bare-host matching is reserved for `domain`-kind feeds.

## Why

A legitimate **SerpApi** support reply (relayed via Front, Message-ID `<cfb570be7c7dd5003ccadfbff281412a@frontapp.com>`) was hard-blocked with **score 100 / action `block` / triage `hard_block`** and signal `confirmed intel hit (urlhaus: github.com)` — the classifier never ran. The email simply linked `https://github.com/rpanigrahi222/intruth-factcheck`.

Root cause: `parseFeedBody()` derived the bare host from every `url`-feed entry and added it to the bloom + exact-match set. URLhaus lists specific malicious URLs, and malware is frequently hosted **on** shared, high-reputation hosts, so a malicious `https://github.com/<evil>/<repo>` entry collapsed to `github.com`. `checkUrlAgainstFeeds()` then tested `[fullUrl, host]` for url feeds, so **any** later email linking to **any** `github.com` URL produced a confirmed hit → `hard_block`. Same blast radius for `drive.google.com`, `raw.githubusercontent.com`, `dropbox.com`, `pastebin.com`, etc.

## Change

- `workers/intel/feeds.ts`
  - `parseFeedBody()`: `url` kind no longer derives/stores the apex host — full URL only.
  - `checkUrlAgainstFeeds()`: url-feed candidates are now `[fullUrl]` (was `[fullUrl, host]`); `domain` feeds still use `[host]`.
  - Exported `parseFeedBody` for unit coverage; updated docstrings.
- `tests/intel/feed-url-host-fp.test.ts` (new): a legit `github.com` link must not match a URLhaus entry hosted on github.com; the exact listed malicious URL still confirms; `parseFeedBody` url/domain behavior.
- `tests/intel/feed-refresh-hardening.test.ts`: updated the dedupe assertion to the corrected contract (full URLs only, no derived host).

## Trade-off

`url` feeds no longer catch *other* paths on a host that appears in the feed. That over-coarse host matching was the exact false-positive source; host-level blocking remains available via `domain`-kind feeds. The exact listed malicious URL still hard-blocks.

## Test plan

- TDD red→green: the new regression test reproduced the production signal exactly (`{ confirmed: true, feedId: "urlhaus", value: "github.com" }`) against the old code, then passed after the fix.
- Full suite: **1633 passed / 0 failed** (128 files).
- `npm run typecheck`: exit 0.

## Out of scope

- `hard_block` triage behavior.
- Releasing the already-blocked SerpApi message (manual mailbox action).
- Broader feed-source host allowlisting / normalized-URL matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)