### PR TITLE
feat: add UI toggle for security.mitigations.dmarc_pass_compensates_method_fail

### DIFF
--- a/app/components/SecuritySettingsPanel.tsx
+++ b/app/components/SecuritySettingsPanel.tsx
@@ -286,6 +286,30 @@ export function SecuritySettingsPanel({ value, onChange }: SecuritySettingsPanel
 				</div>
 			</div>
 
+			{/* Scoring mitigations */}
+			<div className="border-t border-line pt-5">
+				<div className="text-xs font-medium text-ink mb-2">Scoring mitigations</div>
+				<p className="text-xs text-ink-3 mb-3">
+					Compensating controls that adjust how individual auth signals combine into the
+					final verdict score. Enabled by default to reduce false positives on mailing-list
+					and forwarded mail.
+				</p>
+				<Switch
+					label="DMARC=pass cancels per-method SPF/DKIM fail contributions"
+					checked={s.mitigations?.dmarc_pass_compensates_method_fail ?? true}
+					onCheckedChange={(v) => patch({ mitigations: { ...s.mitigations, dmarc_pass_compensates_method_fail: v } })}
+					disabled={!s.enabled}
+				/>
+				<p className="text-xs text-ink-3 mt-2">
+					When on (the default), a DMARC=pass verdict zeroes out the SPF and DKIM
+					per-method fail score contributions. DMARC alignment proves that either SPF or
+					DKIM validated the sending domain — penalising the other method's raw result
+					double-counts the failure and raises false-positive rates on forwarded and
+					mailing-list mail. Disable only if you need stricter scoring on partial auth
+					failures.
+				</p>
+			</div>
+
 			{/* Business hours */}
 			<div className="border-t border-line pt-5">
 				<div className="text-xs font-medium text-ink mb-2">Business hours</div>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -59,6 +59,10 @@ export interface RufIngestionSettings {
 	retain_raw?: boolean;
 }
 
+export interface MitigationSettings {
+	dmarc_pass_compensates_method_fail?: boolean;
+}
+
 export interface SecuritySettings {
 	enabled?: boolean;
 	learning_mode?: boolean;
@@ -82,6 +86,7 @@ export interface SecuritySettings {
 	attachment_policy?: AttachmentPolicySettings;
 	folder_policies?: Record<string, FolderPolicySettings>;
 	ruf_ingestion?: RufIngestionSettings;
+	mitigations?: MitigationSettings;
 }
 
 export interface DmarcRufRecord {

--- a/shared/mailbox-settings.ts
+++ b/shared/mailbox-settings.ts
@@ -50,11 +50,23 @@ const ClassificationSettings = z
   })
   .passthrough();
 
+/**
+ * Compensating-control mitigations for the scoring pipeline (issue #100).
+ * Each field enables or disables a named mitigation. Absent key = on (matches
+ * absent-key-inherits semantics; defaults live in `DEFAULT_MITIGATION_CONFIG`).
+ */
+const MitigationConfig = z
+  .object({
+    dmarc_pass_compensates_method_fail: z.boolean().optional(),
+  })
+  .passthrough();
+
 export const SecuritySettings = z
   .object({
     attachment_policy: AttachmentPolicy.optional(),
     folder_policies: z.record(z.string(), FolderPolicy).optional(),
     classification: ClassificationSettings.optional(),
+    mitigations: MitigationConfig.optional(),
   })
   .passthrough();
 

--- a/tests/frontend/security-settings.test.tsx
+++ b/tests/frontend/security-settings.test.tsx
@@ -81,6 +81,60 @@ async function lastSavedSettings(): Promise<MailboxSettings> {
 	return payload.settings;
 }
 
+describe("SecuritySettingsPanel · mitigations toggle", () => {
+	beforeEach(() => {
+		mutateAsync.mockReset();
+		mutateAsync.mockResolvedValue(undefined);
+	});
+
+	it("reflects default-on state when mitigations key is absent", async () => {
+		mailboxFixture = makeMailbox({ enabled: true });
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /DMARC=pass cancels per-method SPF\/DKIM fail contributions/i,
+		});
+		expect(toggle).toBeChecked();
+	});
+
+	it("persists dmarc_pass_compensates_method_fail: false when toggled off", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox({ enabled: true });
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /DMARC=pass cancels per-method SPF\/DKIM fail contributions/i,
+		});
+		await user.click(toggle);
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		expect(saved.security?.mitigations?.dmarc_pass_compensates_method_fail).toBe(false);
+	});
+
+	it("does not clobber other security fields when toggling mitigations", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox({
+			enabled: true,
+			intel_auto_block: false,
+			mitigations: { dmarc_pass_compensates_method_fail: true },
+		});
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /DMARC=pass cancels per-method SPF\/DKIM fail contributions/i,
+		});
+		await user.click(toggle);
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		expect(saved.security?.mitigations?.dmarc_pass_compensates_method_fail).toBe(false);
+		expect(saved.security?.intel_auto_block).toBe(false);
+	});
+});
+
 describe("SecuritySettingsPanel · attachment + folder controls", () => {
 	beforeEach(() => {
 		mutateAsync.mockReset();


### PR DESCRIPTION
## Summary

- Adds `MitigationConfig` Zod sub-schema (`{ dmarc_pass_compensates_method_fail: z.boolean().optional() }.passthrough()`) to `SecuritySettings` in `shared/mailbox-settings.ts` — the field is now validated, no longer relying on `.passthrough()` alone.
- Adds `MitigationSettings` interface and `mitigations?` field to the `SecuritySettings` UI type in `app/types/index.ts`.
- Adds a "Scoring mitigations" section to `SecuritySettingsPanel` with a labeled Switch reflecting default-on (`?? true`) and help text explaining the DMARC=pass compensating-control behavior; merges into existing `mitigations` to preserve sibling keys.

Closes #524.

## Test plan

- [x] `npm test` — 1636 passing, 0 failing (3 new tests in `tests/frontend/security-settings.test.tsx`)
- [x] `npm run typecheck` — clean (0 errors)

## Choices made

- **Section placement:** "Scoring mitigations" is placed after the RUF ingestion section and before Business hours — adjacent to other scoring-modifier controls and mirroring the RUF section's layout as the issue directs.
- **`MitigationSettings` interface name:** Named `MitigationSettings` (not `MitigationConfig`) in `app/types/index.ts` to follow the existing `RufIngestionSettings` / `AttachmentPolicySettings` naming convention on the UI side; the backend keeps `MitigationConfig`.

## Deferred

None — all Acceptance criteria shipped in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDAVEFEb3j8YJV5ej6F7cZ)_