### PR TITLE
chore(deps): add security-updates group to isolate react-router from unrelated bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,14 @@ updates:
           - "react-router"
           - "@react-router/*"
           - "workers-ai-provider"
+      # Security-update only: keeps react-router and @react-router/* in lockstep so a
+      # security bump never skews react-router vs @react-router/dev (TS2314 on +types).
+      # Without this group, Dependabot bundles all npm security updates into one PR.
+      react-router-security:
+        applies-to: security-updates
+        patterns:
+          - "react-router"
+          - "@react-router/*"
 
   - package-ecosystem: npm
     directory: "/hub"


### PR DESCRIPTION
## Summary

- Adds a `react-router-security` group with `applies-to: security-updates` to `.github/dependabot.yml` for the root npm ecosystem
- This ensures `react-router` and `@react-router/*` always move together in security-triggered PRs — preventing the version skew (`react-router` vs `@react-router/dev`) that causes `TS2314` on generated route types
- Unrelated packages (e.g. `hono`) are no longer bundled into the same PR as a react-router security bump

Closes #536.

## Why

PR #417 (now closed) was a Dependabot grouped security update that bundled `hono` 4.12.18 → 4.12.23 with `react-router` 7.13.1 → 7.15.0. The react-router bump came without a matching `@react-router/dev` bump, causing `TS2314: Generic type 'GetAnnotations' requires 1 type argument(s)` across ~20 generated route files. The whole PR was blocked, holding the harmless hono patch hostage.

Without a `security-updates` group, Dependabot bundles all npm security updates into a single `npm_and_yarn` PR. Adding `react-router-security` (applies-to: security-updates) isolates future react-router security bumps into their own PR, always pairing them with `@react-router/*` so versions stay in lockstep.

## Test plan

- [ ] Config-only change — no application code modified, typecheck and tests are not affected
- [ ] Verified `.github/dependabot.yml` is valid YAML with correct `applies-to: security-updates` key placement (in line with Dependabot v2 docs)
- [ ] Existing version-update groups (`tiptap`, `react`, `cloudflare`, `dev-dependencies`, `production-dependencies`) are untouched

## Notes for reviewer

- `hono` is already at `^4.12.25` on `main` and `react-router` + `@react-router/dev` are both at `^7.18.0` — PR #417 was resolved by subsequent independent updates, so there are no pending version bumps to land here
- A tracking issue for future react-router security migrations has been filed as #538 (per the acceptance criterion requiring an explicit tracking record)
- The `react-router` version-update group (existing, no `applies-to`) already pairs these packages for scheduled bumps; this PR adds the complementary security-update group

_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkQaDrWAnnbT9vAdCGTnX9)_