### PR TITLE
feat: add Catch-all intel toggle to domain settings (#521)

### DIFF
--- a/app/routes/domain-detail.tsx
+++ b/app/routes/domain-detail.tsx
@@ -145,7 +145,7 @@ function DomainBody({
 			{rufData?.enabled && rufData.records.length > 0 && (
 				<RufFailuresTable records={rufData.records} />
 			)}
-			<CatchallProbesCard data={catchallData} isLoading={catchallLoading} />
+			<CatchallProbesCard data={catchallData} isLoading={catchallLoading} domain={data.domain} />
 		</>
 	);
 }
@@ -673,9 +673,11 @@ function RecentCasesList({ cases }: { cases: DomainStats["recentCases"] }) {
 function CatchallProbesCard({
 	data,
 	isLoading,
+	domain,
 }: {
 	data: CatchallSummary | undefined;
 	isLoading: boolean;
+	domain: string;
 }) {
 	if (isLoading) {
 		return (
@@ -700,9 +702,14 @@ function CatchallProbesCard({
 			</div>
 			{empty ? (
 				<p className="text-[12.5px] text-ink-3">
-					No catch-all probe activity recorded. Enable{" "}
-					<span className="pp-mono">catchall_intel</span> on this domain to
-					start collecting directory-harvest data.
+					No catch-all probe activity recorded.{" "}
+					<RouterLink
+						to={`/domains/${encodeURIComponent(domain)}/settings`}
+						className="underline hover:opacity-80"
+					>
+						Enable catch-all intel in domain settings
+					</RouterLink>{" "}
+					to start collecting directory-harvest data.
 				</p>
 			) : (
 				<div className="space-y-5">

--- a/app/routes/domain-settings.tsx
+++ b/app/routes/domain-settings.tsx
@@ -28,6 +28,7 @@ interface DomainSettingsShape {
 	autoDraft?: { enabled?: boolean };
 	security?: SecuritySettings;
 	intel?: { hub?: HubConfigSettings };
+	catchall_intel?: { enabled?: boolean };
 }
 
 /**
@@ -53,6 +54,7 @@ export default function DomainSettingsRoute() {
 	const [autoDraftEnabled, setAutoDraftEnabled] = useState(true);
 	const [modelChoice, setModelChoice] = useState<string>(TEXT_MODELS[0]);
 	const [customModel, setCustomModel] = useState("");
+	const [catchallIntelEnabled, setCatchallIntelEnabled] = useState<boolean | undefined>(undefined);
 	const [isSaving, setIsSaving] = useState(false);
 
 	// Initialise once per domain (same useRef pattern as the per-mailbox
@@ -69,6 +71,7 @@ export default function DomainSettingsRoute() {
 		setHub(s.intel?.hub);
 		setHubErrors(undefined);
 		setAutoDraftEnabled(s.autoDraft?.enabled === undefined ? true : s.autoDraft.enabled);
+		setCatchallIntelEnabled(s.catchall_intel?.enabled);
 
 		const m = s.agentModel ?? availableModels[0] ?? TEXT_MODELS[0];
 		if (availableModels.includes(m)) {
@@ -109,6 +112,7 @@ export default function DomainSettingsRoute() {
 			agentModel: resolvedModel || undefined,
 			security,
 			intel: intelToPersist,
+			catchall_intel: catchallIntelEnabled !== undefined ? { enabled: catchallIntelEnabled } : undefined,
 		};
 
 		setIsSaving(true);
@@ -245,6 +249,27 @@ export default function DomainSettingsRoute() {
 					}}
 					errors={hubErrors}
 				/>
+
+				{/* Catch-all intel */}
+				<div className="pp-card p-5">
+					<div className="text-sm font-medium text-ink mb-4">Catch-all intel</div>
+					<label className="flex items-start justify-between gap-3">
+						<span className="flex flex-col">
+							<span className="text-sm text-ink">Enable catch-all probe capture</span>
+							<span className="text-xs text-ink-3 mt-1 max-w-md">
+								Capture directory-harvest probe emails for this domain. Probes are
+								stored in the catch-all dashboard card for analysis.
+							</span>
+						</span>
+						<input
+							type="checkbox"
+							checked={catchallIntelEnabled ?? false}
+							onChange={(e) => setCatchallIntelEnabled(e.target.checked)}
+							className="mt-1 h-4 w-4 accent-accent shrink-0"
+							aria-label="Enable catch-all probe capture"
+						/>
+					</label>
+				</div>
 
 				<div className="flex justify-end">
 					<Button variant="primary" onClick={handleSave} loading={isSaving}>

--- a/tests/frontend/domain-settings.test.tsx
+++ b/tests/frontend/domain-settings.test.tsx
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 schmug. Licensed under the Apache 2.0 license.
+//
+// Tests for the domain-settings route's Catch-all intel toggle (#521).
+// Covers: load persisted value → toggle → save merges catchall_intel into
+// existing settings without wiping other fields.
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+
+const mutateAsync = vi.fn();
+const updateDomainMock = {
+	mutateAsync,
+	isPending: false,
+};
+
+let domainSettingsFixture: { domain: string; settings: Record<string, unknown> };
+
+vi.mock("~/queries/domain-settings", () => ({
+	useDomainSettings: () => ({ data: domainSettingsFixture, isLoading: false }),
+	useUpdateDomainSettings: () => updateDomainMock,
+}));
+
+vi.mock("~/queries/text-models", () => ({
+	useTextModels: () => ({ models: ["@cf/meta/llama-3.3-70b-instruct-fp8-fast"] }),
+}));
+
+// SecuritySettingsPanel and HubSettingsPanel are heavy — stub them so the
+// test doesn't pull in their full dependency trees.
+vi.mock("~/components/SecuritySettingsPanel", () => ({
+	SecuritySettingsPanel: () => null,
+}));
+vi.mock("~/components/HubSettingsPanel", () => ({
+	HubSettingsPanel: () => null,
+	normalizeHubConfig: () => undefined,
+	validateHubConfig: () => null,
+}));
+
+import DomainSettingsRoute from "~/routes/domain-settings";
+import { renderWithProviders } from "./test-utils";
+
+function renderDomainSettings(domain = "acme.com") {
+	return renderWithProviders(
+		<Routes>
+			<Route path="/domains/:domain/settings" element={<DomainSettingsRoute />} />
+		</Routes>,
+		{ initialEntries: [`/domains/${encodeURIComponent(domain)}/settings`] },
+	);
+}
+
+describe("DomainSettings · Catch-all intel toggle (#521)", () => {
+	beforeEach(() => {
+		mutateAsync.mockReset();
+		mutateAsync.mockResolvedValue(undefined);
+		domainSettingsFixture = { domain: "acme.com", settings: {} };
+	});
+
+	it("renders the catch-all intel toggle unchecked when setting is absent", async () => {
+		domainSettingsFixture = { domain: "acme.com", settings: {} };
+		renderDomainSettings();
+		const toggle = await screen.findByRole("checkbox", {
+			name: /enable catch-all probe capture/i,
+		});
+		expect(toggle).not.toBeChecked();
+	});
+
+	it("renders the toggle checked when catchall_intel.enabled is true on load", async () => {
+		domainSettingsFixture = {
+			domain: "acme.com",
+			settings: { catchall_intel: { enabled: true } },
+		};
+		renderDomainSettings();
+		const toggle = await screen.findByRole("checkbox", {
+			name: /enable catch-all probe capture/i,
+		});
+		expect(toggle).toBeChecked();
+	});
+
+	it("includes catchall_intel in the save payload after toggling on", async () => {
+		const user = userEvent.setup();
+		domainSettingsFixture = {
+			domain: "acme.com",
+			settings: {
+				autoDraft: { enabled: false },
+				agentModel: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+			},
+		};
+		renderDomainSettings();
+
+		const toggle = await screen.findByRole("checkbox", {
+			name: /enable catch-all probe capture/i,
+		});
+		expect(toggle).not.toBeChecked();
+		await user.click(toggle);
+		expect(toggle).toBeChecked();
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+		await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+
+		const payload = mutateAsync.mock.calls[0][0] as Record<string, unknown>;
+		expect((payload.catchall_intel as { enabled: boolean }).enabled).toBe(true);
+	});
+
+	it("save merges catchall_intel into existing settings — other fields are preserved", async () => {
+		const user = userEvent.setup();
+		domainSettingsFixture = {
+			domain: "acme.com",
+			settings: {
+				autoDraft: { enabled: false },
+				agentModel: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+			},
+		};
+		renderDomainSettings();
+
+		const toggle = await screen.findByRole("checkbox", {
+			name: /enable catch-all probe capture/i,
+		});
+		await user.click(toggle);
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+		await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+
+		const payload = mutateAsync.mock.calls[0][0] as Record<string, unknown>;
+		// catchall_intel is now set
+		expect(payload.catchall_intel).toEqual({ enabled: true });
+		// autoDraft is preserved from the loaded settings
+		expect(payload.autoDraft).toEqual({ enabled: false });
+		// agentModel is preserved
+		expect((payload.agentModel as string)).toBe("@cf/meta/llama-3.3-70b-instruct-fp8-fast");
+	});
+
+	it("omits catchall_intel from the payload when the toggle is never touched", async () => {
+		const user = userEvent.setup();
+		domainSettingsFixture = { domain: "acme.com", settings: {} };
+		renderDomainSettings();
+
+		await screen.findByRole("checkbox", { name: /enable catch-all probe capture/i });
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+		await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+
+		const payload = mutateAsync.mock.calls[0][0] as Record<string, unknown>;
+		// Never interacted — absent-key-inherits semantics: don't send it
+		expect(payload.catchall_intel).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a "Catch-all intel" card to the domain settings page with an `enabled` toggle that reflects the persisted `catchall_intel.enabled` value on load.
- Merges `catchall_intel: { enabled }` into the full settings object on save (whole-object replace — no other domain settings are wiped); key is omitted from the payload when the toggle is never touched, preserving absent-key-inherits semantics.
- Updates the "Catch-all probes" empty-state in the domain detail page to link to `/domains/{domain}/settings` instead of referencing the raw `catchall_intel` setting key.

Closes #521.

## Test plan

- [x] `npm test` — 1638 passing, 0 failing (5 new tests in `tests/frontend/domain-settings.test.tsx`)
- [x] `npm run typecheck` — clean (0 errors)

## Choices made

- **`boolean | undefined` state:** `undefined` means never loaded/interacted with (key omitted from PUT payload). `true`/`false` means the user has explicitly set it. This preserves absent-key-inherits semantics — a first-visit save with no interaction doesn't silently stamp `catchall_intel: { enabled: false }` at the domain tier.
- **`retention_days` / `sample_limit` not exposed:** per the Out of scope in #521, only `enabled` is surfaced; the others are a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2X3Z6wtiiCZ6vf1rqwMsA)_