### PR TITLE
feat(domain-settings): add Catch-all intel toggle UI

### DIFF
--- a/app/routes/domain-detail.tsx
+++ b/app/routes/domain-detail.tsx
@@ -145,7 +145,11 @@ function DomainBody({
 			{rufData?.enabled && rufData.records.length > 0 && (
 				<RufFailuresTable records={rufData.records} />
 			)}
-			<CatchallProbesCard data={catchallData} isLoading={catchallLoading} />
+			<CatchallProbesCard
+				data={catchallData}
+				isLoading={catchallLoading}
+				domain={data.domain}
+			/>
 		</>
 	);
 }
@@ -673,9 +677,11 @@ function RecentCasesList({ cases }: { cases: DomainStats["recentCases"] }) {
 function CatchallProbesCard({
 	data,
 	isLoading,
+	domain,
 }: {
 	data: CatchallSummary | undefined;
 	isLoading: boolean;
+	domain: string;
 }) {
 	if (isLoading) {
 		return (
@@ -700,9 +706,14 @@ function CatchallProbesCard({
 			</div>
 			{empty ? (
 				<p className="text-[12.5px] text-ink-3">
-					No catch-all probe activity recorded. Enable{" "}
-					<span className="pp-mono">catchall_intel</span> on this domain to
-					start collecting directory-harvest data.
+					No catch-all probe activity recorded. Turn on{" "}
+					<RouterLink
+						to={`/domains/${encodeURIComponent(domain)}/settings`}
+						className="text-accent hover:underline"
+					>
+						Catch-all intel
+					</RouterLink>{" "}
+					in domain settings to start collecting directory-harvest data.
 				</p>
 			) : (
 				<div className="space-y-5">

--- a/app/routes/domain-settings.tsx
+++ b/app/routes/domain-settings.tsx
@@ -22,12 +22,19 @@ import { TEXT_MODELS } from "shared/mailbox-settings";
 
 const PROMPT_PLACEHOLDER = `(Leave empty to inherit from org-wide /settings)`;
 
+interface CatchallIntelShape {
+	enabled?: boolean;
+	retention_days?: number;
+	sample_limit?: number;
+}
+
 interface DomainSettingsShape {
 	agentSystemPrompt?: string;
 	agentModel?: string;
 	autoDraft?: { enabled?: boolean };
 	security?: SecuritySettings;
 	intel?: { hub?: HubConfigSettings };
+	catchall_intel?: CatchallIntelShape;
 }
 
 /**
@@ -53,6 +60,9 @@ export default function DomainSettingsRoute() {
 	const [autoDraftEnabled, setAutoDraftEnabled] = useState(true);
 	const [modelChoice, setModelChoice] = useState<string>(TEXT_MODELS[0]);
 	const [customModel, setCustomModel] = useState("");
+	const [catchallEnabled, setCatchallEnabled] = useState(false);
+	const [catchallRetention, setCatchallRetention] = useState("");
+	const [catchallSampleLimit, setCatchallSampleLimit] = useState("");
 	const [isSaving, setIsSaving] = useState(false);
 
 	// Initialise once per domain (same useRef pattern as the per-mailbox
@@ -69,6 +79,17 @@ export default function DomainSettingsRoute() {
 		setHub(s.intel?.hub);
 		setHubErrors(undefined);
 		setAutoDraftEnabled(s.autoDraft?.enabled === undefined ? true : s.autoDraft.enabled);
+		setCatchallEnabled(s.catchall_intel?.enabled === true);
+		setCatchallRetention(
+			s.catchall_intel?.retention_days === undefined
+				? ""
+				: String(s.catchall_intel.retention_days),
+		);
+		setCatchallSampleLimit(
+			s.catchall_intel?.sample_limit === undefined
+				? ""
+				: String(s.catchall_intel.sample_limit),
+		);
 
 		const m = s.agentModel ?? availableModels[0] ?? TEXT_MODELS[0];
 		if (availableModels.includes(m)) {
@@ -103,12 +124,35 @@ export default function DomainSettingsRoute() {
 		const normalizedHub = normalizeHubConfig(hub);
 		const intelToPersist = normalizedHub ? { hub: normalizedHub } : undefined;
 
+		// Catch-all intel: always send `enabled`; only send the optional
+		// retention/sample fields when the operator typed a value, so
+		// absent-key-inherits semantics are preserved (the worker's
+		// stripDefaultEqual drops the disabled default after this).
+		const catchallIntel: CatchallIntelShape = { enabled: catchallEnabled };
+		const parsePositiveInt = (raw: string, label: string): number | null | undefined => {
+			const trimmed = raw.trim();
+			if (!trimmed) return undefined;
+			const n = Number(trimmed);
+			if (!Number.isInteger(n) || n <= 0) {
+				feedback.error(`${label} must be a positive whole number.`);
+				return null;
+			}
+			return n;
+		};
+		const retention = parsePositiveInt(catchallRetention, "Retention days");
+		if (retention === null) return;
+		if (retention !== undefined) catchallIntel.retention_days = retention;
+		const sampleLimit = parsePositiveInt(catchallSampleLimit, "Sample limit");
+		if (sampleLimit === null) return;
+		if (sampleLimit !== undefined) catchallIntel.sample_limit = sampleLimit;
+
 		const settings: DomainSettingsShape = {
 			agentSystemPrompt: agentPrompt.trim() || undefined,
 			autoDraft: { enabled: autoDraftEnabled },
 			agentModel: resolvedModel || undefined,
 			security,
 			intel: intelToPersist,
+			catchall_intel: catchallIntel,
 		};
 
 		setIsSaving(true);
@@ -231,6 +275,79 @@ export default function DomainSettingsRoute() {
 							Used for chat and auto-draft for every mailbox under this domain.
 						</p>
 					</div>
+				</div>
+
+				{/* Catch-all intel (#521) */}
+				<div className="pp-card p-5">
+					<div className="text-sm font-medium text-ink mb-1">Catch-all intel</div>
+					<p className="text-xs text-ink-3 mb-4 max-w-md">
+						Capture probes sent to non-existent mailboxes under this domain to
+						surface directory-harvesting attacks. Off by default.
+					</p>
+
+					<label className="flex items-start justify-between gap-3 mb-5">
+						<span className="flex flex-col">
+							<span className="text-sm text-ink">Catch-all probe capture</span>
+							<span className="text-xs text-ink-3 mt-1 max-w-md">
+								Record sources and local-parts targeted at addresses that
+								don't exist on this domain.
+							</span>
+						</span>
+						<input
+							type="checkbox"
+							checked={catchallEnabled}
+							onChange={(e) => setCatchallEnabled(e.target.checked)}
+							className="mt-1 h-4 w-4 accent-accent shrink-0"
+							aria-label="Catch-all probe capture"
+						/>
+					</label>
+
+					<div className="grid grid-cols-2 gap-4">
+						<div>
+							<label
+								htmlFor="catchall-retention-days"
+								className="block text-sm text-ink mb-1.5"
+							>
+								Retention (days)
+							</label>
+							<input
+								id="catchall-retention-days"
+								type="number"
+								min={1}
+								step={1}
+								inputMode="numeric"
+								placeholder="30"
+								value={catchallRetention}
+								onChange={(e) => setCatchallRetention(e.target.value)}
+								disabled={!catchallEnabled}
+								className="w-full rounded-md border border-line bg-paper-2 px-3 py-2 text-sm text-ink placeholder:text-ink-3 focus:outline-none focus:ring-1 focus:ring-accent disabled:opacity-50"
+							/>
+						</div>
+						<div>
+							<label
+								htmlFor="catchall-sample-limit"
+								className="block text-sm text-ink mb-1.5"
+							>
+								Sample limit
+							</label>
+							<input
+								id="catchall-sample-limit"
+								type="number"
+								min={1}
+								step={1}
+								inputMode="numeric"
+								placeholder="50"
+								value={catchallSampleLimit}
+								onChange={(e) => setCatchallSampleLimit(e.target.value)}
+								disabled={!catchallEnabled}
+								className="w-full rounded-md border border-line bg-paper-2 px-3 py-2 text-sm text-ink placeholder:text-ink-3 focus:outline-none focus:ring-1 focus:ring-accent disabled:opacity-50"
+							/>
+						</div>
+					</div>
+					<p className="text-xs text-ink-3 mt-2">
+						Leave the optional fields blank to inherit the defaults (30 days,
+						50 samples).
+					</p>
 				</div>
 
 				{/* Security defaults */}

--- a/tests/frontend/domain-settings-catchall.test.tsx
+++ b/tests/frontend/domain-settings-catchall.test.tsx
@@ -1,0 +1,120 @@
+// Catch-all intel section of `app/routes/domain-settings.tsx` (#521).
+//
+// Verifies the `enabled` toggle reflects the persisted value on load and that
+// saving merges the new `catchall_intel` block into the existing loaded
+// settings rather than replacing the whole tier with `catchall_intel` alone
+// (whole-object replace per tier — wiping auto-draft / agent-model would be a
+// regression). Exercises the real `useDomainSettings` / `useUpdateDomainSettings`
+// hooks against a global-fetch mock dispatched by `new URL(url).pathname`
+// (app/CLAUDE.md test convention).
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router";
+
+// Static text-model list so the agent-model dropdown doesn't need a fetch.
+vi.mock("~/queries/text-models", () => ({
+	useTextModels: () => ({ models: ["@cf/meta/llama-3.3-70b-instruct-fp8-fast"] }),
+}));
+
+import DomainSettingsRoute from "~/routes/domain-settings";
+import { renderWithProviders } from "./test-utils";
+
+const SETTINGS_PATH = "/api/v1/domains/example.com/settings";
+
+let stored: Record<string, unknown>;
+let putBodies: Array<Record<string, unknown>>;
+
+function jsonResponse(data: unknown) {
+	return new Response(JSON.stringify(data), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+beforeEach(() => {
+	putBodies = [];
+	stored = {
+		autoDraft: { enabled: false },
+		agentModel: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+		catchall_intel: { enabled: false },
+	};
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			const { pathname } = new URL(url, "http://localhost");
+			if (pathname === SETTINGS_PATH) {
+				if (init?.method === "PUT") {
+					const body = JSON.parse(init.body as string) as {
+						settings: Record<string, unknown>;
+					};
+					putBodies.push(body.settings);
+					// Whole-object replace per tier — mirror the worker.
+					stored = body.settings;
+					return jsonResponse({ domain: "example.com", settings: stored });
+				}
+				return jsonResponse({ domain: "example.com", settings: stored });
+			}
+			throw new Error(`unexpected fetch: ${pathname}`);
+		}),
+	);
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+function renderDomainSettings() {
+	return renderWithProviders(
+		<Routes>
+			<Route
+				path="/domains/:domain/settings"
+				element={<DomainSettingsRoute />}
+			/>
+		</Routes>,
+		{ initialEntries: ["/domains/example.com/settings"] },
+	);
+}
+
+describe("Domain settings · Catch-all intel section (#521)", () => {
+	it("renders the enabled toggle reflecting the persisted value (off)", async () => {
+		renderDomainSettings();
+		const toggle = await screen.findByRole("checkbox", {
+			name: /catch-all/i,
+		});
+		expect(toggle).not.toBeChecked();
+	});
+
+	it("renders the enabled toggle checked when persisted on", async () => {
+		stored = { ...stored, catchall_intel: { enabled: true } };
+		renderDomainSettings();
+		const toggle = await screen.findByRole("checkbox", {
+			name: /catch-all/i,
+		});
+		expect(toggle).toBeChecked();
+	});
+
+	it("saving with the toggle on merges catchall_intel into existing settings", async () => {
+		const user = userEvent.setup();
+		renderDomainSettings();
+
+		const toggle = await screen.findByRole("checkbox", {
+			name: /catch-all/i,
+		});
+		await user.click(toggle);
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		await waitFor(() => expect(putBodies).toHaveLength(1));
+		const saved = putBodies[0];
+		// The new catchall_intel block is persisted...
+		expect(saved.catchall_intel).toMatchObject({ enabled: true });
+		// ...and the previously-set domain settings are preserved.
+		expect(saved.autoDraft).toEqual({ enabled: false });
+		expect(saved.agentModel).toBe(
+			"@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Closes #521.

The catch-all probe-capture feature (`catchall_intel`) could previously only be enabled by hand-writing domain settings via `PUT /api/v1/domains/<domain>/settings` — there was no web UI control, yet the domain detail page's "Catch-all probes" card told operators to "Enable `catchall_intel` on this domain" with no way to do so.

This adds a **"Catch-all intel"** section to the domain settings page:

- An `enabled` toggle that reflects the persisted value on load and is wired through the existing `useUpdateDomainSettings` mutation.
- Optional `retention_days` / `sample_limit` number inputs (disabled until the toggle is on), with placeholders showing the defaults (30 days / 50 samples).
- The save handler **merges** the new `catchall_intel` block into the already-loaded settings, so other domain-tier settings (auto-draft, agent model, security, hub) are preserved — whole-object-replace-per-tier safe.

The **"Catch-all probes" empty state** on the domain detail page now links to that control (`/domains/<domain>/settings`) instead of naming the raw `catchall_intel` setting key.

## Inheritance / strip semantics

- Optional retention/sample fields are only sent when the operator types a value, preserving absent-key-inherits semantics.
- The client does **not** duplicate `stripDefaultEqual` — the backend's existing strip pass drops the disabled default (`{ enabled: false, retention_days: 30, sample_limit: 50 }`).

## Testing

- New `tests/frontend/domain-settings-catchall.test.tsx` covers the toggle round-trip (load → toggle → save merges into existing settings), exercising the real `useDomainSettings` / `useUpdateDomainSettings` hooks against a global-fetch mock dispatched by `new URL(url).pathname` per `app/CLAUDE.md`.
- `npm test` — 1636 passed.
- `npm run typecheck` — clean.

## Out of scope

- Surfacing `harvest_alert_threshold` / `harvest_alert_window_minutes` (follow-up).
- Any change to the capture pipeline, `CatchallIntelDO`, or the read API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ha1Akz36vGbmLNe3FD98b

---
_Generated by [Claude Code](https://claude.ai/code/session_012ha1Akz36vGbmLNe3FD98b)_