### PR TITLE
fix(hook): narrow stripDefaultEqual guard to endpoint files only

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,12 +24,12 @@
     ],
     "PostToolUse": [
       {
-        "$comment": "stripDefaultEqual must guard settings-tier writes (CLAUDE.md: 'stripDefaultEqual runs on every settings-tier write'; regressed in PRs #148, #154). Coarse file-wide tripwire: a settings-write file that performs an R2/helper write but no longer references stripDefaultEqual is flagged. Heuristic by design — if a write legitimately needs no strip, route it so the file still references stripDefaultEqual or move the write out of these files.",
+        "$comment": "stripDefaultEqual must guard settings-tier writes (CLAUDE.md: 'stripDefaultEqual runs on every settings-tier write'; regressed in PRs #148, #154). Coarse file-wide tripwire: an endpoint file that performs an R2/helper write but no longer references stripDefaultEqual is flagged. Scoped to endpoint files (workers/index.ts, workers/routes/*) and workers/lib/mailbox-settings.ts — NOT the lib reader/writer modules (org-settings.ts, domain-settings.ts) where the strip is applied at the caller (endpoint) layer, not the lib layer. See issue #534.",
         "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_response.filePath // .tool_input.file_path // \"\"' | { read -r f; case \"$f\" in *workers/index.ts|*workers/lib/mailbox-settings.ts|*workers/lib/domain-settings.ts|*workers/lib/org-settings.ts|*workers/security/settings.ts) if [ -f \"$f\" ] && grep -qE 'BUCKET\\.put\\(|putDomainSettings|putMailboxSettings|orgSettingsKey' \"$f\" && ! grep -q 'stripDefaultEqual' \"$f\"; then echo \"Blocked: $f performs a settings-tier write but no longer references stripDefaultEqual. Every settings-tier write (mailboxes/<id>.json, domains/<domain>.json, org/settings.json) must route through stripDefaultEqual from workers/lib/mailbox-settings.ts before BUCKET.put — see CLAUDE.md. This regressed in PRs #148 and #154.\" >&2; exit 2; fi ;; esac; }",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path // \"\"' | { read -r f; case \"$f\" in *workers/index.ts|*workers/lib/mailbox-settings.ts|*workers/security/settings.ts|*workers/routes/*) if [ -f \"$f\" ] && grep -qE 'BUCKET\\.put\\(|putDomainSettings|putMailboxSettings|orgSettingsKey' \"$f\" && ! grep -q 'stripDefaultEqual' \"$f\"; then echo \"Blocked: $f performs a settings-tier write but no longer references stripDefaultEqual. Every settings-tier write (mailboxes/<id>.json, domains/<domain>.json, org/settings.json) must route through stripDefaultEqual from workers/lib/mailbox-settings.ts before BUCKET.put — see CLAUDE.md. This regressed in PRs #148 and #154.\" >&2; exit 2; fi ;; esac; }",
             "statusMessage": "Checking stripDefaultEqual on settings-tier writes..."
           }
         ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,8 @@ persists those values as explicit overrides at the written tier,
 silently shadowing every upstream tier forever — which defeats
 absent-key-inherits semantics for the most common write path.
 
+Hook scope: the PostToolUse stripDefaultEqual guard monitors endpoint files (`workers/index.ts`, `workers/routes/*`) and `workers/lib/mailbox-settings.ts` — NOT `workers/lib/org-settings.ts` or `workers/lib/domain-settings.ts`, because the strip happens at the endpoint layer, not inside those lib helpers (narrowed in PR #534 to eliminate false-positive blocks on the lib readers).
+
 Origin: #106 acceptance criterion 6 originally read "PUT" only. PR #148
 shipped with the strip on mailbox PUT but not on mailbox POST — caught
 by advisor before merge and fixed in the same PR. PR #154 shipped with


### PR DESCRIPTION
## Summary

- Remove `workers/lib/org-settings.ts` and `workers/lib/domain-settings.ts` from the PostToolUse `stripDefaultEqual` hook's case-match pattern — both files legitimately omit `stripDefaultEqual` because the strip is applied at the endpoint layer (`workers/index.ts:769,798,956`), not inside the lib helpers. Including them caused spurious edit blocks on the reader modules.
- Add `*workers/routes/*` to the hook's case pattern to cover the secondary endpoint strip sites.
- Update the hook's `$comment` and add a one-line scope note to CLAUDE.md's `stripDefaultEqual` section.

Closes #534.

## Test plan

- [x] `npm test` — 1647 passing, 0 failing
- [x] `npm run typecheck` — clean (exit 0)

## Choices made

- Dropped the two lib files from the case match rather than adding hunk-level write detection — simpler, matches one of the two approaches the issue explicitly names.
- Added `*workers/routes/*` to monitor the secondary strip sites the issue calls out; the existing workers/index.ts entry already covered the primary site.

## Deferred

None — all Acceptance items shipped in this PR or already on `main` from issue #446 (the `parseSettingsLenient` wiring and regression tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_012xQVaWc3GrZ5LsBLysFYSB)_