### PR TITLE
feat: add UI toggle for security.mitigations.dmarc_pass_compensates_method_fail (#524)

### DIFF
--- a/app/components/SecuritySettingsPanel.tsx
+++ b/app/components/SecuritySettingsPanel.tsx
@@ -286,6 +286,24 @@ export function SecuritySettingsPanel({ value, onChange }: SecuritySettingsPanel
 				</div>
 			</div>
 
+			{/* Scoring mitigations */}
+			<div className="border-t border-line pt-5">
+				<div className="text-xs font-medium text-ink mb-2">Scoring mitigations</div>
+				<p className="text-xs text-ink-3 mb-3">
+					Compensating-control adjustments applied after per-signal scoring. When on, DMARC=pass
+					zeroes out the SPF and DKIM per-method fail contributions — a passing DMARC already
+					proves alignment, so penalising the individual method double-counts the failure and
+					inflates scores for mailing-list and forwarded mail. Disable only if you need strict
+					per-method failure scoring regardless of DMARC outcome.
+				</p>
+				<Switch
+					label="DMARC=pass cancels per-method SPF/DKIM fail contributions"
+					checked={s.mitigations?.dmarc_pass_compensates_method_fail ?? true}
+					onCheckedChange={(v) => patch({ mitigations: { ...s.mitigations, dmarc_pass_compensates_method_fail: v } })}
+					disabled={!s.enabled}
+				/>
+			</div>
+
 			{/* Business hours */}
 			<div className="border-t border-line pt-5">
 				<div className="text-xs font-medium text-ink mb-2">Business hours</div>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -82,6 +82,7 @@ export interface SecuritySettings {
 	attachment_policy?: AttachmentPolicySettings;
 	folder_policies?: Record<string, FolderPolicySettings>;
 	ruf_ingestion?: RufIngestionSettings;
+	mitigations?: { dmarc_pass_compensates_method_fail?: boolean };
 }
 
 export interface DmarcRufRecord {

--- a/shared/mailbox-settings.ts
+++ b/shared/mailbox-settings.ts
@@ -50,11 +50,24 @@ const ClassificationSettings = z
   })
   .passthrough();
 
+/**
+ * Compensating-control mitigations (issue #100). Each field enables or
+ * disables a named mitigation. Absent key = on by default (absent-key-inherits).
+ * See `MitigationConfig` and `DEFAULT_MITIGATION_CONFIG` in
+ * `workers/security/verdict.ts`.
+ */
+const MitigationConfig = z
+  .object({
+    dmarc_pass_compensates_method_fail: z.boolean().optional(),
+  })
+  .passthrough();
+
 export const SecuritySettings = z
   .object({
     attachment_policy: AttachmentPolicy.optional(),
     folder_policies: z.record(z.string(), FolderPolicy).optional(),
     classification: ClassificationSettings.optional(),
+    mitigations: MitigationConfig.optional(),
   })
   .passthrough();
 

--- a/tests/frontend/security-settings.test.tsx
+++ b/tests/frontend/security-settings.test.tsx
@@ -166,3 +166,55 @@ describe("SecuritySettingsPanel · attachment + folder controls", () => {
 		expect(saved.security?.folder_policies?.inbox?.treat_as_verified).toBe(true);
 	});
 });
+
+describe("SecuritySettingsPanel · mitigations toggle", () => {
+	beforeEach(() => {
+		mutateAsync.mockReset();
+		mutateAsync.mockResolvedValue(undefined);
+	});
+
+	it("defaults to checked (true) when mitigations key is absent", async () => {
+		mailboxFixture = makeMailbox({ enabled: true });
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /DMARC=pass cancels per-method SPF\/DKIM fail contributions/i,
+		});
+		expect(toggle).toBeChecked();
+	});
+
+	it("reflects persisted false value when mitigations.dmarc_pass_compensates_method_fail is false", async () => {
+		mailboxFixture = makeMailbox({
+			enabled: true,
+			mitigations: { dmarc_pass_compensates_method_fail: false },
+		});
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /DMARC=pass cancels per-method SPF\/DKIM fail contributions/i,
+		});
+		expect(toggle).not.toBeChecked();
+	});
+
+	it("persists dmarc_pass_compensates_method_fail=false without clobbering other security fields", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox({
+			enabled: true,
+			ruf_ingestion: { enabled: true, retain_raw: false },
+		});
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /DMARC=pass cancels per-method SPF\/DKIM fail contributions/i,
+		});
+		// Default is on (true when absent) — click once to turn it off.
+		await user.click(toggle);
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		expect(saved.security?.mitigations?.dmarc_pass_compensates_method_fail).toBe(false);
+		// Sibling fields must survive the save.
+		expect(saved.security?.ruf_ingestion?.enabled).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `MitigationConfig` Zod sub-schema to `SecuritySettings` in `shared/mailbox-settings.ts` so `mitigations.dmarc_pass_compensates_method_fail` is validated rather than silently passed via `.passthrough()`.
- Adds `mitigations?: { dmarc_pass_compensates_method_fail?: boolean }` to the `SecuritySettings` UI interface in `app/types/index.ts`.
- Adds a "Scoring mitigations" section to `SecuritySettingsPanel` with a labeled toggle and help text; defaults to `true` (on) when the key is absent, merges into existing mitigations on save without clobbering sibling fields.

Closes #524.

## Test plan

- [x] `npm test` — 1543 passing, 0 failing (3 new tests in `tests/frontend/security-settings.test.tsx`)
- [x] `npm run typecheck` — clean (0 errors)

## Choices made

- **Placement after RUF block:** the mitigations section sits between the RUF-ingestion block and Business hours, grouping it with other "pipeline behavior" knobs rather than burying it in the collapsible Attachment/Folder sections.
- **Default-on when absent:** `s.mitigations?.dmarc_pass_compensates_method_fail ?? true` matches the backend `DEFAULT_MITIGATION_CONFIG` so operators see the real effective state on first visit without stamping an explicit value at the mailbox tier.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qs5Gu2UewJv658PK6gUwX2)_