### PR TITLE
feat: add UI toggle for security.mitigations.dmarc_pass_compensates_method_fail (#524)

### DIFF
--- a/app/components/SecuritySettingsPanel.tsx
+++ b/app/components/SecuritySettingsPanel.tsx
@@ -286,6 +286,24 @@ export function SecuritySettingsPanel({ value, onChange }: SecuritySettingsPanel
 				</div>
 			</div>
 
+			{/* DMARC pass compensates method fail */}
+			<div className="border-t border-line pt-5">
+				<div className="text-xs font-medium text-ink mb-2">Scoring mitigations</div>
+				<p className="text-xs text-ink-3 mb-3">
+					When DMARC=pass, the individual SPF and DKIM per-method failure contributions
+					are zeroed out in verdict scoring. DMARC alignment already proves one of the
+					two methods validated the sending domain — penalising the other double-counts
+					the failure and increases false positives on forwarded and mailing-list mail.
+					On by default; disable only if you want fail-closed scoring even when DMARC passes.
+				</p>
+				<Switch
+					label="DMARC pass cancels per-method SPF/DKIM fail contributions"
+					checked={s.mitigations?.dmarc_pass_compensates_method_fail ?? true}
+					onCheckedChange={(v) => patch({ mitigations: { ...s.mitigations, dmarc_pass_compensates_method_fail: v } })}
+					disabled={!s.enabled}
+				/>
+			</div>
+
 			{/* Business hours */}
 			<div className="border-t border-line pt-5">
 				<div className="text-xs font-medium text-ink mb-2">Business hours</div>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -82,6 +82,7 @@ export interface SecuritySettings {
 	attachment_policy?: AttachmentPolicySettings;
 	folder_policies?: Record<string, FolderPolicySettings>;
 	ruf_ingestion?: RufIngestionSettings;
+	mitigations?: { dmarc_pass_compensates_method_fail?: boolean };
 }
 
 export interface DmarcRufRecord {

--- a/shared/mailbox-settings.ts
+++ b/shared/mailbox-settings.ts
@@ -50,11 +50,18 @@ const ClassificationSettings = z
   })
   .passthrough();
 
+const MitigationConfig = z
+  .object({
+    dmarc_pass_compensates_method_fail: z.boolean().optional(),
+  })
+  .passthrough();
+
 export const SecuritySettings = z
   .object({
     attachment_policy: AttachmentPolicy.optional(),
     folder_policies: z.record(z.string(), FolderPolicy).optional(),
     classification: ClassificationSettings.optional(),
+    mitigations: MitigationConfig.optional(),
   })
   .passthrough();
 

--- a/tests/frontend/security-settings.test.tsx
+++ b/tests/frontend/security-settings.test.tsx
@@ -166,3 +166,67 @@ describe("SecuritySettingsPanel · attachment + folder controls", () => {
 		expect(saved.security?.folder_policies?.inbox?.treat_as_verified).toBe(true);
 	});
 });
+
+describe("SecuritySettingsPanel · mitigations toggle", () => {
+	beforeEach(() => {
+		mutateAsync.mockReset();
+		mutateAsync.mockResolvedValue(undefined);
+	});
+
+	it("defaults to checked (true) when mitigations is absent", async () => {
+		mailboxFixture = makeMailbox({ enabled: true });
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /dmarc pass cancels per-method spf\/dkim fail contributions/i,
+		});
+		expect(toggle).toBeChecked();
+	});
+
+	it("toggles off and saves dmarc_pass_compensates_method_fail=false without clobbering other fields", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox({
+			enabled: true,
+			intel_auto_block: true,
+		});
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /dmarc pass cancels per-method spf\/dkim fail contributions/i,
+		});
+		await user.click(toggle);
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		expect(saved.security?.mitigations?.dmarc_pass_compensates_method_fail).toBe(false);
+		// other fields must survive
+		expect(saved.security?.intel_auto_block).toBe(true);
+	});
+
+	it("reflects a persisted true value", async () => {
+		mailboxFixture = makeMailbox({
+			enabled: true,
+			mitigations: { dmarc_pass_compensates_method_fail: true },
+		});
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /dmarc pass cancels per-method spf\/dkim fail contributions/i,
+		});
+		expect(toggle).toBeChecked();
+	});
+
+	it("reflects a persisted false value", async () => {
+		mailboxFixture = makeMailbox({
+			enabled: true,
+			mitigations: { dmarc_pass_compensates_method_fail: false },
+		});
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /dmarc pass cancels per-method spf\/dkim fail contributions/i,
+		});
+		expect(toggle).not.toBeChecked();
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `MitigationConfig` Zod sub-schema to `shared/mailbox-settings.ts` — `mitigations.dmarc_pass_compensates_method_fail` is now validated rather than relying on `.passthrough()`.
- Extends `SecuritySettings` UI interface in `app/types/index.ts` with `mitigations?: { dmarc_pass_compensates_method_fail?: boolean }`.
- Adds a "Scoring mitigations" section to `SecuritySettingsPanel` with a labeled `Switch` that defaults to checked (default-on when field is absent) and merges into existing `mitigations` on change, without clobbering other security fields.

Closes #524.

## Test plan

- [x] `npm test` — 1637 passing, 0 failing (4 new tests in `tests/frontend/security-settings.test.tsx`)
- [x] `npm run typecheck` — clean (0 errors)

## Choices made

- **Default-on via `?? true`:** The toggle reads `s.mitigations?.dmarc_pass_compensates_method_fail ?? true` so an absent key renders as checked, matching the server default without storing anything at the mailbox tier.
- **Merge pattern:** `patch({ mitigations: { ...s.mitigations, dmarc_pass_compensates_method_fail: v } })` mirrors the `ruf_ingestion` merge at line 269 — sibling mitigation keys added in the future survive a toggle of this field.

---
_Generated by [Claude Code](https://claude.ai/code/session_0191DPZwS5k9jdn5MDRZoFRe)_