### PR TITLE
feat: add UI toggle for security.detectors.sender_graph.enabled (#523)

### DIFF
--- a/app/components/SecuritySettingsPanel.tsx
+++ b/app/components/SecuritySettingsPanel.tsx
@@ -322,6 +322,25 @@ export function SecuritySettingsPanel({ value, onChange }: SecuritySettingsPanel
 				/>
 			</div>
 
+			{/* Detectors */}
+			<div className="border-t border-line pt-5">
+				<div className="text-xs font-medium text-ink mb-2">Detectors</div>
+				<p className="text-xs text-ink-3 mb-3">
+					The sender-graph / BEC detector builds a per-mailbox graph of prior senders and
+					flags display-name impersonation — mail whose display name matches a known contact
+					but whose address does not. On by default; disable for a mailbox that receives
+					high-volume bulk mail where display-name reuse is expected and not a risk signal.
+				</p>
+				<Switch
+					label="Sender-graph / BEC detector"
+					checked={s.detectors?.sender_graph?.enabled ?? true}
+					onCheckedChange={(v) => patch({
+						detectors: { ...s.detectors, sender_graph: { ...s.detectors?.sender_graph, enabled: v } },
+					})}
+					disabled={!s.enabled}
+				/>
+			</div>
+
 			{/* Business hours */}
 			<div className="border-t border-line pt-5">
 				<div className="text-xs font-medium text-ink mb-2">Business hours</div>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -88,6 +88,7 @@ export interface SecuritySettings {
 	ruf_ingestion?: RufIngestionSettings;
 	mitigations?: { dmarc_pass_compensates_method_fail?: boolean };
 	classification?: ClassificationSettings;
+	detectors?: { sender_graph?: { enabled?: boolean } };
 }
 
 export interface DmarcRufRecord {

--- a/shared/mailbox-settings.ts
+++ b/shared/mailbox-settings.ts
@@ -62,12 +62,25 @@ const MitigationConfig = z
   })
   .passthrough();
 
+const SenderGraphSettings = z
+  .object({
+    enabled: z.boolean().optional(),
+  })
+  .passthrough();
+
+const DetectorSettings = z
+  .object({
+    sender_graph: SenderGraphSettings.optional(),
+  })
+  .passthrough();
+
 export const SecuritySettings = z
   .object({
     attachment_policy: AttachmentPolicy.optional(),
     folder_policies: z.record(z.string(), FolderPolicy).optional(),
     classification: ClassificationSettings.optional(),
     mitigations: MitigationConfig.optional(),
+    detectors: DetectorSettings.optional(),
   })
   .passthrough();
 

--- a/tests/frontend/security-settings.test.tsx
+++ b/tests/frontend/security-settings.test.tsx
@@ -256,3 +256,67 @@ describe("SecuritySettingsPanel · mitigations toggle", () => {
 		expect(saved.security?.ruf_ingestion?.enabled).toBe(true);
 	});
 });
+
+describe("SecuritySettingsPanel · sender-graph detector toggle", () => {
+	beforeEach(() => {
+		mutateAsync.mockReset();
+		mutateAsync.mockResolvedValue(undefined);
+	});
+
+	it("defaults to checked (true) when detectors is absent", async () => {
+		mailboxFixture = makeMailbox({ enabled: true });
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /sender-graph \/ bec detector/i,
+		});
+		expect(toggle).toBeChecked();
+	});
+
+	it("toggles off and saves sender_graph.enabled=false without clobbering other fields", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox({
+			enabled: true,
+			intel_auto_block: true,
+		});
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /sender-graph \/ bec detector/i,
+		});
+		await user.click(toggle);
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		expect(saved.security?.detectors?.sender_graph?.enabled).toBe(false);
+		// other fields must survive
+		expect(saved.security?.intel_auto_block).toBe(true);
+	});
+
+	it("reflects a persisted true value", async () => {
+		mailboxFixture = makeMailbox({
+			enabled: true,
+			detectors: { sender_graph: { enabled: true } },
+		});
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /sender-graph \/ bec detector/i,
+		});
+		expect(toggle).toBeChecked();
+	});
+
+	it("reflects a persisted false value", async () => {
+		mailboxFixture = makeMailbox({
+			enabled: true,
+			detectors: { sender_graph: { enabled: false } },
+		});
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /sender-graph \/ bec detector/i,
+		});
+		expect(toggle).not.toBeChecked();
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `DetectorSettings` / `SenderGraphSettings` Zod sub-schemas to `shared/mailbox-settings.ts` — `detectors.sender_graph.enabled` is now validated rather than relying on `.passthrough()`.
- Extends `SecuritySettings` UI interface in `app/types/index.ts` with `detectors?: { sender_graph?: { enabled?: boolean } }`.
- Adds a "Detectors" section to `SecuritySettingsPanel` with a labeled `Switch` that defaults to checked (default-on when field is absent) and merges into existing `detectors`/`sender_graph` on change, without clobbering sibling keys.

Closes #523.

## Test plan

- [x] `npm test` — 1637 passing, 0 failing (4 new tests in `tests/frontend/security-settings.test.tsx`)
- [x] `npm run typecheck` — clean (0 errors)

## Choices made

- **Default-on via `?? true`:** `s.detectors?.sender_graph?.enabled ?? true` — absent key renders checked, matching the server default without stamping anything at the mailbox tier.
- **Nested merge:** `patch({ detectors: { ...s.detectors, sender_graph: { ...s.detectors?.sender_graph, enabled: v } } })` preserves both sibling detector keys and sibling sender_graph keys when future fields are added.

---
_Generated by [Claude Code](https://claude.ai/code/session_0191DPZwS5k9jdn5MDRZoFRe)_