### PR TITLE
feat: add UI toggle for security.classification.skip_on_timeout

### DIFF
--- a/app/components/SecuritySettingsPanel.tsx
+++ b/app/components/SecuritySettingsPanel.tsx
@@ -253,6 +253,24 @@ export function SecuritySettingsPanel({ value, onChange }: SecuritySettingsPanel
 				</div>
 			</div>
 
+			{/* Classifier */}
+			<div className="border-t border-line pt-5">
+				<div className="text-xs font-medium text-ink mb-2">Classifier</div>
+				<p className="text-xs text-ink-3 mb-3">
+					Controls what happens when the LLM classifier times out or returns an error.
+					The default (on) is fail-open: a timeout contributes 0 to the verdict and tags the
+					email as <code className="text-ink">llm_unavailable</code>, so transient
+					Workers AI throttling or cold starts don&apos;t send legitimate mail to quarantine.
+					Disable to restore the legacy fail-closed-to-<code className="text-ink">suspicious</code> behavior.
+				</p>
+				<Switch
+					label="Skip classification on timeout (fail-open)"
+					checked={s.classification?.skip_on_timeout ?? true}
+					onCheckedChange={(v) => patch({ classification: { ...s.classification, skip_on_timeout: v } })}
+					disabled={!s.enabled}
+				/>
+			</div>
+
 			{/* DMARC RUF ingestion */}
 			<div className="border-t border-line pt-5">
 				<div className="text-xs font-medium text-ink mb-2">DMARC forensic report ingestion (RUF)</div>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -59,6 +59,10 @@ export interface RufIngestionSettings {
 	retain_raw?: boolean;
 }
 
+export interface ClassificationSettings {
+	skip_on_timeout?: boolean;
+}
+
 export interface SecuritySettings {
 	enabled?: boolean;
 	learning_mode?: boolean;
@@ -83,6 +87,7 @@ export interface SecuritySettings {
 	folder_policies?: Record<string, FolderPolicySettings>;
 	ruf_ingestion?: RufIngestionSettings;
 	mitigations?: { dmarc_pass_compensates_method_fail?: boolean };
+	classification?: ClassificationSettings;
 }
 
 export interface DmarcRufRecord {

--- a/tests/frontend/security-settings.test.tsx
+++ b/tests/frontend/security-settings.test.tsx
@@ -81,6 +81,44 @@ async function lastSavedSettings(): Promise<MailboxSettings> {
 	return payload.settings;
 }
 
+describe("SecuritySettingsPanel · classification.skip_on_timeout toggle", () => {
+	beforeEach(() => {
+		mutateAsync.mockReset();
+		mutateAsync.mockResolvedValue(undefined);
+	});
+
+	it("reflects default-on state when classification key is absent", async () => {
+		mailboxFixture = makeMailbox({ enabled: true });
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /skip classification on timeout/i,
+		});
+		expect(toggle).toBeChecked();
+	});
+
+	it("persists skip_on_timeout: false when toggled off without clobbering other fields", async () => {
+		const user = userEvent.setup();
+		mailboxFixture = makeMailbox({
+			enabled: true,
+			intel_auto_block: false,
+			classification: { skip_on_timeout: true },
+		});
+		renderSettings();
+
+		const toggle = await screen.findByRole("switch", {
+			name: /skip classification on timeout/i,
+		});
+		await user.click(toggle);
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		const saved = await lastSavedSettings();
+		expect(saved.security?.classification?.skip_on_timeout).toBe(false);
+		expect(saved.security?.intel_auto_block).toBe(false);
+	});
+});
+
 describe("SecuritySettingsPanel · attachment + folder controls", () => {
 	beforeEach(() => {
 		mutateAsync.mockReset();


### PR DESCRIPTION
## Summary

- Adds `ClassificationSettings` interface and `classification?` field to the `SecuritySettings` UI type in `app/types/index.ts`.
- Adds a "Classifier" section to `SecuritySettingsPanel` with a labeled Switch reflecting default-on (`?? true`) and help text describing the fail-open vs fail-closed timeout behavior; merges into existing `classification` to preserve sibling keys.

No schema change: `ClassificationSettings` with `skip_on_timeout: z.boolean().optional()` is already validated in `shared/mailbox-settings.ts` (landed in #28).

Closes #522.

## Test plan

- [x] `npm test` — 1640 passing, 0 failing (2 new tests in `tests/frontend/security-settings.test.tsx`)
- [x] `npm run typecheck` — clean (0 errors)

## Choices made

- **Section placement:** "Classifier" sits between the "Automations" block and "DMARC RUF ingestion" — logically adjacent to the other pipeline-behavior knobs (confidence-aware quarantine) rather than buried in the collapsible attachment/folder sections.
- **Default-on via `?? true`:** The toggle reads `s.classification?.skip_on_timeout ?? true` so an absent key renders as checked, matching `DEFAULT_CLASSIFICATION_SETTINGS.skip_on_timeout = true` on the server without writing anything to the mailbox tier on first visit.

## Deferred

None — all Acceptance criteria shipped in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDAVEFEb3j8YJV5ej6F7cZ)_